### PR TITLE
Disable `kFirstRunDesktopRefresh` (fixes missing profile-picker startup toggle)

### DIFF
--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -271,6 +271,9 @@ TEST(FeatureDefaultsTest, DisabledFeatures) {
       &segmentation_platform::features::kSegmentationPlatformFeature,
       &segmentation_platform::features::kSegmentationPlatformTimeDelaySampling,
       &subresource_filter::kAdTagging,
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
+      &switches::kFirstRunDesktopRefresh,
+#endif
       &switches::kSyncEnableBookmarksInTransportMode,
 #if !BUILDFLAG(IS_ANDROID)
       &tabs::kVerticalTabsLaunch,

--- a/chromium_src/components/signin/public/base/signin_switches.cc
+++ b/chromium_src/components/signin/public/base/signin_switches.cc
@@ -4,12 +4,16 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "base/feature_override.h"
+#include "build/build_config.h"
 
 #include <components/signin/public/base/signin_switches.cc>
 
 namespace switches {
 
 OVERRIDE_FEATURE_DEFAULT_STATES({{
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
+    {kFirstRunDesktopRefresh, base::FEATURE_DISABLED_BY_DEFAULT},
+#endif
     {kSyncEnableBookmarksInTransportMode, base::FEATURE_DISABLED_BY_DEFAULT},
 }});
 


### PR DESCRIPTION
CR152 enables `kFirstRunDesktopRefresh` by default on Windows, which swaps the profile picker's "Show on startup" `cr-checkbox` for a `cr-toggle`. Our `cr-toggle` override renders it as a `leo-toggle`, whose colors come from chrome://theme. The picker's startup dialog always runs against the system profile, however, which has no `ThemeService`, so those colors never resolve and the toggle renders invisibly (label only, no control).

Disabling the feature keeps the classic checkbox, which never depended on dynamic theme colors.

Chromium changes:
https://source.chromium.org/chromium/chromium/src/+/ae415764449bf778bcf53db74334de238788bf56

commit ae415764449bf778bcf53db74334de238788bf56
Author: Ernest Nguyen Hung <ernn@google.com>
Date:   Mon Jul 20 03:49:07 2026 -0700

    [FRE] Enable `FirstRunDesktopRefresh` by default on Windows

    It enables `FirstRunDesktopRefresh` by default on Windows, and modifies
    the corresponding fieldtrial testing config entry to exclude Windows. It
    also introduces a separate entry for
    `FirstRunDesktopChoiceScreenRefresh` (releasing as a separate study).

    launch/4449162 (internal only).

    Bug: 475437849
    Change-Id: I1694891fc4b30af5862b76230c6165fec62e3f38
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8101685
    Reviewed-by: James Lee <ljjlee@google.com>
    Reviewed-by: David Roger <droger@chromium.org>
    Commit-Queue: Ernest Nguyen Hung <ernn@google.com>
    Cr-Commit-Position: refs/heads/main@{#1664599}

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58165

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
