### PR TITLE
[Android] Support refreshing custom filter list subscriptions

### DIFF
--- a/android/java/brave-res/layout/item_custom_filter.xml
+++ b/android/java/brave-res/layout/item_custom_filter.xml
@@ -58,6 +58,19 @@
           android:visibility="gone"/>
 
      <ImageView
+          android:id="@+id/iv_refresh"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          app:layout_constraintTop_toTopOf="parent"
+          app:layout_constraintEnd_toStartOf="@id/iv_delete"
+          android:layout_marginEnd="12dp"
+          android:layout_marginTop="4dp"
+          android:contentDescription="@string/accessibility_btn_refresh"
+          app:srcCompat="@drawable/btn_reload_stop"
+          app:tint="@color/add_custom_filter_tint_color"
+          android:visibility="gone"/>
+
+     <ImageView
           android:id="@+id/iv_delete"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"

--- a/android/java/org/chromium/chrome/browser/shields/BraveContentFilteringListener.java
+++ b/android/java/org/chromium/chrome/browser/shields/BraveContentFilteringListener.java
@@ -11,6 +11,8 @@ public interface BraveContentFilteringListener {
     public void onSubscriptionFilterToggle(int position, boolean isEnable);
 
     public void onSubscriptionFilterDelete(int position);
+ 
+    public void onSubscriptionFilterRefresh(int position);
 
     public void onFilterToggle(String uuid, boolean isEnable);
 

--- a/android/java/org/chromium/chrome/browser/shields/ContentFilteringAdapter.java
+++ b/android/java/org/chromium/chrome/browser/shields/ContentFilteringAdapter.java
@@ -77,6 +77,7 @@ public class ContentFilteringAdapter extends RecyclerView.Adapter<RecyclerView.V
                 customFilterListViewHolder.mLastUpdateText.setVisibility(View.GONE);
                 customFilterListViewHolder.mToggleSwitch.setVisibility(View.GONE);
                 customFilterListViewHolder.mUrlText.setVisibility(View.GONE);
+                customFilterListViewHolder.mRefreshImageView.setVisibility(View.GONE);
                 customFilterListViewHolder.mDeleteImageView.setVisibility(View.GONE);
                 customFilterListViewHolder.mArrowImageView.setVisibility(View.VISIBLE);
 
@@ -155,12 +156,22 @@ public class ContentFilteringAdapter extends RecyclerView.Adapter<RecyclerView.V
                         });
 
                 if (mIsEdit) {
+                    customFilterListViewHolder.mRefreshImageView.setVisibility(View.VISIBLE);
                     customFilterListViewHolder.mDeleteImageView.setVisibility(View.VISIBLE);
                     customFilterListViewHolder.mToggleSwitch.setVisibility(View.GONE);
                 } else {
+                    customFilterListViewHolder.mRefreshImageView.setVisibility(View.GONE);
                     customFilterListViewHolder.mDeleteImageView.setVisibility(View.GONE);
                     customFilterListViewHolder.mToggleSwitch.setVisibility(View.VISIBLE);
                 }
