### PR TITLE
Improve import UI interactions and styles

### DIFF
--- a/browser/resources/brave_welcome_page/components/import_profile_detail.style.ts
+++ b/browser/resources/brave_welcome_page/components/import_profile_detail.style.ts
@@ -38,7 +38,12 @@ export const style = scoped.css`
   }
 
   .data-types {
+    .list > * {
+      cursor: pointer;
+    }
+
     leo-checkbox {
+      --leo-checkbox-size: 24px;
       width: 100%;
     }
   }

--- a/browser/resources/brave_welcome_page/components/import_profile_detail.tsx
+++ b/browser/resources/brave_welcome_page/components/import_profile_detail.tsx
@@ -50,6 +50,19 @@ export function ImportProfileDetail(props: Props) {
   const showProfileName =
     browserName && profileName && (browserProfiles.get(browserName) ?? 0) > 1
 
+  const onDataTypeRowClick = (
+    event: React.MouseEvent,
+    type: ImportDataType,
+  ) => {
+    if (
+      event.target instanceof Element
+      && event.target.closest('leo-checkbox')
+    ) {
+      return
+    }
+    props.onDataTypeChanged(type, !dataTypes.includes(type))
+  }
+
   return (
     <div data-css-scope={style.scope}>
       <button
@@ -77,7 +90,10 @@ export function ImportProfileDetail(props: Props) {
         <h4>{getString('WELCOME_PAGE_IMPORT_DATA_TYPES_TITLE')}</h4>
         <div className='list'>
           {availableTypes.map((type) => (
-            <div key={type}>
+            <div
+              key={type}
+              onClick={(event) => onDataTypeRowClick(event, type)}
+            >
               <Checkbox
                 checked={dataTypes.includes(type)}
                 onChange={(event) => {

--- a/browser/resources/brave_welcome_page/components/import_status_view.style.ts
+++ b/browser/resources/brave_welcome_page/components/import_status_view.style.ts
@@ -3,7 +3,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import { color, effect, radius, spacing } from '@brave/leo/tokens/css/variables'
+import {
+  color,
+  duration,
+  easing,
+  effect,
+  radius,
+  spacing,
+} from '@brave/leo/tokens/css/variables'
 import { scoped } from '$web-common/scoped_css'
 import { wideBreakpoint } from './breakpoints'
 
@@ -44,6 +51,14 @@ export const style = scoped.css`
       }
     }
 
+    .source-icon {
+      filter: grayscale(0);
+      opacity: 1;
+      transition:
+        filter ${duration.l} ${easing.inOut},
+        opacity ${duration.l} ${easing.inOut};
+    }
+
     .brave-icon {
       position: relative;
     }
@@ -59,6 +74,11 @@ export const style = scoped.css`
       background: ${color.container.background};
       box-shadow: ${effect.elevation['01']};
     }
+  }
+
+  &[data-import-status='succeeded'] .source-icon {
+    filter: grayscale(1);
+    opacity: 0.5;
   }
 
   .data-types {

--- a/browser/resources/brave_welcome_page/components/import_status_view.tsx
+++ b/browser/resources/brave_welcome_page/components/import_status_view.tsx
@@ -59,7 +59,9 @@ export function ImportStatusView(props: Props) {
       data-import-status={status}
     >
       <div className='header'>
-        <BrowserIcon name={browserName} />
+        <div className='source-icon'>
+          <BrowserIcon name={browserName} />
+        </div>
         <div className='carats'>
           <Icon name='carat-right' />
           <Icon name='carat-right' />

--- a/browser/resources/brave_welcome_page/components/import_step.style.ts
+++ b/browser/resources/brave_welcome_page/components/import_step.style.ts
@@ -44,7 +44,6 @@ style.passthrough.css`
       flex-direction: column;
 
       > * {
-        min-height: calc(24px + 2 * ${spacing.xl});
         padding: ${spacing.l} ${spacing.xl};
         border-bottom: solid 1px ${color.divider.subtle};
         display: flex;


### PR DESCRIPTION
- Resolves https://github.com/brave/brave-browser/issues/58208

## Summary
- Make import data-type checkboxes 24px and toggle from the full row (including padding), with a pointer cursor only while checkboxes are shown.
- After a successful import, fade the selected browser icon to grayscale at 50% opacity.
- Drop the rigid min-height on import list rows so they size to their content.

## Test plan
- [ ] Open onboarding and go to the import step
- [ ] Select a browser profile and confirm data-type checkboxes are 24×24px
- [ ] Click row padding (not just the checkbox/label) and confirm the item toggles
- [ ] Confirm the pointer cursor appears on those rows before import, and not on the in-progress/success lists
- [ ] Start import and confirm the source browser icon stays full color while in progress
- [ ] When import succeeds, confirm the source browser icon animates to grayscale at 50% opacity



<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->