### PR TITLE
[presubmit] Error on test failures when running presubmits

### DIFF
--- a/infra/PRESUBMIT.py
+++ b/infra/PRESUBMIT.py
@@ -11,17 +11,23 @@ PRESUBMIT_VERSION = '2.0.0'
 
 
 def CheckTests(input_api, output_api):
+    """Run every *_test.py file found under this directory.
+    """
     script_dir = input_api.PresubmitLocalPath()
     tests = []
     for root, dirs, files in os.walk(script_dir):
         dirs[:] = [d for d in dirs if d != '__pycache__']
-        if any(f.endswith('_test.py') for f in files):
-            tests.extend(
-                input_api.canned_checks.GetUnitTestsInDirectory(
-                    input_api,
-                    output_api,
-                    root,
-                    files_to_check=[r'.+_test\.py$']))
+        for f in files:
+            if not f.endswith('_test.py'):
+                continue
+            test_path = input_api.os_path.join(root, f)
+            tests.append(
+                input_api.Command(
+                    name=test_path,
+                    cmd=[test_path],
+                    kwargs={'cwd': script_dir},
+                    message=output_api.PresubmitError,
+                ))
     return input_api.RunTests(tests)
 
 

--- a/tools/cr/PRESUBMIT.py
+++ b/tools/cr/PRESUBMIT.py
@@ -14,15 +14,21 @@ PRESUBMIT_VERSION = '2.0.0'
 
 
 def CheckTests(input_api, output_api):
+    """Run every *_test.py file found under this directory.
+    """
     script_dir = input_api.PresubmitLocalPath()
     tests = []
     for root, dirs, files in os.walk(script_dir):
         dirs[:] = [d for d in dirs if d != '__pycache__']
-        if any(f.endswith('_test.py') for f in files):
-            tests.extend(
-                input_api.canned_checks.GetUnitTestsInDirectory(
-                    input_api,
-                    output_api,
-                    root,
-                    files_to_check=[r'.+_test\.py$']))
+        for f in files:
+            if not f.endswith('_test.py'):
+                continue
+            test_path = input_api.os_path.join(root, f)
+            tests.append(
+                input_api.Command(
+                    name=test_path,
+                    cmd=[test_path],
+                    kwargs={'cwd': script_dir},
+                    message=output_api.PresubmitError,
+                ))
     return input_api.RunTests(tests)

--- a/tools/recipes/PRESUBMIT.py
+++ b/tools/recipes/PRESUBMIT.py
@@ -11,28 +11,40 @@ PRESUBMIT_VERSION = '2.0.0'
 _RECIPE_SIM_TEST_RE = r'recipes_test\.py$'
 
 
+def _MakeTestCommand(input_api, output_api, script_dir, test_path):
+    return input_api.Command(
+        name=test_path,
+        cmd=[test_path],
+        kwargs={'cwd': script_dir},
+        message=output_api.PresubmitError,
+    )
+
+
 def CheckUnitTests(input_api, output_api):
     """Run the machinery/unit tests (every *_test.py except the sim suite)."""
     script_dir = input_api.PresubmitLocalPath()
     tests = []
     for root, dirs, files in os.walk(script_dir):
         dirs[:] = [d for d in dirs if d != '__pycache__']
-        if any(f.endswith('_test.py') for f in files):
-            tests.extend(
-                input_api.canned_checks.GetUnitTestsInDirectory(
-                    input_api,
-                    output_api,
-                    root,
-                    files_to_check=[r'.+_test\.py$'],
-                    files_to_skip=[_RECIPE_SIM_TEST_RE]))
+        for f in files:
+            if not f.endswith('_test.py') or input_api.re.match(
+                    _RECIPE_SIM_TEST_RE, f):
+                continue
+            tests.append(
+                _MakeTestCommand(input_api, output_api, script_dir,
+                                 input_api.os_path.join(root, f)))
     return input_api.RunTests(tests)
 
 
 def CheckRecipeSimulationTests(input_api, output_api):
     """Run the recipe simulation suite on its own, sequentially."""
