### PR TITLE
[bots][infra] Initial implementation for `bots.py gen`

### DIFF
--- a/infra/bots/bots.py
+++ b/infra/bots/bots.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import argparse
 import sys
 
+import gen
+import generated_output
 import lookup
 import snapshot
 
@@ -25,11 +27,12 @@ def main(argv: list[str] | None = None) -> int:
 
     snapshot.add_subparser(subparsers)
     lookup.add_subparser(subparsers)
+    gen.add_subparser(subparsers)
 
     args = parser.parse_args(argv)
     try:
         return args.func(args)
-    except lookup.BotsError as e:
+    except generated_output.BotsError as e:
         print(e, file=sys.stderr)
         return 1
 

--- a/infra/bots/bots_test.py
+++ b/infra/bots/bots_test.py
@@ -4,9 +4,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """Thin integration tests for `bots.py`'s CLI wiring: dispatch to the
-`snapshot`/`lookup` subcommands and their error paths. snapshot.py's own
-logic (compute_fresh_output(), write_output()) is covered by
-snapshot_test.py, and lookup.py's by lookup_test.py."""
+`snapshot`/`lookup`/`gen` subcommands and their error paths. Each
+subcommand's own logic is covered by its own <name>_test.py; `gen`'s
+dispatch test stubs out `gen.BuildDirGenerator.run_gn_gen()` so it never
+shells out to a real `gn` binary."""
 
 import contextlib
 import io
@@ -24,6 +25,7 @@ sys.path.insert(
                  'config'))
 
 import bots
+import gen
 import gen_paths
 import lookup
 
@@ -111,6 +113,66 @@ class SnapshotDispatchTest(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
         self.assertNotIn('a-builder', buf.getvalue())
         self.assertNotIn('available builders', buf.getvalue())
+
+
+class GenDispatchTest(unittest.TestCase):
+    """`bots.py gen`'s CLI wiring: dispatch to `gen.cmd_gen()` and the
+    missing-positional/unknown-builder error paths. See gen_test.py for
+    `gen.py`'s own logic (writing args.gn, the secrets stub)."""
+
+    def test_dispatches_to_gen_cmd(self):
+        generated_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(generated_tmp.cleanup)
+        _make_generated_output_dir(generated_tmp.name, ['b'])
+        # `_CHROMIUM_SRC_DIR` is faked so an --out-dir under it passes
+        # cmd_gen()'s "must be inside the source root" check without
+        # touching the real checkout.
+        fake_src_root = tempfile.TemporaryDirectory()
+        self.addCleanup(fake_src_root.cleanup)
+        out_dir = Path(fake_src_root.name) / 'out' / 'b'
+
+        original_output_dir = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(generated_tmp.name)
+        original_src_dir = gen._CHROMIUM_SRC_DIR
+        gen._CHROMIUM_SRC_DIR = Path(fake_src_root.name)
+        original_run_gn_gen = gen.BuildDirGenerator.run_gn_gen
+        gen.BuildDirGenerator.run_gn_gen = lambda self: 0
+        try:
+            ret = bots.main(['gen', 'b', '--out-dir', str(out_dir)])
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original_output_dir
+            gen._CHROMIUM_SRC_DIR = original_src_dir
+            gen.BuildDirGenerator.run_gn_gen = original_run_gn_gen
+
+        self.assertEqual(ret, 0)
+        self.assertEqual((out_dir / 'args.gn').read_text(encoding='utf-8'),
+                         'is_asan = true\n')
+
+    def test_unknown_builder_returns_1(self):
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            ret = bots.main(['gen', 'does-not-exist'])
+        self.assertEqual(ret, 1)
+        self.assertIn('does-not-exist', buf.getvalue())
+
+    def test_missing_positional_lists_available_builders(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        _make_generated_output_dir(tmp.name, ['a-builder', 'b-builder'])
+
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
+        try:
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                with self.assertRaises(SystemExit) as ctx:
+                    bots.main(['gen'])
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original
+
+        self.assertEqual(ctx.exception.code, 2)
+        self.assertIn('a-builder', buf.getvalue())
+        self.assertIn('b-builder', buf.getvalue())
 
 
 if __name__ == '__main__':

--- a/infra/bots/gen.py
+++ b/infra/bots/gen.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""bots gen: write a builder's `args.gn` and run `gn gen`.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import subprocess
+
+import gen_paths
+import generated_output
+
+_CHROMIUM_SRC_DIR = gen_paths.BOTS_DIR.parents[2]
+
+
+class BuildDirGenerator(generated_output.OutputGenerator):
+    """Writes a builder's `args.gn` (and a secrets stub) and runs `gn gen`.
+    """
+
+    def __init__(self, builder_name: str, out_dir: Path | None = None) -> None:
+        super().__init__(builder_name)
+        self.out_dir = out_dir if out_dir is not None else self.default_out_dir(
+        )
+
+    def default_out_dir(self) -> Path:
+        """The output directory this builder gets when none is given.
+        """
+        return _CHROMIUM_SRC_DIR / 'out' / self.builder_name
+
+    def secrets_import_path(self) -> str:
+        """Overrides `OutputGenerator`'s default: the secrets stub this
+        generator writes (`write_build_dir()`) lands in `self.out_dir`,
+        which is not necessarily the default `out/<builder>` once
+        `--out-dir` overrides it, so the import must follow it there.
+        """
+        return '//%s/brave_secrets.gni' % self.out_dir.relative_to(
+            _CHROMIUM_SRC_DIR).as_posix()
+
+    @staticmethod
+    def render_secrets_gni_stub(secrets: dict[str, str]) -> str:
+        """Renders a placeholder `brave_secrets.gni` for a `secrets` map.
+
+        This stub exists so a builder that declares secrets still gets a
+        `gn gen` that succeeds. Every declared GN arg gets a "dummy" value, the
+        same placeholder `gn_args.py` already uses for `brave_google_api_key`.
+        """
+        return ''.join('%s = "dummy"\n' % name for name in sorted(secrets))
+
+    def write_build_dir(self) -> str:
+        """Writes `args.gn` (and a secrets stub, if the builder declares
+        any) into `self.out_dir`, creating it if needed.
+
+        Returns:
+            The rendered `args.gn` text.
+        """
+        resolved = self.read_generated_gn_args()
+        args_gn = self.render_args_gn(resolved)
+
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+        (self.out_dir / 'args.gn').write_text(args_gn,
+                                              encoding='utf-8',
+                                              newline='\n')
+
+        secrets = resolved.get('secrets')
+        if secrets:
+            (self.out_dir / 'brave_secrets.gni').write_text(
+                self.render_secrets_gni_stub(secrets),
+                encoding='utf-8',
+                newline='\n')
+
+        return args_gn
+
+    def run_gn_gen(self) -> int:
+        """Runs `gn gen` against `self.out_dir`.
+
+        `args.gn` is already on disk (`write_build_dir`), so, as `mb.py gen`
+        does, this only ever needs to name the directory; `--check` runs the
+        header checker over the whole graph, matching `mb.py`'s own default.
+        GN resolves the build directory against the source root it finds
+        from the working directory, so this always runs from
+        `_CHROMIUM_SRC_DIR`.
+        """
+        return subprocess.call([
+            'gn', 'gen',
+            str(self.out_dir.relative_to(_CHROMIUM_SRC_DIR)), '--check'
+        ],
+                               cwd=_CHROMIUM_SRC_DIR)
+
+    def gen(self) -> int:
+        """Writes the build directory, then runs `gn gen` against it."""
+        self.write_build_dir()
+        return self.run_gn_gen()
+
+
+def cmd_gen(args: argparse.Namespace) -> int:
+    out_dir = Path(args.out_dir).resolve() if args.out_dir else None
+    generator = BuildDirGenerator(args.builder, out_dir)
+    if not generator.out_dir.is_relative_to(_CHROMIUM_SRC_DIR):
+        raise generated_output.BotsError(
+            '--out-dir %s is not under the chromium checkout root (%s); '
+            'gn requires a build directory inside the source tree.' %
+            (generator.out_dir, _CHROMIUM_SRC_DIR))
+    return generator.gen()
+
+
+def add_subparser(subparsers) -> argparse.ArgumentParser:
+    """Registers the `gen` subcommand onto `bots.py`'s subparsers."""
+    gen_parser = subparsers.add_parser(
+        'gen', description="Write a builder's args.gn and run `gn gen`.")
+    generated_output.add_builder_argument(gen_parser,
+                                          help_text='A builder name, e.g. '
+                                          '"linux-x64-asan-brave".')
+    gen_parser.add_argument(
+        '--out-dir',
+        help='Where to write args.gn and run `gn gen` (default: '
+        'out/<builder>, under the chromium checkout root).')
+    gen_parser.set_defaults(func=cmd_gen)
+    return gen_parser

--- a/infra/bots/gen_test.py
+++ b/infra/bots/gen_test.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for gen.py's own logic: `BuildDirGenerator`'s secrets stub, its
+writing of a build directory's `args.gn`/`brave_secrets.gni`, and
+`cmd_gen()`'s validation and dispatch. `BuildDirGenerator.run_gn_gen()`
+shells out to a real `gn` binary and is exercised manually, not here;
+`cmd_gen()`'s tests stub it out. `bots.py`'s CLI wiring for the `gen`
+subcommand is exercised in bots_test.py instead."""
+
+import argparse
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import gen
+import gen_paths
+import generated_output
+from generated_output_test import _make_generated_output_dir
+
+
+class RenderSecretsGniStubTest(unittest.TestCase):
+
+    def test_empty_secrets_renders_empty(self):
+        self.assertEqual(gen.BuildDirGenerator.render_secrets_gni_stub({}), '')
+
+    def test_every_declared_arg_gets_a_dummy_value(self):
+        rendered = gen.BuildDirGenerator.render_secrets_gni_stub({
+            'brave_services_key': 'BRAVE_SERVICES_KEY',
+            'brave_stats_api_key': 'BRAVE_STATS_API_KEY',
+        })
+        self.assertEqual(
+            rendered, 'brave_services_key = "dummy"\n'
+            'brave_stats_api_key = "dummy"\n')
+
+    def test_no_env_var_name_appears(self):
+        rendered = gen.BuildDirGenerator.render_secrets_gni_stub(
+            {'brave_services_key': 'BRAVE_SERVICES_KEY'})
+        self.assertNotIn('BRAVE_SERVICES_KEY', rendered)
+
+    def test_keys_are_sorted(self):
+        rendered = gen.BuildDirGenerator.render_secrets_gni_stub({
+            'z': 'Z',
+            'a': 'A'
+        })
+        self.assertEqual(rendered, 'a = "dummy"\nz = "dummy"\n')
+
+
+class DefaultOutDirTest(unittest.TestCase):
+
+    def test_is_out_slash_builder_name_under_src_root(self):
+        generator = gen.BuildDirGenerator('linux-x64-asan-brave')
+        self.assertEqual(
+            generator.out_dir,
+            gen._CHROMIUM_SRC_DIR / 'out' / 'linux-x64-asan-brave')
+
+
+class WriteBuildDirTest(unittest.TestCase):
+
+    def test_writes_args_gn(self):
+        generated_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(generated_tmp.cleanup)
+        _make_generated_output_dir(generated_tmp.name, ['b'])
+        out_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(out_tmp.cleanup)
+
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(generated_tmp.name)
+        try:
+            generator = gen.BuildDirGenerator('b', Path(out_tmp.name))
+            args_gn = generator.write_build_dir()
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original
+
+        self.assertEqual(args_gn, 'is_asan = true\n')
+        self.assertEqual(
+            (Path(out_tmp.name) / 'args.gn').read_text(encoding='utf-8'),
+            'is_asan = true\n')
+
+    def test_creates_out_dir_if_missing(self):
+        generated_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(generated_tmp.cleanup)
+        _make_generated_output_dir(generated_tmp.name, ['b'])
+        out_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(out_tmp.cleanup)
+        out_dir = Path(out_tmp.name) / 'nested' / 'out-dir'
+
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(generated_tmp.name)
+        try:
+            gen.BuildDirGenerator('b', out_dir).write_build_dir()
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original
+
+        self.assertTrue((out_dir / 'args.gn').is_file())
+
+    def test_no_secrets_means_no_stub_file(self):
+        generated_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(generated_tmp.cleanup)
+        _make_generated_output_dir(generated_tmp.name, ['b'])
+        out_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(out_tmp.cleanup)
+
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(generated_tmp.name)
+        try:
+            gen.BuildDirGenerator('b', Path(out_tmp.name)).write_build_dir()
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original
+
+        self.assertFalse((Path(out_tmp.name) / 'brave_secrets.gni').is_file())
+
+    def test_declared_secrets_get_a_dummy_stub_file(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        builder_dir = Path(tmp.name) / 'b'
+        builder_dir.mkdir()
+        (builder_dir / 'gn-args.json').write_text(
+            '{"gn_args": {"is_asan": true}, '
+            '"secrets": {"brave_services_key": "BRAVE_SERVICES_KEY"}}',
+            encoding='utf-8')
+        # `_CHROMIUM_SRC_DIR` is faked so a system tmpdir out_dir passes
+        # `secrets_import_path()`'s `relative_to()` without touching the
+        # real checkout.
+        fake_src_root = tempfile.TemporaryDirectory()
+        self.addCleanup(fake_src_root.cleanup)
+        out_dir = Path(fake_src_root.name) / 'out' / 'b'
+
+        original_output_dir = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
+        original_src_dir = gen._CHROMIUM_SRC_DIR
+        gen._CHROMIUM_SRC_DIR = Path(fake_src_root.name)
+        try:
+            gen.BuildDirGenerator('b', out_dir).write_build_dir()
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original_output_dir
+            gen._CHROMIUM_SRC_DIR = original_src_dir
+
+        self.assertEqual(
+            (out_dir / 'brave_secrets.gni').read_text(encoding='utf-8'),
+            'brave_services_key = "dummy"\n')
+
+    def test_secrets_import_path_follows_a_non_default_out_dir(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        builder_dir = Path(tmp.name) / 'b'
+        builder_dir.mkdir()
+        (builder_dir / 'gn-args.json').write_text(
+            '{"gn_args": {"is_asan": true}, '
+            '"secrets": {"brave_services_key": "BRAVE_SERVICES_KEY"}}',
+            encoding='utf-8')
+        fake_src_root = tempfile.TemporaryDirectory()
+        self.addCleanup(fake_src_root.cleanup)
+        # Deliberately not the default `out/b` layout.
+        out_dir = Path(fake_src_root.name) / 'custom' / 'out-dir'
+
+        original_output_dir = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
+        original_src_dir = gen._CHROMIUM_SRC_DIR
+        gen._CHROMIUM_SRC_DIR = Path(fake_src_root.name)
+        try:
+            args_gn = gen.BuildDirGenerator('b', out_dir).write_build_dir()
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original_output_dir
+            gen._CHROMIUM_SRC_DIR = original_src_dir
+
+        self.assertEqual(args_gn.splitlines()[0],
+                         'import("//custom/out-dir/brave_secrets.gni")')
+        self.assertTrue((out_dir / 'brave_secrets.gni').is_file())
+
+    def test_unknown_builder_raises(self):
+        generator = gen.BuildDirGenerator('no-such-builder',
+                                          Path(tempfile.mkdtemp()))
+        with self.assertRaises(generated_output.BotsError):
+            generator.write_build_dir()
+
+
+class CmdGenTest(unittest.TestCase):
+
+    def test_out_dir_outside_src_root_raises(self):
+        args = argparse.Namespace(builder='b', out_dir='/not/under/src/root')
+        with self.assertRaises(generated_output.BotsError):
+            gen.cmd_gen(args)
+
+    def test_dispatches_to_gen(self):
+        generated_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(generated_tmp.cleanup)
+        _make_generated_output_dir(generated_tmp.name, ['b'])
+        # `_CHROMIUM_SRC_DIR` is faked so an --out-dir under it passes
+        # cmd_gen()'s "must be inside the source root" check without
+        # touching the real checkout.
+        fake_src_root = tempfile.TemporaryDirectory()
+        self.addCleanup(fake_src_root.cleanup)
+        out_dir = Path(fake_src_root.name) / 'out' / 'b'
+
+        seen_out_dirs = []
+        original_run_gn_gen = gen.BuildDirGenerator.run_gn_gen
+        gen.BuildDirGenerator.run_gn_gen = (
+            lambda self: seen_out_dirs.append(self.out_dir) or 0)
+        original_src_dir = gen._CHROMIUM_SRC_DIR
+        gen._CHROMIUM_SRC_DIR = Path(fake_src_root.name)
+        original_output_dir = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(generated_tmp.name)
+        try:
+            args = argparse.Namespace(builder='b', out_dir=str(out_dir))
+            ret = gen.cmd_gen(args)
+        finally:
+            gen.BuildDirGenerator.run_gn_gen = original_run_gn_gen
+            gen._CHROMIUM_SRC_DIR = original_src_dir
+            gen_paths.BUILDERS_OUTPUT_DIR = original_output_dir
+
+        self.assertEqual(ret, 0)
+        self.assertEqual(seen_out_dirs, [out_dir])
+        self.assertTrue((out_dir / 'args.gn').is_file())
+
+    def test_default_out_dir_when_not_given(self):
+        generated_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(generated_tmp.cleanup)
+        _make_generated_output_dir(generated_tmp.name, ['b'])
+        fake_src_root = tempfile.TemporaryDirectory()
+        self.addCleanup(fake_src_root.cleanup)
+
+        seen_out_dirs = []
+        original_run_gn_gen = gen.BuildDirGenerator.run_gn_gen
+        gen.BuildDirGenerator.run_gn_gen = (
+            lambda self: seen_out_dirs.append(self.out_dir) or 0)
+        original_src_dir = gen._CHROMIUM_SRC_DIR
+        gen._CHROMIUM_SRC_DIR = Path(fake_src_root.name)
+        original_output_dir = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(generated_tmp.name)
+        try:
+            args = argparse.Namespace(builder='b', out_dir=None)
+            gen.cmd_gen(args)
+        finally:
+            gen.BuildDirGenerator.run_gn_gen = original_run_gn_gen
+            gen._CHROMIUM_SRC_DIR = original_src_dir
+            gen_paths.BUILDERS_OUTPUT_DIR = original_output_dir
+
+        self.assertEqual(seen_out_dirs,
+                         [Path(fake_src_root.name) / 'out' / 'b'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/infra/bots/generated_output.py
+++ b/infra/bots/generated_output.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Base code to for rendering gn args"""
+
+from __future__ import annotations
+
+import argparse
+import functools
+import json
+import sys
+
+import gen_paths
+
+_CHROMIUM_SRC_DIR = gen_paths.BOTS_DIR.parents[2]
+sys.path.insert(0, str(_CHROMIUM_SRC_DIR / 'build'))
+import gn_helpers
+
+
+class BotsError(Exception):
+    """Raised for a user-facing `bots.py` failure, e.g. an unknown builder."""
+
+
+def list_generated_builders() -> list[str]:
+    """Every builder with a generated `gn-args.json`, sorted by name."""
+    if not gen_paths.BUILDERS_OUTPUT_DIR.is_dir():
+        return []
+    return sorted(p.name for p in gen_paths.BUILDERS_OUTPUT_DIR.iterdir()
+                  if (p / 'gn-args.json').is_file())
+
+
+class OutputGenerator:
+    """Resolves and renders one builder's generated `gn-args.json`.
+
+    This class produces the rendered `args.gn` that is used by `bots gen` and
+    `bots lookup`.
+    """
+
+    def __init__(self, builder_name: str) -> None:
+        self.builder_name = builder_name
+
+    def read_generated_gn_args(self) -> dict:
+        """Reads this builder's generated `gn-args.json`.
+
+        Raises:
+            BotsError: this builder has no generated `gn-args.json`.
+        """
+        path = (gen_paths.BUILDERS_OUTPUT_DIR / self.builder_name /
+                'gn-args.json')
+        if not path.is_file():
+            available = list_generated_builders()
+            hint = (' available builders: %s.' %
+                    ', '.join(available) if available else '')
+            raise BotsError(
+                'builder %r not found under %s; run `bots.py snapshot` '
+                'first, or check the name.%s' %
+                (self.builder_name, gen_paths.BUILDERS_OUTPUT_DIR, hint))
+        return json.loads(path.read_bytes().decode('utf-8'))
+
+    def secrets_import_path(self) -> str:
+        """The `//`-prefixed GN label `render_args_gn()` imports secrets from.
+        """
+        return '//out/%s/brave_secrets.gni' % self.builder_name
+
+    def render_args_gn(self, resolved: dict) -> str:
+        """Renders a resolved `gn-args.json` payload as `args.gn` text."""
+        lines = []
+        if resolved.get('secrets'):
+            lines.append('import("%s")' % self.secrets_import_path())
+        if resolved.get('args_file'):
+            lines.append('import("%s")' % resolved['args_file'])
+        lines.append(gn_helpers.ToGNString(resolved['gn_args']))
+        return '\n'.join(lines)
+
+
+def _error_with_available_builders(parser: argparse.ArgumentParser,
+                                   message: str) -> None:
+    """A `parser.error()` replacement that also lists generated builders.
+
+    This is similar to what you would get with argparser errors, with the only
+    addition that it lists the available builders if no builder was provided.
+    """
+    parser.print_usage(sys.stderr)
+    print('%s: error: %s' % (parser.prog, message), file=sys.stderr)
+    builders = list_generated_builders()
+    if builders:
+        print('\navailable builders:', file=sys.stderr)
+        for name in builders:
+            print('  %s' % name, file=sys.stderr)
+    parser.exit(2)
+
+
+def add_builder_argument(subparser: argparse.ArgumentParser, *,
+                         help_text: str) -> None:
+    """Adds the `builder` positional shared by every subcommand that reads
+    one builder's generated output, wiring its usage errors to list the
+    builders actually available under `generated/builders/`.
+    """
+    subparser.add_argument('builder', help=help_text)
+    subparser.error = functools.partial(_error_with_available_builders,
+                                        subparser)

--- a/infra/bots/generated_output_test.py
+++ b/infra/bots/generated_output_test.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for generated_output.py: reading a generated `gn-args.json` and
+rendering it as `args.gn` text, shared by `lookup.py` and `gen.py`. Their own
+CLI-level tests seed a generated output dir the same way and just check that
+they delegate here correctly."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import gen_paths
+import generated_output
+
+
+def _make_generated_output_dir(tmp_dir, builder_names):
+    """Writes a minimal `gn-args.json` for each name under `tmp_dir`."""
+    for name in builder_names:
+        builder_dir = Path(tmp_dir) / name
+        builder_dir.mkdir()
+        (builder_dir / 'gn-args.json').write_text(json.dumps(
+            {'gn_args': {
+                'is_asan': True
+            }}),
+                                                  encoding='utf-8')
+
+
+class ListGeneratedBuildersTest(unittest.TestCase):
+
+    def test_no_output_dir_means_no_builders(self):
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(
+            tempfile.mkdtemp()) / 'does-not-exist'
+        try:
+            self.assertEqual(generated_output.list_generated_builders(), [])
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original
+
+    def test_lists_builders_sorted_by_name(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        _make_generated_output_dir(tmp.name, ['z-builder', 'a-builder'])
+
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
+        try:
+            self.assertEqual(generated_output.list_generated_builders(),
+                             ['a-builder', 'z-builder'])
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original
+
+
+class ReadGeneratedGnArgsTest(unittest.TestCase):
+
+    def test_missing_builder_raises_bots_error(self):
+        with self.assertRaises(generated_output.BotsError):
+            generated_output.OutputGenerator(
+                'no-such-builder').read_generated_gn_args()
+
+    def test_missing_builder_hint_lists_available_builders(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        _make_generated_output_dir(tmp.name, ['a-builder', 'b-builder'])
+
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
+        try:
+            with self.assertRaises(generated_output.BotsError) as ctx:
+                generated_output.OutputGenerator(
+                    'no-such-builder').read_generated_gn_args()
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original
+
+        self.assertIn('a-builder', str(ctx.exception))
+        self.assertIn('b-builder', str(ctx.exception))
+
+
+class RenderArgsGnTest(unittest.TestCase):
+
+    def test_plain_args_no_secrets(self):
+        rendered = generated_output.OutputGenerator('b').render_args_gn(
+            {'gn_args': {
+                'is_asan': True
+            }})
+        self.assertEqual(rendered, 'is_asan = true\n')
+
+    def test_secrets_add_import_line_only_not_values(self):
+        rendered = generated_output.OutputGenerator(
+            'linux-x64-asan-brave').render_args_gn({
+                'gn_args': {
+                    'target_os': 'linux'
+                },
+                'secrets': {
+                    'brave_services_key': 'BRAVE_SERVICES_KEY'
+                },
+            })
+        lines = rendered.split('\n')
+        self.assertEqual(
+            lines[0], 'import("//out/linux-x64-asan-brave/brave_secrets.gni")')
+        self.assertNotIn('BRAVE_SERVICES_KEY', rendered)
+        self.assertNotIn('brave_services_key', rendered)
+
+    def test_args_file_import_line(self):
+        rendered = generated_output.OutputGenerator('b').render_args_gn({
+            'gn_args': {
+                'target_os': 'linux'
+            },
+            'args_file': '//build/args/chromeos.gni',
+        })
+        self.assertEqual(
+            rendered, 'import("//build/args/chromeos.gni")\n'
+            'target_os = "linux"\n')
+
+    def test_keys_are_sorted(self):
+        rendered = generated_output.OutputGenerator('b').render_args_gn(
+            {'gn_args': {
+                'z': True,
+                'a': True
+            }})
+        self.assertEqual(rendered, 'a = true\nz = true\n')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/infra/bots/lookup.py
+++ b/infra/bots/lookup.py
@@ -8,95 +8,20 @@
 from __future__ import annotations
 
 import argparse
-import functools
-import json
-import sys
 
-import gen_paths
-
-_CHROMIUM_SRC_DIR = gen_paths.BOTS_DIR.parents[2]
-sys.path.insert(0, str(_CHROMIUM_SRC_DIR / 'build'))
-import gn_helpers
+import generated_output
 
 
-class BotsError(Exception):
-    """Raised for a user-facing `bots.py lookup` failure, e.g. an unknown
-    builder.
-    """
-
-
-def list_generated_builders() -> list[str]:
-    """Every builder with a generated `gn-args.json`, sorted by name."""
-    if not gen_paths.BUILDERS_OUTPUT_DIR.is_dir():
-        return []
-    return sorted(p.name for p in gen_paths.BUILDERS_OUTPUT_DIR.iterdir()
-                  if (p / 'gn-args.json').is_file())
-
-
-class BuilderLookup:
-    """Resolves and renders one builder's generated `gn-args.json`.
-    """
-
-    def __init__(self, builder_name: str) -> None:
-        self.builder_name = builder_name
-
-    def read_generated_gn_args(self) -> dict:
-        """Reads this builder's generated `gn-args.json`.
-
-        Raises:
-            BotsError: this builder has no generated `gn-args.json`.
-        """
-        path = (gen_paths.BUILDERS_OUTPUT_DIR / self.builder_name /
-                'gn-args.json')
-        if not path.is_file():
-            available = list_generated_builders()
-            hint = (' available builders: %s.' %
-                    ', '.join(available) if available else '')
-            raise BotsError(
-                'builder %r not found under %s; run `bots.py snapshot` '
-                'first, or check the name.%s' %
-                (self.builder_name, gen_paths.BUILDERS_OUTPUT_DIR, hint))
-        return json.loads(path.read_text(encoding='utf-8'))
-
-    def render_args_gn(self, resolved: dict) -> str:
-        """Renders a resolved `gn-args.json` payload as `args.gn` text."""
-        lines = []
-        if resolved.get('secrets'):
-            lines.append('import("//out/%s/brave_secrets.gni")' %
-                         self.builder_name)
-        if resolved.get('args_file'):
-            lines.append('import("%s")' % resolved['args_file'])
-        lines.append(gn_helpers.ToGNString(resolved['gn_args']))
-        return '\n'.join(lines)
-
-    @classmethod
-    def cmd_lookup(cls, args: argparse.Namespace) -> int:
-        lookup = cls(args.builder)
-        resolved = lookup.read_generated_gn_args()
-        args_gn = lookup.render_args_gn(resolved)
-        if args.quiet:
-            print(args_gn, end='')
-        else:
-            print('\nWriting """\\\n%s""" to out/%s/args.gn.\n' %
-                  (args_gn, args.builder))
-        return 0
-
-
-def _error_with_available_builders(parser: argparse.ArgumentParser,
-                                   message: str) -> None:
-    """A `parser.error()` replacement that also lists generated builders.
-
-    This is similar to what you would get with argparser errors, with the only
-    addition that it lists the available builders if no builder was provided.
-    """
-    parser.print_usage(sys.stderr)
-    print('%s: error: %s' % (parser.prog, message), file=sys.stderr)
-    builders = list_generated_builders()
-    if builders:
-        print('\navailable builders:', file=sys.stderr)
-        for name in builders:
-            print('  %s' % name, file=sys.stderr)
-    parser.exit(2)
+def cmd_lookup(args: argparse.Namespace) -> int:
+    generator = generated_output.OutputGenerator(args.builder)
+    resolved = generator.read_generated_gn_args()
+    args_gn = generator.render_args_gn(resolved)
+    if args.quiet:
+        print(args_gn, end='')
+    else:
+        print('\nWriting """\\\n%s""" to out/%s/args.gn.\n' %
+              (args_gn, args.builder))
+    return 0
 
 
 def add_subparser(subparsers) -> argparse.ArgumentParser:
@@ -104,15 +29,13 @@ def add_subparser(subparsers) -> argparse.ArgumentParser:
     lookup_parser = subparsers.add_parser(
         'lookup',
         description='Look up the args.gn a builder would resolve to.')
-    lookup_parser.add_argument('builder',
-                               help='A builder name, e.g. '
-                               '"linux-x64-asan-brave".')
+    generated_output.add_builder_argument(lookup_parser,
+                                          help_text='A builder name, e.g. '
+                                          '"linux-x64-asan-brave".')
     lookup_parser.add_argument(
         '--quiet',
         action='store_true',
         help='Print just the args.gn contents (like `mb.py lookup --quiet`), '
         'instead of the human-readable "would write" preamble.')
-    lookup_parser.set_defaults(func=BuilderLookup.cmd_lookup)
-    lookup_parser.error = functools.partial(_error_with_available_builders,
-                                            lookup_parser)
+    lookup_parser.set_defaults(func=cmd_lookup)
     return lookup_parser

--- a/infra/bots/lookup_test.py
+++ b/infra/bots/lookup_test.py
@@ -3,16 +3,16 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Tests for lookup.py's own logic: `BuilderLookup`'s reading of a
-generated `gn-args.json`, its rendering of `args.gn` text, and its
-`cmd_lookup()` classmethod. `bots.py`'s CLI wiring for the `lookup`
-subcommand (dispatch, missing-positional handling) is exercised in
-bots_test.py instead."""
+"""Tests for lookup.py's own logic: `cmd_lookup()`'s use of
+generated_output.OutputGenerator. Reading a generated `gn-args.json` and
+rendering it as `args.gn` text is OutputGenerator's own logic, tested in
+generated_output_test.py. `bots.py`'s CLI wiring for the `lookup` subcommand
+(dispatch, missing-positional handling) is exercised in bots_test.py
+instead."""
 
 import argparse
 import contextlib
 import io
-import json
 import os
 import sys
 import tempfile
@@ -22,113 +22,9 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import gen_paths
+import generated_output
 import lookup
-
-
-def _make_generated_output_dir(tmp_dir, builder_names):
-    """Writes a minimal `gn-args.json` for each name under `tmp_dir`."""
-    for name in builder_names:
-        builder_dir = Path(tmp_dir) / name
-        builder_dir.mkdir()
-        (builder_dir / 'gn-args.json').write_text(json.dumps(
-            {'gn_args': {
-                'is_asan': True
-            }}),
-                                                  encoding='utf-8')
-
-
-class ListGeneratedBuildersTest(unittest.TestCase):
-
-    def test_no_output_dir_means_no_builders(self):
-        original = gen_paths.BUILDERS_OUTPUT_DIR
-        gen_paths.BUILDERS_OUTPUT_DIR = Path(
-            tempfile.mkdtemp()) / 'does-not-exist'
-        try:
-            self.assertEqual(lookup.list_generated_builders(), [])
-        finally:
-            gen_paths.BUILDERS_OUTPUT_DIR = original
-
-    def test_lists_builders_sorted_by_name(self):
-        tmp = tempfile.TemporaryDirectory()
-        self.addCleanup(tmp.cleanup)
-        _make_generated_output_dir(tmp.name, ['z-builder', 'a-builder'])
-
-        original = gen_paths.BUILDERS_OUTPUT_DIR
-        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
-        try:
-            self.assertEqual(lookup.list_generated_builders(),
-                             ['a-builder', 'z-builder'])
-        finally:
-            gen_paths.BUILDERS_OUTPUT_DIR = original
-
-
-class ReadGeneratedGnArgsTest(unittest.TestCase):
-
-    def test_missing_builder_raises_bots_error(self):
-        with self.assertRaises(lookup.BotsError):
-            lookup.BuilderLookup('no-such-builder').read_generated_gn_args()
-
-    def test_missing_builder_hint_lists_available_builders(self):
-        tmp = tempfile.TemporaryDirectory()
-        self.addCleanup(tmp.cleanup)
-        _make_generated_output_dir(tmp.name, ['a-builder', 'b-builder'])
-
-        original = gen_paths.BUILDERS_OUTPUT_DIR
-        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
-        try:
-            with self.assertRaises(lookup.BotsError) as ctx:
-                lookup.BuilderLookup(
-                    'no-such-builder').read_generated_gn_args()
-        finally:
-            gen_paths.BUILDERS_OUTPUT_DIR = original
-
-        self.assertIn('a-builder', str(ctx.exception))
-        self.assertIn('b-builder', str(ctx.exception))
-
-
-class RenderArgsGnTest(unittest.TestCase):
-
-    def test_plain_args_no_secrets(self):
-        rendered = lookup.BuilderLookup('b').render_args_gn(
-            {'gn_args': {
-                'is_asan': True
-            }})
-        self.assertEqual(rendered, 'is_asan = true\n')
-
-    def test_secrets_add_import_line_only_not_values(self):
-        rendered = lookup.BuilderLookup('linux-x64-asan-brave').render_args_gn(
-            {
-                'gn_args': {
-                    'target_os': 'linux'
-                },
-                'secrets': {
-                    'brave_services_key': 'BRAVE_SERVICES_KEY'
-                },
-            })
-        lines = rendered.split('\n')
-        self.assertEqual(
-            lines[0], 'import("//out/linux-x64-asan-brave/brave_secrets.gni")')
-        self.assertNotIn('BRAVE_SERVICES_KEY', rendered)
-        self.assertNotIn('brave_services_key', rendered)
-
-    def test_args_file_import_line(self):
-        rendered = lookup.BuilderLookup('b').render_args_gn({
-            'gn_args': {
-                'target_os': 'linux'
-            },
-            'args_file': '//build/args/chromeos.gni',
-        })
-        self.assertEqual(
-            rendered, 'import("//build/args/chromeos.gni")\n'
-            'target_os = "linux"\n')
-
-    def test_keys_are_sorted(self):
-        rendered = lookup.BuilderLookup('b').render_args_gn(
-            {'gn_args': {
-                'z': True,
-                'a': True
-            }})
-        self.assertEqual(rendered, 'a = true\nz = true\n')
+from generated_output_test import _make_generated_output_dir
 
 
 class CmdLookupTest(unittest.TestCase):
@@ -144,7 +40,7 @@ class CmdLookupTest(unittest.TestCase):
             args = argparse.Namespace(builder='b', quiet=True)
             buf = io.StringIO()
             with contextlib.redirect_stdout(buf):
-                ret = lookup.BuilderLookup.cmd_lookup(args)
+                ret = lookup.cmd_lookup(args)
         finally:
             gen_paths.BUILDERS_OUTPUT_DIR = original
 
@@ -153,8 +49,8 @@ class CmdLookupTest(unittest.TestCase):
 
     def test_unknown_builder_raises(self):
         args = argparse.Namespace(builder='does-not-exist', quiet=True)
-        with self.assertRaises(lookup.BotsError):
-            lookup.BuilderLookup.cmd_lookup(args)
+        with self.assertRaises(generated_output.BotsError):
+            lookup.cmd_lookup(args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR introduces a basic implmentation for `bots.py gen`, which
generates the output folder, with `args.gn` and `brave_secrets.gni`
provided for the build folder, and `gn gen` called for it.

The implementation for the secrets is still stubbed off and only
assigning `dummy` values.

Bug: https://github.com/brave/brave-browser/issues/47912
