### PR TITLE
[iOS] Temporarily re-add toolbar keyboard background on iOS 26+

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -178,6 +178,12 @@ public class BrowserViewController: UIViewController {
   /// Whether last session was a crash or not
   private let crashedLastSession: Bool
 
+  // A view to place behind the bottom bar down to the toolbar during keyboard animations to avoid
+  // the odd look for the URL bar floating
+  private let bottomBarKeyboardBackground = UIView().then {
+    $0.isUserInteractionEnabled = false
+  }
+
   var toolbarVisibilityViewModel = ToolbarVisibilityViewModel(estimatedTransitionDistance: 44)
   private var toolbarLayoutGuide = UILayoutGuide().then {
     $0.identifier = "toolbar-visibility-layout-guide"
@@ -715,6 +721,8 @@ public class BrowserViewController: UIViewController {
       alongsideTransition: { context in
         if self.isViewLoaded {
           self.updateStatusBarOverlayColor()
+          self.bottomBarKeyboardBackground.backgroundColor =
+            self.privateBrowsingManager.browserColors.chromeBackground
           self.setNeedsStatusBarAppearanceUpdate()
         }
       }
@@ -831,6 +839,7 @@ public class BrowserViewController: UIViewController {
       header.isUsingBottomBar = isUsingBottomBar
       collapsedURLBarView.isUsingBottomBar = isUsingBottomBar
       searchContainer?.isUsingBottomBar = isUsingBottomBar
+      bottomBarKeyboardBackground.isHidden = !isUsingBottomBar
       topToolbar.displayTabTraySwipeGestureRecognizer?.isEnabled = isUsingBottomBar
       updateTabsBarVisibility()
       updateStatusBarOverlayColor()
@@ -863,6 +872,9 @@ public class BrowserViewController: UIViewController {
     view.addSubview(alertStackView)
     view.addSubview(bottomTouchArea)
     view.addSubview(topTouchArea)
+    if #available(iOS 26.0, *) {
+      view.addSubview(bottomBarKeyboardBackground)
+    }
     view.addSubview(footer)
     view.addSubview(statusBarOverlay)
     view.addSubview(header)
@@ -1002,6 +1014,8 @@ public class BrowserViewController: UIViewController {
       .sink(receiveValue: { [weak self] isPrivateBrowsing in
         guard let self = self else { return }
         self.updateStatusBarOverlayColor()
+        self.bottomBarKeyboardBackground.backgroundColor =
+          self.privateBrowsingManager.browserColors.chromeBackground
         self.collapsedURLBarView.browserColors = self.privateBrowsingManager.browserColors
       })
 
@@ -1437,6 +1451,18 @@ public class BrowserViewController: UIViewController {
       make.leading.trailing.equalTo(self.view)
       if toolbar == nil {
         make.height.equalTo(0)
+      }
+    }
+
+    if #available(iOS 26.0, *) {
+      bottomBarKeyboardBackground.snp.remakeConstraints {
+        if self.isUsingBottomBar {
+          $0.top.equalTo(header)
+          $0.bottom.equalTo(footer)
+        } else {
+          $0.top.bottom.equalTo(footer)
+        }
+        $0.leading.trailing.equalToSuperview()
       }
     }
 


### PR DESCRIPTION
This was removed in #39091 however when working on fixing the web view viewports it turns out this is needed until the design of our collapsed toolbar is updated because the web view will no longer be constrained between the toolbars and so will show under the toolbar/keyboard. This can be reverted/removed in the future when our iOS 26+ collapsed url bar design changes to be a floating glass pill style