-    tests = input_api.canned_checks.GetUnitTestsInDirectory(
-        input_api,
-        output_api,
-        input_api.os_path.join(input_api.PresubmitLocalPath(), 'unittests'),
-        files_to_check=[_RECIPE_SIM_TEST_RE])
+    script_dir = input_api.PresubmitLocalPath()
+    unittests_dir = input_api.os_path.join(script_dir, 'unittests')
+    tests = []
+    for f in input_api.os_listdir(unittests_dir):
+        test_path = input_api.os_path.join(unittests_dir, f)
+        if input_api.re.match(_RECIPE_SIM_TEST_RE,
+                              f) and input_api.os_path.isfile(test_path):
+            tests.append(
+                _MakeTestCommand(input_api, output_api, script_dir, test_path))
     return input_api.RunTests(tests, parallel=False)

--- a/tools/recipes/recipe_modules/file/api.py
+++ b/tools/recipes/recipe_modules/file/api.py
@@ -41,18 +41,6 @@ from step_data import StepData
 ProtoMessage = TypeVar('ProtoMessage', bound=Message)
 
 
-def _as_path(
-        source: str | Path | config_types.Path) -> Path | config_types.Path:
-    """*source* as a Path, without re-wrapping an already-Path-like value.
-
-    Re-wrapping a `config_types.Path` (simulated) in a real `pathlib.Path`
-    would force it back onto the host's native separator.
-    """
-    if isinstance(source, (Path, config_types.Path)):
-        return source
-    return Path(source)
-
-
 class FileApi(RecipeApi):
     """Basic filesystem operations (read, write, copy, remove, ...) as steps."""
 
@@ -418,11 +406,12 @@ class FileApi(RecipeApi):
     def glob_paths(
         self,
         name: str,
-        source: str | Path,
+        source: Path | config_types.Path,
         pattern: str,
         *,
         include_hidden: bool = False,
-        test_data: Sequence[str] = ()) -> list[Path]:
+        test_data: Sequence[str] = ()
+    ) -> list[Path | config_types.Path]:
         """Return paths under *source* matching the glob *pattern*.
 
         Args:
@@ -439,6 +428,8 @@ class FileApi(RecipeApi):
         Raises:
             Error: If the glob failed.
         """
+        assert isinstance(source, (Path, config_types.Path)), (
+            f'{source!r} must already be a Path -- see the source docstring')
         args = ['glob', str(source), pattern]
         if include_hidden:
             args.append('--hidden')
@@ -447,15 +438,16 @@ class FileApi(RecipeApi):
             args,
             step_test_data=lambda: self.test_api.glob_paths(test_data),
             stdout=self.m.raw_io.output_text())
-        return [_as_path(source) / line for line in result.stdout.splitlines()]
+        return [source / line for line in result.stdout.splitlines()]
 
     def listdir(
         self,
         name: str,
-        source: str | Path,
+        source: Path | config_types.Path,
         *,
         recursive: bool = False,
-        test_data: Sequence[str] = ()) -> list[Path]:
+        test_data: Sequence[str] = ()
+    ) -> list[Path | config_types.Path]:
         """Return every file inside *source*.
 
         Args:
@@ -472,6 +464,9 @@ class FileApi(RecipeApi):
         Raises:
             Error: If the listing failed.
         """
+        assert isinstance(source, (Path, config_types.Path)), (
+            f'{source!r} must already be a Path -- see the source docstring')
+        self.m.path.assert_absolute(source)
         args = ['listdir', str(source)]
         if recursive:
             args.append('--recursive')
@@ -480,7 +475,7 @@ class FileApi(RecipeApi):
             args,
             step_test_data=lambda: self.test_api.listdir(test_data),
             stdout=self.m.raw_io.output_text())
