### PR TITLE
Fix cr-icon overrides broken by upstream's icon-rounding/normalizatn rename

### DIFF
--- a/chromium_src/ui/webui/resources/cr_elements/cr_icon/cr_icon.ts
+++ b/chromium_src/ui/webui/resources/cr_elements/cr_icon/cr_icon.ts
@@ -70,8 +70,8 @@ const iconMap: { [key: string]: string } = {
     'privacy:content-paste-off': 'copy-off', // clipboard off
     'privacy:credit-card': 'credit-card', // payment handlers
     'privacy:credit-card-off': 'credit-card-off', // payment handlers
-    'settings:bluetooth-scanning': 'bluetooth', // bluetooth scanning
-    'settings:bluetooth-off': 'bluetooth-off', // bluetooth off
+    'settings:bluetooth-searching': 'bluetooth', // bluetooth searching
+    'settings:bluetooth-disabled': 'bluetooth-off', // bluetooth off
     'privacy:warning': 'warning-triangle-outline', // insecure content
     'privacy:federated-identity-api': '', // federated identity (unused)
     'privacy:cardboard': 'virtual-reality', // virtual reality & augmented reality
@@ -83,10 +83,11 @@ const iconMap: { [key: string]: string } = {
     'privacy:zoom-in': 'search-zoom-in', // zoom levels
     'privacy:drive-pdf': 'file', // pdfs
     'privacy:open-in-browser': 'window', // open in browser
-    'settings20:chrome-filled': 'hearts',
+    'settings20:chrome-product': 'hearts',
     'settings20:incognito-unfilled': 'product-private-window',
     'settings20:incognito': 'product-private-window',
     'settings20:lightbulb': 'idea',
+    'settings20:lightbulb-2': 'idea',
     'cr:delete': 'trash', // delete browsing data
     'cr:security': 'lock',
     'privacy:page-info-old': 'tune', // privacy page additional settings
@@ -127,7 +128,12 @@ proto.updateIcon_ = function (this: CrIconElement, ...args: unknown[]) {
         for (const node of this.shadowRoot.querySelectorAll(type)) node.remove()
     }
 
-    const name = iconMap[this.icon]
+    // Upstream's `kWebUIRoundedIcons` rollout picks between a rounded icon name
+    // and a legacy "-old" suffixed name at runtime depending on the feature
+    // state. Both refer to the same icon, so strip the suffix before mapping to
+    // keep overrides working regardless of the feature's enabled state.
+    const unroundedIcon = this.icon.replace(/-old$/, '')
+    const name = iconMap[this.icon] ?? iconMap[unroundedIcon]
     if (name || leoIcons.has(this.icon)) {
         removeAllOfType('svg')
 


### PR DESCRIPTION
Upstream's GlowUp icon-rounding effort renamed several icon IDs referenced by our `iconMap` overrides and introduced an `-old` suffix convention for icons still gated behind the disabled-by-default `kWebUIRoundedIcons` flag. Both patterns silently fell through to upstream's native icon instead of our Leo icon. Strip the `-old` suffix before lookup and update the map keys that were renamed outright.

Chromium changes:
https://chromium.googlesource.com/chromium/src/+/ae25a050e5daba7c46684a9947187c39f9e10370

commit ae25a050e5daba7c46684a9947187c39f9e10370
Author: Emily Shack <emshack@chromium.org>
Date:   Fri Jul 17 10:17:13 2026 -0700

    [GlowUp] Round settings privacy icons (3/4)

    This CL rounds 15 icons to keep CL size manageable, the other icons will
    be addressed in follow-ups as settings/privacy_icons.html is a large
    file.

    See go/chrome-icon-modernization-dd. This is part of a larger effort to
    standardize icon naming, enabling easier bulk updates in the future, as
    well as applying 100% roundedness to all existing icons.

    Bug: 511303545
    Change-Id: Ic8203881c0ccfbbddfdd041ebc667eda74a6da30
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8076302
    Commit-Queue: Emily Shack <emshack@chromium.org>
    Reviewed-by: Mohamed Amir Yosef <mamir@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#1664005}

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58201

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
