### PR TITLE
Restricted Email Aliases service only for regular profiles.

### DIFF
--- a/browser/email_aliases/email_aliases_service_factory.cc
+++ b/browser/email_aliases/email_aliases_service_factory.cc
@@ -43,9 +43,7 @@ EmailAliasesServiceFactory* EmailAliasesServiceFactory::GetInstance() {
 }
 
 EmailAliasesServiceFactory::EmailAliasesServiceFactory()
-    : ProfileKeyedServiceFactory(
-          "EmailAliasesService",
-          ProfileSelections::BuildRedirectedInIncognito()) {
+    : ProfileKeyedServiceFactory("EmailAliasesService") {
   DependsOn(brave_account::BraveAccountServiceFactory::GetInstance());
 }
 

--- a/browser/email_aliases/email_aliases_service_factory_unittest.cc
+++ b/browser/email_aliases/email_aliases_service_factory_unittest.cc
@@ -135,16 +135,14 @@ TEST_F(EmailAliasesServiceFactoryTest, NoServiceForGuestOrSystemProfile) {
 }
 #endif
 
-TEST_F(EmailAliasesServiceFactoryTest, SameServiceForRegularAndIncognito) {
+TEST_F(EmailAliasesServiceFactoryTest, RegularAndIncognito) {
   scoped_feature_list_.InitWithFeatures(
       {brave_account::features::BraveAccountFeatureForTesting(),
        features::kEmailAliases},
       {});
 
-  [[maybe_unused]] auto* profile =
-      profile_manager_.CreateTestingProfile("test");
-  [[maybe_unused]] auto* incognito =
-      profile->GetPrimaryOTRProfile(/*create_if_needed=*/true);
+  auto* profile = profile_manager_.CreateTestingProfile("test");
+  auto* incognito = profile->GetPrimaryOTRProfile(/*create_if_needed=*/true);
   brave_account::BraveAccountServiceFactory::GetInstance()->SetTestingFactory(
       profile, base::BindLambdaForTesting([&](content::BrowserContext* context)
                                               -> std::unique_ptr<KeyedService> {
@@ -155,9 +153,10 @@ TEST_F(EmailAliasesServiceFactoryTest, SameServiceForRegularAndIncognito) {
       }));
   auto* service_regular =
       EmailAliasesServiceFactory::GetServiceForProfile(profile);
+  EXPECT_NE(nullptr, service_regular);
   auto* service_incognito =
       EmailAliasesServiceFactory::GetServiceForProfile(incognito);
-  EXPECT_EQ(service_regular, service_incognito);
+  EXPECT_EQ(nullptr, service_incognito);
 }
 
 }  // namespace email_aliases


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58145

Previously when Email Aliases had an own auth mechanisms, it used `Redirect to original` service instance when instantiated in the incognito windows. It's a bit odd, because the aliases created in the incognito window are stored in the regular profile.
For now, Email Aliases Service depends on Brave Account service which is restricted only for regular profiles, so it makes sense to use the same in EA.

It looks like we could add `read-only` functionality for BA and EA later, it will allow us to use both services in the incognito without affecting the regular profiles.