### PR TITLE
[plaster] `set_feature_flag_default_state` with already set values

### DIFF
--- a/patches/chrome-browser-devtools-features.cc.patch
+++ b/patches/chrome-browser-devtools-features.cc.patch
@@ -1,12 +1,13 @@
 diff --git a/chrome/browser/devtools/features.cc b/chrome/browser/devtools/features.cc
-index 5af5dcc1cc92abe579d72e9c2ffa88181413991d..31177470bb7a38d938c0c730319aadd94ce2de39 100644
+index 5af5dcc1cc92abe579d72e9c2ffa88181413991d..6abc3fd4cca9f7cd72557fac8b0c23f4bf27a1f4 100644
 --- a/chrome/browser/devtools/features.cc
 +++ b/chrome/browser/devtools/features.cc
-@@ -11,7 +11,13 @@ namespace features {
+@@ -11,7 +11,14 @@ namespace features {
  
  // Let the DevTools front-end query an AIDA endpoint for explanations and
  // insights regarding console (error) messages.
 -BASE_FEATURE(kDevToolsConsoleInsights, base::FEATURE_ENABLED_BY_DEFAULT);
++// kDevToolsConsoleInsights feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kDevToolsConsoleInsights, 
 +#if BUILDFLAG(IS_ANDROID)
 +  base::FEATURE_ENABLED_BY_DEFAULT
@@ -17,36 +18,41 @@ index 5af5dcc1cc92abe579d72e9c2ffa88181413991d..31177470bb7a38d938c0c730319aadd9
  const base::FeatureParam<std::string> kDevToolsConsoleInsightsModelId{
      &kDevToolsConsoleInsights, "aida_model_id", /*default_value=*/""};
  const base::FeatureParam<double> kDevToolsConsoleInsightsTemperature{
-@@ -116,7 +122,7 @@ BASE_FEATURE(kDevToolsAiAssistanceStorageAgent,
+@@ -116,7 +123,8 @@ BASE_FEATURE(kDevToolsAiAssistanceStorageAgent,
               base::FEATURE_DISABLED_BY_DEFAULT);
  
  // Whether the DevTools AI Code Completion is enabled.
 -BASE_FEATURE(kDevToolsAiCodeCompletion, base::FEATURE_ENABLED_BY_DEFAULT);
++// kDevToolsAiCodeCompletion feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kDevToolsAiCodeCompletion, base::FEATURE_DISABLED_BY_DEFAULT);
  const base::FeatureParam<std::string> kDevToolsAiCodeCompletionModelId{
      &kDevToolsAiCodeCompletion, "aida_model_id",
      /*default_value=*/""};
-@@ -130,7 +136,7 @@ const base::FeatureParam<DevToolsFreestylerUserTier>
+@@ -130,7 +138,8 @@ const base::FeatureParam<DevToolsFreestylerUserTier>
          &devtools_freestyler_user_tier_options};
  
  // Whether the DevTools AI Code Generation is enabled.
 -BASE_FEATURE(kDevToolsAiCodeGeneration, base::FEATURE_ENABLED_BY_DEFAULT);
++// kDevToolsAiCodeGeneration feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kDevToolsAiCodeGeneration, base::FEATURE_DISABLED_BY_DEFAULT);
  const base::FeatureParam<std::string> kDevToolsAiCodeGenerationModelId{
      &kDevToolsAiCodeGeneration, "aida_model_id",
      /*default_value=*/""};
-@@ -175,7 +181,7 @@ BASE_FEATURE(kDevToolsAiGeneratedTimelineLabels,
+@@ -175,7 +184,8 @@ BASE_FEATURE(kDevToolsAiGeneratedTimelineLabels,
               base::FEATURE_ENABLED_BY_DEFAULT);
  
  // Whether the DevTools AI generated annotation labels in timeline are enabled.
 -BASE_FEATURE(kDevToolsNewPermissionDialog, base::FEATURE_ENABLED_BY_DEFAULT);
++// kDevToolsNewPermissionDialog feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kDevToolsNewPermissionDialog, base::FEATURE_DISABLED_BY_DEFAULT);
  
  // Whether DevTools drawer can be toggled to vertical orientation.
  BASE_FEATURE(kDevToolsVerticalDrawer, base::FEATURE_ENABLED_BY_DEFAULT);
-@@ -214,7 +220,7 @@ BASE_FEATURE(kDevToolsAcceptDebuggingConnections,
+@@ -213,8 +223,9 @@ BASE_FEATURE(kDevToolsAcceptDebuggingConnections,
+ // TODO(crbug.com/442892562): Remove this flag once the feature is launched.
  BASE_FEATURE(kDevToolsShowPolicyDialog, base::FEATURE_ENABLED_BY_DEFAULT);
  
++// kDevToolsAiAssistanceContextSelectionAgent feature state is enforced via plaster rewrite.
  BASE_FEATURE(kDevToolsAiAssistanceContextSelectionAgent,
 -             base::FEATURE_ENABLED_BY_DEFAULT);
 +             base::FEATURE_DISABLED_BY_DEFAULT);

--- a/patches/chrome-browser-enterprise-data_protection-data_protection_features.cc.patch
+++ b/patches/chrome-browser-enterprise-data_protection-data_protection_features.cc.patch
@@ -1,15 +1,17 @@
 diff --git a/chrome/browser/enterprise/data_protection/data_protection_features.cc b/chrome/browser/enterprise/data_protection/data_protection_features.cc
-index 811fc3deff79d061c680414cb68fdfdfd834a8a9..e4b08b38aed721d726c4119da06c57cefbe5ebaa 100644
+index 811fc3deff79d061c680414cb68fdfdfd834a8a9..4209c72791a0f3813b9d107a92164c41699b3791 100644
 --- a/chrome/browser/enterprise/data_protection/data_protection_features.cc
 +++ b/chrome/browser/enterprise/data_protection/data_protection_features.cc
-@@ -8,9 +8,9 @@
+@@ -8,9 +8,11 @@
  
  namespace enterprise_data_protection {
  
 -BASE_FEATURE(kEnableForceDownloadToCloud, base::FEATURE_ENABLED_BY_DEFAULT);
++// kEnableForceDownloadToCloud feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kEnableForceDownloadToCloud, base::FEATURE_DISABLED_BY_DEFAULT);
  
 -BASE_FEATURE(kEnableForceDownloadToOneDrive, base::FEATURE_ENABLED_BY_DEFAULT);
++// kEnableForceDownloadToOneDrive feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kEnableForceDownloadToOneDrive, base::FEATURE_DISABLED_BY_DEFAULT);
  
  BASE_FEATURE(kEnableTabSharingProtection, base::FEATURE_DISABLED_BY_DEFAULT);

--- a/patches/chrome-browser-sharing_hub-sharing_hub_features.cc.patch
+++ b/patches/chrome-browser-sharing_hub-sharing_hub_features.cc.patch
@@ -1,12 +1,13 @@
 diff --git a/chrome/browser/sharing_hub/sharing_hub_features.cc b/chrome/browser/sharing_hub/sharing_hub_features.cc
-index 4ae3f73a0b9cdea299397b62919a55ff72db0607..5ba8ba5a04235475b7ee7bb7978dae2e02833c96 100644
+index 4ae3f73a0b9cdea299397b62919a55ff72db0607..e1f56036d9d7a6de3c53da5c15fba17e75964128 100644
 --- a/chrome/browser/sharing_hub/sharing_hub_features.cc
 +++ b/chrome/browser/sharing_hub/sharing_hub_features.cc
-@@ -66,7 +66,7 @@ bool HasPageAction(content::BrowserContext* context, bool is_popup_mode) {
+@@ -66,7 +66,8 @@ bool HasPageAction(content::BrowserContext* context, bool is_popup_mode) {
  #endif
  }
  
 -BASE_FEATURE(kDesktopScreenshots, base::FEATURE_DISABLED_BY_DEFAULT);
++// kDesktopScreenshots feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kDesktopScreenshots, base::FEATURE_ENABLED_BY_DEFAULT);
  
  #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_CHROMEOS)

--- a/patches/chrome-browser-ui-omnibox-omnibox_next_features.cc.patch
+++ b/patches/chrome-browser-ui-omnibox-omnibox_next_features.cc.patch
@@ -1,17 +1,19 @@
 diff --git a/chrome/browser/ui/omnibox/omnibox_next_features.cc b/chrome/browser/ui/omnibox/omnibox_next_features.cc
-index 5ae5dc66f252474326f726c8d871b04841dcfe96..099993d87b42845208c647456d4eadf5e6e19eff 100644
+index 5ae5dc66f252474326f726c8d871b04841dcfe96..0371932bf0e53db3d778e71d1a8b7dfec957a786 100644
 --- a/chrome/browser/ui/omnibox/omnibox_next_features.cc
 +++ b/chrome/browser/ui/omnibox/omnibox_next_features.cc
-@@ -33,11 +33,11 @@ namespace omnibox {
+@@ -33,11 +33,13 @@ namespace omnibox {
  namespace internal {
  
  // If enabled, shows the omnibox suggestions in the popup in WebUI.
 -BASE_FEATURE(kWebUIOmniboxPopup, ENABLED);
++// kWebUIOmniboxPopup feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kWebUIOmniboxPopup, DISABLED);
  
  // If enabled, Omnibox popup will transition to AI-Mode with the compose-box
  // panel taking up the whole of the popup, covering the location bar completely.
 -BASE_FEATURE(kWebUIOmniboxAimPopup, ENABLED);
++// kWebUIOmniboxAimPopup feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kWebUIOmniboxAimPopup, DISABLED);
  
  // If enabled, the Omnibox Popup will enable a different UI state when on a

--- a/patches/chrome-browser-ui-ui_features.cc.patch
+++ b/patches/chrome-browser-ui-ui_features.cc.patch
@@ -1,28 +1,32 @@
 diff --git a/chrome/browser/ui/ui_features.cc b/chrome/browser/ui/ui_features.cc
-index b41ed22c0ab92738b1b1fc52347e58cc047e55b6..a1e894cc7ab0dcee80f37e299441be90dbd291a6 100644
+index b41ed22c0ab92738b1b1fc52347e58cc047e55b6..7cf6a4a49bd46bf4355cd2a0dc589da8ca1b5d0d 100644
 --- a/chrome/browser/ui/ui_features.cc
 +++ b/chrome/browser/ui/ui_features.cc
-@@ -106,7 +106,7 @@ bool IsWebuiRefresh2026Enabled() {
+@@ -106,7 +106,8 @@ bool IsWebuiRefresh2026Enabled() {
  BASE_FEATURE(kDseIntegrity, base::FEATURE_ENABLED_BY_DEFAULT);
  // Enables the feature to remove the last confirmation dialog when relaunching
  // to update Chrome.
 -BASE_FEATURE(kFewerUpdateConfirmations, base::FEATURE_ENABLED_BY_DEFAULT);
++// kFewerUpdateConfirmations feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kFewerUpdateConfirmations, base::FEATURE_DISABLED_BY_DEFAULT);
  
  BASE_FEATURE(kLegacySearchIntegrityCheck, base::FEATURE_DISABLED_BY_DEFAULT);
  #endif
-@@ -124,7 +124,7 @@ BASE_FEATURE(kExtensionsPinnedByDefault, base::FEATURE_DISABLED_BY_DEFAULT);
+@@ -124,7 +125,8 @@ BASE_FEATURE(kExtensionsPinnedByDefault, base::FEATURE_DISABLED_BY_DEFAULT);
  #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
  // Shows an infobar on PDFs offering to become the default PDF viewer if Chrome
  // isn't the default already.
 -BASE_FEATURE(kPdfInfoBar, base::FEATURE_ENABLED_BY_DEFAULT);
++// kPdfInfoBar feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kPdfInfoBar, base::FEATURE_DISABLED_BY_DEFAULT);
  
  BASE_FEATURE(kSeparateDefaultAndPinPrompt, base::FEATURE_DISABLED_BY_DEFAULT);
  BASE_FEATURE_PARAM(int,
-@@ -247,12 +247,7 @@ bool IsTabGroupHoverCardsEnabled() {
+@@ -246,13 +248,9 @@ bool IsTabGroupHoverCardsEnabled() {
+ 
  // Enables preview images in tab-hover cards.
  // https://crbug.com/41439486
++// kTabHoverCardImages feature state is enforced via plaster rewrite.
  BASE_FEATURE(kTabHoverCardImages,
 -#if BUILDFLAG(IS_MAC)
 -             base::FEATURE_DISABLED_BY_DEFAULT

--- a/patches/chrome-common-chrome_features.cc.patch
+++ b/patches/chrome-common-chrome_features.cc.patch
@@ -1,26 +1,28 @@
 diff --git a/chrome/common/chrome_features.cc b/chrome/common/chrome_features.cc
-index bdeedbf2ac08aba3903c20875ecabf6bd41cd201..f29a73916afdf8fe5f72e3cacfb8816031617778 100644
+index bdeedbf2ac08aba3903c20875ecabf6bd41cd201..4a2fdf2e906e65a9eaae6898aeed2c2ec83aa752 100644
 --- a/chrome/common/chrome_features.cc
 +++ b/chrome/common/chrome_features.cc
-@@ -190,7 +190,7 @@ bool RemoteActorCredentialSharingEnabled() {
+@@ -190,7 +190,8 @@ bool RemoteActorCredentialSharingEnabled() {
  }
  
  // Controls the enablement of structured metrics on Windows, Linux, and Mac.
 -BASE_FEATURE(kChromeStructuredMetrics, base::FEATURE_ENABLED_BY_DEFAULT);
++// kChromeStructuredMetrics feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kChromeStructuredMetrics, base::FEATURE_DISABLED_BY_DEFAULT);
  
  // Moves the Extensions "puzzle piece" icon from the title bar into the app menu
  // for web app windows.
-@@ -212,7 +212,7 @@ BASE_FEATURE(kDesktopPWAsPreventClose,
+@@ -212,7 +213,8 @@ BASE_FEATURE(kDesktopPWAsPreventClose,
  );
  
  // Adds a user settings that allows PWAs to be opened with a tab strip.
 -BASE_FEATURE(kDesktopPWAsTabStripSettings, base::FEATURE_DISABLED_BY_DEFAULT);
++// kDesktopPWAsTabStripSettings feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kDesktopPWAsTabStripSettings, base::FEATURE_ENABLED_BY_DEFAULT);
  
  // Removes the Window Controls Overlay toggle button from the PWA toolbar
  // and auto-enables WCO when the app developer specifies it in the manifest.
-@@ -377,7 +377,7 @@ const char kGlicActorUiDebounceTimerName[] = "glic-actor-ui-debounce-timer";
+@@ -377,7 +379,7 @@ const char kGlicActorUiDebounceTimerName[] = "glic-actor-ui-debounce-timer";
  
  // Controls whether the task icon in the actor ui is enabled.
  const base::FeatureParam<bool> kGlicActorUiTaskIcon{
@@ -29,29 +31,32 @@ index bdeedbf2ac08aba3903c20875ecabf6bd41cd201..f29a73916afdf8fe5f72e3cacfb88160
  // Controls whether the Actor Overlay in the actor ui is enabled.
  const base::FeatureParam<bool> kGlicActorUiOverlay{
      &kGlicActorUi, kGlicActorUiOverlayName, true};
-@@ -1270,7 +1270,7 @@ const base::FeatureParam<bool>
+@@ -1270,7 +1272,8 @@ const base::FeatureParam<bool>
  
  // Enables HTTPS-First Mode in a balanced configuration that doesn't warn on
  // HTTP when HTTPS can't be reasonably expected.
 -BASE_FEATURE(kHttpsFirstBalancedMode, base::FEATURE_ENABLED_BY_DEFAULT);
++// kHttpsFirstBalancedMode feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kHttpsFirstBalancedMode, base::FEATURE_DISABLED_BY_DEFAULT);
  
  // Automatically enables HTTPS-First Mode in a balanced configuration when
  // possible.
-@@ -1608,7 +1608,7 @@ BASE_FEATURE(kSafetyHubTrustSafetySentimentSurvey,
+@@ -1608,7 +1611,8 @@ BASE_FEATURE(kSafetyHubTrustSafetySentimentSurvey,
  // Safe Browsing Reporting to perform a k-anonymous query to see if Google knows
  // about an SCT seen in the wild. If it hasn't been seen, then it is considered
  // a security incident and uploaded to Google.
 -BASE_FEATURE(kSCTAuditingHashdance, base::FEATURE_ENABLED_BY_DEFAULT);
++// kSCTAuditingHashdance feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kSCTAuditingHashdance, base::FEATURE_DISABLED_BY_DEFAULT);
  
  // An estimated high bound for the time it takes Google to ingest updates to an
  // SCT log. Chrome will wait for at least this time plus the Log's Maximum Merge
-@@ -1763,7 +1763,7 @@ const base::FeatureParam<base::TimeDelta>
+@@ -1763,7 +1767,8 @@ const base::FeatureParam<base::TimeDelta>
  #if !BUILDFLAG(IS_ANDROID)
  // Enables the second version of the sentiment survey for users of Trust &
  // Safety features, using HaTS.
 -BASE_FEATURE(kTrustSafetySentimentSurveyV2, base::FEATURE_ENABLED_BY_DEFAULT);
++// kTrustSafetySentimentSurveyV2 feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kTrustSafetySentimentSurveyV2, base::FEATURE_DISABLED_BY_DEFAULT);
  // The minimum and maximum time after a user has interacted with a Trust and
  // Safety feature that they are eligible to be surveyed.

--- a/patches/components-aggregation_service-features.cc.patch
+++ b/patches/components-aggregation_service-features.cc.patch
@@ -1,10 +1,12 @@
 diff --git a/components/aggregation_service/features.cc b/components/aggregation_service/features.cc
-index f38918997afd60b790a873dc3424c52ea1762fb8..6fca59388d1b0b654e0cb2da0079a559bbd97c7e 100644
+index f38918997afd60b790a873dc3424c52ea1762fb8..b5cfe3d0d91bbee82834c16d68d66fbe7a93febe 100644
 --- a/components/aggregation_service/features.cc
 +++ b/components/aggregation_service/features.cc
-@@ -12,7 +12,7 @@
+@@ -11,8 +11,9 @@
+ 
  namespace aggregation_service {
  
++// kAggregationServiceMultipleCloudProviders feature state is enforced via plaster rewrite.
  BASE_FEATURE(kAggregationServiceMultipleCloudProviders,
 -             base::FEATURE_ENABLED_BY_DEFAULT);
 +             base::FEATURE_DISABLED_BY_DEFAULT);

--- a/patches/components-attribution_reporting-features.cc.patch
+++ b/patches/components-attribution_reporting-features.cc.patch
@@ -1,12 +1,13 @@
 diff --git a/components/attribution_reporting/features.cc b/components/attribution_reporting/features.cc
-index b199e7682ad3396b6e66e62dd927b9e81e157382..7eda43f1027d03c6b9244a65cf4a6c798c86d569 100644
+index b199e7682ad3396b6e66e62dd927b9e81e157382..d1a0acd91b6546416d1b524aa2e0544b7c8982f6 100644
 --- a/components/attribution_reporting/features.cc
 +++ b/components/attribution_reporting/features.cc
-@@ -9,6 +9,6 @@
+@@ -9,6 +9,7 @@
  namespace attribution_reporting::features {
  
  // Controls whether the Conversion Measurement API infrastructure is enabled.
 -BASE_FEATURE(kConversionMeasurement, base::FEATURE_ENABLED_BY_DEFAULT);
++// kConversionMeasurement feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kConversionMeasurement, base::FEATURE_DISABLED_BY_DEFAULT);
  
  }  // namespace attribution_reporting::features

--- a/patches/components-autofill-core-common-autofill_debug_features.cc.patch
+++ b/patches/components-autofill-core-common-autofill_debug_features.cc.patch
@@ -1,12 +1,13 @@
 diff --git a/components/autofill/core/common/autofill_debug_features.cc b/components/autofill/core/common/autofill_debug_features.cc
-index 4fb9b840fa20f2218e7f67a4001e11f625857121..6f512a7d91e05b699d4b7ad53a84bb639e7ed0dc 100644
+index 4fb9b840fa20f2218e7f67a4001e11f625857121..47788ea7df268f5d1b2082e2dbace8f9fa677316 100644
 --- a/components/autofill/core/common/autofill_debug_features.cc
 +++ b/components/autofill/core/common/autofill_debug_features.cc
-@@ -127,7 +127,7 @@ BASE_FEATURE_PARAM(std::string,
+@@ -127,7 +127,8 @@ BASE_FEATURE_PARAM(std::string,
  // autofill server API url up to the parent "directory" of the "query" and
  // "upload" resources.
  // i.e., https://other.autofill.server:port/tbproxy/af/
 -BASE_FEATURE(kAutofillServerCommunication, base::FEATURE_ENABLED_BY_DEFAULT);
++// kAutofillServerCommunication feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kAutofillServerCommunication, base::FEATURE_DISABLED_BY_DEFAULT);
  
  // When set to a non-zero value, the value is attached as an experiment ID to

--- a/patches/components-autofill-core-common-autofill_features.cc.patch
+++ b/patches/components-autofill-core-common-autofill_features.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/components/autofill/core/common/autofill_features.cc b/components/autofill/core/common/autofill_features.cc
-index fd05187842faa97877683525b98f31413491589c..6e224348e3ae42d7c972e7cbae2f61982bf541cb 100644
+index fd05187842faa97877683525b98f31413491589c..34907eebc1b1ed1648ecd4f780c550f2a5f3bc60 100644
 --- a/components/autofill/core/common/autofill_features.cc
 +++ b/components/autofill/core/common/autofill_features.cc
 @@ -276,7 +276,7 @@ BASE_FEATURE_PARAM(
@@ -11,11 +11,12 @@ index fd05187842faa97877683525b98f31413491589c..6e224348e3ae42d7c972e7cbae2f6198
  
  // The maximum duration for which an AutofillAI server model response is kept in
  // the local cache. NOTE: It is advisable to choose a value that is at least as
-@@ -1049,7 +1049,7 @@ BASE_FEATURE(kUseSettingsAddressEditorInPaymentsRequest,
+@@ -1049,7 +1049,8 @@ BASE_FEATURE(kUseSettingsAddressEditorInPaymentsRequest,
  
  // Defines if the "Your Saved Info" page is eligible to be shown in Chrome
  // settings.
 -BASE_FEATURE(kYourSavedInfoSettingsPage, base::FEATURE_ENABLED_BY_DEFAULT);
++// kYourSavedInfoSettingsPage feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kYourSavedInfoSettingsPage, base::FEATURE_DISABLED_BY_DEFAULT);
  
  #undef WALLET_SUPPORTED_COUNTRIES

--- a/patches/components-commerce-core-commerce_feature_list.cc.patch
+++ b/patches/components-commerce-core-commerce_feature_list.cc.patch
@@ -1,21 +1,24 @@
 diff --git a/components/commerce/core/commerce_feature_list.cc b/components/commerce/core/commerce_feature_list.cc
-index 30567b8c4ae4498861fd49e92038fc8cd1405df1..d5e68d43a623459a34b68fb7c6c43ed11e33c2fa 100644
+index 30567b8c4ae4498861fd49e92038fc8cd1405df1..296a689a7651f7ee9d7efa93c884b06f94380c82 100644
 --- a/components/commerce/core/commerce_feature_list.cc
 +++ b/components/commerce/core/commerce_feature_list.cc
-@@ -126,7 +126,7 @@ const re2::RE2& GetCouponPartnerMerchantPattern() {
+@@ -125,8 +125,9 @@ const re2::RE2& GetCouponPartnerMerchantPattern() {
+ 
  BASE_FEATURE(kCommerceAllowLocalImages, base::FEATURE_DISABLED_BY_DEFAULT);
  
++// kCommerceAllowOnDemandBookmarkUpdates feature state is enforced via plaster rewrite.
  BASE_FEATURE(kCommerceAllowOnDemandBookmarkUpdates,
 -             base::FEATURE_ENABLED_BY_DEFAULT);
 +             base::FEATURE_DISABLED_BY_DEFAULT);
  
  BASE_FEATURE(kCommerceMerchantViewer, base::FEATURE_DISABLED_BY_DEFAULT);
  
-@@ -227,7 +227,7 @@ BASE_FEATURE(kInStockNotification, base::FEATURE_DISABLED_BY_DEFAULT);
+@@ -227,7 +228,8 @@ BASE_FEATURE(kInStockNotification, base::FEATURE_DISABLED_BY_DEFAULT);
  
  BASE_FEATURE(kShoppingPageTypes, base::FEATURE_DISABLED_BY_DEFAULT);
  
 -BASE_FEATURE(kRetailCoupons, base::FEATURE_ENABLED_BY_DEFAULT);
++// kRetailCoupons feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kRetailCoupons, base::FEATURE_DISABLED_BY_DEFAULT);
  
  BASE_FEATURE(kCommerceDeveloper, base::FEATURE_DISABLED_BY_DEFAULT);

--- a/patches/components-heap_profiling-in_process-heap_profiler_parameters.cc.patch
+++ b/patches/components-heap_profiling-in_process-heap_profiler_parameters.cc.patch
@@ -1,12 +1,13 @@
 diff --git a/components/heap_profiling/in_process/heap_profiler_parameters.cc b/components/heap_profiling/in_process/heap_profiler_parameters.cc
-index fb16321e89570ef25f378fb4890d2fe5cf308d2c..4e7431bbfcc90680d39ff43f2c32c26398c87976 100644
+index fb16321e89570ef25f378fb4890d2fe5cf308d2c..6e9b428585be82d0595ae02d820d870f26f5c2ab 100644
 --- a/components/heap_profiling/in_process/heap_profiler_parameters.cc
 +++ b/components/heap_profiling/in_process/heap_profiler_parameters.cc
-@@ -125,7 +125,7 @@ constexpr base::FeatureParam<double> kUtilityHashSetLoadFactor{
+@@ -125,7 +125,8 @@ constexpr base::FeatureParam<double> kUtilityHashSetLoadFactor{
  
  }  // namespace
  
 -BASE_FEATURE(kHeapProfilerReporting, base::FEATURE_ENABLED_BY_DEFAULT);
++// kHeapProfilerReporting feature state is enforced via plaster rewrite.
 +BASE_FEATURE(kHeapProfilerReporting, base::FEATURE_DISABLED_BY_DEFAULT);
  
  const base::FeatureParam<double> kStableProbability{

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -3889,7 +3889,8 @@ class RegexMacroDispatchTest(unittest.TestCase):
             '      feature_name: kFoo\n'
             '      value: base::FEATURE_DISABLED_BY_DEFAULT\n')
         self.assertEqual(
-            result, 'BASE_FEATURE(kFoo, base::FEATURE_DISABLED_BY_DEFAULT);')
+            result, '// kFoo feature state is enforced via plaster rewrite.\n'
+            'BASE_FEATURE(kFoo, base::FEATURE_DISABLED_BY_DEFAULT);')
 
     def test_registered_under_its_bare_name(self):
         # The YAML key is the op id with its `cxx.` prefix stripped.
@@ -3964,22 +3965,23 @@ class RegexMacroDispatchTest(unittest.TestCase):
             '      value: base::FEATURE_DISABLED_BY_DEFAULT\n',
             'Only one rewriter allowed per entry')
 
-    def test_count_mismatch_when_value_already_set(self):
-        # `RegexMacro.apply` reports the macro's own match count through the
-        # normal `count:` diagnostic, same as any other rewriter: applying an
-        # override that is already in effect is 0 matches against the
-        # default expectation of 1.
-        with self.assertRaises(plaster.PlasterApplyError) as cm:
-            self._apply(
-                'already_set.cc',
-                'BASE_FEATURE(kFoo, base::FEATURE_DISABLED_BY_DEFAULT);',
-                'substitutions:\n'
-                '  - description: Ship kFoo disabled.\n'
-                '    set_feature_flag_default_state:\n'
-                '      feature_name: kFoo\n'
-                '      value: base::FEATURE_DISABLED_BY_DEFAULT\n')
-        self.assertIn('Unexpected number of matches (0 vs 1)',
-                      str(cm.exception))
+    def test_still_matches_and_applies_when_value_already_set(self):
+        # The macro always matches -- and so always reports a `count:` of 1,
+        # never 0 -- even when the current value already equals the one
+        # being set, so the substitution can never silently stop applying as
+        # upstream's own default happens to converge on ours. The comment it
+        # inserts is what makes this rerun visible in the diff.
+        result = self._apply(
+            'already_set.cc',
+            'BASE_FEATURE(kFoo, base::FEATURE_DISABLED_BY_DEFAULT);',
+            'substitutions:\n'
+            '  - description: Ship kFoo disabled.\n'
+            '    set_feature_flag_default_state:\n'
+            '      feature_name: kFoo\n'
+            '      value: base::FEATURE_DISABLED_BY_DEFAULT\n')
+        self.assertEqual(
+            result, '// kFoo feature state is enforced via plaster rewrite.\n'
+            'BASE_FEATURE(kFoo, base::FEATURE_DISABLED_BY_DEFAULT);')
 
     def test_rejected_on_a_non_cxx_source(self):
         with self.assertRaises(ValueError) as cm:
@@ -6251,10 +6253,11 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
                                      feature_name='kIPHDiscardRingFeature',
                                      value='base::FEATURE_ENABLED_BY_DEFAULT')
         self.assertEqual(matches, 1)
-        self.assertEqual(content,
-                         ('BASE_FEATURE(kIPHDiscardRingFeature,\n'
-                          '             "IPH_DiscardRing",\n'
-                          '             base::FEATURE_ENABLED_BY_DEFAULT);\n'))
+        self.assertEqual(content, (
+            '// kIPHDiscardRingFeature feature state is enforced via plaster rewrite.\n'
+            'BASE_FEATURE(kIPHDiscardRingFeature,\n'
+            '             "IPH_DiscardRing",\n'
+            '             base::FEATURE_ENABLED_BY_DEFAULT);\n'))
 
     def test_three_argument_flips_enabled_to_disabled(self):
         source = ('BASE_FEATURE(kFoo,\n'
@@ -6265,9 +6268,11 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
                                      value='base::FEATURE_DISABLED_BY_DEFAULT')
         self.assertEqual(matches, 1)
         self.assertEqual(
-            content, ('BASE_FEATURE(kFoo,\n'
-                      '             "Foo",\n'
-                      '             base::FEATURE_DISABLED_BY_DEFAULT);\n'))
+            content,
+            ('// kFoo feature state is enforced via plaster rewrite.\n'
+             'BASE_FEATURE(kFoo,\n'
+             '             "Foo",\n'
+             '             base::FEATURE_DISABLED_BY_DEFAULT);\n'))
 
     def test_three_argument_single_line(self):
         source = 'BASE_FEATURE(kFoo, "Foo", base::FEATURE_DISABLED_BY_DEFAULT);'
@@ -6276,7 +6281,7 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
                                      value='base::FEATURE_ENABLED_BY_DEFAULT')
         self.assertEqual(matches, 1)
         self.assertEqual(
-            content,
+            content, '// kFoo feature state is enforced via plaster rewrite.\n'
             'BASE_FEATURE(kFoo, "Foo", base::FEATURE_ENABLED_BY_DEFAULT);')
 
     # -- modern two-argument form: BASE_FEATURE(kFoo, state) -----------------
@@ -6289,9 +6294,11 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
                                      feature_name='kMyFeature',
                                      value='base::FEATURE_ENABLED_BY_DEFAULT')
         self.assertEqual(matches, 1)
-        self.assertEqual(content,
-                         ('BASE_FEATURE(kMyFeature,\n'
-                          '             base::FEATURE_ENABLED_BY_DEFAULT);\n'))
+        self.assertEqual(
+            content,
+            ('// kMyFeature feature state is enforced via plaster rewrite.\n'
+             'BASE_FEATURE(kMyFeature,\n'
+             '             base::FEATURE_ENABLED_BY_DEFAULT);\n'))
 
     def test_two_argument_form_single_line(self):
         source = 'BASE_FEATURE(kMyFeature, base::FEATURE_DISABLED_BY_DEFAULT);'
@@ -6301,6 +6308,7 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
         self.assertEqual(matches, 1)
         self.assertEqual(
             content,
+            '// kMyFeature feature state is enforced via plaster rewrite.\n'
             'BASE_FEATURE(kMyFeature, base::FEATURE_ENABLED_BY_DEFAULT);')
 
     # -- preprocessor-conditional state: per-platform default states are
@@ -6329,6 +6337,9 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
         self.assertNotIn('FEATURE_ENABLED_BY_DEFAULT', content)
         self.assertIn('BASE_FEATURE(kStackScanMaxFramePointerToStackEndGap,',
                       content)
+        self.assertIn(
+            '// kStackScanMaxFramePointerToStackEndGap feature state is '
+            'enforced via plaster rewrite.', content)
         self.assertTrue(
             content.rstrip().endswith('base::FEATURE_DISABLED_BY_DEFAULT);'))
 
@@ -6348,8 +6359,9 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
                                      value='base::FEATURE_ENABLED_BY_DEFAULT')
         self.assertEqual(matches, 1)
         self.assertEqual(
-            content,
-            'BASE_FEATURE(kFoo,\nbase::FEATURE_ENABLED_BY_DEFAULT);\n')
+            content, '// kFoo feature state is enforced via plaster rewrite.\n'
+            'BASE_FEATURE(kFoo,\n'
+            'base::FEATURE_ENABLED_BY_DEFAULT);\n')
 
     # -- namespace qualification: the state is matched wholesale, so any
     # spelling works without special-casing.
@@ -6361,7 +6373,9 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
                                      value='FEATURE_ENABLED_BY_DEFAULT')
         self.assertEqual(matches, 1)
         self.assertEqual(
-            content, 'BASE_FEATURE(kMyFeature, FEATURE_ENABLED_BY_DEFAULT);')
+            content,
+            '// kMyFeature feature state is enforced via plaster rewrite.\n'
+            'BASE_FEATURE(kMyFeature, FEATURE_ENABLED_BY_DEFAULT);')
 
     def test_fully_qualified_state(self):
         source = 'BASE_FEATURE(kMyFeature, ::base::FEATURE_DISABLED_BY_DEFAULT);'
@@ -6372,6 +6386,7 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
         self.assertEqual(matches, 1)
         self.assertEqual(
             content,
+            '// kMyFeature feature state is enforced via plaster rewrite.\n'
             'BASE_FEATURE(kMyFeature, ::base::FEATURE_ENABLED_BY_DEFAULT);')
 
     def test_closing_parenthesis_is_preserved(self):
@@ -6383,12 +6398,14 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
                                value='base::FEATURE_ENABLED_BY_DEFAULT')
         self.assertTrue(content.rstrip().endswith(');'))
 
-    # -- `value` introducing a brand-new conditional: unlike the
-    # already-conditional sources above, `value` itself is plugged into the
-    # lookahead raw. `BUILDFLAG(IS_ANDROID)` is a real, unescaped capture
-    # group once spliced in, which shifts every group number after it -- the
-    # replace template's `\4` stops pointing at the literal `);` capture, and
-    # the call's real closing paren is silently dropped instead of appended.
+    # -- `value` introducing a brand-new conditional: `value` is only ever
+    # spliced into `replace`, never into the compiled `re_pattern`, so a
+    # `BUILDFLAG(IS_ANDROID)` inside it can no longer shift the pattern's own
+    # capture-group numbering. The inserted comment names `feature_name`
+    # rather than `value` for exactly this case: `feature_name` is always a
+    # single identifier, so the comment stays a single, short line above the
+    # `BASE_FEATURE` call regardless of how many lines a multi-line `value`
+    # like this one spans below it.
 
     def test_new_conditional_value_with_parens_keeps_the_closing_paren(self):
         source = 'BASE_FEATURE(kFoo, base::FEATURE_ENABLED_BY_DEFAULT);\n'
@@ -6402,6 +6419,14 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
         self.assertEqual(matches, 1)
         self.assertIn('BUILDFLAG(IS_ANDROID)', content)
         self.assertTrue(content.rstrip('\n').endswith('#endif);'))
+        self.assertEqual(
+            content, '// kFoo feature state is enforced via plaster rewrite.\n'
+            'BASE_FEATURE(kFoo, \n'
+            '#if BUILDFLAG(IS_ANDROID)\n'
+            '             base::FEATURE_ENABLED_BY_DEFAULT\n'
+            '#else\n'
+            '             base::FEATURE_DISABLED_BY_DEFAULT\n'
+            '#endif);\n')
 
     # -- multiple features in one file: every pairing of "fewer commas"
     # (two-argument/conditional) and "more commas" (three-argument) forms,
@@ -6424,7 +6449,8 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
         self.assertEqual(matches, 1)
         self.assertEqual(
             content,
-            ('BASE_FEATURE(kFeatureA, base::FEATURE_ENABLED_BY_DEFAULT);\n'
+            ('// kFeatureA feature state is enforced via plaster rewrite.\n'
+             'BASE_FEATURE(kFeatureA, base::FEATURE_ENABLED_BY_DEFAULT);\n'
              '\n'
              'BASE_FEATURE(kFeatureB,\n'
              '             "FeatureB",\n'
@@ -6445,6 +6471,7 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
             content,
             ('BASE_FEATURE(kFeatureA, base::FEATURE_DISABLED_BY_DEFAULT);\n'
              '\n'
+             '// kFeatureB feature state is enforced via plaster rewrite.\n'
              'BASE_FEATURE(kFeatureB,\n'
              '             "FeatureB",\n'
              '             base::FEATURE_ENABLED_BY_DEFAULT);\n'))
@@ -6462,7 +6489,8 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
         self.assertEqual(matches, 1)
         self.assertEqual(
             content,
-            ('BASE_FEATURE(kFeatureA,\n'
+            ('// kFeatureA feature state is enforced via plaster rewrite.\n'
+             'BASE_FEATURE(kFeatureA,\n'
              '             "FeatureA",\n'
              '             base::FEATURE_ENABLED_BY_DEFAULT);\n'
              '\n'
@@ -6485,6 +6513,7 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
              '             "FeatureA",\n'
              '             base::FEATURE_DISABLED_BY_DEFAULT);\n'
              '\n'
+             '// kFeatureB feature state is enforced via plaster rewrite.\n'
              'BASE_FEATURE(kFeatureB, base::FEATURE_ENABLED_BY_DEFAULT);\n'))
 
     def test_only_the_named_feature_is_overridden_when_both_are_three_argument(
@@ -6505,37 +6534,49 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
             '             "FeatureA",\n'
             '             base::FEATURE_DISABLED_BY_DEFAULT', content)
         self.assertIn(
-            'kFeatureB,\n'
+            '// kFeatureB feature state is enforced via plaster rewrite.\n'
+            'BASE_FEATURE(kFeatureB,\n'
             '             "FeatureB",\n'
             '             base::FEATURE_ENABLED_BY_DEFAULT', content)
 
-    # -- idempotency and no-match cases --------------------------------------
+    # -- always-matches cases -------------------------------------------------
     #
-    # Setting a feature to the value it already has finds no match (`count`
-    # of 0) and leaves the text untouched, rather than reporting a match that
-    # happens to be a no-op on the text: `count` is meant to answer "did this
-    # override actually take effect", not merely "was the call found".
+    # Setting a feature to the value it already has still finds a match
+    # (`count` of 1, never 0) and still rewrites the text, inserting the
+    # `// <feature_name> feature state is enforced via plaster rewrite.`
+    # comment: `count` answers "is this override in force", not "did the
+    # text change shape", so the substitution can never silently stop
+    # applying just because upstream's own default has converged on the
+    # value Brave wants.
 
-    def test_no_match_when_two_argument_form_already_has_the_value(self):
+    def test_still_matches_when_two_argument_form_already_has_the_value(self):
         source = 'BASE_FEATURE(kFoo, base::FEATURE_DISABLED_BY_DEFAULT);'
         matches, content = self._run(source,
                                      feature_name='kFoo',
                                      value='base::FEATURE_DISABLED_BY_DEFAULT')
-        self.assertEqual(matches, 0)
-        self.assertEqual(content, source)
+        self.assertEqual(matches, 1)
+        self.assertEqual(
+            content, '// kFoo feature state is enforced via plaster rewrite.\n'
+            'BASE_FEATURE(kFoo, base::FEATURE_DISABLED_BY_DEFAULT);')
 
-    def test_no_match_when_three_argument_form_already_has_the_value(self):
+    def test_still_matches_when_three_argument_form_already_has_the_value(
+            self):
         source = ('BASE_FEATURE(kFoo,\n'
                   '             "Foo",\n'
                   '             base::FEATURE_DISABLED_BY_DEFAULT);\n')
         matches, content = self._run(source,
                                      feature_name='kFoo',
                                      value='base::FEATURE_DISABLED_BY_DEFAULT')
-        self.assertEqual(matches, 0)
-        self.assertEqual(content, source)
+        self.assertEqual(matches, 1)
+        self.assertEqual(
+            content,
+            ('// kFoo feature state is enforced via plaster rewrite.\n'
+             'BASE_FEATURE(kFoo,\n'
+             '             "Foo",\n'
+             '             base::FEATURE_DISABLED_BY_DEFAULT);\n'))
 
     def test_still_matches_when_the_value_actually_differs(self):
-        # Sanity check alongside the no-match cases above: a genuinely
+        # Sanity check alongside the always-matches cases above: a genuinely
         # different value must still be found and applied.
         source = ('BASE_FEATURE(kFoo,\n'
                   '             "Foo",\n'
@@ -6544,14 +6585,17 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
                                      feature_name='kFoo',
                                      value='base::FEATURE_ENABLED_BY_DEFAULT')
         self.assertEqual(matches, 1)
-        self.assertEqual(content,
-                         ('BASE_FEATURE(kFoo,\n'
-                          '             "Foo",\n'
-                          '             base::FEATURE_ENABLED_BY_DEFAULT);\n'))
+        self.assertEqual(
+            content,
+            ('// kFoo feature state is enforced via plaster rewrite.\n'
+             'BASE_FEATURE(kFoo,\n'
+             '             "Foo",\n'
+             '             base::FEATURE_ENABLED_BY_DEFAULT);\n'))
 
-    def test_no_match_is_specific_to_the_named_feature(self):
+    def test_match_is_specific_to_the_named_feature(self):
         # The other feature in the file already holds the value being set on
-        # kFeatureA, but that must not suppress the (real) change to kFeatureA.
+        # kFeatureA; that's irrelevant to kFeatureA's own match, and kFeatureB
+        # is untouched since it isn't the one named.
         source = (
             'BASE_FEATURE(kFeatureA, base::FEATURE_DISABLED_BY_DEFAULT);\n'
             '\n'
@@ -6562,14 +6606,16 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
         self.assertEqual(matches, 1)
         self.assertEqual(
             content,
-            ('BASE_FEATURE(kFeatureA, base::FEATURE_ENABLED_BY_DEFAULT);\n'
+            ('// kFeatureA feature state is enforced via plaster rewrite.\n'
+             'BASE_FEATURE(kFeatureA, base::FEATURE_ENABLED_BY_DEFAULT);\n'
              '\n'
              'BASE_FEATURE(kFeatureB, base::FEATURE_ENABLED_BY_DEFAULT);\n'))
 
-    def test_no_match_case_does_not_leak_into_a_later_call(self):
-        # kFeatureA already has the value being set (should be a no-match),
-        # while kFeatureB, later in the file, does not. The no-match on
-        # kFeatureA must not cause the engine to drift onto kFeatureB instead.
+    def test_already_set_match_does_not_leak_into_a_later_call(self):
+        # kFeatureA already has the value being set -- and now matches
+        # because of that, not despite it -- while kFeatureB, later in the
+        # file, isn't targeted at all. kFeatureA's match must not cause the
+        # engine to drift onto kFeatureB instead.
         source = (
             'BASE_FEATURE(kFeatureA, base::FEATURE_DISABLED_BY_DEFAULT);\n'
             '\n'
@@ -6579,13 +6625,22 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
         matches, content = self._run(source,
                                      feature_name='kFeatureA',
                                      value='base::FEATURE_DISABLED_BY_DEFAULT')
-        self.assertEqual(matches, 0)
-        self.assertEqual(content, source)
+        self.assertEqual(matches, 1)
+        self.assertEqual(
+            content,
+            ('// kFeatureA feature state is enforced via plaster rewrite.\n'
+             'BASE_FEATURE(kFeatureA, base::FEATURE_DISABLED_BY_DEFAULT);\n'
+             '\n'
+             'BASE_FEATURE(kFeatureB,\n'
+             '             "FeatureB",\n'
+             '             base::FEATURE_ENABLED_BY_DEFAULT);\n'))
 
-    def test_preprocessor_conditional_is_never_treated_as_already_set(self):
+    def test_preprocessor_conditional_state_is_replaced_by_a_matching_branch(
+            self):
         # A conditional last argument is never a bare token, so it can never
-        # equal `value` outright -- setting either branch's own value is still
-        # a match, replacing the whole conditional.
+        # equal `value` outright -- but every match rewrites regardless, so
+        # setting either branch's own value still replaces the whole
+        # conditional wholesale.
         source = ('BASE_FEATURE(kFoo,\n'
                   '#if BUILDFLAG(IS_CHROMEOS)\n'
                   '             FEATURE_ENABLED_BY_DEFAULT\n'
@@ -6598,7 +6653,9 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
                                      value='FEATURE_DISABLED_BY_DEFAULT')
         self.assertEqual(matches, 1)
         self.assertEqual(
-            content, 'BASE_FEATURE(kFoo,\nFEATURE_DISABLED_BY_DEFAULT);\n')
+            content, '// kFoo feature state is enforced via plaster rewrite.\n'
+            'BASE_FEATURE(kFoo,\n'
+            'FEATURE_DISABLED_BY_DEFAULT);\n')
 
     def test_no_match_for_a_different_feature_name(self):
         source = 'BASE_FEATURE(kFoo, base::FEATURE_DISABLED_BY_DEFAULT);'

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -617,6 +617,9 @@ regex: ^{class_name}$
             "description": """\
 Sets a new value to a `BASE_FEATURE` feature flag.
 
+`set_feature_flag_default_state` can be safely used even when the value being
+assigned is already set, with the intent of preventing sliding back.
+
 ```yaml
 substitutions:
   - description: Ship kMyFeature disabled.
@@ -626,6 +629,7 @@ substitutions:
 ```
 
 ```diff
++// kMyFeature feature state is enforced via plaster rewrite.
  BASE_FEATURE(kMyFeature,
               "MyFeature",
 -             base::FEATURE_ENABLED_BY_DEFAULT);
@@ -642,8 +646,8 @@ substitutions:
                     "description": "The new value, e.g. `base::FEATURE_DISABLED_BY_DEFAULT`.",
                 },
             ],
-            "re_pattern": "(BASE_FEATURE\\(\\s*{feature_name}\\s*,)(?!(?:[^;]*,)?\\s*{value}\\s*\\);)([^;]*,)?(\\s*)[^;]*?(\\);)",
-            "replace": "\\1\\2\\3{value}\\4",
+            "re_pattern": "([ \\t]*)(BASE_FEATURE\\(\\s*{feature_name}\\s*,)([^;]*,)?(\\s*)[^;]*?(\\);)",
+            "replace": "\\1// {feature_name} feature state is enforced via plaster rewrite.\\n\\1\\2\\3\\4{value}\\5",
         },
     },
 }


### PR DESCRIPTION
This PR relaxes the way `set_feature_flag_default_state` works, to
permit it to be used to assign a value to a feature flag that already
has that value. This is important for the rebase process, as it reduces
churn whenever upstream changes the value of the flag, when we know on
our end we do not intend to do so.

With this change, the regex macro always adds a comment on top, which
guarantees that a given substitution always generates a change, even if
the targeted value is already in place.

Fixed: https://github.com/brave/brave-browser/issues/58198
