### PR TITLE
[iOS] Use obscured insets on iOS 26+ for web view viewport handling

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -413,7 +413,7 @@ extension BrowserViewController: TabManagerDelegate {
       duration: duration,
       makeConstraints: { make in
         make.left.right.equalTo(self.view)
-        make.bottom.equalTo(self.webViewContainer)
+        make.bottom.equalTo(self.pageOverlayLayoutGuide)
       },
       completion: { [weak self] in
         if toast is ButtonToast {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
@@ -85,7 +85,18 @@ extension BrowserViewController: TabObserver {
     }
   }
 
+  public func tabWasShown(_ tab: some TabState) {
+    if #available(iOS 26.0, *) {
+      updateWebViewObscuredInsets()
+    }
+  }
+
   public func tabDidCommitNavigation(_ tab: some TabState) {
+    // Odd Chromium behaviour resets the web views obscured insets when a navigation starts due to
+    // a bug with their fullscreen support, so we must set this again after a commit
+    if #available(iOS 26.0, *) {
+      updateWebViewObscuredInsets()
+    }
     // Reset the stored http request now that load has committed.
     tab.upgradedHTTPSRequest = nil
     tab.upgradeHTTPSTimeoutTimer?.invalidate()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -688,11 +688,13 @@ public class BrowserViewController: UIViewController {
     var minViewportInset = UIEdgeInsets()
     var maxViewportInset = UIEdgeInsets()
     if isUsingBottomBar {
+      minViewportInset.top = view.safeAreaInsets.top
+      maxViewportInset.top = view.safeAreaInsets.top
       minViewportInset.bottom = footer.bounds.height + collapsedURLBarView.bounds.height
       maxViewportInset.bottom = footer.bounds.height + header.expandedBarStackView.bounds.height
     } else {
-      minViewportInset.top = collapsedURLBarView.bounds.height
-      maxViewportInset.top = header.expandedBarStackView.bounds.height
+      minViewportInset.top = view.safeAreaInsets.top + collapsedURLBarView.bounds.height
+      maxViewportInset.top = view.safeAreaInsets.top + header.expandedBarStackView.bounds.height
       minViewportInset.bottom = footer.bounds.height
       maxViewportInset.bottom = footer.bounds.height
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -679,7 +679,7 @@ public class BrowserViewController: UIViewController {
   }
 
   @available(iOS 26.0, *)
-  private func updateWebViewObscuredInsets() {
+  func updateWebViewObscuredInsets() {
     guard let webViewProxy = tabManager.selectedTab?.webViewProxy else { return }
 
     collapsedURLBarView.layoutIfNeeded()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -87,9 +87,6 @@ public class BrowserViewController: UIViewController {
     return bottomTouchArea
   }()
 
-  /// These constraints allow to show/hide tabs bar
-  private var webViewContainerTopOffset: Constraint?
-
   /// Backdrop used for displaying greyed background for private tabs
   private let webViewContainerBackdrop: UIView = {
     let webViewContainerBackdrop = UIView()
@@ -681,6 +678,74 @@ public class BrowserViewController: UIViewController {
     statusBarOverlay.isHidden = view.safeAreaInsets.top.isZero
   }
 
+  @available(iOS 26.0, *)
+  private func updateWebViewObscuredInsets() {
+    guard let webViewProxy = tabManager.selectedTab?.webViewProxy else { return }
+
+    collapsedURLBarView.layoutIfNeeded()
+    header.expandedBarStackView.layoutIfNeeded()
+
+    var minViewportInset = UIEdgeInsets()
+    var maxViewportInset = UIEdgeInsets()
+    if isUsingBottomBar {
+      minViewportInset.bottom = footer.bounds.height + collapsedURLBarView.bounds.height
+      maxViewportInset.bottom = footer.bounds.height + header.expandedBarStackView.bounds.height
+    } else {
+      minViewportInset.top = collapsedURLBarView.bounds.height
+      maxViewportInset.top = header.expandedBarStackView.bounds.height
+      minViewportInset.bottom = footer.bounds.height
+      maxViewportInset.bottom = footer.bounds.height
+    }
+    webViewProxy.setMinimumViewportInset(minViewportInset, maximumViewportInset: maxViewportInset)
+
+    let toolbarInsets = UIEdgeInsets(
+      top: max(
+        0,
+        toolbarLayoutGuide.layoutFrame.minY + (isUsingBottomBar ? 0 : header.bounds.height)
+      ),
+      left: 0,
+      bottom: max(
+        0,
+        view.bounds.height
+          - (toolbarLayoutGuide.layoutFrame.maxY
+            - (isUsingBottomBar
+              ? header.bounds.height + footer.bounds.height : footer.bounds.height))
+      ),
+      right: 0
+    )
+
+    // Obscured insets actually have to include safe area insets for some reason, toolbarInsets
+    // already include it so we override the values entirely
+    var obscuredInsets = view.safeAreaInsets
+    obscuredInsets.top = toolbarInsets.top
+    obscuredInsets.bottom = toolbarInsets.bottom
+
+    // Setting obscuredInsets actually includes a side-effect of setting the web views contentInset
+    webViewProxy.obscuredInsets = obscuredInsets
+
+    // But we still need to update the scroll indicator insets manually
+    var scrollIndicatorInsets = UIEdgeInsets(
+      top: max(0, toolbarInsets.top - view.safeAreaInsets.top),
+      left: 0,
+      bottom: max(0, toolbarInsets.bottom - view.safeAreaInsets.bottom),
+      right: 0
+    )
+
+    if let keyboardState, case let keyboardHeight = keyboardState.intersectionHeightForView(view),
+      keyboardHeight > 0
+    {
+      var contentInsets = webViewProxy.scrollView?.contentInset ?? .zero
+      contentInsets.bottom = keyboardHeight + toolbarInsets.bottom
+      webViewProxy.scrollView?.contentInset = contentInsets
+      if isUsingBottomBar {
+        scrollIndicatorInsets.bottom = 0
+      } else {
+        scrollIndicatorInsets.bottom -= toolbarInsets.bottom
+      }
+    }
+    webViewProxy.scrollView?.scrollIndicatorInsets = scrollIndicatorInsets
+  }
+
   fileprivate func updateToolbarStateForTraitCollection(
     _ newCollection: UITraitCollection,
     withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator? = nil
@@ -1226,6 +1291,12 @@ public class BrowserViewController: UIViewController {
       make.height.equalTo(UX.TabsBar.height)
     }
 
+    if #available(iOS 26.0, *) {
+      webViewContainer.snp.makeConstraints {
+        $0.edges.equalToSuperview()
+      }
+    }
+
     webViewContainerBackdrop.snp.makeConstraints { make in
       make.edges.equalTo(webViewContainer)
     }
@@ -1257,6 +1328,10 @@ public class BrowserViewController: UIViewController {
       view.bounds.height - view.safeAreaInsets.top
     toolbarVisibilityViewModel.minimumCollapsableTransitionDistance =
       header.bounds.height + footer.bounds.height
+
+    if #available(iOS 26.0, *) {
+      updateWebViewObscuredInsets()
+    }
   }
 
   override public var canBecomeFirstResponder: Bool {
@@ -1416,22 +1491,21 @@ public class BrowserViewController: UIViewController {
       }
     }
 
-    webViewContainer.snp.remakeConstraints { make in
-      make.left.right.equalTo(self.view)
+    if #unavailable(iOS 26.0) {
+      webViewContainer.snp.remakeConstraints { make in
+        make.left.right.equalTo(self.view)
 
-      if self.isUsingBottomBar {
-        webViewContainerTopOffset =
+        if self.isUsingBottomBar {
           make.top.equalTo(self.readerModeBar?.snp.bottom ?? self.toolbarLayoutGuide.snp.top)
-          .constraint
-      } else {
-        webViewContainerTopOffset =
-          make.top.equalTo(self.readerModeBar?.snp.bottom ?? self.header.snp.bottom).constraint
-      }
+        } else {
+          make.top.equalTo(self.readerModeBar?.snp.bottom ?? self.header.snp.bottom)
+        }
 
-      if self.isUsingBottomBar {
-        make.bottom.equalTo(self.header.snp.top)
-      } else {
-        make.bottom.equalTo(self.footer.snp.top)
+        if self.isUsingBottomBar {
+          make.bottom.equalTo(self.header.snp.top)
+        } else {
+          make.bottom.equalTo(self.footer.snp.top)
+        }
       }
     }
 
@@ -1489,11 +1563,9 @@ public class BrowserViewController: UIViewController {
     // The home controller may change sizes if we tap the URL bar while on about:home.
     pageOverlayLayoutGuide.snp.remakeConstraints { make in
       if self.isUsingBottomBar {
-        webViewContainerTopOffset =
-          make.top.equalTo(readerModeBar?.snp.bottom ?? self.toolbarLayoutGuide).constraint
+        make.top.equalTo(readerModeBar?.snp.bottom ?? self.toolbarLayoutGuide)
       } else {
-        webViewContainerTopOffset =
-          make.top.equalTo(readerModeBar?.snp.bottom ?? self.header.snp.bottom).constraint
+        make.top.equalTo(readerModeBar?.snp.bottom ?? self.header.snp.bottom)
       }
 
       make.left.right.equalTo(self.view)

--- a/ios/brave-ios/Sources/Web/TabState.swift
+++ b/ios/brave-ios/Sources/Web/TabState.swift
@@ -368,11 +368,13 @@ extension TabState {
 }
 
 /// A basic proxy over the underlying web view that may be displaying web content
-public protocol WebViewProxy {
+public protocol WebViewProxy: AnyObject {
   var scrollView: UIScrollView? { get }
   var bounds: CGRect { get }
   var frame: CGRect { get }
   var isKeyboardVisible: Bool { get }
+  var obscuredInsets: UIEdgeInsets { get set }
+  func setMinimumViewportInset(_ minInset: UIEdgeInsets, maximumViewportInset: UIEdgeInsets)
   func becomeFirstResponder() -> Bool
 }
 


### PR DESCRIPTION
This change fixes updates the layout of web views on iOS 26+ to rely on content inset/obscured inset rather than altering the web view frame when web view occluding toolbars change size. This fixes a number of viewport related bugs that Brave has had on iOS 26+ and opens up options for Liquid Glass designs for the toolbars

- Resolves https://github.com/brave/brave-browser/issues/54921
- Resolves https://github.com/brave/brave-browser/issues/47891

### Test
Test matrix: 
- Top bar mode, bottom bar mode (iPhone only)
- iPhone (Portrait/Landscape), iPad

Notable sites to test:
- CSS keyboard check: https://test-website-a.pages.dev/viewport-keyboard/default.html  
    - This should report in that no change was made to the css viewport when the keyboard is active in bottom bar mode
- Fixed element pages: https://m.youtube.com (result pages)
    - These should have fixed elements still pin correctly to the toolbars even while collapsing
- Instagram reel shared in Messaged & opened from Messages tab. Should be able to unmute the video with this change.

Viewport changes only affect iOS 26+, 1 small change on both 18/26 is specifically around toasts, however this should match prior behaviour.

The testing is mostly about verifying that scrolling collapses toolbars like normal and that web view content is still visible at the edges (top of the web view in top bar mode, bottom of the web view in bottom bar mode) 