+
+                customFilterListViewHolder.mRefreshImageView.setOnClickListener(
+                        view -> {
+                            if (mIsEdit) {
+                                mBraveContentFileringListener.onSubscriptionFilterRefresh(
+                                        holder.getAdapterPosition() - TWO_ITEMS_SPACE);
+                            }
+                        });
 
                 customFilterListViewHolder.mDeleteImageView.setOnClickListener(
                         view -> {
@@ -285,6 +296,7 @@ public class ContentFilteringAdapter extends RecyclerView.Adapter<RecyclerView.V
         TextView mTitleText;
         TextView mLastUpdateText;
         TextView mUrlText;
+        ImageView mRefreshImageView;
         ImageView mDeleteImageView;
         ImageView mArrowImageView;
         MaterialSwitch mToggleSwitch;
@@ -295,6 +307,7 @@ public class ContentFilteringAdapter extends RecyclerView.Adapter<RecyclerView.V
             mTitleText = (TextView) itemView.findViewById(R.id.title_text);
             mLastUpdateText = (TextView) itemView.findViewById(R.id.last_update_text);
             mUrlText = (TextView) itemView.findViewById(R.id.url_text);
+            mRefreshImageView = (ImageView) itemView.findViewById(R.id.iv_refresh);
             mDeleteImageView = (ImageView) itemView.findViewById(R.id.iv_delete);
             mArrowImageView = (ImageView) itemView.findViewById(R.id.iv_arrow);
             mToggleSwitch = (MaterialSwitch) itemView.findViewById(R.id.toggle_switch);

--- a/android/java/org/chromium/chrome/browser/shields/ContentFilteringFragment.java
+++ b/android/java/org/chromium/chrome/browser/shields/ContentFilteringFragment.java
@@ -162,6 +162,21 @@ public class ContentFilteringFragment extends BravePreferenceFragment
     }
 
     @Override
+    public void onSubscriptionFilterRefresh(int position) {
+        if (mFilterListAndroidHandler != null
+                && mSubscriptionFilterLists != null
+                && position < mSubscriptionFilterLists.size()) {
+            SubscriptionInfo customFilter = mSubscriptionFilterLists.get(position);
+            mFilterListAndroidHandler.refreshSubscription(customFilter.subscriptionUrl);
+            Toast.makeText(
+                            getActivity(),
+                            getString(R.string.update_filter_list_success_text),
+                            Toast.LENGTH_SHORT)
+                    .show();
+        }
+    }
+
+    @Override
     public void onCustomFilters() {
         if (mSubscriptionFilterLists.size() > 0) {
             isEditSelected(false);

--- a/components/brave_shields/content/browser/filter_list_service.cc
+++ b/components/brave_shields/content/browser/filter_list_service.cc
@@ -110,6 +110,11 @@ void FilterListService::DeleteSubscription(const GURL& sub_url) {
       sub_url);
 }
 
+void FilterListService::RefreshSubscription(const GURL& sub_url) {
+  ad_block_service_->subscription_service_manager()->RefreshSubscription(
+      sub_url, /*from_ui=*/true);
+}
+
 void FilterListService::GetCustomFilters(GetCustomFiltersCallback callback) {
   std::move(callback).Run(
       ad_block_service_->custom_filters_provider()->GetCustomFilters());

--- a/components/brave_shields/content/browser/filter_list_service.h
+++ b/components/brave_shields/content/browser/filter_list_service.h
@@ -37,6 +37,7 @@ class FilterListService : public KeyedService,
   void CreateSubscription(const GURL& subscription_url) override;
   void EnableSubscription(const GURL& sub_url, bool enabled) override;
   void DeleteSubscription(const GURL& sub_url) override;
+  void RefreshSubscription(const GURL& sub_url) override;
   void GetFilterLists(GetFilterListsCallback callback) override;
   void GetCustomFilters(GetCustomFiltersCallback callback) override;
   void UpdateCustomFilters(const std::string& custom_filters,

--- a/components/brave_shields/core/common/filter_list.mojom
+++ b/components/brave_shields/core/common/filter_list.mojom
@@ -27,6 +27,7 @@ interface FilterListAndroidHandler {
   CreateSubscription(url.mojom.Url subscription_url);
   EnableSubscription(url.mojom.Url sub_url, bool enabled);
   DeleteSubscription(url.mojom.Url sub_url);
+  RefreshSubscription(url.mojom.Url sub_url);
   GetFilterLists() => (mojo_base.mojom.ListValue filterLists);
   GetCustomFilters() => (string custom_filters);
   UpdateCustomFilters(string custom_filters) => (bool is_updated);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
This addresses the use case mentioned in: https://github.com/brave/brave-browser/issues/36987
Please note that the current update button mentioned in https://github.com/brave/brave-browser/issues/35216 only updates the internal list, not custom items, as noted by the follow-up comment: https://github.com/brave/brave-browser/issues/35216#issuecomment-2166850372

## Description

Adds UI and IPC support on Android to manually refresh/update custom filter list subscriptions.
This would bring the feature parity with the desktop version.

## Test Plan

1. Open Brave on Android and navigate to **Settings** > **Brave Shields & privacy** > **Content filtering**.
2. Add a custom filter list subscription URL if not already present.
3. Tap the **Edit** button in the top right.
4. Verify that each custom filter item displays a refresh/reload icon next to the delete icon.
5. Tap the refresh icon on a custom filter item.
6. Verify that a toast appears notifying that the filter list is updating / updated successfully and verify network traffic/filter list re-fetch.
