### PR TITLE
[ads] Retry confirmation token refill after 429 Too Many Requests

### DIFF
--- a/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.cc
+++ b/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.cc
@@ -162,8 +162,10 @@ RefillConfirmationTokens::HandleRequestSignedTokensUrlResponse(
   }
 
   if (mojom_url_response.code != net::HTTP_CREATED) {
-    const bool should_retry = HttpStatusCodeClass(mojom_url_response.code) !=
-                              HttpStatusCodeClassType::kClientError;
+    const bool should_retry =
+        mojom_url_response.code == net::HTTP_TOO_MANY_REQUESTS ||
+        HttpStatusCodeClass(mojom_url_response.code) !=
+            HttpStatusCodeClassType::kClientError;
     return UrlResponseError({.message = "Failed to request signed tokens",
                              .should_retry = should_retry});
   }
@@ -241,10 +243,12 @@ RefillConfirmationTokens::HandleGetSignedTokensUrlResponse(
 
   if (mojom_url_response.code != net::HTTP_OK &&
       mojom_url_response.code != net::HTTP_UNAUTHORIZED) {
-    return UrlResponseError(
-        {.message = "Failed to get signed tokens",
-         .should_retry = HttpStatusCodeClass(mojom_url_response.code) !=
-                         HttpStatusCodeClassType::kClientError});
+    const bool should_retry =
+        mojom_url_response.code == net::HTTP_TOO_MANY_REQUESTS ||
+        HttpStatusCodeClass(mojom_url_response.code) !=
+            HttpStatusCodeClassType::kClientError;
+    return UrlResponseError({.message = "Failed to get signed tokens",
+                             .should_retry = should_retry});
   }
 
   std::optional<base::DictValue> dict =

--- a/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens_unittest.cc
+++ b/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens_unittest.cc
@@ -169,6 +169,38 @@ TEST_F(BraveAdsRefillConfirmationTokensTest,
 }
 
 TEST_F(BraveAdsRefillConfirmationTokensTest,
+       RetryRequestSignedTokensAfterTooManyRequests) {
+  // Arrange
+  test::BuildAndSetIssuers();
+
+  test::MockTokenGenerator(/*count=*/50);
+
+  const test::URLResponseMap url_responses = {
+      {BuildRequestSignedTokensUrlPath(test::kWalletPaymentId),
+       {{net::HTTP_TOO_MANY_REQUESTS,
+         /*response_body=*/std::string(
+             net::GetHttpReasonPhrase(net::HTTP_TOO_MANY_REQUESTS))},
+        {net::HTTP_CREATED, test::BuildRequestSignedTokensUrlResponseBody()}}},
+      {BuildGetSignedTokensUrlPath(test::kWalletPaymentId,
+                                   test::kRequestSignedTokensNonce),
+       {{net::HTTP_OK, test::BuildGetSignedTokensUrlResponseBody()}}}};
+  test::MockUrlResponses(ads_client_mock_, url_responses);
+
+  const WalletInfo wallet = test::Wallet();
+
+  // Act & Assert
+  const ::testing::InSequence s;
+  EXPECT_CALL(delegate_mock_, OnFailedToRefillConfirmationTokens);
+  EXPECT_CALL(delegate_mock_, OnWillRetryRefillingConfirmationTokens);
+  EXPECT_CALL(delegate_mock_, OnDidRetryRefillingConfirmationTokens);
+  EXPECT_CALL(delegate_mock_, OnDidRefillConfirmationTokens);
+  refill_confirmation_tokens_.MaybeRefill(wallet);
+  FastForwardClockToNextPendingTask();
+
+  EXPECT_EQ(50U, ConfirmationTokenCount());
+}
+
+TEST_F(BraveAdsRefillConfirmationTokensTest,
        DoNotRefillConfirmationTokensIfRequestSignedTokensIsMissingNonce) {
   // Arrange
   test::BuildAndSetIssuers();
@@ -190,6 +222,39 @@ TEST_F(BraveAdsRefillConfirmationTokensTest,
   refill_confirmation_tokens_.MaybeRefill(wallet);
 
   EXPECT_EQ(0U, ConfirmationTokenCount());
+}
+
+TEST_F(BraveAdsRefillConfirmationTokensTest,
+       RetryGetSignedTokensAfterTooManyRequests) {
+  // Arrange
+  test::BuildAndSetIssuers();
+
+  test::MockTokenGenerator(/*count=*/50);
+
+  const test::URLResponseMap url_responses = {
+      {BuildRequestSignedTokensUrlPath(test::kWalletPaymentId),
+       {{net::HTTP_CREATED, test::BuildRequestSignedTokensUrlResponseBody()},
+        {net::HTTP_CREATED, test::BuildRequestSignedTokensUrlResponseBody()}}},
+      {BuildGetSignedTokensUrlPath(test::kWalletPaymentId,
+                                   test::kRequestSignedTokensNonce),
+       {{net::HTTP_TOO_MANY_REQUESTS,
+         /*response_body=*/std::string(
+             net::GetHttpReasonPhrase(net::HTTP_TOO_MANY_REQUESTS))},
+        {net::HTTP_OK, test::BuildGetSignedTokensUrlResponseBody()}}}};
+  test::MockUrlResponses(ads_client_mock_, url_responses);
+
+  const WalletInfo wallet = test::Wallet();
+
+  // Act & Assert
+  const ::testing::InSequence s;
+  EXPECT_CALL(delegate_mock_, OnFailedToRefillConfirmationTokens);
+  EXPECT_CALL(delegate_mock_, OnWillRetryRefillingConfirmationTokens);
+  EXPECT_CALL(delegate_mock_, OnDidRetryRefillingConfirmationTokens);
+  EXPECT_CALL(delegate_mock_, OnDidRefillConfirmationTokens);
+  refill_confirmation_tokens_.MaybeRefill(wallet);
+  FastForwardClockToNextPendingTask();
+
+  EXPECT_EQ(50U, ConfirmationTokenCount());
 }
 
 TEST_F(BraveAdsRefillConfirmationTokensTest,


### PR DESCRIPTION
PR #33287 stopped retrying on any 4xx response to avoid retrying permanent client errors, but 429 is transient and should still be retried.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58153

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