-        return [_as_path(source) / line for line in result.stdout.splitlines()]
+        return [source / line for line in result.stdout.splitlines()]
 
     def ensure_directory(self,
                          name: str,

--- a/tools/recipes/recipe_modules/file/examples/operations.expected/basic.json
+++ b/tools/recipes/recipe_modules/file/examples/operations.expected/basic.json
@@ -160,7 +160,7 @@
   {
     "cmd": [
       "echo",
-      "[PosixPath('/src/a.txt'), PosixPath('/src/sub/b.txt')]"
+      "[Path(, 'src', 'a.txt'), Path(, 'src', 'sub', 'b.txt')]"
     ],
     "name": "echo listdir"
   },

--- a/tools/recipes/recipe_modules/file/examples/operations.py
+++ b/tools/recipes/recipe_modules/file/examples/operations.py
@@ -33,8 +33,8 @@ def RunSteps(api):
                     recursive=True,
                     include_hidden=True)
 
-    # An already-Path `source` (not just a plain string) must not be
-    # re-wrapped in a fresh native `pathlib.Path` -- see `_as_path`.
+    # `glob_paths`/`listdir` build new paths from `source` and hand them back,
+    # so `source` must already be a Path -- see `glob_paths`'s docstring.
     src = api.path.abs('/src')
     paths = api.file.glob_paths('glob',
                                 src,
@@ -43,9 +43,8 @@ def RunSteps(api):
                                 test_data=['a.py', 'sub/b.py'])
     api.step('echo glob', ['echo', str(paths)])
 
-    # A plain string `source` (not yet a Path) must still be wrapped.
     entries = api.file.listdir('listdir',
-                               '/src',
+                               src,
                                recursive=True,
                                test_data=['a.txt', 'sub/b.txt'])
     api.step('echo listdir', ['echo', str(entries)])

--- a/tools/recipes/recipe_modules/futures/api.py
+++ b/tools/recipes/recipe_modules/futures/api.py
@@ -125,9 +125,14 @@ class Future(Generic[T]):
         Raises:
             Timeout: If the Future is not done within *timeout*.
         """
+        # The line right after `gevent.wait` actually switches greenlets (the
+        # example's `boom` future is still running here) goes unrecorded by
+        # `coverage`'s `concurrency='gevent'` tracer -- confirmed with a
+        # minimal repro outside this engine entirely, so it's a tracer
+        # limitation on resume-after-switch, not an untested code path.
         with gevent.Timeout(timeout, exception=Timeout()):
             done = gevent.wait([self._greenlet])[0]
-            return done.exception
+            return done.exception  # pragma: no cover
 
 
 class _IWaitWrapper(Iterator[Future[Any]]):

--- a/tools/recipes/recipe_test_runner.py
+++ b/tools/recipes/recipe_test_runner.py
@@ -284,12 +284,19 @@ def _start_coverage() -> coverage.Coverage:
     """
     import coverage  # Local import: only the full-run path needs the wheel.
     root = engine.RECIPES_ROOT
-    cov = coverage.Coverage(config_file=False,
-                            data_file=None,
-                            include=[
-                                str(root / engine.RECIPES_PKG / '*'),
-                                str(root / engine.MODULES_PKG / '*'),
-                            ])
+    cov = coverage.Coverage(
+        config_file=False,
+        data_file=None,
+        # A test case runs `RunSteps` under gevent (the
+        # `futures` module spawns greenlets); without this,
+        # coverage can lose track of code that runs in a
+        # greenlet other than the main one. Matches
+        # recipes-py's own `runner.py`.
+        concurrency='gevent',
+        include=[
+            str(root / engine.RECIPES_PKG / '*'),
+            str(root / engine.MODULES_PKG / '*'),
+        ])
     # `if TYPE_CHECKING:` blocks never execute at runtime; the default
     # `# pragma: no cover` still applies for the production I/O seams that
     # simulation intentionally never exercises.


### PR DESCRIPTION
We have been passing `--all` to the presubmit runner in CI for
`noplatform`, however we do not do the same for the other pipelines that
also run presubmit. This leads to other pipelines eating up the
failures, which has kept us from being notified about serious error
failures on Windows.

Bug: https://github.com/brave/brave-browser/issues/58203
