### PR TITLE
[VPN 2.0] Endpoint-based API: CreateSupportTicket

### DIFF
--- a/components/brave_vpn/browser/v2/BUILD.gn
+++ b/components/brave_vpn/browser/v2/BUILD.gn
@@ -43,6 +43,7 @@ static_library("browser") {
     "//components/prefs",
     "//net",
     "//services/network/public/cpp",
+    "//third_party/icu",
     "//ui/base",
     "//url",
   ]

--- a/components/brave_vpn/browser/v2/api/BUILD.gn
+++ b/components/brave_vpn/browser/v2/api/BUILD.gn
@@ -11,15 +11,16 @@ source_set("api") {
   sources = [
     "brave_vpn_api_client.cc",
     "brave_vpn_api_client.h",
+    "endpoint_constants.h",
     "error_body.h",
     "purchase_endpoints.h",
     "raw_json_response_body.h",
+    "support_endpoints.h",
   ]
 
   public_deps = [
     "//base",
     "//brave/components/brave_account/endpoint_client",
-    "//brave/components/brave_vpn/common",
     "//url",
   ]
 
@@ -36,6 +37,7 @@ source_set("unit_tests") {
   sources = [
     "brave_vpn_api_client_unittest.cc",
     "purchase_endpoints_unittest.cc",
+    "support_endpoints_unittest.cc",
   ]
 
   deps = [

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client.cc
@@ -28,6 +28,7 @@ using brave_account::endpoint_client::WithHeaders;
 
 namespace brave_vpn::v2 {
 
+using endpoints::CreateSupportTicket;
 using endpoints::GetSubscriberCredential;
 using endpoints::GetSubscriberCredentialV12;
 using endpoints::VerifyPurchaseToken;
@@ -185,6 +186,43 @@ void BraveVpnApiClient::OnVerifyPurchaseTokenResponse(
           })
           .transform_error([](endpoints::RawJsonResponseBody error) {
             return std::move(error.json);
+          }));
+}
+
+void BraveVpnApiClient::CreateSupportTicket(
+    CreateSupportTicketCallback callback,
+    const std::string& email,
+    const std::string& subject,
+    const std::string& body,
+    const std::string& subscriber_credential,
+    const std::string& timezone) {
+  auto request = MakeRequest<CreateSupportTicket::Request>();
+  request.body.email = email;
+  request.body.subject = subject;
+  request.body.body = body;
+  request.body.subscriber_credential = subscriber_credential;
+  request.body.timezone = timezone;
+
+  Client<endpoints::CreateSupportTicket>::Send(
+      url_loader_factory_, std::move(request),
+      base::BindOnce(&BraveVpnApiClient::OnCreateSupportTicketResponse,
+                     weak_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void BraveVpnApiClient::OnCreateSupportTicketResponse(
+    CreateSupportTicketCallback callback,
+    endpoints::CreateSupportTicket::Response response) {
+  if (auto unrecoverable = MaybeDescribeUnrecoverableResponse(response)) {
+    return std::move(callback).Run(base::unexpected(*std::move(unrecoverable)));
+  }
+
+  std::move(callback).Run(
+      std::move(CHECK_DEREF(response.body))
+          .transform([](endpoints::RawJsonResponseBody success) {
+            return std::move(success.json);
+          })
+          .transform_error([](endpoints::VpnErrorBody error) {
+            return std::move(error.error_title);
           }));
 }
 

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h
@@ -13,6 +13,7 @@
 #include "base/memory/weak_ptr.h"
 #include "base/types/expected.h"
 #include "brave/components/brave_vpn/browser/v2/api/purchase_endpoints.h"
+#include "brave/components/brave_vpn/browser/v2/api/support_endpoints.h"
 
 namespace network {
 class SharedURLLoaderFactory;
@@ -68,6 +69,19 @@ class BraveVpnApiClient {
                                    const std::string& product_type,
                                    const std::string& bundle_id);
 
+  // Connect API: CreateSupportTicket.
+  // Submits a customer support inquiry. On success: the server's confirmation
+  // JSON (an echo of the submitted data). On failure: a user-facing error
+  // string.
+  using CreateSupportTicketCallback =
+      base::OnceCallback<void(base::expected<std::string, std::string>)>;
+  virtual void CreateSupportTicket(CreateSupportTicketCallback callback,
+                                   const std::string& email,
+                                   const std::string& subject,
+                                   const std::string& body,
+                                   const std::string& subscriber_credential,
+                                   const std::string& timezone);
+
  private:
   void OnGetSubscriberCredentialResponse(
       SubscriberCredentialCallback callback,
@@ -75,6 +89,9 @@ class BraveVpnApiClient {
   void OnVerifyPurchaseTokenResponse(
       VerifyPurchaseTokenCallback callback,
       endpoints::VerifyPurchaseToken::Response response);
+  void OnCreateSupportTicketResponse(
+      CreateSupportTicketCallback callback,
+      endpoints::CreateSupportTicket::Response response);
 
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   base::WeakPtrFactory<BraveVpnApiClient> weak_factory_{this};

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
@@ -37,6 +37,10 @@ constexpr char kTestBundleId[] = "test-bundle-id";
 constexpr char kTestSkusCredential[] = "test-skus-credential";
 constexpr char kTestSubscriberCredential[] = "test-subscriber-credential";
 constexpr char kTestEnvironment[] = "test-env";
+constexpr char kTestEmail[] = "user@example.com";
+constexpr char kTestSubject[] = "Help";
+constexpr char kTestBody[] = "It doesn't connect.";
+constexpr char kTestTimezone[] = "America/Los_Angeles";
 
 // Canonical JSON (compact, keys sorted): MockResponseFor re-serializes the
 // body via ToValue() and the client re-parses it via FromValue(), so only
@@ -218,8 +222,8 @@ INSTANTIATE_TEST_SUITE_P(
                           .body = base::ok(endpoints::RawJsonResponseBody{
                               .json = kTestSuccessJson})},
              .expected = base::ok(kTestSuccessJson)},
-         // non-2xx error body is *also* forwarded verbatim (raw on both sides),
-         // not collapsed to a VpnErrorBody title.
+         // A non-2xx error body is *also* forwarded verbatim (raw on both
+         // sides), not collapsed to a VpnErrorBody title.
          VerifyPurchaseTokenTestCase{
              .test_name = "RequestError",
              .response = {.net_error = net::OK,
@@ -228,6 +232,48 @@ INSTANTIATE_TEST_SUITE_P(
                               base::unexpected(endpoints::RawJsonResponseBody{
                                   .json = kTestErrorJson})},
              .expected = base::unexpected(kTestErrorJson)}})),
+    [](const auto& info) { return info.param.test_name; });
+
+struct CreateSupportTicketTestCase {
+  std::string test_name;
+  endpoints::CreateSupportTicket::Response response;
+  base::expected<std::string, std::string> expected;
+};
+
+using BraveVpnApiClientCreateSupportTicketTest =
+    BraveVpnApiClientTest<CreateSupportTicketTestCase>;
+
+TEST_P(BraveVpnApiClientCreateSupportTicketTest, MapsResponseToResult) {
+  const auto& test_case = GetParam();
+  MockResponseFor<endpoints::CreateSupportTicket>(url_loader_factory_,
+                                                  test_case.response);
+  EXPECT_EQ(CallClientApi(&BraveVpnApiClient::CreateSupportTicket, kTestEmail,
+                          kTestSubject, kTestBody, kTestSubscriberCredential,
+                          kTestTimezone),
+            test_case.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BraveVpnApiClientTests,
+    BraveVpnApiClientCreateSupportTicketTest,
+    testing::ValuesIn(WithCommonUnrecoverableCases<CreateSupportTicketTestCase>(
+        {// 2xx echoes the confirmation JSON verbatim.
+         CreateSupportTicketTestCase{
+             .test_name = "Success",
+             .response = {.net_error = net::OK,
+                          .status_code = net::HTTP_OK,
+                          .body = base::ok(endpoints::RawJsonResponseBody{
+                              .json = kTestSuccessJson})},
+             .expected = base::ok(kTestSuccessJson)},
+         // A non-2xx response with a parseable error body surfaces its title.
+         CreateSupportTicketTestCase{
+             .test_name = "RequestError",
+             .response = {.net_error = net::OK,
+                          .status_code = net::HTTP_BAD_REQUEST,
+                          .body = base::unexpected(endpoints::VpnErrorBody{
+                              .error_title = "Invalid credential.",
+                              .error_message = "expired"})},
+             .expected = base::unexpected("Invalid credential.")}})),
     [](const auto& info) { return info.param.test_name; });
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/api/endpoint_constants.h
+++ b/components/brave_vpn/browser/v2/api/endpoint_constants.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_ENDPOINT_CONSTANTS_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_ENDPOINT_CONSTANTS_H_
+
+namespace brave_vpn::v2::endpoints {
+
+// Guardian Connect API host name.
+inline constexpr char kVpnHost[] = "connect-api.guardianapp.com";
+
+// Endpoint request APIs.
+inline constexpr char kCreateSubscriberCredentialApi[] =
+    "api/v1.2/subscriber-credential/create";
+inline constexpr char kVerifyPurchaseTokenApi[] =
+    "api/v1.1/verify-purchase-token";
+inline constexpr char kCreateSupportTicketApi[] =
+    "api/v1.2/partners/support-ticket";
+
+// Endpoint request JSON keys that can be shared between multiple APIs.
+inline constexpr char kProductTypeKey[] = "product-type";
+inline constexpr char kProductIdKey[] = "product-id";
+inline constexpr char kPurchaseTokenKey[] = "purchase-token";
+inline constexpr char kBundleIdKey[] = "bundle-id";
+inline constexpr char kValidationMethodKey[] = "validation-method";
+inline constexpr char kSkusCredentialKey[] = "brave-vpn-premium-monthly-pass";
+inline constexpr char kSubscriberCredentialKey[] = "subscriber-credential";
+inline constexpr char kEmailKey[] = "email";
+inline constexpr char kSubjectKey[] = "subject";
+inline constexpr char kSupportTicketKey[] = "support-ticket";
+inline constexpr char kPartnerClientIdKey[] = "partner-client-id";
+inline constexpr char kPaymentValidationMethodKey[] =
+    "payment-validation-method";
+
+// Default payment validation method used by Brave.
+inline constexpr char kValidationMethodDefaultValue[] = "brave-premium";
+
+}  // namespace brave_vpn::v2::endpoints
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_ENDPOINT_CONSTANTS_H_

--- a/components/brave_vpn/browser/v2/api/purchase_endpoints.h
+++ b/components/brave_vpn/browser/v2/api/purchase_endpoints.h
@@ -13,9 +13,9 @@
 #include "base/values.h"
 #include "brave/components/brave_account/endpoint_client/request_types.h"
 #include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_vpn/browser/v2/api/endpoint_constants.h"
 #include "brave/components/brave_vpn/browser/v2/api/error_body.h"
 #include "brave/components/brave_vpn/browser/v2/api/raw_json_response_body.h"
-#include "brave/components/brave_vpn/common/brave_vpn_constants.h"
 #include "url/gurl.h"
 #include "url/url_constants.h"
 
@@ -24,14 +24,6 @@
 
 namespace brave_vpn::v2::endpoints {
 
-inline constexpr char kProductTypeKey[] = "product-type";
-inline constexpr char kProductIdKey[] = "product-id";
-inline constexpr char kPurchaseTokenKey[] = "purchase-token";
-inline constexpr char kBundleIdKey[] = "bundle-id";
-inline constexpr char kValidationMethodKey[] = "validation-method";
-inline constexpr char kValidationMethodDefaultValue[] = "brave-premium";
-inline constexpr char kSkusCredentialKey[] = "brave-vpn-premium-monthly-pass";
-inline constexpr char kSubscriberCredentialKey[] = "subscriber-credential";
 inline constexpr char kHeaderBravePaymentsEnvironment[] =
     "Brave-Payments-Environment";
 
@@ -99,7 +91,7 @@ struct GetSubscriberCredentialBase {
   static GURL URL() {
     return GURL(base::StrCat({url::kHttpsScheme, url::kStandardSchemeSeparator,
                               kVpnHost}))
-        .Resolve(kCreateSubscriberCredentialV12);
+        .Resolve(kCreateSubscriberCredentialApi);
   }
 };
 
@@ -136,7 +128,7 @@ struct VerifyPurchaseToken {
   static GURL URL() {
     return GURL(base::StrCat({url::kHttpsScheme, url::kStandardSchemeSeparator,
                               kVpnHost}))
-        .Resolve(kVerifyPurchaseToken);
+        .Resolve(kVerifyPurchaseTokenApi);
   }
 };
 

--- a/components/brave_vpn/browser/v2/api/support_endpoints.h
+++ b/components/brave_vpn/browser/v2/api/support_endpoints.h
@@ -1,0 +1,78 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_SUPPORT_ENDPOINTS_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_SUPPORT_ENDPOINTS_H_
+
+#include <string>
+
+#include "base/base64.h"
+#include "base/strings/strcat.h"
+#include "base/strings/string_util.h"
+#include "base/values.h"
+#include "brave/components/brave_account/endpoint_client/request_types.h"
+#include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_vpn/browser/v2/api/endpoint_constants.h"
+#include "brave/components/brave_vpn/browser/v2/api/error_body.h"
+#include "brave/components/brave_vpn/browser/v2/api/raw_json_response_body.h"
+#include "url/gurl.h"
+#include "url/url_constants.h"
+
+// CreateSupportTicket hits the fixed Guardian account host (kVpnHost).
+
+namespace brave_vpn::v2::endpoints {
+
+inline constexpr char kPartnerClientIdValue[] = "com.brave.browser";
+inline constexpr char kTimezoneMetadataKey[] = "timezone";
+
+// CreateSupportTicket API submits a customer support inquiry to Guardian.
+// On success (200), the request JSON is echoed back as confirmation; since it
+// carries no new information, it's forwarded verbatim via RawJsonResponseBody
+// rather than parsed into fields.
+struct CreateSupportTicketRequestBody {
+  std::string email;
+  std::string subject;
+  std::string body;
+  std::string subscriber_credential;
+  std::string timezone;
+
+  base::DictValue ToValue() const {
+    const std::string body_with_metadata = base::StrCat(
+        {body, "\n\n", kSubscriberCredentialKey, ": ", subscriber_credential,
+         "\n", kPaymentValidationMethodKey, ": ", kValidationMethodDefaultValue,
+         "\n", kTimezoneMetadataKey, ": ", timezone});
+
+    std::string email_trimmed, subject_trimmed, body_trimmed;
+    base::TrimWhitespaceASCII(email, base::TRIM_ALL, &email_trimmed);
+    base::TrimWhitespaceASCII(subject, base::TRIM_ALL, &subject_trimmed);
+    base::TrimWhitespaceASCII(body_with_metadata, base::TRIM_ALL,
+                              &body_trimmed);
+
+    return base::DictValue()
+        .Set(kEmailKey, email_trimmed)
+        .Set(kSubjectKey, subject_trimmed)
+        .Set(kSupportTicketKey, base::Base64Encode(body_trimmed))
+        .Set(kPartnerClientIdKey, kPartnerClientIdValue)
+        .Set(kPaymentValidationMethodKey, kValidationMethodDefaultValue)
+        .Set(kSubscriberCredentialKey, subscriber_credential);
+  }
+};
+
+struct CreateSupportTicket {
+  using Request =
+      brave_account::endpoint_client::POST<CreateSupportTicketRequestBody>;
+  using Response = brave_account::endpoint_client::Response<RawJsonResponseBody,
+                                                            VpnErrorBody>;
+
+  static GURL URL() {
+    return GURL(base::StrCat({url::kHttpsScheme, url::kStandardSchemeSeparator,
+                              kVpnHost}))
+        .Resolve(kCreateSupportTicketApi);
+  }
+};
+
+}  // namespace brave_vpn::v2::endpoints
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_SUPPORT_ENDPOINTS_H_

--- a/components/brave_vpn/browser/v2/api/support_endpoints_unittest.cc
+++ b/components/brave_vpn/browser/v2/api/support_endpoints_unittest.cc
@@ -1,0 +1,48 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/api/support_endpoints.h"
+
+#include "base/base64.h"
+#include "base/strings/strcat.h"
+#include "base/values.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2::endpoints {
+namespace {
+constexpr char kTestEmail[] = "user@example.com";
+constexpr char kTestSubject[] = "Help";
+constexpr char kTestBody[] = "It doesn't connect.";
+constexpr char kTestSubscriberCredential[] = "test-subscriber-credential";
+constexpr char kTestTimezone[] = "America/Los_Angeles";
+}  // namespace
+
+TEST(SupportEndpointsTest, CreateSupportTicketRequestBodyToValue) {
+  const CreateSupportTicketRequestBody body{
+      .email = kTestEmail,
+      .subject = kTestSubject,
+      .body = kTestBody,
+      .subscriber_credential = kTestSubscriberCredential,
+      .timezone = kTestTimezone};
+
+  // The encoded ticket body embeds credential, validation method, and
+  // timezone as text lines, in addition to the separate JSON fields above.
+  const std::string expected_encoded_body = base::Base64Encode(base::StrCat(
+      {kTestBody, "\n\n", kSubscriberCredentialKey, ": ",
+       kTestSubscriberCredential, "\n", kPaymentValidationMethodKey, ": ",
+       kValidationMethodDefaultValue, "\n", kTimezoneMetadataKey, ": ",
+       kTestTimezone}));
+
+  EXPECT_EQ(body.ToValue(),
+            base::DictValue()
+                .Set(kEmailKey, kTestEmail)
+                .Set(kSubjectKey, kTestSubject)
+                .Set(kSupportTicketKey, expected_encoded_body)
+                .Set(kPartnerClientIdKey, kPartnerClientIdValue)
+                .Set(kPaymentValidationMethodKey, kValidationMethodDefaultValue)
+                .Set(kSubscriberCredentialKey, kTestSubscriberCredential));
+}
+
+}  // namespace brave_vpn::v2::endpoints

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_desktop.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_desktop.cc
@@ -3,15 +3,42 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <memory>
+#include <optional>
+#include <string>
 #include <utility>
 
+#include "base/functional/bind.h"
 #include "base/notimplemented.h"
+#include "base/types/expected.h"
+#include "brave/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h"
 #include "brave/components/brave_vpn/browser/v2/brave_vpn_service_impl.h"
 #include "brave/components/brave_vpn/browser/v2/purchased_state_manager.h"
 #include "brave/components/brave_vpn/common/brave_vpn_constants.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#include "third_party/icu/source/i18n/unicode/timezone.h"
 
 namespace brave_vpn::v2 {
+namespace {
+std::string GetTimeZoneName() {
+  std::unique_ptr<icu::TimeZone> zone(icu::TimeZone::createDefault());
+  icu::UnicodeString id;
+  zone->getID(id);
+  std::string current_time_zone;
+  id.toUTF8String<std::string>(current_time_zone);
+  return current_time_zone;
+}
+
+// Bridges the endpoint client's typed result to the mojom
+// (bool success, string response) contract used by CreateSupportTicket.
+void RunCreateSupportTicketCallback(
+    BraveVpnServiceImpl::CreateSupportTicketCallback callback,
+    base::expected<std::string, std::string> result) {
+  const bool success = result.has_value();
+  std::move(callback).Run(success,
+                          success ? std::string() : std::move(result).error());
+}
+}  // namespace
 
 bool BraveVpnServiceImpl::IsConnected() const {
   NOTIMPLEMENTED();
@@ -76,8 +103,19 @@ void BraveVpnServiceImpl::CreateSupportTicket(
     const std::string& subject,
     const std::string& body,
     CreateSupportTicketCallback callback) {
-  NOTIMPLEMENTED();
-  std::move(callback).Run(false, {});
+  if (!api_client_) {
+    std::move(callback).Run(false, {});
+    return;
+  }
+  std::optional<std::string> subscriber_credential =
+      purchased_state_manager_
+          ? purchased_state_manager_->GetSubscriberCredential()
+          : std::nullopt;
+
+  api_client_->CreateSupportTicket(
+      base::BindOnce(&RunCreateSupportTicketCallback, std::move(callback)),
+      email, subject, body, subscriber_credential.value_or(""),
+      GetTimeZoneName());
 }
 
 void BraveVpnServiceImpl::GetSupportData(GetSupportDataCallback callback) {

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_unittest.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_unittest.cc
@@ -21,6 +21,7 @@
 #include "brave/components/skus/browser/test/fake_skus_service.h"
 #include "brave/components/skus/common/features.h"
 #include "brave/components/skus/common/skus_sdk.mojom.h"
+#include "build/build_config.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/testing_pref_service.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
@@ -33,6 +34,7 @@ namespace brave_vpn::v2 {
 namespace {
 constexpr char kTestDomain[] = "vpn.brave.com";
 constexpr char kTestEnvironment[] = "unittest-env";
+constexpr char kTestEmail[] = "test@example.com";
 }  // namespace
 
 class BraveVpnServiceImplTest : public testing::Test {
@@ -111,13 +113,24 @@ TEST_F(BraveVpnServiceImplTest, SafeDefaultsAfterShutdown) {
   service_->ReloadPurchasedState();
   service_->LoadPurchasedState(kTestDomain);
   EXPECT_EQ(skus_bind_count_, 0);
-
-  base::test::TestFuture<mojom::PurchasedInfoPtr> future;
-  service_->GetPurchasedState(future.GetCallback());
-  const mojom::PurchasedInfoPtr& info = future.Get();
-  ASSERT_TRUE(info);
-  EXPECT_EQ(info->state, mojom::PurchasedState::NOT_PURCHASED);
-  EXPECT_EQ(info->description, std::nullopt);
+  {
+    base::test::TestFuture<mojom::PurchasedInfoPtr> future;
+    service_->GetPurchasedState(future.GetCallback());
+    const mojom::PurchasedInfoPtr& info = future.Get();
+    ASSERT_TRUE(info);
+    EXPECT_EQ(info->state, mojom::PurchasedState::NOT_PURCHASED);
+    EXPECT_EQ(info->description, std::nullopt);
+  }
+#if !BUILDFLAG(IS_ANDROID)
+  {
+    base::test::TestFuture<bool, std::string> future;
+    service_->CreateSupportTicket(
+        kTestEmail, "subject", "body",
+        future.GetCallback<bool, const std::string&>());
+    EXPECT_FALSE(future.Get<0>());
+    EXPECT_TRUE(future.Get<1>().empty());
+  }
+#endif  // !BUILDFLAG(IS_ANDROID)
 }
 
 }  // namespace brave_vpn::v2


### PR DESCRIPTION
Port `CreateSupportTicket` to the endpoint client. Success returns the server's confirmation JSON verbatim via RawJsonResponseBody, since 200 just echoes the submitted data, as per recent changes by Guardian.

Per Guardian, subscriber-credential and payment-validation-method go both as JSON fields and as text lines embedded in the base64-encoded ticket body; timezone is embedded in the body text only.

Move endpoint constants into a new `endpoint_constants.h`, dropping the "api" target's dependency on `brave_vpn/common`.

Implements part of https://github.com/brave/brave-browser/issues/54600

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
