### PR TITLE
[ads] Consolidate opt-out ads prefs into a single pref

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BackgroundImagesPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BackgroundImagesPreferences.java
@@ -95,9 +95,7 @@ public class BackgroundImagesPreferences extends BravePreferenceFragment
                     UserPrefs.get(getProfile())
                             .getBoolean(BravePref.NEW_TAB_PAGE_SHOW_BACKGROUND_IMAGE));
             mShowSponsoredImagesPref.setChecked(
-                    UserPrefs.get(getProfile())
-                            .getBoolean(
-                                    BravePref.NEW_TAB_PAGE_SHOW_SPONSORED_IMAGES_BACKGROUND_IMAGE));
+                    UserPrefs.get(getProfile()).getBoolean(BravePref.SPONSORED_ENABLED));
             mShowSponsoredImagesPref.setOnPreferenceChangeListener(this);
         }
         mLearnMorePreference =
@@ -182,10 +180,7 @@ public class BackgroundImagesPreferences extends BravePreferenceFragment
                     .setBoolean(BravePref.NEW_TAB_PAGE_SHOW_BACKGROUND_IMAGE, (boolean) newValue);
             BraveRelaunchUtils.askForRelaunch(getActivity());
         } else if (PREF_SHOW_SPONSORED_IMAGES.equals(key)) {
-            UserPrefs.get(getProfile())
-                    .setBoolean(
-                            BravePref.NEW_TAB_PAGE_SHOW_SPONSORED_IMAGES_BACKGROUND_IMAGE,
-                            (boolean) newValue);
+            UserPrefs.get(getProfile()).setBoolean(BravePref.SPONSORED_ENABLED, (boolean) newValue);
             BraveRelaunchUtils.askForRelaunch(getActivity());
         } else if (PREF_SHOW_TOP_SITES.equals(key)) {
             NtpUtil.setDisplayTopSites((boolean) newValue);

--- a/browser/android/preferences/BUILD.gn
+++ b/browser/android/preferences/BUILD.gn
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/brave_ads/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
 import("//build/config/android/rules.gni")
 
@@ -56,6 +57,10 @@ java_cpp_strings("java_pref_names_srcjar") {
     "//brave/components/request_otr/common/pref_names.h",
     "//components/translate/core/browser/translate_pref_names.h",
   ]
+
+  if (enable_brave_ads) {
+    sources += [ "//brave/components/brave_ads/core/public/prefs/pref_names.h" ]
+  }
 
   if (enable_brave_wallet) {
     sources += [ "//brave/components/decentralized_dns/core/pref_names.h" ]

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -494,7 +494,6 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterStringPref(kNewTabPageClockFormat, "");
   registry->RegisterBooleanPref(kNewTabPageShowStats, true);
   registry->RegisterBooleanPref(kNewTabPageShowRewards, true);
-  registry->RegisterBooleanPref(kNewTabPageShowSponsoredSites, true);
 
 #if BUILDFLAG(ENABLE_BRAVE_TALK)
   registry->RegisterBooleanPref(brave_talk::prefs::kNewTabPageShowBraveTalk,

--- a/browser/brave_rewards/test/rewards_p3a_browsertest.cc
+++ b/browser/brave_rewards/test/rewards_p3a_browsertest.cc
@@ -23,7 +23,6 @@
 #include "brave/components/brave_rewards/content/rewards_service_observer.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "brave/components/constants/brave_paths.h"
-#include "brave/components/ntp_background_images/common/pref_names.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/test/base/in_process_browser_test.h"
@@ -177,9 +176,7 @@ IN_PROC_BROWSER_TEST_F(RewardsP3ABrowserTest, ToggleAdTypes) {
   prefs->SetBoolean(brave_ads::prefs::kNotificationsEnabled, false);
   histogram_tester_->ExpectBucketCount(p3a::kAdTypesEnabledHistogramName, 1, 1);
 
-  prefs->SetBoolean(ntp_background_images::prefs::
-                        kNewTabPageShowSponsoredImagesBackgroundImage,
-                    false);
+  prefs->SetBoolean(brave_ads::prefs::kSponsoredEnabled, false);
   histogram_tester_->ExpectBucketCount(p3a::kAdTypesEnabledHistogramName, 0, 1);
 
   prefs->SetBoolean(brave_ads::prefs::kNotificationsEnabled, true);

--- a/browser/extensions/BUILD.gn
+++ b/browser/extensions/BUILD.gn
@@ -104,6 +104,7 @@ source_set("extensions") {
     "//brave/common",
     "//brave/common/extensions/api",
     "//brave/components/ai_chat/core/common/buildflags",
+    "//brave/components/brave_ads/buildflags",
     "//brave/components/brave_extension:static_resources",
     "//brave/components/brave_news/common/buildflags",
     "//brave/components/brave_rewards/core",
@@ -150,6 +151,10 @@ source_set("extensions") {
 
   if (use_gcm_from_platform) {
     deps += [ "//components/gcm_driver" ]
+  }
+
+  if (enable_brave_ads) {
+    deps += [ "//brave/components/brave_ads/core/public:headers" ]
   }
 
   if (enable_brave_wayback_machine) {

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -8,6 +8,7 @@
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/common/pref_names.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
+#include "brave/components/brave_ads/buildflags/buildflags.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "brave/components/brave_shields/core/common/pref_names.h"
@@ -39,6 +40,10 @@
 #include "components/history/core/common/pref_names.h"
 #include "components/omnibox/browser/omnibox_prefs.h"
 #include "extensions/buildflags/buildflags.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 
 #if BUILDFLAG(ENABLE_BRAVE_TALK)
 #include "brave/components/brave_talk/pref_names.h"
@@ -95,8 +100,6 @@
 namespace extensions {
 
 using ntp_background_images::prefs::kNewTabPageShowBackgroundImage;
-using ntp_background_images::prefs::
-    kNewTabPageShowSponsoredImagesBackgroundImage;
 
 namespace settings_api = api::settings_private;
 
@@ -205,8 +208,10 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetAllowlistedKeys() {
   (*s_brave_allowlist)[debounce::prefs::kDebounceEnabled] =
       settings_api::PrefType::kBoolean;
   // new tab prefs
-  (*s_brave_allowlist)[kNewTabPageShowSponsoredImagesBackgroundImage] =
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+  (*s_brave_allowlist)[brave_ads::prefs::kSponsoredEnabled] =
       settings_api::PrefType::kBoolean;
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
   (*s_brave_allowlist)[kNewTabPageShowBackgroundImage] =
       settings_api::PrefType::kBoolean;
   (*s_brave_allowlist)[kNewTabPageShowClock] = settings_api::PrefType::kBoolean;

--- a/browser/misc_metrics/profile_misc_metrics_service.cc
+++ b/browser/misc_metrics/profile_misc_metrics_service.cc
@@ -13,6 +13,7 @@
 #include "brave/browser/misc_metrics/profile_new_tab_metrics.h"
 #include "brave/browser/misc_metrics/theme_metrics.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_ads/buildflags/buildflags.h"
 #include "brave/components/brave_shields/core/common/pref_names.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/misc_metrics/autofill_metrics.h"
@@ -37,6 +38,10 @@
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/browser/ai_chat_metrics.h"
 #endif  // BUILDFLAG(ENABLE_AI_CHAT)
+
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 
 #if BUILDFLAG(IS_ANDROID)
 #include "brave/browser/misc_metrics/misc_android_metrics.h"
@@ -110,10 +115,12 @@ ProfileMiscMetricsService::ProfileMiscMetricsService(
         prefs::kSearchSuggestEnabled,
         base::BindRepeating(&ProfileMiscMetricsService::ReportSimpleMetrics,
                             base::Unretained(this)));
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
     pref_change_registrar_.Add(
-        kNewTabPageShowSponsoredSites,
+        brave_ads::prefs::kSponsoredEnabled,
         base::BindRepeating(&ProfileMiscMetricsService::ReportSimpleMetrics,
                             base::Unretained(this)));
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
   }
 #endif
   auto* personal_data_manager =
@@ -166,8 +173,12 @@ void ProfileMiscMetricsService::ReportSimpleMetrics() {
       profile_prefs_->GetBoolean(brave_shields::prefs::kAdBlockDeveloperMode);
   UMA_HISTOGRAM_EXACT_LINEAR(kShieldsDevModeEnabledHistogramName,
                              shields_dev_mode_enabled ? 1 : INT_MAX - 1, 2);
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
   bool show_sponsored_sites =
-      profile_prefs_->GetBoolean(kNewTabPageShowSponsoredSites);
+      profile_prefs_->GetBoolean(brave_ads::prefs::kSponsoredEnabled);
+#else
+  bool show_sponsored_sites = false;
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
   UMA_HISTOGRAM_EXACT_LINEAR(kNewTabPageShowSponsoredSitesHistogramName,
                              show_sponsored_sites ? INT_MAX - 1 : 0, 2);
 }

--- a/browser/profiles/brave_profile_manager.cc
+++ b/browser/profiles/brave_profile_manager.cc
@@ -25,7 +25,6 @@
 #include "brave/components/constants/brave_constants.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/content_settings/core/browser/brave_content_settings_pref_provider.h"
-#include "brave/components/ntp_background_images/browser/ntp_p3a_util.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
 #include "brave/components/request_otr/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
@@ -49,6 +48,8 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
 #include "brave/browser/brave_ads/ads_service_factory.h"
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
+#include "brave/components/ntp_background_images/browser/ntp_p3a_util.h"
 #endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
@@ -70,8 +71,6 @@
 using brave_shields::ControlType;
 using content::BrowserThread;
 using ntp_background_images::prefs::kNewTabPageShowBackgroundImage;
-using ntp_background_images::prefs::
-    kNewTabPageShowSponsoredImagesBackgroundImage;  // NOLINT
 
 namespace {
 
@@ -105,14 +104,16 @@ void MigrateHttpsUpgradeSettings(Profile* profile) {
 }
 
 void RecordInitialP3AValues(Profile* profile) {
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
   // Preference is unregistered for some reason in profile_manager_unittest
   // TODO(bsclifton): create a proper testing profile
   if (!profile->GetPrefs()->FindPreference(kNewTabPageShowBackgroundImage) ||
       !profile->GetPrefs()->FindPreference(
-          kNewTabPageShowSponsoredImagesBackgroundImage)) {
+          brave_ads::prefs::kSponsoredEnabled)) {
     return;
   }
   ntp_background_images::RecordSponsoredImagesEnabledP3A(profile->GetPrefs());
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
   if (profile->IsRegularProfile()) {
     auto* map = HostContentSettingsMapFactory::GetForProfile(profile);
     MaybeRecordInitialShieldsSettings(

--- a/browser/ui/webui/brave_new_tab_page_refresh/BUILD.gn
+++ b/browser/ui/webui/brave_new_tab_page_refresh/BUILD.gn
@@ -211,13 +211,18 @@ source_set("browser_tests") {
 source_set("unit_tests") {
   testonly = true
 
-  sources = [ "sponsored_sites_facade_unittest.cc" ]
+  sources = []
+
+  if (enable_brave_ads) {
+    sources += [ "sponsored_sites_facade_unittest.cc" ]
+  }
 
   deps = [
     ":brave_new_tab_page_refresh",
     ":mojom",
     "//base",
     "//base/test:test_support",
+    "//brave/components/brave_ads/buildflags",
     "//brave/components/brave_rewards/core",
     "//brave/components/brave_rewards/core/buildflags",
     "//brave/components/constants",
@@ -232,4 +237,8 @@ source_set("unit_tests") {
     "//testing/gtest",
     "//url",
   ]
+
+  if (enable_brave_ads) {
+    deps += [ "//brave/components/brave_ads/core" ]
+  }
 }

--- a/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_handler.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_handler.cc
@@ -17,6 +17,7 @@
 #include "brave/browser/ui/webui/brave_new_tab_page_refresh/sponsored_sites_facade.h"
 #include "brave/browser/ui/webui/brave_new_tab_page_refresh/top_sites_facade.h"
 #include "brave/browser/ui/webui/brave_new_tab_page_refresh/vpn_facade.h"
+#include "brave/components/brave_ads/buildflags/buildflags.h"
 #include "brave/components/brave_perf_predictor/common/pref_names.h"
 #include "brave/components/brave_search_conversion/pref_names.h"
 #include "brave/components/brave_talk/buildflags/buildflags.h"
@@ -37,11 +38,33 @@
 #include "ui/base/window_open_disposition_utils.h"
 #include "url/gurl.h"
 
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
+
 #if BUILDFLAG(ENABLE_BRAVE_TALK)
 #include "brave/components/brave_talk/pref_names.h"
 #endif
 
 namespace brave_new_tab_page_refresh {
+
+namespace {
+
+bool IsSponsoredAdsEnabled(const PrefService& pref_service) {
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+  return pref_service.GetBoolean(brave_ads::prefs::kSponsoredEnabled);
+#else
+  return false;
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
+}
+
+void SetSponsoredAdsEnabled(PrefService& pref_service, bool enabled) {
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+  pref_service.SetBoolean(brave_ads::prefs::kSponsoredEnabled, enabled);
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
+}
+
+}  // namespace
 
 NewTabPageHandler::NewTabPageHandler(
     mojo::PendingReceiver<mojom::NewTabPageHandler> receiver,
@@ -111,18 +134,13 @@ void NewTabPageHandler::SetBackgroundsEnabled(
 
 void NewTabPageHandler::GetSponsoredImagesEnabled(
     GetSponsoredImagesEnabledCallback callback) {
-  bool sponsored_images_enabled = pref_service_->GetBoolean(
-      ntp_background_images::prefs::
-          kNewTabPageShowSponsoredImagesBackgroundImage);
-  std::move(callback).Run(sponsored_images_enabled);
+  std::move(callback).Run(IsSponsoredAdsEnabled(*pref_service_));
 }
 
 void NewTabPageHandler::SetSponsoredImagesEnabled(
     bool enabled,
     SetSponsoredImagesEnabledCallback callback) {
-  pref_service_->SetBoolean(ntp_background_images::prefs::
-                                kNewTabPageShowSponsoredImagesBackgroundImage,
-                            enabled);
+  SetSponsoredAdsEnabled(*pref_service_, enabled);
   std::move(callback).Run();
 }
 
@@ -364,15 +382,13 @@ void NewTabPageHandler::SetShowTopSites(bool show_top_sites,
 
 void NewTabPageHandler::GetShowSponsoredSites(
     GetShowSponsoredSitesCallback callback) {
-  std::move(callback).Run(
-      pref_service_->GetBoolean(kNewTabPageShowSponsoredSites));
+  std::move(callback).Run(IsSponsoredAdsEnabled(*pref_service_));
 }
 
 void NewTabPageHandler::SetShowSponsoredSites(
     bool show_sponsored_sites,
     SetShowSponsoredSitesCallback callback) {
-  pref_service_->SetBoolean(kNewTabPageShowSponsoredSites,
-                            show_sponsored_sites);
+  SetSponsoredAdsEnabled(*pref_service_, show_sponsored_sites);
   std::move(callback).Run();
 }
 

--- a/browser/ui/webui/brave_new_tab_page_refresh/sponsored_sites_facade.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/sponsored_sites_facade.cc
@@ -12,14 +12,18 @@
 #include "base/functional/bind.h"
 #include "base/task/bind_post_task.h"
 #include "base/time/time.h"
+#include "brave/components/brave_ads/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
-#include "brave/components/constants/pref_names.h"
 #include "brave/components/ntp_background_images/browser/ntp_sponsored_sites_data.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
 #include "components/history/core/browser/history_service.h"
 #include "components/history/core/browser/history_types.h"
 #include "components/prefs/pref_service.h"
 #include "url/gurl.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
 #include "brave/components/brave_rewards/core/pref_names.h"
@@ -121,15 +125,17 @@ bool SponsoredSitesFacade::IsEligible() const {
 }
 
 bool SponsoredSitesFacade::IsEnabled() const {
-  return pref_service_->GetBoolean(kNewTabPageShowSponsoredSites);
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+  return pref_service_->GetBoolean(brave_ads::prefs::kSponsoredEnabled);
+#else
+  return false;
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 }
 
 bool SponsoredSitesFacade::IsNewTabPageAdsEnabled() const {
   return pref_service_->GetBoolean(
              ntp_background_images::prefs::kNewTabPageShowBackgroundImage) &&
-         pref_service_->GetBoolean(
-             ntp_background_images::prefs::
-                 kNewTabPageShowSponsoredImagesBackgroundImage);
+         IsEnabled();
 }
 
 bool SponsoredSitesFacade::IsRewardsWalletConnected() const {

--- a/browser/ui/webui/brave_new_tab_page_refresh/sponsored_sites_facade_unittest.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/sponsored_sites_facade_unittest.cc
@@ -20,8 +20,9 @@
 #include "base/test/values_test_util.h"
 #include "base/time/time.h"
 #include "brave/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page.mojom.h"
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
+#include "brave/components/brave_ads/core/public/prefs/pref_registry.h"
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
-#include "brave/components/constants/pref_names.h"
 #include "brave/components/ntp_background_images/browser/ntp_sponsored_sites_data.h"
 #include "brave/components/ntp_background_images/browser/test/fake_ntp_background_images_service.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
@@ -103,8 +104,7 @@ class SponsoredSitesFacadeTest : public testing::Test {
  public:
   void SetUp() override {
     ntp_background_images::RegisterProfilePrefs(profile_prefs_.registry());
-    profile_prefs_.registry()->RegisterBooleanPref(
-        kNewTabPageShowSponsoredSites, true);
+    brave_ads::RegisterProfilePrefs(profile_prefs_.registry());
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
     brave_rewards::RegisterProfilePrefs(profile_prefs_.registry());
 #endif  // BUILDFLAG(ENABLE_BRAVE_REWARDS)
@@ -173,7 +173,7 @@ class SponsoredSitesFacadeTest : public testing::Test {
 };
 
 TEST_F(SponsoredSitesFacadeTest, ReturnsNoSitesWhenSponsoredSitesDisabled) {
-  profile_prefs_.SetBoolean(kNewTabPageShowSponsoredSites, false);
+  profile_prefs_.SetBoolean(brave_ads::prefs::kSponsoredEnabled, false);
 
   auto facade = CreateFacade();
   background_images_service_->OnGetSponsoredSitesData(CreateSponsoredSitesData(

--- a/browser/ui/webui/brave_new_tab_page_refresh/update_observer.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/update_observer.cc
@@ -10,6 +10,7 @@
 
 #include "brave/browser/ntp_background/ntp_background_prefs.h"
 #include "brave/browser/ui/webui/brave_new_tab_page_refresh/top_sites_facade.h"
+#include "brave/components/brave_ads/buildflags/buildflags.h"
 #include "brave/components/brave_perf_predictor/common/pref_names.h"
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_search_conversion/pref_names.h"
@@ -19,6 +20,10 @@
 #include "brave/components/ntp_background_images/common/pref_names.h"
 #include "chrome/browser/new_tab_page/prefs/ntp_pref_names.h"
 #include "chrome/common/pref_names.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
 #include "brave/components/brave_rewards/core/pref_names.h"
@@ -38,10 +43,10 @@ UpdateObserver::UpdateObserver(PrefService& pref_service,
   // one off should also hide the tiles.
   AddPrefListener(ntp_background_images::prefs::kNewTabPageShowBackgroundImage,
                   {Source::kBackgrounds, Source::kTopSites});
-  AddPrefListener(ntp_background_images::prefs::
-                      kNewTabPageShowSponsoredImagesBackgroundImage,
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+  AddPrefListener(brave_ads::prefs::kSponsoredEnabled,
                   {Source::kBackgrounds, Source::kTopSites});
-  AddPrefListener(kNewTabPageShowSponsoredSites, Source::kTopSites);
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
   AddPrefListener(NTPBackgroundPrefs::kPrefName, Source::kBackgrounds);
   AddPrefListener(NTPBackgroundPrefs::kCustomImageListPrefName,
                   Source::kBackgrounds);

--- a/browser/ui/webui/brave_rewards/rewards_page_handler.cc
+++ b/browser/ui/webui/brave_rewards/rewards_page_handler.cc
@@ -27,7 +27,6 @@
 #include "brave/components/brave_rewards/core/rewards_util.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/l10n/common/locale_util.h"
-#include "brave/components/ntp_background_images/common/pref_names.h"
 #include "components/grit/brave_components_strings.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "components/prefs/pref_service.h"
@@ -65,10 +64,8 @@ class RewardsPageHandler::UpdateObserver
       : update_callback_(std::move(update_callback)) {
     rewards_observation_.Observe(rewards_service);
     pref_change_registrar_.Init(pref_service);
-    AddPrefListener(ntp_background_images::prefs::
-                        kNewTabPageShowSponsoredImagesBackgroundImage,
-                    UpdateSource::kAds);
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
+    AddPrefListener(brave_ads::prefs::kSponsoredEnabled, UpdateSource::kAds);
     AddPrefListener(brave_ads::prefs::kNotificationsEnabled,
                     UpdateSource::kAds);
     AddPrefListener(brave_ads::prefs::kMaximumNotificationAdsPerHour,
@@ -414,8 +411,7 @@ void RewardsPageHandler::GetAdsSettings(GetAdsSettingsCallback callback) {
       ads_service_->IsBrowserUpgradeRequiredToServeAds();
   settings->is_supported_region = brave_ads::IsSupportedRegion();
   settings->new_tab_page_ads_enabled =
-      prefs_->GetBoolean(ntp_background_images::prefs::
-                             kNewTabPageShowSponsoredImagesBackgroundImage);
+      prefs_->GetBoolean(brave_ads::prefs::kSponsoredEnabled);
   settings->notification_ads_enabled =
       prefs_->GetBoolean(brave_ads::prefs::kNotificationsEnabled);
 
@@ -505,9 +501,7 @@ void RewardsPageHandler::SetAdTypeEnabled(brave_ads::mojom::AdType ad_type,
   using AdType = brave_ads::mojom::AdType;
   switch (ad_type) {
     case AdType::kNewTabPageAd:
-      prefs_->SetBoolean(ntp_background_images::prefs::
-                             kNewTabPageShowSponsoredImagesBackgroundImage,
-                         enabled);
+      prefs_->SetBoolean(brave_ads::prefs::kSponsoredEnabled, enabled);
       break;
     case AdType::kNotificationAd:
       prefs_->SetBoolean(brave_ads::prefs::kNotificationsEnabled, enabled);

--- a/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
@@ -48,6 +48,7 @@
 #include "brave/browser/brave_ads/ads_service_factory.h"
 #include "brave/browser/ntp_background/new_tab_takeover_infobar_delegate.h"
 #include "brave/components/brave_ads/core/public/ads_util.h"
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
 #endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 
 #if BUILDFLAG(ENABLE_BRAVE_NEWS)
@@ -61,8 +62,6 @@
 using ntp_background_images::ViewCounterServiceFactory;
 using ntp_background_images::prefs::kBrandedWallpaperNotificationDismissed;
 using ntp_background_images::prefs::kNewTabPageShowBackgroundImage;
-using ntp_background_images::prefs::
-    kNewTabPageShowSponsoredImagesBackgroundImage;  // NOLINT
 
 namespace {
 
@@ -89,9 +88,12 @@ base::DictValue GetPreferencesDictionary(PrefService* prefs) {
   base::DictValue pref_data;
   pref_data.Set("showBackgroundImage",
                 prefs->GetBoolean(kNewTabPageShowBackgroundImage));
-  pref_data.Set(
-      "brandedWallpaperOptIn",
-      prefs->GetBoolean(kNewTabPageShowSponsoredImagesBackgroundImage));
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+  pref_data.Set("brandedWallpaperOptIn",
+                prefs->GetBoolean(brave_ads::prefs::kSponsoredEnabled));
+#else
+  pref_data.Set("brandedWallpaperOptIn", false);
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
   pref_data.Set("showClock", prefs->GetBoolean(kNewTabPageShowClock));
   std::string_view clock_format = prefs->GetString(kNewTabPageClockFormat);
   // The current version of the NTP uses an "h" prefix for the clock format.
@@ -300,10 +302,12 @@ void BraveNewTabMessageHandler::OnJavascriptAllowed() {
       kNewTabPageShowBackgroundImage,
       base::BindRepeating(&BraveNewTabMessageHandler::OnPreferencesChanged,
                           base::Unretained(this)));
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
   pref_change_registrar_.Add(
-      kNewTabPageShowSponsoredImagesBackgroundImage,
+      brave_ads::prefs::kSponsoredEnabled,
       base::BindRepeating(&BraveNewTabMessageHandler::OnPreferencesChanged,
                           base::Unretained(this)));
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
   pref_change_registrar_.Add(
       brave_search_conversion::prefs::kShowNTPSearchBox,
       base::BindRepeating(&BraveNewTabMessageHandler::OnPreferencesChanged,
@@ -448,10 +452,12 @@ void BraveNewTabMessageHandler::HandleSaveNewTabPagePref(
   const auto settings_value_bool = settings_value.GetBool();
   if (settings_key_input == "showBackgroundImage") {
     settings_key = kNewTabPageShowBackgroundImage;
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
   } else if (settings_key_input == "brandedWallpaperOptIn") {
     // TODO(simonhong): I think above |brandedWallpaperOptIn| should be changed
     // to |sponsoredImagesWallpaperOptIn|.
-    settings_key = kNewTabPageShowSponsoredImagesBackgroundImage;
+    settings_key = brave_ads::prefs::kSponsoredEnabled;
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
   } else if (settings_key_input == "showClock") {
     settings_key = kNewTabPageShowClock;
   } else if (settings_key_input == "showStats") {

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -38,6 +38,7 @@
 #include "base/time/time.h"
 #include "base/timer/timer.h"
 #include "base/trace_event/trace_event.h"
+#include "base/values.h"
 #include "brave/components/brave_ads/browser/bat_ads_service_factory.h"
 #include "brave/components/brave_ads/browser/component_updater/resource_component.h"
 #include "brave/components/brave_ads/browser/device_id/device_id.h"
@@ -272,20 +273,13 @@ bool AdsServiceImpl::UserHasJoinedBraveRewards() const {
   return prefs_->GetBoolean(brave_rewards::prefs::kEnabled);
 }
 
-bool AdsServiceImpl::UserHasOptedInToNewTabPageAds() const {
-  return prefs_->GetBoolean(
-             ntp_background_images::prefs::kNewTabPageShowBackgroundImage) &&
-         prefs_->GetBoolean(ntp_background_images::prefs::
-                                kNewTabPageShowSponsoredImagesBackgroundImage);
+bool AdsServiceImpl::IsSponsoredAdsEnabled() const {
+  return prefs_->GetBoolean(prefs::kSponsoredEnabled);
 }
 
 bool AdsServiceImpl::IsNotificationAdsEnabled() const {
   return prefs_->GetBoolean(brave_rewards::prefs::kEnabled) &&
          prefs_->GetBoolean(prefs::kNotificationsEnabled);
-}
-
-bool AdsServiceImpl::UserHasOptedInToSearchResultAds() const {
-  return prefs_->GetBoolean(prefs::kOptedInToSearchResultAds);
 }
 
 bool AdsServiceImpl::CanStartBatAdsService() const {
@@ -302,9 +296,9 @@ bool AdsServiceImpl::CanStartBatAdsService() const {
     return true;
   }
 
-  // The user has not joined Brave Rewards, so we only start the service if the
-  // user has opted in to new tab takeover, or search result ads.
-  return UserHasOptedInToNewTabPageAds() || UserHasOptedInToSearchResultAds();
+  // The user has not joined Brave Rewards, so we only start the service if
+  // sponsored ads are enabled.
+  return IsSponsoredAdsEnabled();
 }
 
 void AdsServiceImpl::MaybeStartBatAdsService() {
@@ -570,10 +564,28 @@ void AdsServiceImpl::ClearAllPrefsAndAdsServiceDataAndMaybeRestart(
   }
   VLOG(6) << "Clearing ads data";
 
-  // Clear all ads preferences.
-  prefs_->ClearPrefsWithPrefixSilently("brave.brave_ads");
+  ClearAdsPrefs();
 
   ClearAdsServiceDataAndMaybeRestart(std::move(callback));
+}
+
+void AdsServiceImpl::ClearAdsPrefs() {
+  // Stop observing prefs before they are set below, otherwise the pref change
+  // may trigger an Ads service start or stop before its data is cleared.
+  pref_change_registrar_.RemoveAll();
+
+  std::optional<bool> sponsored_enabled;
+  if (prefs_->HasPrefPath(prefs::kSponsoredEnabled)) {
+    sponsored_enabled = prefs_->GetBoolean(prefs::kSponsoredEnabled);
+  }
+
+  prefs_->ClearPrefsWithPrefixSilently("brave.brave_ads");
+
+  if (sponsored_enabled) {
+    prefs_->SetBoolean(prefs::kSponsoredEnabled, *sponsored_enabled);
+  }
+
+  InitializePrefChangeRegistrar();
 }
 
 void AdsServiceImpl::ClearAdsServiceDataAndMaybeRestart(
@@ -705,9 +717,9 @@ void AdsServiceImpl::InitializePrefChangeRegistrar() {
 
   InitializeBraveRewardsPrefChangeRegistrar();
   InitializeSubdivisionTargetingPrefChangeRegistrar();
-  InitializeNewTabPageAdsPrefChangeRegistrar();
+  InitializeNewTabPageBackgroundImagePrefChangeRegistrar();
   InitializeNotificationAdsPrefChangeRegistrar();
-  InitializeSearchResultAdsPrefChangeRegistrar();
+  InitializeSponsoredAdsPrefChangeRegistrar();
 }
 
 void AdsServiceImpl::InitializeBraveRewardsPrefChangeRegistrar() {
@@ -737,20 +749,12 @@ void AdsServiceImpl::InitializeSubdivisionTargetingPrefChangeRegistrar() {
                           prefs::kSubdivisionTargetingAutoDetectedSubdivision));
 }
 
-void AdsServiceImpl::InitializeNewTabPageAdsPrefChangeRegistrar() {
+void AdsServiceImpl::InitializeNewTabPageBackgroundImagePrefChangeRegistrar() {
   pref_change_registrar_.Add(
       ntp_background_images::prefs::kNewTabPageShowBackgroundImage,
       base::BindRepeating(
-          &AdsServiceImpl::OnAdsPrefChanged, base::Unretained(this),
+          &AdsServiceImpl::NotifyPrefChanged, base::Unretained(this),
           ntp_background_images::prefs::kNewTabPageShowBackgroundImage));
-
-  pref_change_registrar_.Add(
-      ntp_background_images::prefs::
-          kNewTabPageShowSponsoredImagesBackgroundImage,
-      base::BindRepeating(&AdsServiceImpl::OnAdsPrefChanged,
-                          base::Unretained(this),
-                          ntp_background_images::prefs::
-                              kNewTabPageShowSponsoredImagesBackgroundImage));
 }
 
 void AdsServiceImpl::InitializeNotificationAdsPrefChangeRegistrar() {
@@ -766,9 +770,9 @@ void AdsServiceImpl::InitializeNotificationAdsPrefChangeRegistrar() {
                           prefs::kMaximumNotificationAdsPerHour));
 }
 
-void AdsServiceImpl::InitializeSearchResultAdsPrefChangeRegistrar() {
+void AdsServiceImpl::InitializeSponsoredAdsPrefChangeRegistrar() {
   pref_change_registrar_.Add(
-      prefs::kOptedInToSearchResultAds,
+      prefs::kSponsoredEnabled,
       base::BindRepeating(&AdsServiceImpl::OnAdsPrefChanged,
                           base::Unretained(this)));
 }

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -151,9 +151,8 @@ class AdsServiceImpl : public AdsService,
   void UnregisterLanguageResourceComponent();
 
   bool UserHasJoinedBraveRewards() const;
-  bool UserHasOptedInToNewTabPageAds() const;
+  bool IsSponsoredAdsEnabled() const;
   bool IsNotificationAdsEnabled() const;
-  bool UserHasOptedInToSearchResultAds() const;
 
   bool CanStartBatAdsService() const;
   void MaybeStartBatAdsService();
@@ -178,6 +177,7 @@ class AdsServiceImpl : public AdsService,
                                                       bool shutdown_succeeded);
   void ClearAllPrefsAndAdsServiceDataAndMaybeRestart(ResultCallback callback,
                                                      bool shutdown_succeeded);
+  void ClearAdsPrefs();
   void ClearAdsServiceDataAndMaybeRestart(ResultCallback callback);
   void ClearAdsServiceDataAndMaybeRestartCallback(ResultCallback callback,
                                                   bool success);
@@ -200,9 +200,9 @@ class AdsServiceImpl : public AdsService,
   void InitializePrefChangeRegistrar();
   void InitializeBraveRewardsPrefChangeRegistrar();
   void InitializeSubdivisionTargetingPrefChangeRegistrar();
-  void InitializeNewTabPageAdsPrefChangeRegistrar();
+  void InitializeNewTabPageBackgroundImagePrefChangeRegistrar();
   void InitializeNotificationAdsPrefChangeRegistrar();
-  void InitializeSearchResultAdsPrefChangeRegistrar();
+  void InitializeSponsoredAdsPrefChangeRegistrar();
   void OnAdsPrefChanged(const std::string& path);
   void OnVariationsCountryPrefChanged();
   void NotifyPrefChanged(const std::string& path) const;

--- a/components/brave_ads/browser/ads_service_impl_unittest.cc
+++ b/components/brave_ads/browser/ads_service_impl_unittest.cc
@@ -70,11 +70,7 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
     RegisterProfilePrefs(prefs_.registry());
     brave_rewards::RegisterProfilePrefs(prefs_.registry());
     prefs_.registry()->RegisterBooleanPref(
-        ntp_background_images::prefs::kNewTabPageShowBackgroundImage, false);
-    prefs_.registry()->RegisterBooleanPref(
-        ntp_background_images::prefs::
-            kNewTabPageShowSponsoredImagesBackgroundImage,
-        false);
+        ntp_background_images::prefs::kNewTabPageShowBackgroundImage, true);
 
     RegisterLocalStatePrefs(local_state_.registry());
     local_state_.registry()->RegisterStringPref(
@@ -165,11 +161,11 @@ class BraveAdsAdsServiceImplTest : public testing::Test {
 
 TEST_F(BraveAdsAdsServiceImplTest, ServiceStartsWhenOptedInToSearchResultAds) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
   Startup();
 
   // Act
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
 
   // Assert
   EXPECT_EQ(1U, bat_ads_service_factory_->launch_count());
@@ -177,16 +173,12 @@ TEST_F(BraveAdsAdsServiceImplTest, ServiceStartsWhenOptedInToSearchResultAds) {
 
 TEST_F(BraveAdsAdsServiceImplTest, ServiceStartsWhenOptedInToNewTabPageAds) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
   Startup();
 
   // Act
-  prefs_.SetBoolean(
-      ntp_background_images::prefs::kNewTabPageShowBackgroundImage, true);
   ASSERT_EQ(0U, bat_ads_service_factory_->launch_count());
-  prefs_.SetBoolean(ntp_background_images::prefs::
-                        kNewTabPageShowSponsoredImagesBackgroundImage,
-                    true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
 
   // Assert
   EXPECT_EQ(1U, bat_ads_service_factory_->launch_count());
@@ -194,11 +186,11 @@ TEST_F(BraveAdsAdsServiceImplTest, ServiceStartsWhenOptedInToNewTabPageAds) {
 
 TEST_F(BraveAdsAdsServiceImplTest, ServiceInitializesAfterStarting) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
   Startup();
 
   // Act
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
 
   // Assert
   EXPECT_TRUE(base::test::RunUntil(
@@ -207,12 +199,12 @@ TEST_F(BraveAdsAdsServiceImplTest, ServiceInitializesAfterStarting) {
 
 TEST_F(BraveAdsAdsServiceImplTest, ServiceStopsWhenInitializationFails) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
   Startup();
   bat_ads_service_factory_->set_simulate_initialization_failure();
 
   // Act
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   ASSERT_TRUE(base::test::RunUntil(
       [&] { return bat_ads_service_factory_->shutdown_count() == 1U; }));
 
@@ -223,17 +215,14 @@ TEST_F(BraveAdsAdsServiceImplTest, ServiceStopsWhenInitializationFails) {
 
 TEST_F(BraveAdsAdsServiceImplTest, ServiceDoesNotStartWhenAlreadyRunning) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
   Startup();
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   ASSERT_EQ(1U, bat_ads_service_factory_->launch_count());
 
   // Act
-  prefs_.SetBoolean(
-      ntp_background_images::prefs::kNewTabPageShowBackgroundImage, true);
-  prefs_.SetBoolean(ntp_background_images::prefs::
-                        kNewTabPageShowSponsoredImagesBackgroundImage,
-                    true);
+  prefs_.SetBoolean(brave_rewards::prefs::kEnabled, true);
+  prefs_.SetBoolean(prefs::kNotificationsEnabled, true);
 
   // Assert
   EXPECT_EQ(1U, bat_ads_service_factory_->launch_count());
@@ -242,7 +231,7 @@ TEST_F(BraveAdsAdsServiceImplTest, ServiceDoesNotStartWhenAlreadyRunning) {
 TEST_F(BraveAdsAdsServiceImplTest,
        ServiceDoesNotStartWhenShuttingDownBeforeStartupCompletes) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
 
   // Act
   Shutdown();
@@ -254,13 +243,13 @@ TEST_F(BraveAdsAdsServiceImplTest,
 
 TEST_F(BraveAdsAdsServiceImplTest, ServiceDoesNotStartAfterProfileShutdown) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
   Startup();
   ASSERT_EQ(0U, bat_ads_service_factory_->launch_count());
 
   // Act
   Shutdown();
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
 
   // Assert
   EXPECT_EQ(0U, bat_ads_service_factory_->launch_count());
@@ -268,42 +257,31 @@ TEST_F(BraveAdsAdsServiceImplTest, ServiceDoesNotStartAfterProfileShutdown) {
 
 TEST_F(BraveAdsAdsServiceImplTest, ServiceStopsWhenOptedOutOfAllAds) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
-  prefs_.SetBoolean(
-      ntp_background_images::prefs::kNewTabPageShowBackgroundImage, true);
-  prefs_.SetBoolean(ntp_background_images::prefs::
-                        kNewTabPageShowSponsoredImagesBackgroundImage,
-                    true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   Startup();
   ASSERT_EQ(1U, bat_ads_service_factory_->launch_count());
 
   // Act
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
   ASSERT_EQ(1U, bat_ads_service_factory_->launch_count());
-  prefs_.SetBoolean(
-      ntp_background_images::prefs::kNewTabPageShowBackgroundImage, false);
-  ASSERT_EQ(1U, bat_ads_service_factory_->launch_count());
-  prefs_.SetBoolean(ntp_background_images::prefs::
-                        kNewTabPageShowSponsoredImagesBackgroundImage,
-                    false);
 
   // Assert
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   EXPECT_EQ(2U, bat_ads_service_factory_->launch_count());
 }
 
 TEST_F(BraveAdsAdsServiceImplTest,
        ServiceStartsAgainAfterOptingOutThenBackInToSearchResultAds) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
   Startup();
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   ASSERT_EQ(1U, bat_ads_service_factory_->launch_count());
 
   // Act
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
   ASSERT_EQ(1U, bat_ads_service_factory_->launch_count());
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
 
   // Assert
   EXPECT_EQ(2U, bat_ads_service_factory_->launch_count());
@@ -312,30 +290,40 @@ TEST_F(BraveAdsAdsServiceImplTest,
 TEST_F(BraveAdsAdsServiceImplTest,
        ServiceStartsAgainAfterOptingOutThenBackInToNewTabPageAds) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
   Startup();
-  prefs_.SetBoolean(
-      ntp_background_images::prefs::kNewTabPageShowBackgroundImage, true);
-  prefs_.SetBoolean(ntp_background_images::prefs::
-                        kNewTabPageShowSponsoredImagesBackgroundImage,
-                    true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   ASSERT_EQ(1U, bat_ads_service_factory_->launch_count());
 
   // Act
-  prefs_.SetBoolean(
-      ntp_background_images::prefs::kNewTabPageShowBackgroundImage, false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
   ASSERT_EQ(1U, bat_ads_service_factory_->launch_count());
-  prefs_.SetBoolean(
-      ntp_background_images::prefs::kNewTabPageShowBackgroundImage, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
 
   // Assert
   EXPECT_EQ(2U, bat_ads_service_factory_->launch_count());
 }
 
 TEST_F(BraveAdsAdsServiceImplTest,
+       ServiceDoesNotStopWhenNewTabPageBackgroundImagesAreDisabled) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
+  Startup();
+  ASSERT_EQ(1U, bat_ads_service_factory_->launch_count());
+
+  // Act
+  prefs_.SetBoolean(
+      ntp_background_images::prefs::kNewTabPageShowBackgroundImage, false);
+
+  // Assert
+  EXPECT_EQ(1U, bat_ads_service_factory_->launch_count());
+  EXPECT_EQ(0U, bat_ads_service_factory_->shutdown_count());
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
        DoesNotLaunchServiceWhenVariationsCountryChangesWhileAdsIsDisabled) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
   Startup();
   ASSERT_EQ(0U, bat_ads_service_factory_->launch_count());
 
@@ -349,7 +337,7 @@ TEST_F(BraveAdsAdsServiceImplTest,
 TEST_F(BraveAdsAdsServiceImplTest,
        DoesNotRestartServiceWhenVariationsCountryChangesWhileRunning) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   Startup();
   ASSERT_EQ(1U, bat_ads_service_factory_->launch_count());
 
@@ -366,7 +354,7 @@ TEST_F(BraveAdsAdsServiceImplTest,
 // `Startup`, keeping each test's trigger isolated.
 TEST_F(BraveAdsAdsServiceImplTest, ServiceStartsWhenNotificationAdsAreEnabled) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
   Startup();
   prefs_.SetBoolean(brave_rewards::prefs::kEnabled, true);
   ASSERT_EQ(0U, bat_ads_service_factory_->launch_count());
@@ -380,7 +368,7 @@ TEST_F(BraveAdsAdsServiceImplTest, ServiceStartsWhenNotificationAdsAreEnabled) {
 
 TEST_F(BraveAdsAdsServiceImplTest, ServiceStartsWhenUserHasJoinedBraveRewards) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
   prefs_.SetBoolean(brave_rewards::prefs::kEnabled, true);
 
   // Act
@@ -394,7 +382,7 @@ TEST_F(
     BraveAdsAdsServiceImplTest,
     ServiceDoesNotStopWhenNotificationAdsAreDisabledWhileOptedInToSearchResultAds) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   prefs_.SetBoolean(brave_rewards::prefs::kEnabled, true);
   prefs_.SetBoolean(prefs::kNotificationsEnabled, true);
   Startup();
@@ -412,7 +400,7 @@ TEST_F(
 TEST_F(BraveAdsAdsServiceImplTest,
        ServiceDoesNotStartForSearchResultAdsWhenRewardsIsDisabledByPolicy) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   prefs_.SetManagedPref(brave_rewards::prefs::kDisabledByPolicy,
                         base::Value(true));
 
@@ -426,11 +414,7 @@ TEST_F(BraveAdsAdsServiceImplTest,
 TEST_F(BraveAdsAdsServiceImplTest,
        ServiceDoesNotStartForNewTabPageAdsWhenRewardsIsDisabledByPolicy) {
   // Arrange
-  prefs_.SetBoolean(
-      ntp_background_images::prefs::kNewTabPageShowBackgroundImage, true);
-  prefs_.SetBoolean(ntp_background_images::prefs::
-                        kNewTabPageShowSponsoredImagesBackgroundImage,
-                    true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   prefs_.SetManagedPref(brave_rewards::prefs::kDisabledByPolicy,
                         base::Value(true));
 
@@ -445,7 +429,7 @@ TEST_F(BraveAdsAdsServiceImplTest,
 TEST_F(BraveAdsAdsServiceImplTest,
        ServiceDoesNotStartForNotificationAdsWhenRewardsIsDisabledByPolicy) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
   prefs_.SetBoolean(brave_rewards::prefs::kEnabled, true);
   prefs_.SetBoolean(prefs::kNotificationsEnabled, true);
   prefs_.SetManagedPref(brave_rewards::prefs::kDisabledByPolicy,
@@ -462,7 +446,7 @@ TEST_F(
     BraveAdsAdsServiceImplTest,
     ServiceDoesNotStartWhenUserHasJoinedBraveRewardsButRewardsIsDisabledByPolicy) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
   prefs_.SetBoolean(brave_rewards::prefs::kEnabled, true);
   prefs_.SetManagedPref(brave_rewards::prefs::kDisabledByPolicy,
                         base::Value(true));
@@ -478,7 +462,7 @@ TEST_F(
 TEST_F(BraveAdsAdsServiceImplTest,
        ProcessIdleStateNotifiesWhenUserBecomesIdle) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   Startup();
   ASSERT_TRUE(base::test::RunUntil(
       [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
@@ -493,7 +477,7 @@ TEST_F(BraveAdsAdsServiceImplTest,
 
 TEST_F(BraveAdsAdsServiceImplTest, ProcessIdleStateNotifiesWhenScreenLocks) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   Startup();
   ASSERT_TRUE(base::test::RunUntil(
       [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
@@ -508,7 +492,7 @@ TEST_F(BraveAdsAdsServiceImplTest, ProcessIdleStateNotifiesWhenScreenLocks) {
 
 TEST_F(BraveAdsAdsServiceImplTest, ProcessIdleStateDoesNotNotifyIdleTwice) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   Startup();
   ASSERT_TRUE(base::test::RunUntil(
       [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
@@ -531,7 +515,7 @@ TEST_F(BraveAdsAdsServiceImplTest, ProcessIdleStateDoesNotNotifyIdleTwice) {
 TEST_F(BraveAdsAdsServiceImplTest,
        ProcessIdleStateNotifiesWhenUserBecomesActive) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   Startup();
   ASSERT_TRUE(base::test::RunUntil(
       [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
@@ -550,7 +534,7 @@ TEST_F(BraveAdsAdsServiceImplTest,
 TEST_F(BraveAdsAdsServiceImplTest,
        ProcessIdleStateNotifiesWhenUserBecomesActiveAfterScreenLock) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   Startup();
   ASSERT_TRUE(base::test::RunUntil(
       [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
@@ -570,7 +554,7 @@ TEST_F(BraveAdsAdsServiceImplTest,
 TEST_F(BraveAdsAdsServiceImplTest,
        ProcessIdleStateDoesNotSetScreenWasLockedWhenActiveTransitionsFromIdle) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   Startup();
   ASSERT_TRUE(base::test::RunUntil(
       [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
@@ -590,7 +574,7 @@ TEST_F(BraveAdsAdsServiceImplTest,
 TEST_F(BraveAdsAdsServiceImplTest,
        ProcessIdleStatePassesIdleTimeWhenUserBecomesActive) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   Startup();
   ASSERT_TRUE(base::test::RunUntil(
       [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
@@ -609,7 +593,7 @@ TEST_F(BraveAdsAdsServiceImplTest,
 
 TEST_F(BraveAdsAdsServiceImplTest, ProcessIdleStateDoesNotNotifyActiveTwice) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   Startup();
   ASSERT_TRUE(base::test::RunUntil(
       [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
@@ -692,7 +676,7 @@ TEST_F(BraveAdsAdsServiceImplTest,
        RegistersLanguageResourceComponentWhenUserOptsInToNotificationAds) {
   // Arrange: start the service via search result ads and wait for
   // initialization so `bat_ads_service_remote_` is bound.
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   prefs_.SetBoolean(brave_rewards::prefs::kEnabled, true);
   prefs_.SetBoolean(prefs::kNotificationsEnabled, false);
   Startup();
@@ -709,7 +693,7 @@ TEST_F(BraveAdsAdsServiceImplTest,
        UnregistersLanguageResourceComponentWhenUserOptsOutOfNotificationAds) {
   // Arrange: start with notification ads enabled so the language component
   // is already registered; service must be running before opting out.
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   prefs_.SetBoolean(brave_rewards::prefs::kEnabled, true);
   prefs_.SetBoolean(prefs::kNotificationsEnabled, true);
   Startup();
@@ -728,7 +712,7 @@ TEST_F(BraveAdsAdsServiceImplTest,
        UnregistersResourceComponentsWhenServiceBecomesIneligible) {
   // Arrange: start the service so resource components are registered; then
   // disable ads via policy to trigger unregistration.
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   Startup();
   ASSERT_TRUE(base::test::RunUntil(
       [&] { return bat_ads_service_factory_->initialize_count() == 1U; }));
@@ -745,7 +729,7 @@ TEST_F(BraveAdsAdsServiceImplTest,
 TEST_F(BraveAdsAdsServiceImplTest,
        ClearDataReportsFailureWhenBatAdsDisconnectsDuringShutdown) {
   // Arrange
-  prefs_.SetBoolean(prefs::kOptedInToSearchResultAds, true);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
   bat_ads_service_factory_->set_simulate_shutdown_disconnect();
   Startup();
   ASSERT_TRUE(base::test::RunUntil(
@@ -758,6 +742,69 @@ TEST_F(BraveAdsAdsServiceImplTest,
 
   // Assert
   EXPECT_FALSE(test_future.Get());
+}
+
+TEST_F(BraveAdsAdsServiceImplTest, ClearDataClearsAdsPrefs) {
+  // Arrange
+  prefs_.SetString(prefs::kDiagnosticId, "foo");
+  Startup();
+
+  base::test::TestFuture<bool> test_future;
+
+  // Act
+  ClearData(test_future.GetCallback());
+  ASSERT_TRUE(test_future.Get());
+
+  // Assert
+  EXPECT_FALSE(prefs_.HasPrefPath(prefs::kDiagnosticId));
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       ClearDataPreservesSponsoredEnabledPrefWhenOptedOut) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
+  Startup();
+
+  base::test::TestFuture<bool> test_future;
+
+  // Act
+  ClearData(test_future.GetCallback());
+  ASSERT_TRUE(test_future.Get());
+
+  // Assert
+  EXPECT_FALSE(prefs_.GetBoolean(prefs::kSponsoredEnabled));
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       ClearDataPreservesSponsoredEnabledPrefWhenOptedIn) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
+  Startup();
+
+  base::test::TestFuture<bool> test_future;
+
+  // Act
+  ClearData(test_future.GetCallback());
+  ASSERT_TRUE(test_future.Get());
+
+  // Assert
+  EXPECT_TRUE(prefs_.GetBoolean(prefs::kSponsoredEnabled));
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       ClearDataDoesNotSetSponsoredEnabledPrefWhenUnset) {
+  // Arrange
+  Startup();
+
+  base::test::TestFuture<bool> test_future;
+
+  // Act
+  ClearData(test_future.GetCallback());
+  ASSERT_TRUE(test_future.Get());
+
+  // Assert
+  EXPECT_FALSE(prefs_.HasPrefPath(prefs::kSponsoredEnabled));
+  EXPECT_TRUE(prefs_.GetBoolean(prefs::kSponsoredEnabled));
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/browser/virtual_pref/virtual_pref_provider.cc
+++ b/components/brave_ads/core/browser/virtual_pref/virtual_pref_provider.cc
@@ -13,6 +13,7 @@
 #include "base/values.h"
 #include "base/version_info/version_info.h"
 #include "brave/components/brave_ads/core/public/common/locale/locale_util.h"
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
 #include "brave/components/skus/browser/pref_names.h"
@@ -128,8 +129,7 @@ bool IsSurveyPanelist(const PrefService& prefs) {
 
   if (!prefs.GetBoolean(
           ntp_background_images::prefs::kNewTabPageShowBackgroundImage) ||
-      !prefs.GetBoolean(ntp_background_images::prefs::
-                            kNewTabPageShowSponsoredImagesBackgroundImage)) {
+      !prefs.GetBoolean(brave_ads::prefs::kSponsoredEnabled)) {
     return false;
   }
 

--- a/components/brave_ads/core/browser/virtual_pref/virtual_pref_provider_unittest.cc
+++ b/components/brave_ads/core/browser/virtual_pref/virtual_pref_provider_unittest.cc
@@ -14,6 +14,7 @@
 #include "base/version_info/version_info.h"
 #include "brave/components/brave_ads/core/browser/virtual_pref/test/virtual_pref_provider_delegate_mock.h"
 #include "brave/components/brave_ads/core/internal/common/locale/test/fake_locale.h"
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
 #include "brave/components/skus/browser/pref_names.h"
@@ -34,10 +35,7 @@ class BraveAdsVirtualPrefProviderTest : public ::testing::Test {
         true);
     prefs_.registry()->RegisterBooleanPref(
         ntp_background_images::prefs::kNewTabPageShowBackgroundImage, true);
-    prefs_.registry()->RegisterBooleanPref(
-        ntp_background_images::prefs::
-            kNewTabPageShowSponsoredImagesBackgroundImage,
-        true);
+    prefs_.registry()->RegisterBooleanPref(prefs::kSponsoredEnabled, true);
     prefs_.registry()->RegisterBooleanPref(
         brave_rewards::prefs::kDisabledByPolicy, false);
     local_state_.registry()->RegisterDictionaryPref(skus::prefs::kSkusState);
@@ -144,9 +142,7 @@ TEST_F(BraveAdsVirtualPrefProviderTest,
   // Arrange
   prefs_.SetBoolean(
       ntp_background_images::prefs::kNewTabPageShowBackgroundImage, false);
-  prefs_.SetBoolean(ntp_background_images::prefs::
-                        kNewTabPageShowSponsoredImagesBackgroundImage,
-                    false);
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
 
   // Act
   const base::DictValue virtual_prefs = GetVirtualPrefs();

--- a/components/brave_ads/core/internal/common/subdivision/subdivision_unittest.cc
+++ b/components/brave_ads/core/internal/common/subdivision/subdivision_unittest.cc
@@ -119,9 +119,7 @@ TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingOutOfNewTabPageAds) {
   // Act & Assert
   SetProfileBooleanPref(
       ntp_background_images::prefs::kNewTabPageShowBackgroundImage, false);
-  SetProfileBooleanPref(ntp_background_images::prefs::
-                            kNewTabPageShowSponsoredImagesBackgroundImage,
-                        false);
+  SetProfileBooleanPref(prefs::kSponsoredEnabled, false);
 }
 
 TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingInToNewTabPageAds) {
@@ -135,9 +133,7 @@ TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingInToNewTabPageAds) {
   // Act & Assert
   SetProfileBooleanPref(
       ntp_background_images::prefs::kNewTabPageShowBackgroundImage, true);
-  SetProfileBooleanPref(ntp_background_images::prefs::
-                            kNewTabPageShowSponsoredImagesBackgroundImage,
-                        true);
+  SetProfileBooleanPref(prefs::kSponsoredEnabled, true);
 }
 
 TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingOutOfSearchResultAds) {
@@ -147,7 +143,7 @@ TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingOutOfSearchResultAds) {
   EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision).Times(0);
 
   // Act & Assert
-  SetProfileBooleanPref(prefs::kOptedInToSearchResultAds, false);
+  SetProfileBooleanPref(prefs::kSponsoredEnabled, false);
 }
 
 TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingInToSearchResultAds) {
@@ -159,7 +155,7 @@ TEST_F(BraveAdsSubdivisionTest, DoNotFetchWhenOptingInToSearchResultAds) {
   EXPECT_CALL(subdivision_observer_mock_, OnDidUpdateSubdivision).Times(0);
 
   // Act & Assert
-  SetProfileBooleanPref(prefs::kOptedInToSearchResultAds, true);
+  SetProfileBooleanPref(prefs::kSponsoredEnabled, true);
 }
 
 TEST_F(BraveAdsSubdivisionTest,

--- a/components/brave_ads/core/internal/common/test/pref_registry_test_util.cc
+++ b/components/brave_ads/core/internal/common/test/pref_registry_test_util.cc
@@ -33,7 +33,7 @@ void RegisterProfilePrefs() {
   RegisterProfileBooleanPref(prefs::kNotificationsEnabled, true);
   RegisterProfileInt64Pref(prefs::kMaximumNotificationAdsPerHour, -1);
 
-  RegisterProfileBooleanPref(prefs::kOptedInToSearchResultAds, true);
+  RegisterProfileBooleanPref(prefs::kSponsoredEnabled, true);
 
   RegisterProfileBooleanPref(prefs::kShouldAllowSubdivisionTargeting, false);
   RegisterProfileStringPref(prefs::kSubdivisionTargetingUserSelectedSubdivision,
@@ -71,9 +71,6 @@ void RegisterProfilePrefs() {
   // New tab page background image prefs.
   RegisterProfileBooleanPref(
       ntp_background_images::prefs::kNewTabPageShowBackgroundImage, true);
-  RegisterProfileBooleanPref(ntp_background_images::prefs::
-                                 kNewTabPageShowSponsoredImagesBackgroundImage,
-                             true);
   RegisterProfileBooleanPref(
       ntp_background_images::prefs::kNewTabPageSponsoredImagesSurveyPanelist,
       true);

--- a/components/brave_ads/core/internal/prefs/obsolete_pref_util.cc
+++ b/components/brave_ads/core/internal/prefs/obsolete_pref_util.cc
@@ -32,6 +32,9 @@ constexpr std::string_view kObsoleteNotificationAdDidFallbackToCustom =
 constexpr std::string_view kObsoleteOptedInToNotificationAds =
     "brave.brave_ads.enabled";
 
+constexpr std::string_view kObsoleteOptedInToSearchResultAds =
+    "brave.brave_ads.opted_in_to_search_result_ads";
+
 constexpr std::string_view kNewTabPageEventCountConstellationDictPref =
     "brave.brave_ads.p3a.ntp_event_count_constellation";
 constexpr std::string_view kNewTabPageKnownCampaignsDictPref =
@@ -57,6 +60,7 @@ void RegisterProfilePrefsForMigration(PrefRegistrySimple* const registry) {
 
   // Added 08/2026.
   registry->RegisterBooleanPref(kObsoleteOptedInToNotificationAds, false);
+  registry->RegisterBooleanPref(kObsoleteOptedInToSearchResultAds, true);
 }
 
 void MigrateObsoleteProfilePrefs(PrefService* const prefs) {
@@ -76,8 +80,9 @@ void MigrateObsoleteProfilePrefs(PrefService* const prefs) {
   if (prefs->HasPrefPath(kObsoleteOptedInToNotificationAds)) {
     prefs->SetBoolean(prefs::kNotificationsEnabled,
                       prefs->GetBoolean(kObsoleteOptedInToNotificationAds));
-    prefs->ClearPref(kObsoleteOptedInToNotificationAds);
   }
+  prefs->ClearPref(kObsoleteOptedInToNotificationAds);
+  prefs->ClearPref(kObsoleteOptedInToSearchResultAds);
 }
 
 void RegisterLocalStatePrefsForMigration(PrefRegistrySimple* registry) {

--- a/components/brave_ads/core/internal/prefs/pref_path_util.cc
+++ b/components/brave_ads/core/internal/prefs/pref_path_util.cc
@@ -19,16 +19,11 @@ bool DoesMatchUserHasJoinedBraveRewardsPrefPath(std::string_view path) {
 
 bool DoesMatchUserHasOptedInToNewTabPageAdsPrefPath(std::string_view path) {
   return path == ntp_background_images::prefs::kNewTabPageShowBackgroundImage ||
-         path == ntp_background_images::prefs::
-                     kNewTabPageShowSponsoredImagesBackgroundImage;
+         path == prefs::kSponsoredEnabled;
 }
 
 bool DoesMatchNotificationAdsEnabledPrefPath(std::string_view path) {
   return path == prefs::kNotificationsEnabled;
-}
-
-bool DoesMatchUserHasOptedInToSearchResultAdsPrefPath(std::string_view path) {
-  return path == prefs::kOptedInToSearchResultAds;
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/prefs/pref_path_util.h
+++ b/components/brave_ads/core/internal/prefs/pref_path_util.h
@@ -16,8 +16,6 @@ bool DoesMatchUserHasOptedInToNewTabPageAdsPrefPath(std::string_view path);
 
 bool DoesMatchNotificationAdsEnabledPrefPath(std::string_view path);
 
-bool DoesMatchUserHasOptedInToSearchResultAdsPrefPath(std::string_view path);
-
 }  // namespace brave_ads
 
 #endif  // BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_PREFS_PREF_PATH_UTIL_H_

--- a/components/brave_ads/core/internal/prefs/pref_registry.cc
+++ b/components/brave_ads/core/internal/prefs/pref_registry.cc
@@ -33,7 +33,7 @@ void RegisterProfilePrefs(PrefRegistrySimple* const registry) {
   registry->RegisterBooleanPref(prefs::kNotificationsEnabled, false);
   registry->RegisterInt64Pref(prefs::kMaximumNotificationAdsPerHour, -1);
 
-  registry->RegisterBooleanPref(prefs::kOptedInToSearchResultAds, true);
+  registry->RegisterBooleanPref(prefs::kSponsoredEnabled, true);
 
   registry->RegisterBooleanPref(prefs::kShouldAllowSubdivisionTargeting, false);
   registry->RegisterStringPref(

--- a/components/brave_ads/core/internal/settings/settings.cc
+++ b/components/brave_ads/core/internal/settings/settings.cc
@@ -38,9 +38,7 @@ bool UserHasJoinedBraveRewardsAndConnectedWallet() {
 bool UserHasOptedInToNewTabPageAds() {
   return GetProfileBooleanPref(
              ntp_background_images::prefs::kNewTabPageShowBackgroundImage) &&
-         GetProfileBooleanPref(
-             ntp_background_images::prefs::
-                 kNewTabPageShowSponsoredImagesBackgroundImage);
+         GetProfileBooleanPref(prefs::kSponsoredEnabled);
 }
 
 bool IsNotificationAdsEnabled() {
@@ -56,7 +54,7 @@ int GetMaximumNotificationAdsPerHour() {
 }
 
 bool UserHasOptedInToSearchResultAds() {
-  return GetProfileBooleanPref(prefs::kOptedInToSearchResultAds);
+  return GetProfileBooleanPref(prefs::kSponsoredEnabled);
 }
 
 bool UserHasOptedInToSurveyPanelist() {

--- a/components/brave_ads/core/internal/settings/test/settings_test_util.cc
+++ b/components/brave_ads/core/internal/settings/test/settings_test_util.cc
@@ -24,9 +24,7 @@ void DisconnectExternalBraveRewardsWallet() {
 void OptOutOfNewTabPageAds() {
   SetProfileBooleanPrefValue(
       ntp_background_images::prefs::kNewTabPageShowBackgroundImage, false);
-  SetProfileBooleanPrefValue(ntp_background_images::prefs::
-                                 kNewTabPageShowSponsoredImagesBackgroundImage,
-                             false);
+  SetProfileBooleanPrefValue(prefs::kSponsoredEnabled, false);
 }
 
 void DisableNotificationAds() {
@@ -39,7 +37,7 @@ void SetMaximumNotificationAdsPerHour(int max_ads_per_hour) {
 }
 
 void OptOutOfSearchResultAds() {
-  SetProfileBooleanPrefValue(prefs::kOptedInToSearchResultAds, false);
+  SetProfileBooleanPrefValue(prefs::kSponsoredEnabled, false);
 }
 
 void OptOutOfAllAds() {

--- a/components/brave_ads/core/internal/targeting/behavioral/anti_targeting/resource/anti_targeting_resource_unittest.cc
+++ b/components/brave_ads/core/internal/targeting/behavioral/anti_targeting/resource/anti_targeting_resource_unittest.cc
@@ -120,9 +120,7 @@ TEST_F(BraveAdsAntiTargetingResourceTest,
   // Act
   SetProfileBooleanPref(
       ntp_background_images::prefs::kNewTabPageShowBackgroundImage, true);
-  SetProfileBooleanPref(ntp_background_images::prefs::
-                            kNewTabPageShowSponsoredImagesBackgroundImage,
-                        true);
+  SetProfileBooleanPref(prefs::kSponsoredEnabled, true);
 
   // Assert
   ASSERT_TRUE(base::test::RunUntil([this] { return resource_->IsLoaded(); }));
@@ -132,7 +130,6 @@ TEST_F(BraveAdsAntiTargetingResourceTest,
        DoNotResetResourceIfAlreadyOptedInToNewTabPageAds) {
   // Arrange
   test::DisableNotificationAds();
-  test::OptOutOfSearchResultAds();
 
   ads_client_notifier_.NotifyResourceComponentDidChange(
       test::kCountryComponentManifestVersion, test::kCountryComponentId);
@@ -141,9 +138,7 @@ TEST_F(BraveAdsAntiTargetingResourceTest,
   // Act
   SetProfileBooleanPref(
       ntp_background_images::prefs::kNewTabPageShowBackgroundImage, true);
-  SetProfileBooleanPref(ntp_background_images::prefs::
-                            kNewTabPageShowSponsoredImagesBackgroundImage,
-                        true);
+  SetProfileBooleanPref(prefs::kSponsoredEnabled, true);
 
   // Assert
   EXPECT_TRUE(resource_->IsLoaded());
@@ -169,7 +164,6 @@ TEST_F(BraveAdsAntiTargetingResourceTest,
        DoNotResetResourceIfNotificationAdsAlreadyEnabled) {
   // Arrange
   test::OptOutOfNewTabPageAds();
-  test::OptOutOfSearchResultAds();
 
   ads_client_notifier_.NotifyResourceComponentDidChange(
       test::kCountryComponentManifestVersion, test::kCountryComponentId);
@@ -192,7 +186,7 @@ TEST_F(BraveAdsAntiTargetingResourceTest,
   ASSERT_FALSE(resource_->IsLoaded());
 
   // Act
-  SetProfileBooleanPref(prefs::kOptedInToSearchResultAds, true);
+  SetProfileBooleanPref(prefs::kSponsoredEnabled, true);
 
   // Assert
   EXPECT_FALSE(resource_->IsLoaded());

--- a/components/brave_ads/core/internal/targeting/behavioral/purchase_intent/resource/purchase_intent_resource_unittest.cc
+++ b/components/brave_ads/core/internal/targeting/behavioral/purchase_intent/resource/purchase_intent_resource_unittest.cc
@@ -121,9 +121,7 @@ TEST_F(BraveAdsPurchaseIntentResourceTest,
   // Act
   SetProfileBooleanPref(
       ntp_background_images::prefs::kNewTabPageShowBackgroundImage, true);
-  SetProfileBooleanPref(ntp_background_images::prefs::
-                            kNewTabPageShowSponsoredImagesBackgroundImage,
-                        true);
+  SetProfileBooleanPref(prefs::kSponsoredEnabled, true);
 
   // Assert
   EXPECT_FALSE(resource_->IsLoaded());
@@ -149,7 +147,6 @@ TEST_F(BraveAdsPurchaseIntentResourceTest,
        DoNotResetResourceIfNotificationAdsAlreadyEnabled) {
   // Arrange
   test::OptOutOfNewTabPageAds();
-  test::OptOutOfSearchResultAds();
 
   ads_client_notifier_.NotifyResourceComponentDidChange(
       test::kCountryComponentManifestVersion, test::kCountryComponentId);
@@ -172,7 +169,7 @@ TEST_F(BraveAdsPurchaseIntentResourceTest,
   ASSERT_FALSE(resource_->IsLoaded());
 
   // Act
-  SetProfileBooleanPref(prefs::kOptedInToSearchResultAds, true);
+  SetProfileBooleanPref(prefs::kSponsoredEnabled, true);
 
   // Assert
   EXPECT_FALSE(resource_->IsLoaded());

--- a/components/brave_ads/core/internal/targeting/contextual/text_classification/resource/text_classification_resource_unittest.cc
+++ b/components/brave_ads/core/internal/targeting/contextual/text_classification/resource/text_classification_resource_unittest.cc
@@ -134,9 +134,7 @@ TEST_F(BraveAdsTextClassificationResourceTest,
   // Act
   SetProfileBooleanPref(
       ntp_background_images::prefs::kNewTabPageShowBackgroundImage, true);
-  SetProfileBooleanPref(ntp_background_images::prefs::
-                            kNewTabPageShowSponsoredImagesBackgroundImage,
-                        true);
+  SetProfileBooleanPref(prefs::kSponsoredEnabled, true);
 
   // Assert
   EXPECT_FALSE(resource_->IsLoaded());
@@ -162,7 +160,6 @@ TEST_F(BraveAdsTextClassificationResourceTest,
        DoNotResetResourceIfNotificationAdsAlreadyEnabled) {
   // Arrange
   test::OptOutOfNewTabPageAds();
-  test::OptOutOfSearchResultAds();
 
   ads_client_notifier_.NotifyResourceComponentDidChange(
       test::kLanguageComponentManifestVersion, test::kLanguageComponentId);
@@ -185,7 +182,7 @@ TEST_F(BraveAdsTextClassificationResourceTest,
   ASSERT_FALSE(resource_->IsLoaded());
 
   // Act
-  SetProfileBooleanPref(prefs::kOptedInToSearchResultAds, true);
+  SetProfileBooleanPref(prefs::kSponsoredEnabled, true);
 
   // Assert
   EXPECT_FALSE(resource_->IsLoaded());

--- a/components/brave_ads/core/public/prefs/pref_names.h
+++ b/components/brave_ads/core/public/prefs/pref_names.h
@@ -13,7 +13,8 @@ static_assert(BUILDFLAG(ENABLE_BRAVE_ADS));
 namespace brave_ads::prefs {
 
 // IMPORTANT: Prefs that need clearing should be prefixed with
-// `brave.brave_ads`.
+// `brave.brave_ads`. `kSponsoredEnabled` is the exception; it records a user
+// choice that must outlive ads data, so `ClearAdsPrefs` restores it.
 
 // Ads prefs.
 inline constexpr char kFirstRunAt[] = "brave.brave_ads.first_run_at";
@@ -27,8 +28,7 @@ inline constexpr char kNotificationsEnabled[] =
 inline constexpr char kMaximumNotificationAdsPerHour[] =
     "brave.brave_ads.ads_per_hour";
 
-inline constexpr char kOptedInToSearchResultAds[] =
-    "brave.brave_ads.opted_in_to_search_result_ads";
+inline constexpr char kSponsoredEnabled[] = "brave.brave_ads.sponsored.enabled";
 
 inline constexpr char kShouldAllowSubdivisionTargeting[] =
     "brave.brave_ads.should_allow_ads_subdivision_targeting";

--- a/components/brave_rewards/content/rewards_p3a.cc
+++ b/components/brave_rewards/content/rewards_p3a.cc
@@ -9,7 +9,6 @@
 #include "base/metrics/histogram_macros.h"
 #include "brave/components/brave_ads/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
-#include "brave/components/ntp_background_images/common/pref_names.h"
 #include "brave/components/p3a_utils/bucket.h"
 #include "brave/components/time_period_storage/monthly_storage.h"
 #include "components/prefs/pref_service.h"
@@ -84,9 +83,7 @@ void RecordAdTypesEnabled(PrefService* prefs) {
     UMA_HISTOGRAM_EXACT_LINEAR(kAdTypesEnabledHistogramName, INT_MAX - 1, 4);
     return;
   }
-  int ntp_enabled =
-      prefs->GetBoolean(ntp_background_images::prefs::
-                            kNewTabPageShowSponsoredImagesBackgroundImage);
+  int ntp_enabled = prefs->GetBoolean(brave_ads::prefs::kSponsoredEnabled);
   int notification_enabled =
       prefs->GetBoolean(brave_ads::prefs::kNotificationsEnabled);
   int answer = (notification_enabled << 1) | ntp_enabled;

--- a/components/brave_rewards/content/rewards_service_impl.cc
+++ b/components/brave_rewards/content/rewards_service_impl.cc
@@ -299,8 +299,7 @@ void RewardsServiceImpl::InitPrefChangeRegistrar() {
       base::BindRepeating(&RewardsServiceImpl::OnPreferenceChanged,
                           base::Unretained(this)));
   profile_pref_change_registrar_.Add(
-      ntp_background_images::prefs::
-          kNewTabPageShowSponsoredImagesBackgroundImage,
+      brave_ads::prefs::kSponsoredEnabled,
       base::BindRepeating(&RewardsServiceImpl::OnPreferenceChanged,
                           base::Unretained(this)));
 #endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
@@ -318,8 +317,7 @@ void RewardsServiceImpl::OnPreferenceChanged(const std::string& key) {
   }
 
 #if BUILDFLAG(ENABLE_BRAVE_ADS)
-  if (key == ntp_background_images::prefs::
-                 kNewTabPageShowSponsoredImagesBackgroundImage ||
+  if (key == brave_ads::prefs::kSponsoredEnabled ||
       key == brave_ads::prefs::kNotificationsEnabled) {
     p3a::RecordAdTypesEnabled(prefs_);
   }

--- a/components/constants/pref_names.h
+++ b/components/constants/pref_names.h
@@ -73,9 +73,6 @@ inline constexpr char kNewTabPageClockFormat[] =
 inline constexpr char kNewTabPageShowStats[] = "brave.new_tab_page.show_stats";
 inline constexpr char kNewTabPageShowRewards[] =
     "brave.new_tab_page.show_rewards";
-inline constexpr char kNewTabPageShowSponsoredSites[] =
-    "brave.new_tab_page.show_sponsored_sites";
-
 inline constexpr char kNewTabPageShowBraveVPN[] =
     "brave.new_tab_page.show_brave_vpn";
 inline constexpr char kNewTabPageHideAllWidgets[] =

--- a/components/ntp_background_images/browser/BUILD.gn
+++ b/components/ntp_background_images/browser/BUILD.gn
@@ -21,8 +21,6 @@ static_library("browser") {
     "ntp_background_images_service.h",
     "ntp_background_images_update_util.cc",
     "ntp_background_images_update_util.h",
-    "ntp_p3a_util.cc",
-    "ntp_p3a_util.h",
     "ntp_sponsored_images_data.cc",
     "ntp_sponsored_images_data.h",
     "ntp_sponsored_rich_media_ad_event_handler.cc",
@@ -92,6 +90,11 @@ static_library("browser") {
   }
 
   if (enable_brave_ads) {
+    sources += [
+      "ntp_p3a_util.cc",
+      "ntp_p3a_util.h",
+    ]
+
     deps += [ "//brave/components/brave_ads/core" ]
 
     if (!is_ios) {

--- a/components/ntp_background_images/browser/ntp_p3a_util.cc
+++ b/components/ntp_background_images/browser/ntp_p3a_util.cc
@@ -7,6 +7,8 @@
 
 #include "base/check.h"
 #include "base/metrics/histogram_macros.h"
+#include "brave/components/brave_ads/buildflags/buildflags.h"
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
 #include "components/prefs/pref_service.h"
 
@@ -17,7 +19,7 @@ void RecordSponsoredImagesEnabledP3A(const PrefService* const prefs) {
 
   const bool is_sponsored_image_enabled =
       prefs->GetBoolean(prefs::kNewTabPageShowBackgroundImage) &&
-      prefs->GetBoolean(prefs::kNewTabPageShowSponsoredImagesBackgroundImage);
+      prefs->GetBoolean(brave_ads::prefs::kSponsoredEnabled);
   UMA_HISTOGRAM_BOOLEAN("Brave.NTP.SponsoredMediaType",
                         is_sponsored_image_enabled);
 }

--- a/components/ntp_background_images/browser/ntp_p3a_util.h
+++ b/components/ntp_background_images/browser/ntp_p3a_util.h
@@ -6,6 +6,10 @@
 #ifndef BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_NTP_P3A_UTIL_H_
 #define BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_NTP_P3A_UTIL_H_
 
+#include "brave/components/brave_ads/buildflags/buildflags.h"
+
+static_assert(BUILDFLAG(ENABLE_BRAVE_ADS));
+
 class PrefService;
 
 namespace ntp_background_images {

--- a/components/ntp_background_images/browser/view_counter_service.cc
+++ b/components/ntp_background_images/browser/view_counter_service.cc
@@ -21,12 +21,12 @@
 #include "base/logging.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/task/thread_pool.h"
+#include "brave/components/brave_ads/buildflags/buildflags.h"
 #include "brave/components/brave_ads/core/browser/service/ads_service.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "brave/components/ntp_background_images/browser/brave_ntp_custom_background_service.h"
 #include "brave/components/ntp_background_images/browser/ntp_background_images_data.h"
-#include "brave/components/ntp_background_images/browser/ntp_p3a_util.h"
 #include "brave/components/ntp_background_images/browser/ntp_sponsored_images_data.h"
 #include "brave/components/ntp_background_images/browser/url_constants.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
@@ -38,6 +38,11 @@
 #include "components/content_settings/core/common/content_settings.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
 #include "components/prefs/pref_service.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
+#include "brave/components/ntp_background_images/browser/ntp_p3a_util.h"
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 
 namespace ntp_background_images {
 
@@ -100,10 +105,12 @@ ViewCounterService::ViewCounterService(
       brave_rewards::prefs::kEnabled,
       base::BindRepeating(&ViewCounterService::OnPreferenceChanged,
                           weak_ptr_factory_.GetWeakPtr()));
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
   pref_change_registrar_.Add(
-      prefs::kNewTabPageShowSponsoredImagesBackgroundImage,
+      brave_ads::prefs::kSponsoredEnabled,
       base::BindRepeating(&ViewCounterService::OnPreferenceChanged,
                           weak_ptr_factory_.GetWeakPtr()));
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
   pref_change_registrar_.Add(
       prefs::kNewTabPageShowBackgroundImage,
       base::BindRepeating(&ViewCounterService::OnPreferenceChanged,
@@ -307,10 +314,12 @@ void ViewCounterService::OnPreferenceChanged(const std::string& pref_name) {
     return;
   }
 
-  if (pref_name == prefs::kNewTabPageShowBackgroundImage ||
-      pref_name == prefs::kNewTabPageShowSponsoredImagesBackgroundImage) {
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+  if (pref_name == brave_ads::prefs::kSponsoredEnabled ||
+      pref_name == prefs::kNewTabPageShowBackgroundImage) {
     RecordSponsoredImagesEnabledP3A(prefs_);
   }
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 
   ResetModel();
 }
@@ -370,9 +379,12 @@ bool ViewCounterService::IsShowBackgroundImageOptedIn() const {
 }
 
 bool ViewCounterService::IsSponsoredImagesWallpaperOptedIn() const {
-  return prefs_->GetBoolean(
-      prefs::kNewTabPageShowSponsoredImagesBackgroundImage) &&
-        is_supported_locale_;
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+  return prefs_->GetBoolean(brave_ads::prefs::kSponsoredEnabled) &&
+         is_supported_locale_;
+#else
+  return false;
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 }
 
 void ViewCounterService::OnGetCurrentBrandedWallpaper(

--- a/components/ntp_background_images/browser/view_counter_service_unittest.cc
+++ b/components/ntp_background_images/browser/view_counter_service_unittest.cc
@@ -20,6 +20,8 @@
 #include "base/test/test_future.h"
 #include "base/test/values_test_util.h"
 #include "brave/components/brave_ads/core/browser/service/test/ads_service_mock.h"
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
+#include "brave/components/brave_ads/core/public/prefs/pref_registry.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "brave/components/brave_rewards/core/pref_registry.h"
 #include "brave/components/ntp_background_images/browser/features.h"
@@ -203,6 +205,7 @@ class ViewCounterServiceTest : public testing::Test {
 
   void SetUp() override {
     brave_rewards::RegisterProfilePrefs(prefs_.registry());
+    brave_ads::RegisterProfilePrefs(prefs_.registry());
     RegisterProfilePrefs(prefs_.registry());
     HostContentSettingsMap::RegisterProfilePrefs(prefs_.registry());
 
@@ -251,8 +254,7 @@ class ViewCounterServiceTest : public testing::Test {
   }
 
   void SetSponsoredImagesVisibility(bool should_show) {
-    prefs_.SetBoolean(prefs::kNewTabPageShowSponsoredImagesBackgroundImage,
-                      should_show);
+    prefs_.SetBoolean(brave_ads::prefs::kSponsoredEnabled, should_show);
   }
 
   void MockSponsoredImagesData(WallpaperType wallpaper_type) {

--- a/components/ntp_background_images/common/BUILD.gn
+++ b/components/ntp_background_images/common/BUILD.gn
@@ -3,6 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/brave_ads/buildflags/buildflags.gni")
+
 source_set("common") {
   sources = [
     "infobar_constants.h",
@@ -13,7 +15,12 @@ source_set("common") {
     "view_counter_pref_registry.h",
   ]
   deps = [
+    "//brave/components/brave_ads/buildflags",
     "//components/pref_registry",
     "//components/prefs",
   ]
+
+  if (enable_brave_ads) {
+    deps += [ "//brave/components/brave_ads/core/public:headers" ]
+  }
 }

--- a/components/ntp_background_images/common/pref_names.h
+++ b/components/ntp_background_images/common/pref_names.h
@@ -12,8 +12,6 @@ inline constexpr char kNewTabPageSponsoredImagesSurveyPanelist[] =
     "brave.new_tab_page.sponsored_images.survey_panelist";
 inline constexpr char kBrandedWallpaperNotificationDismissed[] =
     "brave.branded_wallpaper_notification_dismissed";
-inline constexpr char kNewTabPageShowSponsoredImagesBackgroundImage[] =
-    "brave.new_tab_page.show_branded_background_image";
 inline constexpr char kNewTabPageShowBackgroundImage[] =
     "brave.new_tab_page.show_background_image";
 inline constexpr char kNewTabTakeoverInfobarRemainingDisplayCount[] =

--- a/components/ntp_background_images/common/view_counter_pref_registry.cc
+++ b/components/ntp_background_images/common/view_counter_pref_registry.cc
@@ -5,12 +5,17 @@
 
 #include "brave/components/ntp_background_images/common/view_counter_pref_registry.h"
 
+#include "brave/components/brave_ads/buildflags/buildflags.h"
 #include "brave/components/ntp_background_images/common/infobar_constants.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
 #include "brave/components/ntp_background_images/common/view_counter_pref_names.h"
 #include "components/pref_registry/pref_registry_syncable.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
 
 namespace ntp_background_images {
 
@@ -31,6 +36,12 @@ constexpr char kNewTabTakeoverInfobarShowCount[] =
 constexpr char kNewTabPageSuperReferralThemesOption[] =
     "brave.new_tab_page.super_referral_themes_option";
 
+// Added 08/2026.
+constexpr char kObsoleteNewTabPageShowSponsoredImages[] =
+    "brave.new_tab_page.show_branded_background_image";
+constexpr char kObsoleteNewTabPageShowSponsoredSites[] =
+    "brave.new_tab_page.show_sponsored_sites";
+
 }  // namespace
 
 void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
@@ -43,8 +54,6 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
                                 false);
   registry->RegisterBooleanPref(prefs::kBrandedWallpaperNotificationDismissed,
                                 false);
-  registry->RegisterBooleanPref(
-      prefs::kNewTabPageShowSponsoredImagesBackgroundImage, true);
   registry->RegisterBooleanPref(prefs::kNewTabPageShowBackgroundImage, true);
   registry->RegisterIntegerPref(
       prefs::kNewTabTakeoverInfobarRemainingDisplayCount,
@@ -62,6 +71,10 @@ void RegisterProfilePrefsForMigration(
 
   // Added 11/2025.
   registry->RegisterIntegerPref(kNewTabPageSuperReferralThemesOption, 0);
+
+  // Added 08/2026.
+  registry->RegisterBooleanPref(kObsoleteNewTabPageShowSponsoredImages, true);
+  registry->RegisterBooleanPref(kObsoleteNewTabPageShowSponsoredSites, true);
 }
 
 void MigrateObsoleteProfilePrefs(PrefService* prefs) {
@@ -73,6 +86,19 @@ void MigrateObsoleteProfilePrefs(PrefService* prefs) {
 
   // Added 11/2025.
   prefs->ClearPref(kNewTabPageSuperReferralThemesOption);
+
+  // Added 08/2026.
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+  if (prefs->HasPrefPath(kObsoleteNewTabPageShowSponsoredImages) ||
+      prefs->HasPrefPath(kObsoleteNewTabPageShowSponsoredSites)) {
+    prefs->SetBoolean(
+        brave_ads::prefs::kSponsoredEnabled,
+        prefs->GetBoolean(kObsoleteNewTabPageShowSponsoredImages) &&
+            prefs->GetBoolean(kObsoleteNewTabPageShowSponsoredSites));
+  }
+#endif  // BUILDFLAG(ENABLE_BRAVE_ADS)
+  prefs->ClearPref(kObsoleteNewTabPageShowSponsoredImages);
+  prefs->ClearPref(kObsoleteNewTabPageShowSponsoredSites);
 }
 
 }  // namespace ntp_background_images

--- a/ios/browser/api/ads/brave_ads.mm
+++ b/ios/browser/api/ads/brave_ads.mm
@@ -212,8 +212,7 @@ constexpr NSString* kAdsResourceComponentMetadataVersion = @".v1";
   [self setProfilePref:ntp_background_images::prefs::
                            kNewTabPageShowBackgroundImage
                  value:base::Value(isEnabled)];
-  [self setProfilePref:ntp_background_images::prefs::
-                           kNewTabPageShowSponsoredImagesBackgroundImage
+  [self setProfilePref:brave_ads::prefs::kSponsoredEnabled
                  value:base::Value(isEnabled)];
 }
 

--- a/ios/browser/brave_ads/ads_service_impl_ios.h
+++ b/ios/browser/brave_ads/ads_service_impl_ios.h
@@ -154,6 +154,7 @@ class AdsServiceImplIOS : public AdsService {
   void ShutdownAdsCallback(ResultCallback callback, bool success);
 
   void ClearAdsData(ResultCallback callback, bool success);
+  void ClearAdsPrefs();
   void ClearAdsDataCallback(ResultCallback callback);
 
   const raw_ref<PrefService> prefs_;

--- a/ios/browser/brave_ads/ads_service_impl_ios.mm
+++ b/ios/browser/brave_ads/ads_service_impl_ios.mm
@@ -20,6 +20,7 @@
 #include "base/notimplemented.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/task/thread_pool.h"
+#include "base/values.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_util.h"
 #include "brave/components/brave_ads/core/public/ads.h"
@@ -27,6 +28,7 @@
 #include "brave/components/brave_ads/core/public/ads_client/ads_client.h"
 #include "brave/components/brave_ads/core/public/ads_constants.h"
 #include "brave/components/brave_ads/core/public/command_line_switches/command_line_switches_util.h"
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
 #include "brave/components/brave_rewards/core/rewards_util.h"
 #include "components/prefs/pref_service.h"
 #include "sql/database.h"
@@ -469,7 +471,7 @@ void AdsServiceImplIOS::ClearAdsData(ResultCallback callback, bool success) {
 
   // Clear preferences only after confirming shutdown succeeded so the pref
   // state and database are always cleared together or not at all.
-  prefs_->ClearPrefsWithPrefixSilently("brave.brave_ads");
+  ClearAdsPrefs();
 
   file_task_runner_->PostTaskAndReply(
       FROM_HERE,
@@ -482,6 +484,19 @@ void AdsServiceImplIOS::ClearAdsData(ResultCallback callback, bool success) {
           storage_path_),
       base::BindOnce(&AdsServiceImplIOS::ClearAdsDataCallback,
                      weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void AdsServiceImplIOS::ClearAdsPrefs() {
+  std::optional<bool> sponsored_enabled;
+  if (prefs_->HasPrefPath(prefs::kSponsoredEnabled)) {
+    sponsored_enabled = prefs_->GetBoolean(prefs::kSponsoredEnabled);
+  }
+
+  prefs_->ClearPrefsWithPrefixSilently("brave.brave_ads");
+
+  if (sponsored_enabled) {
+    prefs_->SetBoolean(prefs::kSponsoredEnabled, *sponsored_enabled);
+  }
 }
 
 void AdsServiceImplIOS::ClearAdsDataCallback(ResultCallback callback) {


### PR DESCRIPTION
The PR replaces all opt-out Brave Ads preferences (which are search result ads, new tab page sponsored images, and sponsored sites) with one `brave.brave_ads.sponsored.enabled` preference. During migration the new preference is set to enabled only when both the sponsored images and sponsored sites preferences were enabled. The obsolete search result ads preference is discarded without affecting the new preference.

`UserHasOptedInTo...` functions will be renamed to `IsSponsoredAdsEnabled` in follow-up PRs.

<!-- Add brave-browser issue below that this PR will resolve -->
Part of https://github.com/brave/brave-browser/issues/57204

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
