### PR TITLE
[recipes] Platform-independent Path for the `path` module

### DIFF
--- a/tools/recipes/config_types.py
+++ b/tools/recipes/config_types.py
@@ -1,0 +1,305 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Copyright 2013 The LUCI Authors
+# Use of this source code is governed under the Apache License, Version 2.0
+# that can be found in the LICENSE file.
+"""A platform-independent `Path`, ported from recipes-py's `config_types.py`.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+from dataclasses import dataclass, field
+from typing import ClassVar, Generator
+
+
+def reset_global_variable_assignments() -> None:
+    """Resets `Path._OS_SEP` to `None`.
+
+    Called by the test runner before each test case, so a case whose `DEPS`
+    never instantiate the `path` module doesn't inherit a stale separator left
+    behind by a previous case.
+    """
+    Path._OS_SEP = None
+
+
+# These two exception classes inherit from ValueError because the
+# corresponding errors in stdlib `pathlib` use ValueError.
+class RelativeToDifferentBases(ValueError):
+    pass
+
+
+class RelativeToNotParent(ValueError):
+    pass
+
+
+@dataclass(frozen=True, order=True)
+class ResolvedBasePath:
+    """A resolved base path.
+
+    In test mode this holds a literal placeholder string like `'[CACHE]'`,
+    `'[HOME]'`, the token *being* the value, from construction, so there is
+    nothing to rewrite into a token later. Outside of test mode it holds a
+    real absolute filesystem path string.
+    """
+    resolved: str
+
+    def __repr__(self) -> str:
+        return self.resolved
+
+
+@dataclass(frozen=True)
+class Path:
+    """An absolute path, relative to a `ResolvedBasePath` base.
+
+    Made aware of the currently simulated path separator via the `path`
+    recipe module's `initialise()`, which assigns to this class's `_OS_SEP`.
+    """
+    base: ResolvedBasePath
+    pieces: tuple[str, ...]
+
+    # HACK: directly assigned to by the `path` recipe module, populated with
+    # the current (possibly simulated) path separator character ('/' or
+    # '\\'). Reset between test cases by reset_global_variable_assignments().
+    _OS_SEP: ClassVar[str | None] = None
+
+    # Caches the output of __str__. Not a @functools.cache on __str__ itself.
+    # since that would create a global dict keyed by Path instances that
+    # captures whatever _OS_SEP was at call time, even though _OS_SEP can
+    # change between test cases -- the plain instance field self-invalidates
+    # by construction (a fresh Path is built every time a base path changes).
+    _str: str | None = field(default=None,
+                             repr=False,
+                             hash=False,
+                             compare=False)
+
+    def __init__(self, base: ResolvedBasePath, *pieces: str):
+        """Creates a Path.
+
+        Args:
+            base: The ResolvedBasePath this Path is relative to.
+            pieces: The components of the path relative to base.
+                - Pieces are always split on '/'. If `_OS_SEP` is '\\'
+                  (a simulated Windows run), pieces are also split on '\\'.
+                - A '..' piece must not go above `base`: `Path(base, '..',
+                  'x')` raises ValueError, but `Path(base, 'x', '..')` is OK
+                  (equivalent to `Path(base)`).
+                - Empty pieces and '.' pieces are ignored.
+                - A piece containing '\\' before `_OS_SEP` is known (i.e.
+                  before the `path` module has initialised) raises
+                  ValueError -- use '/' instead.
+        """
+        super().__init__()
+        if not isinstance(base, ResolvedBasePath):
+            raise ValueError(
+                'First argument to Path must be a ResolvedBasePath, got '
+                f'{base!r} ({type(base)!r})')
+
+        has_backslashes = False
+        for i, piece in enumerate(pieces):
+            if not isinstance(piece, str):
+                raise ValueError(
+                    'Variadic arguments to Path must only be `str`, '
+                    f'argument {i} was {piece!r} ({type(piece)!r})')
+            has_backslashes = has_backslashes or '\\' in piece
+
+        # We always separate on '/', regardless of _OS_SEP, since callers
+        # routinely pass pieces that already contain a slash. A backslash is
+        # ambiguous before _OS_SEP is known, so it's rejected outright rather
+        # than guessed at.
+        if self._OS_SEP is None and has_backslashes:
+            raise ValueError(
+                f'Cannot instantiate Path({base!r}, {pieces!r}) - pieces '
+                'contain a backslash and the path module has not been '
+                'initialised yet. Use "/" (even for windows) or pass the '
+                'pieces to join separately.')
+        need_backslash_split = has_backslashes and self._OS_SEP == '\\'
+
+        normalized_pieces = []
+        for piece in pieces:
+            slash_pieces = piece.split('/')
+            if need_backslash_split:
+                new_slash_pieces = []
+                for sp in slash_pieces:
+                    new_slash_pieces.extend(sp.split(self._OS_SEP))
+                slash_pieces = new_slash_pieces
+            normalized_pieces.extend(p for p in slash_pieces if p and p != '.')
+
+        # Collapse '..' against the immediately preceding piece. Starting at
+        # index 1 (not 0) means a leading '..' is never collapsed inline. it
+        # falls through to the check below and raises instead.
+        i = 1
+        while 0 < i < len(normalized_pieces):
+            piece = normalized_pieces[i]
+            if piece == '..':
+                normalized_pieces[i - 1:i + 1] = []
+                i -= 1
+            else:
+                i += 1
+
+        if normalized_pieces and normalized_pieces[0] == '..':
+            raise ValueError(
+                f'Unable to compute {base!r} / {pieces!r} without going '
+                'above the base.')
+
+        # Frozen dataclass: assign via object.__setattr__ (documented escape
+        # hatch for frozen-instance __init__).
+        object.__setattr__(self, 'base', base)
+        object.__setattr__(self, 'pieces', tuple(normalized_pieces))
+
+    @property
+    def parents(self) -> Generator[Path, None, None]:
+        """For 'foo/bar/baz', yield 'foo/bar' then 'foo'."""
+        prev: Path = self
+        curr: Path = self.parent
+        while prev != curr:
+            yield curr
+            prev, curr = curr, curr.parent
+
+    @property
+    def parent(self) -> Path:
+        """For 'foo/bar/baz', return 'foo/bar'."""
+        return Path(self.base, *self.pieces[0:-1])
+
+    @property
+    def name(self) -> str:
+        """For 'foo/bar/baz', return 'baz'."""
+        return self.pieces[-1]
+
+    @property
+    def stem(self) -> str:
+        """For 'dir/foo.tar.gz', return 'foo.tar'."""
+        return self.name.rsplit('.', 1)[0]
+
+    @property
+    def suffix(self) -> str:
+        """For 'dir/foo.tar.gz', return '.gz'."""
+        parts = self.name.rsplit('.', 1)
+        if len(parts) == 1:
+            return ''
+        return '.' + parts[1]
+
+    @property
+    def suffixes(self) -> list[str]:
+        """For 'dir/foo.tar.gz', return ['.tar', '.gz']."""
+        return [f'.{x}' for x in self.name.split('.')[1:]]
+
+    def as_posix(self) -> str:
+        """The '/'-joined form of this path, regardless of `_OS_SEP`.
+
+        Not part of upstream recipes-py: needed so callers that must key a
+        path deterministically (e.g. a simulated filesystem's lookup table)
+        aren't at the mercy of whichever separator the current test case
+        happens to simulate.
+        """
+        return '/'.join(itertools.chain((str(self.base), ), self.pieces))
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, str):
+            return str(self) == other
+        if not isinstance(other, Path):
+            return NotImplemented
+        return self.base == other.base and self.pieces == other.pieces
+
+    def __lt__(self, other: object) -> bool:
+        if isinstance(other, str):
+            return str(self) < other
+        if not isinstance(other, Path):
+            return NotImplemented
+        return (self.base, self.pieces) < (other.base, other.pieces)
+
+    def __truediv__(self, piece: str | Path) -> Path:
+        """Shorthand '/'-operator for .joinpath(), returning a new path."""
+        return self.joinpath(piece)
+
+    def joinpath(self, *pieces: str | Path) -> Path:
+        """Appends *pieces to this Path, returning a new Path.
+
+        Args:
+            pieces: The components of the path relative to base. If a
+                component is a Path instance, the returned path is
+                equivalent to calling joinpath on that component with any
+                following components (an absolute-path "reroot", matching
+                stdlib pathlib's joinpath behavior for absolute paths). The
+                normal Path __init__ rules for '..' and '.' apply.
+
+        Returns:
+            The new Path.
+        """
+        if not pieces:
+            return self
+        for i, p in enumerate(pieces):
+            if isinstance(p, Path):
+                return p.joinpath(*pieces[i + 1:])
+        return Path(
+            self.base,
+            # Propagate None so an accidental join with None raises in
+            # Path.__init__'s type check, rather than being silently dropped.
+            *[
+                p for p in itertools.chain(self.pieces, pieces)
+                if p or p is None
+            ])
+
+    def __str__(self) -> str:
+        if self._str is None:
+            if not self._OS_SEP:
+                raise ValueError(
+                    'Unable to render Path to string - the path module has '
+                    'not been initialised yet.')
+            str_val = self._OS_SEP.join(
+                itertools.chain((str(self.base), ), self.pieces))
+            object.__setattr__(self, '_str', str_val)
+            return str_val
+        return self._str
+
+    def __repr__(self) -> str:
+        s = 'Path(%r' % (self.base, )
+        if self.pieces:
+            s += ', %s' % ', '.join(repr(x) for x in self.pieces)
+        return s + ')'
+
+    def __hash__(self) -> int:
+        return hash(('config_types.Path', self.base, self.pieces))
+
+    def relative_to(self, other: Path, *, walk_up: bool = False) -> str:
+        """Gives one path relative to another, as a plain (always '/'-joined,
+        regardless of `_OS_SEP`) string.
+
+        Examples:
+            '[CACHE]/foo/bar'.relative_to('[CACHE]/foo') -> 'bar'
+            '[CACHE]/foo/bar/baz'.relative_to('[CACHE]/foo') -> 'bar/baz'
+            '[CACHE]/foo'.relative_to('[CACHE]/bar') -> ValueError
+            '[CACHE]/foo'.relative_to('[CACHE]/bar', walk_up=True)
+                -> '../foo'
+            '[CACHE]/foo'.relative_to('[CLEANUP]/bar') -> ValueError
+
+        Assumes other is a directory.
+
+        Args:
+            other: Path to give self relative to.
+            walk_up: Allow '..' in the return value.
+        """
+        if self.base != other.base:
+            raise RelativeToDifferentBases(
+                f'{self!r} and {other!r} have different bases')
+
+        if not walk_up and other not in self.parents:
+            raise RelativeToNotParent(
+                f'{other!r} not in parents of {self!r} and walk_up=False')
+
+        result = []
+
+        for parent in itertools.chain([self], self.parents):
+            if parent != other and parent not in other.parents:
+                result.append(parent.name)
+
+        for parent in itertools.chain([other], other.parents):
+            if parent == self or parent in self.parents:
+                break
+            result.append('..')
+
+        return '/'.join(reversed(result))

--- a/tools/recipes/engine.py
+++ b/tools/recipes/engine.py
@@ -197,13 +197,14 @@ class _Engine:
         # in test mode: it seeds this onto every module (so the seam modules
         # simulate I/O) and does not touch the real cwd.
         self._test = test
+
         # Root directory the job runs in. Recipe paths (b/src, out, ...) are
-        # derived from it by the `path` module.
+        # derived from it by the `path` module. In test mode this value is
+        # never actually read: `PathApi`'s properties branch on `self._test`
+        # directly and return a `[WORKSPACE]`-rooted `config_types.Path`
+        # instead.
         if self._test is not None:
-            # Fixed synthetic workspace so module-derived paths are
-            # deterministic; never chdir'd into (nothing runs on disk).
-            from simulation import SIM_WORKSPACE
-            self._workspace = Path(str(SIM_WORKSPACE))
+            self._workspace = Path.cwd()
         elif workspace:
             self._workspace = Path(workspace).expanduser().resolve()
             # Run from the workspace so every subprocess the recipes launch

--- a/tools/recipes/recipe_modules/brave_core_checkout/api.py
+++ b/tools/recipes/recipe_modules/brave_core_checkout/api.py
@@ -11,6 +11,7 @@ import contextlib
 import logging
 from pathlib import Path, PurePosixPath
 
+import config_types
 from recipe_api import RecipeApi
 
 # Default SSH remote for the brave-core repository.
@@ -83,7 +84,7 @@ class BraveCoreCheckoutApi(RecipeApi):
         """
         if dest is None:
             dest = self.m.path.brave_core
-        single = isinstance(paths, (str, Path))
+        single = isinstance(paths, (str, Path, config_types.Path))
         rel_paths = [str(paths)] if single else [str(p) for p in paths]
         if not rel_paths:
             raise ValueError('deploy() requires at least one path')

--- a/tools/recipes/recipe_modules/chromium_checkout/api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/api.py
@@ -15,9 +15,8 @@ import subprocess
 
 from recipe_api import RecipeApi
 
-# A file that is reliably present in any Chromium checkout, used as a token to
-# decide whether a path holds a valid repo.
-CHROME_VERSION_FILE = Path('chrome/VERSION')
+# `chrome/VERSION` is a reliable fingerprint for a Chromium repo.
+CHROME_VERSION_FILE = 'chrome/VERSION'
 
 # Hermetic Windows toolchain base URL, so the checkout can build without a local
 # Visual Studio install. Set only when not already configured by the caller.
@@ -125,7 +124,7 @@ class ChromiumCheckoutApi(RecipeApi):
 
     def has_valid_checkout(self, chromium_src: str | Path) -> bool:
         """Return whether *chromium_src* points to a valid Chromium repo."""
-        chromium_src = Path(chromium_src)
+        chromium_src = self.m.path.abs(chromium_src)
         # `chrome/VERSION` is an unmistakable trait of a proper checkout.
         if not self.m.path.exists(chromium_src / CHROME_VERSION_FILE):
             return False
@@ -169,7 +168,7 @@ class ChromiumCheckoutApi(RecipeApi):
         (branch/tag/commit) isn't known ahead of time, so it's re-pointed at
         the mirror and *ref* is fetched and checked out explicitly.
         """
-        chromium_src = Path(chromium_src)
+        chromium_src = self.m.path.abs(chromium_src)
         is_tag = bool(ref and _is_tag_ref(ref))
         is_commit = bool(ref and not is_tag and _is_commit_hash_ref(ref))
         is_qualified_ref = bool(ref and not is_tag and not is_commit

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_hermetic_toolchain.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_hermetic_toolchain.json
@@ -6,7 +6,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/b/src/third_party/depot_tools"
+      "[WORKSPACE]\\b\\src\\third_party\\depot_tools"
     ],
     "env": {
       "CHROME_HEADLESS": "1"
@@ -30,7 +30,7 @@
       "--oneline",
       "chrome/VERSION"
     ],
-    "cwd": "[WORKSPACE]/b/src",
+    "cwd": "[WORKSPACE]\\b\\src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -77,7 +77,7 @@
       "origin",
       "/b/cache/chromium.googlesource.com-chromium-src"
     ],
-    "cwd": "[WORKSPACE]/b/src",
+    "cwd": "[WORKSPACE]\\b\\src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -92,7 +92,7 @@
       "origin",
       "https://chromium.googlesource.com/chromium/src.git"
     ],
-    "cwd": "[WORKSPACE]/b/src",
+    "cwd": "[WORKSPACE]\\b\\src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -105,7 +105,7 @@
       "origin",
       "main"
     ],
-    "cwd": "[WORKSPACE]/b/src",
+    "cwd": "[WORKSPACE]\\b\\src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -118,7 +118,7 @@
       "--force",
       "FETCH_HEAD"
     ],
-    "cwd": "[WORKSPACE]/b/src",
+    "cwd": "[WORKSPACE]\\b\\src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -126,10 +126,10 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3.bat",
+      "[WORKSPACE]\\b\\src\\third_party\\depot_tools\\vpython3.bat",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/chromium_checkout/resources/win_toolchain_hash.py",
-      "[WORKSPACE]/b/src/build/vs_toolchain.py",
+      "[WORKSPACE]\\b\\src\\build\\vs_toolchain.py",
       "https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-2.on.aws/windows-hermetic-toolchain/",
       "--json-output",
       "/path/to/tmp/json"
@@ -146,7 +146,7 @@
       "--force",
       "-D"
     ],
-    "cwd": "[WORKSPACE]/b/src",
+    "cwd": "[WORKSPACE]\\b\\src",
     "env": {
       "CHROME_HEADLESS": "1"
     },

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_toolchain_hash_pinned.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_toolchain_hash_pinned.json
@@ -6,7 +6,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/b/src/third_party/depot_tools"
+      "[WORKSPACE]\\b\\src\\third_party\\depot_tools"
     ],
     "env": {
       "CHROME_HEADLESS": "1"
@@ -30,7 +30,7 @@
       "--oneline",
       "chrome/VERSION"
     ],
-    "cwd": "[WORKSPACE]/b/src",
+    "cwd": "[WORKSPACE]\\b\\src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -77,7 +77,7 @@
       "origin",
       "/b/cache/chromium.googlesource.com-chromium-src"
     ],
-    "cwd": "[WORKSPACE]/b/src",
+    "cwd": "[WORKSPACE]\\b\\src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -92,7 +92,7 @@
       "origin",
       "https://chromium.googlesource.com/chromium/src.git"
     ],
-    "cwd": "[WORKSPACE]/b/src",
+    "cwd": "[WORKSPACE]\\b\\src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -105,7 +105,7 @@
       "origin",
       "main"
     ],
-    "cwd": "[WORKSPACE]/b/src",
+    "cwd": "[WORKSPACE]\\b\\src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -118,7 +118,7 @@
       "--force",
       "FETCH_HEAD"
     ],
-    "cwd": "[WORKSPACE]/b/src",
+    "cwd": "[WORKSPACE]\\b\\src",
     "env": {
       "CHROME_HEADLESS": "1"
     },
@@ -126,10 +126,10 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3.bat",
+      "[WORKSPACE]\\b\\src\\third_party\\depot_tools\\vpython3.bat",
       "-u",
       "[RECIPES_ROOT]/recipe_modules/chromium_checkout/resources/win_toolchain_hash.py",
-      "[WORKSPACE]/b/src/build/vs_toolchain.py",
+      "[WORKSPACE]\\b\\src\\build\\vs_toolchain.py",
       "https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-2.on.aws/windows-hermetic-toolchain/",
       "--json-output",
       "/path/to/tmp/json"
@@ -146,7 +146,7 @@
       "--force",
       "-D"
     ],
-    "cwd": "[WORKSPACE]/b/src",
+    "cwd": "[WORKSPACE]\\b\\src",
     "env": {
       "CHROME_HEADLESS": "1"
     },

--- a/tools/recipes/recipe_modules/context/api.py
+++ b/tools/recipes/recipe_modules/context/api.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from types import MappingProxyType
 from typing import Any
 
+import config_types
 from engine_types import PerGreenletState
 from recipe_api import RecipeApi
 
@@ -57,7 +58,7 @@ class _State(PerGreenletState):
 
     # Defaults are immutable, to prevent them becoming shared global state if
     # something ever mutates in place rather than replacing wholesale.
-    cwd: Path | None = None
+    cwd: Path | config_types.Path | None = None
     env: Mapping[str, str | None] = MappingProxyType({})
     env_prefixes: Mapping[str, tuple[str, ...]] = MappingProxyType({})
     env_suffixes: Mapping[str, tuple[str, ...]] = MappingProxyType({})
@@ -97,7 +98,7 @@ class ContextApi(RecipeApi):
     @contextlib.contextmanager
     def __call__(
         self,
-        cwd: str | Path | None = None,
+        cwd: str | Path | config_types.Path | None = None,
         env_prefixes: Mapping[str, Sequence[str | Path]] | None = None,
         env_suffixes: Mapping[str, Sequence[str | Path]] | None = None,
         env: Mapping[str, str | None] | None = None,
@@ -154,8 +155,13 @@ class ContextApi(RecipeApi):
 
         try:
             if cwd is not None:
-                _check_type('cwd', cwd, (str, Path))
-                _push('cwd', Path(cwd))
+                _check_type('cwd', cwd, (str, Path, config_types.Path))
+                # A `config_types.Path` (simulated) is already the value we
+                # want; only a plain str/real Path needs wrapping.
+                _push(
+                    'cwd',
+                    cwd if isinstance(cwd, (Path,
+                                            config_types.Path)) else Path(cwd))
             _add('env_prefixes', env_prefixes, _as_prefixes)
             _add('env_suffixes', env_suffixes, _as_suffixes)
             _add('env', env, _as_env)
@@ -165,7 +171,7 @@ class ContextApi(RecipeApi):
                 setattr(self._state, member, val)
 
     @property
-    def cwd(self) -> Path | None:
+    def cwd(self) -> Path | config_types.Path | None:
         """The cwd steps run in, or `None` to inherit the engine's cwd."""
         return self._state.cwd
 

--- a/tools/recipes/recipe_modules/depot_tools/api.py
+++ b/tools/recipes/recipe_modules/depot_tools/api.py
@@ -15,7 +15,7 @@ from recipe_api import RecipeApi
 DEPOT_TOOLS_URL = 'https://chromium.googlesource.com/chromium/tools/depot_tools'
 
 # the relative path for depot_tools in the chromium checkout.
-DEPOT_TOOLS_PATH = Path('third_party') / 'depot_tools'
+DEPOT_TOOLS_PATH = 'third_party/depot_tools'
 
 
 class DepotToolsApi(RecipeApi):
@@ -45,7 +45,7 @@ class DepotToolsApi(RecipeApi):
         if resolved is not None:
             logging.debug('depot_tools already on PATH, skipping clone')
             # Using whatever depot_tools is already on PATH.
-            self._depot_tools_path = Path(resolved).parent
+            self._depot_tools_path = self.m.path.abs(resolved).parent
             return
 
         # Checking for a standalone depot_tools inside what would be a supposed

--- a/tools/recipes/recipe_modules/depot_tools/examples/full.expected/windows.json
+++ b/tools/recipes/recipe_modules/depot_tools/examples/full.expected/windows.json
@@ -6,7 +6,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/b/src/third_party/depot_tools"
+      "[WORKSPACE]\\b\\src\\third_party\\depot_tools"
     ],
     "name": "clone depot_tools"
   },
