### PR TITLE
Features selection - List of updates

### DIFF
--- a/browser/resources/brave_welcome_page/components/product_card.style.ts
+++ b/browser/resources/brave_welcome_page/components/product_card.style.ts
@@ -3,27 +3,41 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { color, radius, spacing } from '@brave/leo/tokens/css/variables'
+import {
+  color,
+  duration,
+  easing,
+  icon,
+  radius,
+  spacing,
+} from '@brave/leo/tokens/css/variables'
 import { scoped } from '$web-common/scoped_css'
 
 export const style = scoped.css`
   & {
+    --leo-checkbox-size: ${icon.l};
+
     display: flex;
     gap: ${spacing['2Xl']};
     align-items: center;
-    padding: ${spacing.xl};
+    padding: ${spacing.xl} ${spacing['2Xl']} ${spacing.xl} ${spacing.xl} ;
     border-radius: ${radius.xl};
     background: ${color.material.regular};
+    cursor: pointer;
+    transition:
+      opacity ${duration.s} ${easing.out},
+      filter ${duration.s} ${easing.out};
+  }
+
+  &.unchecked {
+    opacity: 0.5;
+    filter: grayscale(1);
   }
 
   img {
     width: 100px;
     height: auto;
     border-radius: ${radius.l};
-  }
-
-  h3 {
-    opacity: 0.9;
   }
 
   p {

--- a/browser/resources/brave_welcome_page/components/product_card.tsx
+++ b/browser/resources/brave_welcome_page/components/product_card.tsx
@@ -22,7 +22,11 @@ interface Props {
 
 export function ProductCard(props: Props) {
   return (
-    <div data-css-scope={style.scope}>
+    <div
+      data-css-scope={style.scope}
+      className={props.checked ? undefined : 'unchecked'}
+      onClick={() => props.onChange(!props.checked)}
+    >
       <img src={props.image} />
       <div className='text'>
         <h3>{props.title}</h3>
@@ -35,6 +39,7 @@ export function ProductCard(props: Props) {
                 href={props.learnMoreUrl}
                 target='_blank'
                 rel='noopener noreferrer'
+                onClick={(event) => event.stopPropagation()}
               >
                 {getString('WELCOME_PAGE_LEARN_MORE_LINK_LABEL')}
               </SecureLink>


### PR DESCRIPTION
## Summary
- Make the entire product card clickable so it toggles the checkbox, while the Learn more link still opens without changing selection.
- Size the Leo checkbox at 24px (`icon.l`).
- When unchecked, fade the card to 50% opacity and apply a grayscale filter, with a short opacity/filter transition.

- Resolves https://github.com/brave/brave-browser/issues/58211

## Test plan
- [ ] On the welcome features and metrics steps, clicking anywhere on a product card checks/unchecks it.
- [ ] Clicking Learn more opens the link and does not toggle the card.
- [ ] Unchecked cards are dimmed (0.5 opacity) and grayscale; checked cards are full color.
- [ ] The opacity and grayscale change animates instead of snapping.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->