@@ -18,7 +18,7 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3.bat",
+      "[WORKSPACE]\\b\\src\\third_party\\depot_tools\\vpython3.bat",
       "--version"
     ],
     "name": "use vpython3"

--- a/tools/recipes/recipe_modules/env/__init__.py
+++ b/tools/recipes/recipe_modules/env/__init__.py
@@ -4,4 +4,4 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """`env` module: mockable access to environment variables and PATH lookup."""
 
-DEPS = []
+DEPS = ['path']

--- a/tools/recipes/recipe_modules/env/api.py
+++ b/tools/recipes/recipe_modules/env/api.py
@@ -34,9 +34,9 @@ class _RealEnv:  # pragma: no cover - production env backend, not simulated.
     def which(self, cmd: str) -> str | None:
         return shutil.which(cmd)
 
-    def prepend_path(self, entry: str) -> None:
+    def prepend_path(self, entry: str, pathsep: str) -> None:
         current = os.environ.get('PATH', '')
-        os.environ['PATH'] = (os.pathsep.join([entry, current])
+        os.environ['PATH'] = (pathsep.join([entry, current])
                               if current else entry)
 
 
@@ -58,9 +58,9 @@ class _SimEnv:
     def which(self, cmd: str) -> str | None:
         return self._test.which_map.get(cmd)
 
-    def prepend_path(self, entry: str) -> None:
+    def prepend_path(self, entry: str, pathsep: str) -> None:
         current = self._test.env.get('PATH', '')
-        self._test.env['PATH'] = (os.pathsep.join([entry, current])
+        self._test.env['PATH'] = (pathsep.join([entry, current])
                                   if current else entry)
 
 
@@ -100,4 +100,4 @@ class EnvApi(RecipeApi):
 
     def prepend_path(self, entry: str | os.PathLike) -> None:
         """Prepend *entry* to `PATH` so later steps find binaries there."""
-        self._backend.prepend_path(str(entry))
+        self._backend.prepend_path(str(entry), self.m.path.pathsep)

--- a/tools/recipes/recipe_modules/file/__init__.py
+++ b/tools/recipes/recipe_modules/file/__init__.py
@@ -9,4 +9,4 @@ File content travels in and out of the step through placeholders (see
 `api.py`).
 """
 
-DEPS = ['depot_tools', 'json', 'proto', 'raw_io', 'step']
+DEPS = ['depot_tools', 'json', 'path', 'proto', 'raw_io', 'step']

--- a/tools/recipes/recipe_modules/file/api.py
+++ b/tools/recipes/recipe_modules/file/api.py
@@ -27,13 +27,13 @@ written into a step log), which needs step presentation, and `symlink_tree`
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-import os
 from pathlib import Path
 import subprocess
 from typing import Any, TypeVar
 
 from google.protobuf.message import Message
 
+import config_types
 from recipe_api import OutputPlaceholder, Placeholder, RecipeApi
 from recipe_test_api import StepTestData
 from step_data import StepData
@@ -44,6 +44,18 @@ from step_data import StepData
 _FILEUTIL = Path(__file__).resolve().parent / 'resources' / 'fileutil.py'
 
 ProtoMessage = TypeVar('ProtoMessage', bound=Message)
+
+
+def _as_path(
+        source: str | Path | config_types.Path) -> Path | config_types.Path:
+    """*source* as a Path, without re-wrapping an already-Path-like value.
+
+    Re-wrapping a `config_types.Path` (simulated) in a real `pathlib.Path`
+    would force it back onto the host's native separator.
+    """
+    if isinstance(source, (Path, config_types.Path)):
+        return source
+    return Path(source)
 
 
 class FileApi(RecipeApi):
@@ -439,7 +451,7 @@ class FileApi(RecipeApi):
             args,
             step_test_data=lambda: self.test_api.glob_paths(test_data),
             stdout=self.m.raw_io.output_text())
-        return [Path(source) / line for line in result.stdout.splitlines()]
+        return [_as_path(source) / line for line in result.stdout.splitlines()]
 
     def listdir(
         self,
@@ -472,7 +484,7 @@ class FileApi(RecipeApi):
             args,
             step_test_data=lambda: self.test_api.listdir(test_data),
             stdout=self.m.raw_io.output_text())
-        return [Path(source) / line for line in result.stdout.splitlines()]
+        return [_as_path(source) / line for line in result.stdout.splitlines()]
 
     def ensure_directory(self,
                          name: str,
@@ -578,7 +590,7 @@ class FileApi(RecipeApi):
         Raises:
             Error: If hashing failed.
         """
-        rel_paths = [os.path.relpath(str(p), str(base_path)) for p in paths]
+        rel_paths = [self.m.path.relpath(p, base_path) for p in paths]
         result = self._run(
             name, ['compute_hash', str(base_path), *rel_paths],
             step_test_data=lambda: self.test_api.compute_hash(test_data),

--- a/tools/recipes/recipe_modules/file/examples/operations.expected/basic.json
+++ b/tools/recipes/recipe_modules/file/examples/operations.expected/basic.json
@@ -140,7 +140,7 @@
   {
     "cmd": [
       "echo",
-      "[PosixPath('/src/a.py'), PosixPath('/src/sub/b.py')]"
+      "[Path(, 'src', 'a.py'), Path(, 'src', 'sub', 'b.py')]"
     ],
     "name": "echo glob"
   },

--- a/tools/recipes/recipe_modules/file/examples/operations.py
+++ b/tools/recipes/recipe_modules/file/examples/operations.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import post_process
 
-DEPS = ['file', 'step']
+DEPS = ['file', 'path', 'step']
 
 
 def RunSteps(api):
@@ -33,13 +33,17 @@ def RunSteps(api):
                     recursive=True,
                     include_hidden=True)
 
+    # An already-Path `source` (not just a plain string) must not be
+    # re-wrapped in a fresh native `pathlib.Path` -- see `_as_path`.
+    src = api.path.abs('/src')
     paths = api.file.glob_paths('glob',
-                                '/src',
+                                src,
                                 '*.py',
                                 include_hidden=True,
                                 test_data=['a.py', 'sub/b.py'])
     api.step('echo glob', ['echo', str(paths)])
 
+    # A plain string `source` (not yet a Path) must still be wrapped.
     entries = api.file.listdir('listdir',
                                '/src',
                                recursive=True,
@@ -56,8 +60,10 @@ def RunSteps(api):
     api.file.truncate('truncate', '/big.bin', size_mb=10)
     api.file.flatten_single_directories('flatten', '/nested')
 
-    sha = api.file.compute_hash('compute hash', ['/base/a.txt', '/base/dir'],
-                                '/base',
+    base = api.path.abs('/base')
+    sha = api.file.compute_hash('compute hash',
+                                [str(base / 'a.txt'), base / 'dir'],
+                                base,
                                 test_data='deadbeef')
     api.step('echo hash', ['echo', sha])
 
@@ -100,7 +106,7 @@ def GenTests(api):
         api.step_data('file hash', api.file.file_hash('bead')),
         api.step_data('is executable', api.file.is_executable(False)),
         api.post_process(post_process.StepCommandContains, 'echo glob',
-                         ['echo', "[PosixPath('/src/seeded.py')]"]),
+                         ['echo', "[Path(, 'src', 'seeded.py')]"]),
         api.post_process(post_process.StepCommandContains, 'echo sizes',
                          ['echo', '[7]']),
         api.post_process(post_process.StepCommandContains, 'echo hash',

--- a/tools/recipes/recipe_modules/json/api.py
+++ b/tools/recipes/recipe_modules/json/api.py
@@ -23,6 +23,7 @@ from typing import Any
 from google.protobuf import json_format as jsonpb
 from google.protobuf import struct_pb2
 
+import config_types
 from recipe_api import OutputPlaceholder, RecipeApi, returns_placeholder
 
 # JSON is meant to be read by whoever debugs a build, so anything encoded here
@@ -37,7 +38,7 @@ MAX_SAFE_INTEGER = (2**53) - 1
 
 def _default_serializer(obj: Any):
     """Make the types recipes pass around routinely JSON-serializable."""
-    if isinstance(obj, Path):
+    if isinstance(obj, (Path, config_types.Path)):
         return str(obj)
     if isinstance(obj, struct_pb2.Struct):
         # A proto Struct has exactly one sensible JSON form, so coercing it

--- a/tools/recipes/recipe_modules/json/examples/full.py
+++ b/tools/recipes/recipe_modules/json/examples/full.py
@@ -64,7 +64,7 @@ def RunSteps(api):
     # Encoding: `dumps` handles the types recipes pass around routinely; other
     # types raise `TypeError`, same as stdlib's `json.dumps` (see
     # `recipe_modules/json/tests/errors.py`).
-    assert api.json.dumps(api.path.workspace) == '"/b/w"'
+    assert api.json.dumps(api.path.workspace) == '"[WORKSPACE]"'
     assert api.json.dumps(
         struct_pb2.Struct(fields={'foo': struct_pb2.Value(
             string_value='bar')})) == ('{"foo": "bar"}')

--- a/tools/recipes/recipe_modules/osx_sdk/api.py
+++ b/tools/recipes/recipe_modules/osx_sdk/api.py
@@ -13,11 +13,11 @@ from typing import Any
 
 from recipe_api import RecipeApi
 
-# Repo-relative path (under brave-core) to the CLI wrapping `EphemeralXcode`.
-EPHEMERAL_XCODE_SCRIPT = Path('tools/cr/toolchains/ephemeral_xcode.py')
+# Path to `EphemeralXcode`.
+EPHEMERAL_XCODE_SCRIPT = 'tools/cr/toolchains/ephemeral_xcode.py'
 
-# Repo-relative path (under a Chromium checkout) to the macOS SDK pin.
-MAC_SDK_GNI_PATH = Path('build/config/mac/mac_sdk.gni')
+# Path for Chromium's macOS SDK pin.
+MAC_SDK_GNI_PATH = 'build/config/mac/mac_sdk.gni'
 
 # The resource script `ensure()` runs to read `MAC_SDK_GNI_PATH`. Lives
 # alongside this module (not under brave-core), so it's always present -- no

--- a/tools/recipes/recipe_modules/path/__init__.py
+++ b/tools/recipes/recipe_modules/path/__init__.py
@@ -4,4 +4,4 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """Core `path` module: engine-provided, workspace-relative job paths."""
 
-DEPS = []
+DEPS = ['context']

--- a/tools/recipes/recipe_modules/path/api.py
+++ b/tools/recipes/recipe_modules/path/api.py
@@ -6,10 +6,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+import ntpath
 import os
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+import posixpath
 import tempfile
 
+import config_types
 from recipe_api import RecipeApi
 
 
@@ -33,11 +37,58 @@ class _RealFs:  # pragma: no cover - production filesystem backend.
         parent.mkdir(parents=True, exist_ok=True)
         return Path(tempfile.mkdtemp(prefix=f'{prefix}_', dir=parent))
 
+    def mkstemp(self, parent: Path, prefix: str) -> Path:
+        parent.mkdir(parents=True, exist_ok=True)
+        fd, name = tempfile.mkstemp(prefix=f'{prefix}_', dir=parent)
+        os.close(fd)
+        return Path(name)
+
     def abs(self, path: str | Path) -> Path:
         return Path(path).expanduser().resolve()
 
     def home(self) -> Path:
         return Path.home()
+
+    def relpath(self, path: str | Path, start: str | Path) -> str:
+        return os.path.relpath(str(path), str(start))
+
+    def dirname(self, path: str | Path) -> str | Path:
+        return path.parent if isinstance(path, Path) else os.path.dirname(path)
+
+    def basename(self, path: str | Path) -> str:
+        return os.path.basename(str(path))
+
+    def splitext(self, path: str | Path) -> tuple[str | Path, str]:
+        if isinstance(path, Path):
+            return path.parent / path.stem, path.suffix
+        return os.path.splitext(path)
+
+    def join(self, path: str | Path, *paths: str | Path) -> str:
+        return os.path.join(str(path), *[str(p) for p in paths])
+
+    def normpath(self, path: str | Path) -> str:
+        return os.path.normpath(str(path))
+
+    def abspath(self, path: str | Path) -> str:
+        # Not bare os.path.abspath: that skips `~`-expansion, which `abs()`
+        # (and _SimFs.abspath below) does -- routing both through `abs()`
+        # keeps the two backends' contracts identical.
+        return str(self.abs(path))
+
+    def realpath(self, path: str | Path) -> str:
+        return str(self.abs(path))
+
+    def is_absolute(self, path: str | Path) -> bool:
+        return Path(path).is_absolute()
+
+    @property
+    def sep(self) -> str:
+        return os.sep
+
+    @property
+    def pathsep(self) -> str:
+        return os.pathsep
+
 
 
 class _SimFs:
@@ -49,24 +100,30 @@ class _SimFs:
 
     def __init__(self, test) -> None:
         self._test = test
+        # `ntpath`/`posixpath` are pure lexical stdlib modules -- no real
+        # filesystem or host-OS interaction -- so either is safely usable
+        # regardless of the real host, unlike `os.path` (which is always
+        # whichever of the two the real host happens to be).
+        self._path_mod = ntpath if test.platform == 'win' else posixpath
 
-    def exists(self, path: str | Path) -> bool:
+    def exists(self, path: str | Path | config_types.Path) -> bool:
         return self._test.fs.exists(path)
 
-    def is_dir(self, path: str | Path) -> bool:
+    def is_dir(self, path: str | Path | config_types.Path) -> bool:
         return self._test.fs.is_dir(path)
 
-    def is_file(self, path: str | Path) -> bool:
+    def is_file(self, path: str | Path | config_types.Path) -> bool:
         return self._test.fs.is_file(path)
 
-    def mkdir(self, path: str | Path, *, parents: bool,
+    def mkdir(self, path: str | Path | config_types.Path, *, parents: bool,
               exist_ok: bool) -> None:
         # The simulated fs has no real directory tree: `add_dir` is idempotent
         # and implies parents, so these flags don't apply here.
         del parents, exist_ok
         self._test.fs.add_dir(path)
 
-    def mkdtemp(self, parent: Path, prefix: str) -> Path:
+    def mkdtemp(self, parent: config_types.Path,
+                prefix: str) -> config_types.Path:
         # Numbered per prefix rather than randomized, so a run that makes
         # temporary directories still has reproducible expectations.
         self._test.temp_counter[prefix] += 1
@@ -74,14 +131,100 @@ class _SimFs:
         self._test.fs.add_dir(path)
         return path
 
-    def abs(self, path: str | Path) -> Path:
-        text = str(path)
-        if text.startswith('~'):
-            text = str(self._test.home) + text[1:]
-        return Path(os.path.normpath(text))
+    def mkstemp(self, parent: config_types.Path,
+                prefix: str) -> config_types.Path:
+        # Shares `mkdtemp`'s counter (keyed by prefix, not by file-vs-dir), so
+        # a temp file and a temp dir with the same prefix never collide.
+        self._test.temp_counter[prefix] += 1
+        path = parent / f'{prefix}_tmp_{self._test.temp_counter[prefix]}'
+        self._test.fs.add_file(path)
+        return path
 
-    def home(self) -> Path:
-        return self._test.home
+    def abs(self, path: str | Path | config_types.Path) -> config_types.Path:
+        if isinstance(path, config_types.Path):
+            return path
+        text = str(path)
+        if text == '~':
+            return self.home()
+        if text.startswith('~/'):
+            return self.home().joinpath(text[2:])
+        # No named base to resolve a bare string against (e.g. a test-seeded
+        # `env.which()` result): split it into an empty base plus one piece
+        # per path segment, rather than one opaque unsplit base, so `.parent`/
+        # `.name`/further joins on the result behave like any other Path --
+        # only the anchor ('/') is dropped, since it isn't a real segment.
+        # Lexically posix-only, never the real host's os.path.
+        pure = PurePosixPath(text)
+        pieces = [p for p in pure.parts if p != pure.anchor]
+        return config_types.Path(config_types.ResolvedBasePath(''), *pieces)
+
+    def home(self) -> config_types.Path:
+        return config_types.Path(config_types.ResolvedBasePath(
+            self._test.home))
+
+    def relpath(self, path: str | Path | config_types.Path,
+                start: str | Path | config_types.Path) -> str:
+        if isinstance(path, config_types.Path) and isinstance(
+                start, config_types.Path):
+            return path.relative_to(start, walk_up=True)
+        return posixpath.relpath(str(path), str(start))
+
+    def dirname(
+        self, path: str | Path | config_types.Path
+    ) -> str | Path | config_types.Path:
+        if isinstance(path, config_types.Path):
+            return path.parent
+        return self._path_mod.dirname(str(path))
+
+    def basename(self, path: str | Path | config_types.Path) -> str:
+        return self._path_mod.basename(str(path))
+
+    def splitext(
+        self, path: str | Path | config_types.Path
+    ) -> tuple[str | Path | config_types.Path, str]:
+        if isinstance(path, config_types.Path):
+            return path.parent.joinpath(path.stem), path.suffix
+        return self._path_mod.splitext(str(path))
+
+    def join(self, path: str | Path | config_types.Path, *paths:
+             str | Path | config_types.Path) -> str:
+        return self._path_mod.join(str(path), *[str(p) for p in paths])
+
+    def normpath(self, path: str | Path | config_types.Path) -> str:
+        # Purely lexical (unlike abspath/realpath below): normpath never
+        # consults the real cwd, so delegating straight to the simulated
+        # platform's path module is safe.
+        return self._path_mod.normpath(str(path))
+
+    def abspath(self, path: str | Path | config_types.Path) -> str:
+        # NOT self._path_mod.abspath: that falls back to the real host's
+        # os.getcwd() for a non-absolute input, which would silently depend
+        # on the real machine running the test. `abs()` already handles this
+        # deterministically (never touching the real cwd/filesystem).
+        return str(self.abs(path))
+
+    def realpath(self, path: str | Path | config_types.Path) -> str:
+        # Same reasoning as abspath: no real filesystem resolution here.
+        return str(self.abs(path))
+
+    def is_absolute(self, path: str | Path | config_types.Path) -> bool:
+        # Any config_types.Path is inherently absolute by construction (it's
+        # always rooted in a resolved base). Purely lexical either way --
+        # unlike abspath/realpath, isabs never needs to resolve anything, so
+        # there's no cwd/symlink pitfall to avoid here.
+        if isinstance(path, config_types.Path):
+            return True
+        return self._path_mod.isabs(str(path))
+
+    @property
+    def sep(self) -> str:
+        # The single source of truth for the simulated separator, so this
+        # always agrees with how a `config_types.Path` renders.
+        return config_types.Path._OS_SEP  # pylint: disable=protected-access
+
+    @property
+    def pathsep(self) -> str:
+        return ';' if self.sep == '\\' else ':'
 
 
 class PathApi(RecipeApi):
@@ -94,31 +237,35 @@ class PathApi(RecipeApi):
     """
 
     @property
-    def workspace(self) -> Path:
-        """Root directory the job runs in (engine-provided)."""
-        return self._workspace
+    def workspace(self) -> str | Path | config_types.Path:
+        """Root directory the job runs in (engine-provided in production;
+        a `[WORKSPACE]`-rooted `config_types.Path` token in test mode)."""
+        if self._test is not None:
+            return config_types.Path(
+                config_types.ResolvedBasePath(self._workspace_token))
+        return self._workspace  # pragma: no cover - production only
 
     @property
-    def chromium_src(self) -> Path:
+    def chromium_src(self) -> str | Path | config_types.Path:
         """Chromium `src/` checkout: `<workspace>/b/src`.
 
         Named `b` to keep paths short on Windows, as long paths on Windows can
         cause linking errors for code we have no control over (e.g. LLVM).
         """
-        return self._workspace / 'b' / 'src'
+        return self.workspace / 'b' / 'src'
 
     @property
-    def brave_core(self) -> Path:
+    def brave_core(self) -> str | Path | config_types.Path:
         """brave-core checkout inside Chromium: `<chromium_src>/brave`."""
         return self.chromium_src / 'brave'
 
     @property
-    def out(self) -> Path:
+    def out(self) -> str | Path | config_types.Path:
         """Build output directory: `<workspace>/out`."""
-        return self._workspace / 'out'
+        return self.workspace / 'out'
 
     @property
-    def cleanup_dir(self) -> Path:
+    def cleanup_dir(self) -> str | Path | config_types.Path:
         """Scratch directory: `<workspace>/rc`.
 
         Everything under here is disposable -- treat it as empty at the start of
@@ -126,7 +273,7 @@ class PathApi(RecipeApi):
         it makes, so a step that needs somewhere to write throwaway output has a
         home for it that nothing else has to clean up.
         """
-        return self._workspace / 'rc'
+        return self.workspace / 'rc'
 
     # Filesystem seams. The real-vs-simulated choice is made once in
     # `initialise()` by picking a backend. The methods below just delegate, so
@@ -138,32 +285,44 @@ class PathApi(RecipeApi):
         # Default to the real filesystem; swapped for a simulated backend in
         # test mode by initialise() (once the engine has seeded `_test`).
         self._fs = _RealFs()
+        # Set for real by initialise() in test mode; the `workspace` property
+        # only reads it there, so the production-only `None` is never used.
+        self._workspace_token: str | None = None
 
     def initialise(self) -> None:
         if self._test is not None:
+            # Local import: `simulation` (and the `gevent` it pulls in) is
+            # test-only, so keep it off the production import path (matches
+            # `step/api.py`'s `_prod_runner_lazy` convention).
+            import simulation  # pylint: disable=import-outside-toplevel
+            self._workspace_token = simulation.WORKSPACE_TOKEN
             self._fs = _SimFs(self._test)
+            # Simulated separator, driven by the platform under test -- never
+            # the real host's `sys.platform`/`os.sep`.
+            config_types.Path._OS_SEP = (  # pylint: disable=protected-access
+                '\\' if self._test.platform == 'win' else '/')
 
-    def exists(self, path: str | Path) -> bool:
+    def exists(self, path: str | Path | config_types.Path) -> bool:
         """Whether *path* exists (a file or a directory)."""
         return self._fs.exists(path)
 
-    def is_dir(self, path: str | Path) -> bool:
+    def is_dir(self, path: str | Path | config_types.Path) -> bool:
         """Whether *path* exists and is a directory."""
         return self._fs.is_dir(path)
 
-    def is_file(self, path: str | Path) -> bool:
+    def is_file(self, path: str | Path | config_types.Path) -> bool:
         """Whether *path* exists and is a regular file."""
         return self._fs.is_file(path)
 
     def mkdir(self,
-              path: str | Path,
+              path: str | Path | config_types.Path,
               *,
               parents: bool = True,
               exist_ok: bool = True) -> None:
         """Create directory *path* (creating parents by default)."""
         self._fs.mkdir(path, parents=parents, exist_ok=exist_ok)
 
-    def mkdtemp(self, prefix: str = 'tmp') -> Path:
+    def mkdtemp(self, prefix: str = 'tmp') -> str | Path | config_types.Path:
         """Create a new temporary directory under `cleanup_dir`, and return it.
 
         Args:
@@ -175,7 +334,23 @@ class PathApi(RecipeApi):
         """
         return self._fs.mkdtemp(self.cleanup_dir, prefix)
 
-    def abs(self, path: str | Path) -> Path:
+    def mkstemp(self, prefix: str = 'tmp') -> str | Path | config_types.Path:
+        """Create a new temporary file under `cleanup_dir`, and return it.
+
+        Args:
+            prefix: Prepended to the file's name, to say what it is for.
+
+        Unlike `tempfile.mkstemp`, the file's file descriptor is closed. If you
+        need the full security properties of `mkstemp`, outsource this to a
+        resource script instead.
+
+        In test mode nothing is created on disk (see `mkdtemp`).
+        """
+        return self._fs.mkstemp(self.cleanup_dir, prefix)
+
+    def abs(
+        self, path: str | Path | config_types.Path
+    ) -> str | Path | config_types.Path:
         """Return an absolute, `~`-expanded, normalized `Path`.
 
         Replaces `Path(p).expanduser().resolve()`. In test mode `~` expands to
@@ -184,6 +359,128 @@ class PathApi(RecipeApi):
         """
         return self._fs.abs(path)
 
-    def home(self) -> Path:
+    def home(self) -> str | Path | config_types.Path:
         """The user's home directory (simulated in test mode)."""
         return self._fs.home()
+
+    def relpath(self, path: str | Path | config_types.Path,
+                start: str | Path | config_types.Path) -> str:
+        """*path* relative to *start*. Roughly equivalent to `os.path.relpath`,
+        except *start* is required (there is no implicit real cwd here)."""
+        return self._fs.relpath(path, start)
+
+    def dirname(
+        self, path: str | Path | config_types.Path
+    ) -> str | Path | config_types.Path:
+        """For `foo/bar/baz`, return `foo/bar`. Equivalent to
+        `os.path.dirname`, except a `Path` argument returns a `Path`
+        (`.parent`), matching the type of the input."""
+        return self._fs.dirname(path)
+
+    def basename(self, path: str | Path | config_types.Path) -> str:
+        """For `foo/bar/baz`, return `baz`. Equivalent to `os.path.basename`
+        -- always a `str`, regardless of *path*'s type."""
+        return self._fs.basename(path)
+
+    def split(
+        self, path: str | Path | config_types.Path
+    ) -> tuple[str | Path | config_types.Path, str]:
+        """`(dirname(path), basename(path))`. Equivalent to `os.path.split`."""
+        return self.dirname(path), self.basename(path)
+
+    def splitext(
+        self, path: str | Path | config_types.Path
+    ) -> tuple[str | Path | config_types.Path, str]:
+        """For `foo/bar.baz`, return `(foo/bar, '.baz')`. Equivalent to
+        `os.path.splitext`; the first item matches the type of *path*."""
+        return self._fs.splitext(path)
+
+    def join(self, path: str | Path | config_types.Path, *paths:
+             str | Path | config_types.Path) -> str:
+        """Equivalent to `os.path.join`. Always returns a `str` -- a `Path`
+        already has `joinpath`/`/` for joining and returning a `Path`."""
+        return self._fs.join(path, *paths)
+
+    def normpath(self, path: str | Path | config_types.Path) -> str:
+        """Equivalent to `os.path.normpath`."""
+        return self._fs.normpath(path)
+
+    def abspath(self, path: str | Path | config_types.Path) -> str:
+        """An absolute, `~`-expanded, fully resolved path, as a `str`.
+
+        Unlike `os.path.abspath`, this also expands `~` -- it's `str(abs(p))`
+        in both production and test mode, so the two backends agree exactly.
+        Never resolves against a real cwd in test mode (see `abs`).
+        """
+        return self._fs.abspath(path)
+
+    def realpath(self, path: str | Path | config_types.Path) -> str:
+        """An absolute, `~`-expanded, fully resolved path, as a `str`.
+
+        Same as `abspath` -- with `abs()` already fully resolving (including
+        symlinks in production), there's no further distinction to draw
+        between "absolute" and "real" here.
+        """
+        return self._fs.realpath(path)
+
+    def is_absolute(self, path: str | Path | config_types.Path) -> bool:
+        """Whether *path* is already absolute. Purely lexical (unlike
+        `abspath`/`realpath`, never resolves anything)."""
+        return self._fs.is_absolute(path)
+
+    def expandvars(self, path: str) -> str:
+        """Mostly equivalent to `os.path.expandvars`, with some limitations.
+
+        Limited to variables set in the `context` module's `env`. Variables
+        must be of the form `${VARNAME}`, not just `$VARNAME`.
+        """
+        for key, value in self.m.context.env.items():
+            if value is not None:
+                path = path.replace(f'${{{key}}}', value)
+        return path
+
+    def assert_absolute(self, path: str | Path | config_types.Path) -> None:
+        """Raises `AssertionError` unless *path* is already absolute."""
+        if not self.is_absolute(path):
+            raise AssertionError(f'{path!r} is not absolute')
+
+    def mock_add_file(self, path: str | Path | config_types.Path) -> None:
+        """For testing purposes, mark that file *path* exists. No-op in
+        production."""
+        if self._test is not None:
+            self._test.fs.add_file(path)
+
+    def mock_add_directory(self, path: str | Path | config_types.Path) -> None:
+        """For testing purposes, mark that directory *path* exists. No-op in
+        production."""
+        if self._test is not None:
+            self._test.fs.add_dir(path)
+
+    def mock_copy_paths(self, source: str | Path | config_types.Path,
+                        dest: str | Path | config_types.Path) -> None:
+        """For testing purposes, copy *source* (and everything nested under
+        it) to *dest*. No-op in production."""
+        if self._test is not None:
+            self._test.fs.copy(source, dest)
+
+    def mock_remove_paths(
+            self,
+            path: str | Path | config_types.Path,
+            should_remove: Callable[[str], bool] = lambda p: True) -> None:
+        """For testing purposes, mark that *path* (and everything nested
+        under it for which *should_remove* returns True) no longer exists.
+        No-op in production.
+        """
+        if self._test is not None:
+            self._test.fs.remove(path, should_remove)
+
+    @property
+    def sep(self) -> str:
+        """Equivalent to `os.sep` (the simulated platform's, in test mode)."""
+        return self._fs.sep
+
+    @property
+    def pathsep(self) -> str:
+        """Equivalent to `os.pathsep` (the simulated platform's, in test
+        mode)."""
+        return self._fs.pathsep

--- a/tools/recipes/recipe_modules/path/examples/full.expected/seeded_linux.json
+++ b/tools/recipes/recipe_modules/path/examples/full.expected/seeded_linux.json
@@ -23,6 +23,13 @@
   {
     "cmd": [
       "echo",
+      "[HOME]"
+    ],
+    "name": "home again"
+  },
+  {
+    "cmd": [
+      "echo",
       "[HOME]/cache"
     ],
     "name": "cache"

--- a/tools/recipes/recipe_modules/path/examples/full.expected/seeded_win.json
+++ b/tools/recipes/recipe_modules/path/examples/full.expected/seeded_win.json
@@ -2,7 +2,14 @@
   {
     "cmd": [
       "echo",
-      "[WORKSPACE]/out"
+      "present"
+    ],
+    "name": "found version"
+  },
+  {
+    "cmd": [
+      "echo",
+      "[WORKSPACE]\\out"
     ],
     "name": "out ready"
   },
@@ -23,16 +30,16 @@
   {
     "cmd": [
       "echo",
-      "[HOME]/cache"
+      "[HOME]\\cache"
     ],
     "name": "cache"
   },
   {
     "cmd": [
       "echo",
-      "[WORKSPACE]/rc/tmp_tmp_1",
-      "[WORKSPACE]/rc/tmp_tmp_2",
-      "[WORKSPACE]/rc/unpacked_tmp_1"
+      "[WORKSPACE]\\rc\\tmp_tmp_1",
+      "[WORKSPACE]\\rc\\tmp_tmp_2",
+      "[WORKSPACE]\\rc\\unpacked_tmp_1"
     ],
     "name": "temp dirs"
   },

--- a/tools/recipes/recipe_modules/path/examples/full.py
+++ b/tools/recipes/recipe_modules/path/examples/full.py
@@ -8,10 +8,17 @@ from __future__ import annotations
 
 import post_process
 
-DEPS = ['path', 'step']
+DEPS = ['path', 'platform', 'step']
 
 
 def RunSteps(api):
+    if api.platform.is_win:
+        assert api.path.sep == '\\'
+        assert api.path.pathsep == ';'
+    else:
+        assert api.path.sep == '/'
+        assert api.path.pathsep == ':'
+
     # Probe a seeded file, then create and re-probe a directory: the created
     # directory must "exist" for the rest of the run.
     if api.path.exists(api.path.chromium_src / 'chrome/VERSION'):
@@ -19,8 +26,9 @@ def RunSteps(api):
     api.path.mkdir(api.path.out)
     if api.path.is_dir(api.path.out):
         api.step('out ready', ['echo', str(api.path.out)])
-    # Exercise the home() seam and `~`-expansion via abs().
+    # Exercise the home() seam and `~`/`~/...`-expansion via abs().
     api.step('home', ['echo', str(api.path.home())])
+    api.step('home again', ['echo', str(api.path.abs('~'))])
     api.step('cache', ['echo', str(api.path.abs('~/cache'))])
 
     # Temporary directories live under the job's scratch space, and exist for
@@ -35,22 +43,33 @@ def RunSteps(api):
 
 
 def GenTests(api):
-    yield api.test(
-        'seeded',
-        api.path.files('b/src/chrome/VERSION'),
-        api.post_process(post_process.MustRun, 'found version'),
-        api.post_process(post_process.MustRun, 'out ready'),
-        api.post_process(post_process.StepCommandContains, 'out ready',
-                         ['[WORKSPACE]/out']),
-        api.post_process(post_process.StepCommandContains, 'home', ['[HOME]']),
-        api.post_process(post_process.StepCommandContains, 'cache',
-                         ['[HOME]/cache']),
-        api.post_process(post_process.StepCommandContains, 'temp dirs', [
-            '[WORKSPACE]/rc/tmp_tmp_1', '[WORKSPACE]/rc/tmp_tmp_2',
-            '[WORKSPACE]/rc/unpacked_tmp_1'
-        ]),
-        api.post_process(post_process.StatusSuccess),
-    )
+    # `config_types.Path._OS_SEP` is driven by the simulated platform, not the
+    # real host running the test suite: run the same case under both `linux` and
+    # `win`, and check the separator in the recorded commands actually flips,
+    # independent of whatever machine runs this test.
+    for plat in ('linux', 'win'):
+        sep = '\\' if plat == 'win' else '/'
+        yield api.test(
+            f'seeded_{plat}',
+            api.platform.name(plat),
+            api.path.files('b/src/chrome/VERSION'),
+            api.post_process(post_process.MustRun, 'found version'),
+            api.post_process(post_process.MustRun, 'out ready'),
+            api.post_process(post_process.StepCommandContains, 'out ready',
+                             [f'[WORKSPACE]{sep}out']),
+            api.post_process(post_process.StepCommandContains, 'home',
+                             ['[HOME]']),
+            api.post_process(post_process.StepCommandContains, 'home again',
+                             ['[HOME]']),
+            api.post_process(post_process.StepCommandContains, 'cache',
+                             [f'[HOME]{sep}cache']),
+            api.post_process(post_process.StepCommandContains, 'temp dirs', [
+                f'[WORKSPACE]{sep}rc{sep}tmp_tmp_1',
+                f'[WORKSPACE]{sep}rc{sep}tmp_tmp_2',
+                f'[WORKSPACE]{sep}rc{sep}unpacked_tmp_1'
+            ]),
+            api.post_process(post_process.StatusSuccess),
+        )
     yield api.test(
         'absent',
         api.post_process(post_process.DoesNotRun, 'found version'),

--- a/tools/recipes/recipe_modules/path/examples/os_path_compat.expected/linux.json
+++ b/tools/recipes/recipe_modules/path/examples/os_path_compat.expected/linux.json
@@ -1,0 +1,47 @@
+[
+  {
+    "cmd": [
+      "echo",
+      "[WORKSPACE]/rc/scratch_tmp_1"
+    ],
+    "name": "mkstemp"
+  },
+  {
+    "cmd": [
+      "echo",
+      "True"
+    ],
+    "name": "scratch is file"
+  },
+  {
+    "cmd": [
+      "echo",
+      "True"
+    ],
+    "name": "scratch dir is dir"
+  },
+  {
+    "cmd": [
+      "echo",
+      "True"
+    ],
+    "name": "copy is file"
+  },
+  {
+    "cmd": [
+      "echo",
+      "False"
+    ],
+    "name": "scratch removed"
+  },
+  {
+    "cmd": [
+      "echo",
+      "True"
+    ],
+    "name": "copy survives removal"
+  },
+  {
+    "name": "$result"
+  }
+]

--- a/tools/recipes/recipe_modules/path/examples/os_path_compat.expected/win.json
+++ b/tools/recipes/recipe_modules/path/examples/os_path_compat.expected/win.json
@@ -1,0 +1,47 @@
+[
+  {
+    "cmd": [
+      "echo",
+      "[WORKSPACE]\\rc\\scratch_tmp_1"
+    ],
+    "name": "mkstemp"
+  },
+  {
+    "cmd": [
+      "echo",
+      "True"
+    ],
+    "name": "scratch is file"
+  },
+  {
+    "cmd": [
+      "echo",
+      "True"
+    ],
+    "name": "scratch dir is dir"
+  },
+  {
+    "cmd": [
+      "echo",
+      "True"
+    ],
+    "name": "copy is file"
+  },
+  {
+    "cmd": [
+      "echo",
+      "False"
+    ],
+    "name": "scratch removed"
+  },
+  {
+    "cmd": [
+      "echo",
+      "True"
+    ],
+    "name": "copy survives removal"
+  },
+  {
+    "name": "$result"
+  }
+]

--- a/tools/recipes/recipe_modules/path/examples/os_path_compat.py
+++ b/tools/recipes/recipe_modules/path/examples/os_path_compat.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipe exercising the `path` module's `os.path`-equivalent helpers
+(`dirname`/`basename`/`split`/`splitext`/`join`/`normpath`/`abspath`/
+`realpath`/`is_absolute`/`assert_absolute`/`expandvars`/`mkstemp`) and its
+test-only `mock_add_file`/`mock_add_directory`/`mock_copy_paths`/
+`mock_remove_paths` seams.
+"""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['context', 'path', 'platform', 'step']
+
+
+def RunSteps(api):
+    sample = api.path.chromium_src / 'chrome' / 'VERSION'
+
+    # dirname/basename/split: a Path argument keeps dirname a Path; basename
+    # is always a str regardless of the argument's type.
+    assert api.path.dirname(sample) == api.path.chromium_src / 'chrome'
+    assert api.path.basename(sample) == 'VERSION'
+    assert api.path.split(sample) == (api.path.chromium_src / 'chrome',
+                                      'VERSION')
+
+    # Same, but for a plain string argument -- dirname then returns a str.
+    sample_str = api.path.join(str(api.path.chromium_src), 'chrome', 'VERSION')
+    assert api.path.dirname(sample_str) == api.path.join(
+        str(api.path.chromium_src), 'chrome')
+    assert api.path.basename(sample_str) == 'VERSION'
+
+    # splitext strips only the last extension, on both a Path and a str.
+    archive = api.path.out / 'archive.tar.gz'
+    assert api.path.splitext(archive) == (api.path.out / 'archive.tar', '.gz')
+    archive_str = api.path.join(str(api.path.out), 'archive.tar.gz')
+    assert api.path.splitext(archive_str) == (api.path.join(
+        str(api.path.out), 'archive.tar'), '.gz')
+
+    # normpath collapses '..'/'.' lexically.
+    messy = api.path.join(str(api.path.workspace), 'a', '..', 'b')
+    assert api.path.normpath(messy) == api.path.join(str(api.path.workspace),
+                                                     'b')
+
+    # abspath/realpath expand '~' and fully resolve, exactly like abs().
+    assert api.path.abspath('~/x') == str(api.path.home() / 'x')
+    assert api.path.realpath('~/x') == str(api.path.home() / 'x')
+
+    # is_absolute/assert_absolute.
+    assert api.path.is_absolute(api.path.workspace)
+    assert not api.path.is_absolute('relative/path')
+    api.path.assert_absolute(api.path.workspace)
+    raised = False
+    try:
+        api.path.assert_absolute('relative/path')
+    except AssertionError as exc:
+        raised = True
+        assert 'not absolute' in str(exc), exc
+    assert raised, 'expected assert_absolute to raise on a relative path'
+
+    # expandvars substitutes ${VAR} from the context module's current env.
+    with api.context(env={'BUILD_TAG': 'v1'}):
+        assert api.path.expandvars('${BUILD_TAG}/out') == 'v1/out'
+
+    # mkstemp: like mkdtemp, but for a file.
+    scratch_file = api.path.mkstemp('scratch')
+    assert scratch_file.parent == api.path.cleanup_dir
+    api.step('mkstemp', ['echo', str(scratch_file)])
+
+    # mock_add_file/mock_add_directory/mock_copy_paths/mock_remove_paths are
+    # test-only seams for marking simulated filesystem state mid-run (no-ops
+    # in production) -- checked via step output + post_process below, since
+    # asserting the result directly wouldn't hold outside simulation.
+    scratch = api.path.out / 'scratch.txt'
+    api.path.mock_add_file(scratch)
+    api.step('scratch is file', ['echo', str(api.path.is_file(scratch))])
+
+    scratch_dir = api.path.out / 'scratch_dir'
+    api.path.mock_add_directory(scratch_dir)
+    api.step('scratch dir is dir', ['echo', str(api.path.is_dir(scratch_dir))])
+
+    copy_dest = api.path.out / 'scratch_copy.txt'
+    api.path.mock_copy_paths(scratch, copy_dest)
+    api.step('copy is file', ['echo', str(api.path.is_file(copy_dest))])
+
+    api.path.mock_remove_paths(scratch)
+    api.step('scratch removed', ['echo', str(api.path.is_file(scratch))])
+    api.step('copy survives removal',
+             ['echo', str(api.path.is_file(copy_dest))])
+
+
+def GenTests(api):
+    # Run under both simulated platforms: every assertion above is built
+    # entirely from other `api.path.*` calls (never a hardcoded '/' or '\\'),
+    # so it should hold either way -- the same proof of separator-independence
+    # as `examples/full.py`.
+    for plat in ('linux', 'win'):
+        sep = '\\' if plat == 'win' else '/'
+        yield api.test(
+            plat,
+            api.platform.name(plat),
+            api.post_process(post_process.StepCommandContains, 'mkstemp',
+                             [f'[WORKSPACE]{sep}rc{sep}scratch_tmp_1']),
+            api.post_process(post_process.StepCommandContains,
+                             'scratch is file', ['True']),
+            api.post_process(post_process.StepCommandContains,
+                             'scratch dir is dir', ['True']),
+            api.post_process(post_process.StepCommandContains, 'copy is file',
+                             ['True']),
+            api.post_process(post_process.StepCommandContains,
+                             'scratch removed', ['False']),
+            api.post_process(post_process.StepCommandContains,
+                             'copy survives removal', ['True']),
+            api.post_process(post_process.StatusSuccess),
+        )

--- a/tools/recipes/recipe_test_runner.py
+++ b/tools/recipes/recipe_test_runner.py
@@ -35,6 +35,7 @@ import sys
 import time
 from typing import TYPE_CHECKING
 
+import config_types
 import engine
 from engine_types import PerGreenletStateRegistry
 import simulation
@@ -170,6 +171,10 @@ def _simulate(
     # instances are per-engine, so without this the previous case's states pile
     # up and get their setters replayed into this case's greenlets.
     PerGreenletStateRegistry.clear()
+    # Defense-in-depth: a case whose DEPS never instantiate the `path` module
+    # would otherwise inherit whatever separator a previous case's `path`
+    # module left behind in this class-level variable.
+    config_types.reset_global_variable_assignments()
     # A fresh engine per case: module instances are cached per engine, so
     # reusing one would leak state (deployed depot_tools, set env vars, ...).
     eng = engine._Engine(  # pylint: disable=protected-access
@@ -190,7 +195,7 @@ def _simulate(
     except Exception as exc:  # pylint: disable=broad-except
         # Any other exception is an infra/logic error (bad input, missing dep).
         failure = {'humanReason': str(exc)}
-    steps = simulation.build_steps(ctx.step_runner, failure, ctx)
+    steps = simulation.build_steps(ctx.step_runner, failure)
     return steps, ctx
 
 

--- a/tools/recipes/recipes/toolchains/windows/build_windows_toolchain.expected/win.json
+++ b/tools/recipes/recipes/toolchains/windows/build_windows_toolchain.expected/win.json
@@ -10,7 +10,7 @@
       "--branch",
       "master",
       "git@github.com:brave/brave-core.git",
-      "[WORKSPACE]/b/src/brave"
+      "[WORKSPACE]\\b\\src\\brave"
     ],
     "name": "clone brave-core (shallow, sparse)"
   },
@@ -18,7 +18,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/b/src/brave",
+      "[WORKSPACE]\\b\\src\\brave",
       "sparse-checkout",
       "list"
     ],
@@ -28,7 +28,7 @@
     "cmd": [
       "git",
       "-C",
-      "[WORKSPACE]/b/src/brave",
+      "[WORKSPACE]\\b\\src\\brave",
       "sparse-checkout",
       "add",
       "tools/cr/toolchains"
@@ -42,7 +42,7 @@
       "--depth",
       "1",
       "https://chromium.googlesource.com/chromium/tools/depot_tools",
-      "[WORKSPACE]/b/src/third_party/depot_tools"
+      "[WORKSPACE]\\b\\src\\third_party\\depot_tools"
     ],
     "name": "clone depot_tools"
   },
@@ -54,10 +54,10 @@
   },
   {
     "cmd": [
-      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3.bat",
-      "[WORKSPACE]/b/src/brave/tools/cr/toolchains/build_windows_toolchain.py",
+      "[WORKSPACE]\\b\\src\\third_party\\depot_tools\\vpython3.bat",
+      "[WORKSPACE]\\b\\src\\brave\\tools\\cr\\toolchains\\build_windows_toolchain.py",
       "--out-dir",
-      "[WORKSPACE]/out",
+      "[WORKSPACE]\\out",
       "--chromium-tag",
       "150.0.7841.1",
       "--clear",

--- a/tools/recipes/simulation.py
+++ b/tools/recipes/simulation.py
@@ -18,8 +18,12 @@ Holds everything needed to run a recipe with zero real side effects:
     nothing, and hands back the canned retcode. Both also answer the `step`
     module's request for a step's simulated data -- production with a
     `DisabledTestData`, so placeholders know they are running for real.
-  * expectation helpers: `stabilize` (machine paths -> `[WORKSPACE]`/`[HOME]`
-    tokens), `build_steps`, and `apply_post_process`.
+  * expectation helpers: `stabilize` (the one remaining real machine path,
+    `RECIPES_ROOT`, -> `[RECIPES_ROOT]`), `build_steps`, and
+    `apply_post_process`. `[WORKSPACE]`/`[HOME]` need no such rewriting: the
+    `path` recipe module builds them as literal `config_types.Path` tokens
+    from the start (see `recipe_modules/path/api.py`), so they never appear as
+    real machine paths in the first place.
 
 Deliberately never imports `engine` (the engine imports this), so there is no
 cycle: the test runner in `engine.py` drives a recipe, then hands the recorded
@@ -41,18 +45,17 @@ from typing import Any
 # `futures` module would hand out concurrency that never actually overlaps.
 from gevent import subprocess
 
+import config_types
 from check import Check, Checker, PostProcessError, VerifySubset
 from engine_env import merge_envs
 import post_process as pp
 from recipe_test_api import (DisabledTestData, PostprocessHookContext,
                              StepTestData, TestData)
 
-# Fixed synthetic locations used in test mode. They are never touched on disk;
-# they exist only so module-derived paths are deterministic, and are rewritten
-# to tokens in expectations so goldens are machine-independent.
-SIM_WORKSPACE = PurePosixPath('/b/w')
-SIM_HOME = PurePosixPath('/b/home')
-
+# The literal tokens `recipe_modules/path/api.py` builds its simulated
+# `workspace`/`home` config_types.Path values from directly -- there is no
+# real-looking fake path to later rewrite into these; the token is the value
+# from construction (see config_types.py's module docstring).
 WORKSPACE_TOKEN = '[WORKSPACE]'
 HOME_TOKEN = '[HOME]'
 
@@ -69,8 +72,8 @@ SIM_TOTAL_MEMORY = 16 * 1024
 # This engine's own root (`tools/recipes/`), for stabilizing commands that
 # reference a resource file living next to a recipe module (e.g. `file`'s
 # `resources/fileutil.py`) via a real `Path(__file__).resolve()`-derived
-# path -- unlike `SIM_WORKSPACE`/`SIM_HOME`, this is a real machine path even
-# in test mode, so it varies by checkout location unless stabilized here too.
+# path -- unlike `WORKSPACE_TOKEN`/`HOME_TOKEN`, this is a real machine path
+# even in test mode, so it varies by checkout location unless stabilized here.
 # Computed independently of (but always equal to) `engine.RECIPES_ROOT`,
 # since both are `Path(__file__).resolve().parent` of a sibling file in this
 # same directory; this module deliberately never imports `engine` (see the
@@ -79,8 +82,16 @@ RECIPES_ROOT = Path(__file__).resolve().parent
 RECIPES_ROOT_TOKEN = '[RECIPES_ROOT]'
 
 
-def _norm(path: str | Path) -> str:
-    """Normalize a path to a stable string key for the simulated filesystem."""
+def _norm(path: str | Path | config_types.Path) -> str:
+    """Normalize a path to a stable string key for the simulated filesystem.
+
+    `config_types.Path.as_posix()` is used (not `str()`) because `str()`
+    renders with whatever separator the current case is simulating -- under a
+    `platform='win'` case that's `\\`, and `PurePosixPath` would then treat
+    the whole backslash-joined string as one opaque filename component.
+    """
+    if isinstance(path, config_types.Path):
+        return path.as_posix()
     return str(PurePosixPath(str(path)))
 
 
@@ -120,6 +131,34 @@ class SimFS:
 
     def add_dir(self, path: str | Path) -> None:
         self._dirs.add(_norm(path))
+
+    def copy(self, source: str | Path, dest: str | Path) -> None:
+        """Duplicates `source`, and everything nested under it, to `dest`."""
+        source = _norm(source)
+        dest = _norm(dest)
+        if source == dest:
+            raise ValueError(f'source and dest are the same path: {source!r}')
+        prefix = source.rstrip('/') + '/'
+        for collection in (self._files, self._dirs):
+            for path in [
+                    p for p in collection
+                    if p == source or p.startswith(prefix)
+            ]:
+                collection.add(dest + path[len(source):])
+
+    def remove(self,
+               path: str | Path,
+               should_remove: Callable[[str], bool] = lambda p: True) -> None:
+        """Removes `path`, and everything nested under it matching
+        `should_remove`, from the simulated filesystem."""
+        path = _norm(path)
+        prefix = path.rstrip('/') + '/'
+        for collection in (self._files, self._dirs):
+            collection -= {
+                p
+                for p in collection
+                if (p == path or p.startswith(prefix)) and should_remove(p)
+            }
 
 
 class SubprocessStepRunner:
@@ -261,7 +300,7 @@ class TestContext:
                  files: Iterable[str | Path] = (),
                  dirs: Iterable[str | Path] = (),
                  which_map: dict[str, str] | None = None,
-                 home: str | Path = SIM_HOME,
+                 home: str = HOME_TOKEN,
                  test_data: TestData | None = None) -> None:
         self.platform = platform
         self.bits = bits
@@ -271,7 +310,9 @@ class TestContext:
         self.env = dict(env or {})
         self.fs = SimFS(files, dirs)
         self.which_map = dict(which_map or {})
-        self.home = Path(str(home))
+        # The resolved-base string `_SimFs.home()` wraps in a fresh
+        # `config_types.Path` -- a literal token by default (`[HOME]`).
+        self.home = str(home)
         # Per-prefix counter behind `api.path.mkdtemp`, so a run's temporary
         # directories get stable, ordered names instead of random ones.
         self.temp_counter: Counter[str] = Counter()
@@ -305,21 +346,26 @@ class TestContext:
 
 
 def _resolve_seed(path: str) -> str:
-    """Resolve a seeded path: absolute as-is, relative under the workspace."""
+    """Resolve a seeded path: absolute or already-tokenized (a leading
+    `[TOKEN]`, e.g. `[HOME]/...`) as-is, relative under the workspace."""
     pure = PurePosixPath(path)
-    return str(pure if pure.is_absolute() else SIM_WORKSPACE / pure)
+    if pure.is_absolute() or path.startswith('['):
+        return str(pure)
+    return f'{WORKSPACE_TOKEN}/{pure}'
 
 
-def stabilize(value: str, context: TestContext | None = None) -> str:
-    """Rewrite machine-specific path prefixes to stable tokens."""
-    value = value.replace(str(RECIPES_ROOT), RECIPES_ROOT_TOKEN)
-    value = value.replace(str(SIM_WORKSPACE), WORKSPACE_TOKEN)
-    home = str(context.home) if context is not None else str(SIM_HOME)
-    return value.replace(home, HOME_TOKEN)
+def stabilize(value: str) -> str:
+    """Rewrite the one remaining real machine path prefix to a stable token.
+
+    `[WORKSPACE]`/`[HOME]` need no rewriting here: `recipe_modules/path/api.py`
+    builds them as literal `config_types.Path` tokens from construction, so
+    they never appear as real machine paths in a step's recorded strings.
+    """
+    return value.replace(str(RECIPES_ROOT), RECIPES_ROOT_TOKEN)
 
 
-def build_steps(runner: SimulationStepRunner, failure: dict | None,
-                context: TestContext) -> dict[str, dict]:
+def build_steps(runner: SimulationStepRunner,
+                failure: dict | None) -> dict[str, dict]:
     """Assemble the ordered `{name: step}` map (+ `$result`) for post-process.
 
     Paths are stabilized here so post-process checks and the written expectation
@@ -332,21 +378,21 @@ def build_steps(runner: SimulationStepRunner, failure: dict | None,
     for step in runner.recorded_steps:
         entry: dict[str, Any] = {
             'name': step['name'],
-            'cmd': [stabilize(arg, context) for arg in step['cmd']],
+            'cmd': [stabilize(arg) for arg in step['cmd']],
         }
         if 'cwd' in step:
-            entry['cwd'] = stabilize(step['cwd'], context)
+            entry['cwd'] = stabilize(step['cwd'])
         if 'stdin' in step:
-            entry['stdin'] = stabilize(step['stdin'], context)
+            entry['stdin'] = stabilize(step['stdin'])
         if 'env' in step:
             entry['env'] = {
-                k: (None if v is None else stabilize(v, context))
+                k: (None if v is None else stabilize(v))
                 for k, v in step['env'].items()
             }
         for affix in ('env_prefixes', 'env_suffixes'):
             if affix in step:
                 entry[affix] = {
-                    k: [stabilize(v, context) for v in values]
+                    k: [stabilize(v) for v in values]
                     for k, values in step[affix].items()
                 }
         if 'retcode' in step:
@@ -358,7 +404,7 @@ def build_steps(runner: SimulationStepRunner, failure: dict | None,
         if 'humanReason' in failure:
             failure = {
                 **failure,
-                'humanReason': stabilize(failure['humanReason'], context),
+                'humanReason': stabilize(failure['humanReason']),
             }
         result['failure'] = failure
     steps[pp.RESULT_STEP] = result

--- a/tools/recipes/unittests/config_types_test.py
+++ b/tools/recipes/unittests/config_types_test.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for the platform-independent `Path` in config_types.py."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# pylint: disable=wrong-import-position
+import config_types
+from config_types import (Path, RelativeToDifferentBases, RelativeToNotParent,
+                          ResolvedBasePath, reset_global_variable_assignments)
+
+
+def _base(token='[CACHE]'):
+    return ResolvedBasePath(token)
+
+
+class PathConstructionTest(unittest.TestCase):
+
+    def setUp(self):
+        config_types.Path._OS_SEP = '/'
+
+    def tearDown(self):
+        reset_global_variable_assignments()
+
+    def test_splits_on_slash_and_drops_empty_and_dot_pieces(self):
+        p = Path(_base(), 'a/b', '', '.', 'c')
+        self.assertEqual(p.pieces, ('a', 'b', 'c'))
+
+    def test_dotdot_collapses_against_preceding_piece(self):
+        p = Path(_base(), 'a', 'b', '..')
+        self.assertEqual(p.pieces, ('a', ))
+
+    def test_dotdot_above_base_raises(self):
+        with self.assertRaises(ValueError):
+            Path(_base(), '..', 'something')
+
+    def test_non_str_piece_raises(self):
+        with self.assertRaises(ValueError):
+            Path(_base(), 123)
+
+    def test_non_resolved_base_path_raises(self):
+        with self.assertRaises(ValueError):
+            Path('[CACHE]', 'a')
+
+    def test_backslash_piece_before_os_sep_known_raises(self):
+        config_types.Path._OS_SEP = None
+        with self.assertRaises(ValueError):
+            Path(_base(), 'a\\b')
+
+    def test_backslash_piece_split_only_when_os_sep_is_backslash(self):
+        config_types.Path._OS_SEP = '\\'
+        p = Path(_base(), 'a\\b\\c')
+        self.assertEqual(p.pieces, ('a', 'b', 'c'))
+
+        config_types.Path._OS_SEP = '/'
+        p = Path(_base(), 'a\\b')
+        self.assertEqual(p.pieces, ('a\\b', ))
+
+
+class PathJoinTest(unittest.TestCase):
+
+    def setUp(self):
+        config_types.Path._OS_SEP = '/'
+
+    def tearDown(self):
+        reset_global_variable_assignments()
+
+    def test_truediv_appends_a_piece(self):
+        p = Path(_base()) / 'foo' / 'bar'
+        self.assertEqual(p.pieces, ('foo', 'bar'))
+
+    def test_joinpath_appends_multiple_pieces(self):
+        p = Path(_base()).joinpath('foo', 'bar')
+        self.assertEqual(p.pieces, ('foo', 'bar'))
+
+    def test_joinpath_no_pieces_returns_self(self):
+        p = Path(_base(), 'foo')
+        self.assertIs(p.joinpath(), p)
+
+    def test_joinpath_with_a_path_piece_reroots(self):
+        other = Path(_base('[HOME]'), 'x')
+        p = Path(_base(), 'foo').joinpath('ignored', other, 'y')
+        self.assertEqual(p.base, _base('[HOME]'))
+        self.assertEqual(p.pieces, ('x', 'y'))
+
+
+class PathPartsTest(unittest.TestCase):
+
+    def setUp(self):
+        config_types.Path._OS_SEP = '/'
+
+    def tearDown(self):
+        reset_global_variable_assignments()
+
+    def test_parent_and_parents(self):
+        p = Path(_base(), 'foo', 'bar', 'baz')
+        self.assertEqual(p.parent.pieces, ('foo', 'bar'))
+        self.assertEqual([x.pieces for x in p.parents], [('foo', 'bar'),
+                                                         ('foo', ), ()])
+
+    def test_name(self):
+        self.assertEqual(Path(_base(), 'foo', 'bar').name, 'bar')
+
+    def test_stem_and_suffix(self):
+        p = Path(_base(), 'dir', 'foo.tar.gz')
+        self.assertEqual(p.stem, 'foo.tar')
+        self.assertEqual(p.suffix, '.gz')
+        self.assertEqual(p.suffixes, ['.tar', '.gz'])
+
+    def test_suffix_empty_when_no_dot(self):
+        self.assertEqual(Path(_base(), 'foo').suffix, '')
+        self.assertEqual(Path(_base(), 'foo').suffixes, [])
+
+
+class PathStrTest(unittest.TestCase):
+
+    def tearDown(self):
+        reset_global_variable_assignments()
+
+    def test_raises_before_os_sep_is_set(self):
+        config_types.Path._OS_SEP = None
+        with self.assertRaises(ValueError):
+            str(Path(_base(), 'foo'))
+
+    def test_renders_with_slash(self):
+        config_types.Path._OS_SEP = '/'
+        self.assertEqual(str(Path(_base(), 'foo', 'bar')), '[CACHE]/foo/bar')
+
+    def test_renders_with_backslash_when_simulating_windows(self):
+        config_types.Path._OS_SEP = '\\'
+        self.assertEqual(str(Path(_base(), 'foo', 'bar')), '[CACHE]\\foo\\bar')
+
+    def test_as_posix_ignores_os_sep(self):
+        config_types.Path._OS_SEP = '\\'
+        self.assertEqual(
+            Path(_base(), 'foo', 'bar').as_posix(), '[CACHE]/foo/bar')
+
+
+class PathRelativeToTest(unittest.TestCase):
+
+    def setUp(self):
+        config_types.Path._OS_SEP = '/'
+
+    def tearDown(self):
+        reset_global_variable_assignments()
+
+    def test_simple_child(self):
+        self.assertEqual(
+            Path(_base(), 'foo', 'bar').relative_to(Path(_base(), 'foo')),
+            'bar')
+
+    def test_not_a_parent_raises_without_walk_up(self):
+        with self.assertRaises(RelativeToNotParent):
+            Path(_base(), 'foo').relative_to(Path(_base(), 'bar'))
+
+    def test_not_a_parent_walks_up_when_allowed(self):
+        self.assertEqual(
+            Path(_base(), 'foo').relative_to(Path(_base(), 'bar'),
+                                             walk_up=True), '../foo')
+
+    def test_different_bases_raises(self):
+        with self.assertRaises(RelativeToDifferentBases):
+            Path(_base(), 'foo').relative_to(Path(_base('[HOME]'), 'bar'))
+
+
+class PathEqualityAndHashTest(unittest.TestCase):
+
+    def setUp(self):
+        config_types.Path._OS_SEP = '/'
+
+    def tearDown(self):
+        reset_global_variable_assignments()
+
+    def test_equal_paths_are_equal(self):
+        self.assertEqual(Path(_base(), 'foo'), Path(_base(), 'foo'))
+
+    def test_compares_equal_to_its_own_str(self):
+        p = Path(_base(), 'foo')
+        self.assertEqual(p, str(p))
+
+    def test_lt_compares_to_str(self):
+        self.assertLess(Path(_base(), 'a'), '[CACHE]/b')
+
+    def test_hashable_and_usable_as_a_dict_key(self):
+        p1 = Path(_base(), 'foo')
+        p2 = Path(_base(), 'foo')
+        self.assertEqual(hash(p1), hash(p2))
+        self.assertEqual({p1: 'x'}[p2], 'x')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/recipes/unittests/simulation_test.py
+++ b/tools/recipes/unittests/simulation_test.py
@@ -129,39 +129,47 @@ class TestContextTest(unittest.TestCase):
         self.assertEqual(ctx.platform, 'mac')
         self.assertEqual(ctx.env['K'], 'V')
         self.assertEqual(ctx.which_map['gclient'], '/g')
-        # Relative seed resolves under the simulated workspace.
+        # Relative seed resolves under the simulated workspace token.
         self.assertTrue(
-            ctx.fs.is_file('/b/w/brave-browser/src/chrome/VERSION'))
+            ctx.fs.is_file('[WORKSPACE]/brave-browser/src/chrome/VERSION'))
 
 
 class ExpectationTest(unittest.TestCase):
 
     def test_stabilize_tokens(self):
-        ctx = simulation.TestContext()
-        self.assertEqual(simulation.stabilize('/b/w/out/x', ctx),
+        # `[WORKSPACE]`/`[HOME]` need no rewriting -- `recipe_modules/path/
+        # api.py` builds them as literal `config_types.Path` tokens from
+        # construction, so an already-tokenized string passes through as-is.
+        self.assertEqual(simulation.stabilize('[WORKSPACE]/out/x'),
                          '[WORKSPACE]/out/x')
-        self.assertEqual(simulation.stabilize('/b/home/.cache', ctx),
+        self.assertEqual(simulation.stabilize('[HOME]/.cache'),
                          '[HOME]/.cache')
+        # RECIPES_ROOT is the one remaining real machine path: it's still
+        # rewritten, since resource scripts genuinely live there on disk.
+        real_path = f'{simulation.RECIPES_ROOT}/recipe_modules/file'
+        self.assertEqual(simulation.stabilize(real_path),
+                         '[RECIPES_ROOT]/recipe_modules/file')
 
     def test_build_steps_success_result(self):
         runner = simulation.SimulationStepRunner()
-        _run(runner, {'name': 'a', 'cmd': ['/b/w/out/tool']})
-        steps = simulation.build_steps(runner, None, simulation.TestContext())
+        _run(runner, {'name': 'a', 'cmd': ['[WORKSPACE]/out/tool']})
+        steps = simulation.build_steps(runner, None)
         self.assertEqual(steps['a']['cmd'], ['[WORKSPACE]/out/tool'])
         # A successful run's $result carries no failure key.
         self.assertEqual(steps[pp.RESULT_STEP], {'name': '$result'})
 
     def test_build_steps_failure_result_stabilizes_reason(self):
         runner = simulation.SimulationStepRunner()
-        failure = {'humanReason': 'boom at /b/w/out/tool'}
-        steps = simulation.build_steps(runner, failure,
-                                       simulation.TestContext())
+        failure = {
+            'humanReason': f'boom at {simulation.RECIPES_ROOT}/recipe_modules/file'
+        }
+        steps = simulation.build_steps(runner, failure)
         # An infra failure carries only humanReason (paths stabilized).
         self.assertEqual(
             steps[pp.RESULT_STEP], {
                 'name': '$result',
                 'failure': {
-                    'humanReason': 'boom at [WORKSPACE]/out/tool'
+                    'humanReason': 'boom at [RECIPES_ROOT]/recipe_modules/file'
                 },
             })
 


### PR DESCRIPTION
`api.path.*` (workspace, chromium_src, out, cleanup_dir, ...) now builds `config_types.Path` under simulation instead of real `pathlib.Path`. A real Path renders with the *host's* separator, so a simulated Windows case running on a real Windows CI runner silently would render with `/` instead of `\`. In many of our goldens we have paths listed lie:

```json
"[WORKSPACE]/b/src/third_party/depot_tools/vpython3.bat"
```

This has never worked on Windows, and therefore this new path layer is being introduced to solve that.

`config_types.Path` never touches real `pathlib`/`os.path`, rather it stores components as a tuple, split on `/`, and only joins them into a string via a class-level `_OS_SEP` that the `path` module sets explicitly from the platform under test:

```py
for plat in ('linux', 'win'):
    yield api.test(f'seeded_{plat}', api.platform.name(plat), ...)
```

This now correctly renders `[WORKSPACE]\out\tool` for the `win` case and `[WORKSPACE]/out/tool` for `linux`, regardless of which machine actually runs the test suite.

Supporting functions have been also introduced with it `path`:

```py
out = api.path.out
api.path.relpath(out / 'a.txt', out)   # 'a.txt'
api.path.mkstemp('scratch')            # like mkdtemp, for a file
api.path.dirname(out / 'a.txt')        # out
api.env.prepend_path(tool_dir)         # now uses api.path.pathsep
```

Bug: https://github.com/brave/brave-browser/issues/56748
