### PR TITLE
Pass initiator_origin when opening links in containers.

### DIFF
--- a/browser/containers/BUILD.gn
+++ b/browser/containers/BUILD.gn
@@ -53,6 +53,7 @@ source_set("browser_tests") {
     "//chrome/browser",
     "//chrome/browser/browsing_data:constants",
     "//chrome/browser/prefs:util",
+    "//chrome/browser/renderer_context_menu:test_support",
     "//chrome/browser/ui/views/page_action:page_action_test_support",
     "//chrome/browser/ui/zoom",
     "//chrome/browser/web_applications",

--- a/browser/containers/containers_browsertest.cc
+++ b/browser/containers/containers_browsertest.cc
@@ -12,6 +12,7 @@
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/location.h"
+#include "base/strings/string_split.h"
 #include "base/test/run_until.h"
 #include "base/test/test_future.h"
 #include "base/threading/thread_restrictions.h"
@@ -34,6 +35,7 @@
 #include "chrome/browser/browsing_data/chrome_browsing_data_remover_constants.h"
 #include "chrome/browser/prefs/session_startup_pref.h"
 #include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/renderer_context_menu/render_view_context_menu_test_util.h"
 #include "chrome/browser/sessions/exit_type_service.h"
 #include "chrome/browser/sessions/tab_restore_service_factory.h"
 #include "chrome/browser/ui/actions/chrome_action_id.h"
@@ -102,6 +104,7 @@
 #include "ui/views/view.h"
 #include "ui/views/view_utils.h"
 #include "url/gurl.h"
+#include "url/origin.h"
 
 namespace containers {
 
@@ -114,6 +117,14 @@ constexpr char kFarblingPluginsStringScript[] =
 
 // Name of the container seeded by tests that exercise the --container switch.
 constexpr char kNamedContainerName[] = "Command Line Named Container";
+
+std::vector<std::string> GetEchoedHeaders(content::WebContents* web_contents) {
+  const std::string response_body =
+      content::EvalJs(web_contents, "document.body.textContent")
+          .ExtractString();
+  return base::SplitString(response_body, "\n", base::TRIM_WHITESPACE,
+                           base::SPLIT_WANT_NONEMPTY);
+}
 
 // Returns the storage partition config of the tab at `index`, after waiting for
 // it to finish loading, or std::nullopt if the tab can't be loaded. `location`
@@ -1063,6 +1074,57 @@ IN_PROC_BROWSER_TEST_F(ContainersBrowserTest, OpenUrlInContainer) {
               std::string::npos);
   EXPECT_EQ("value1",
             content::EvalJs(web_contents, GetLocalStorageJS("container_key")));
+}
+
+IN_PROC_BROWSER_TEST_F(ContainersBrowserTest,
+                       OpenLinkInContainerSetsSecFetchSiteWithoutReferrer) {
+  const GURL source_url("https://a.test/simple.html");
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), source_url));
+
+  const GURL dest_url("https://b.test/echoheader?Referer&Sec-Fetch-Site");
+
+  auto container = containers::mojom::Container::New();
+  container->id = "test-container";
+  container->name = "Test Container";
+  container->icon = containers::mojom::Icon::kWork;
+  container->background_color = SK_ColorBLUE;
+
+  content::ContextMenuParams params;
+  params.frame_origin = url::Origin::Create(source_url);
+  params.page_url = source_url;
+  params.frame_url = source_url;
+  params.link_url = dest_url;
+
+  TestRenderViewContextMenu menu(*browser()
+                                      ->tab_strip_model()
+                                      ->GetActiveWebContents()
+                                      ->GetPrimaryMainFrame(),
+                                 params);
+
+  content::TestNavigationObserver observer(dest_url);
+  observer.StartWatchingNewWebContents();
+  menu.OnContainerSelected(container);
+  observer.Wait();
+
+  content::WebContents* web_contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+  ASSERT_TRUE(web_contents);
+  EXPECT_EQ(dest_url, web_contents->GetLastCommittedURL());
+
+  const std::vector<std::string> echoed_headers =
+      GetEchoedHeaders(web_contents);
+  ASSERT_EQ(2u, echoed_headers.size());
+  EXPECT_EQ("None", echoed_headers[0]);
+  EXPECT_EQ("cross-site", echoed_headers[1]);
+
+  content::StoragePartition* storage_partition =
+      web_contents->GetPrimaryMainFrame()->GetStoragePartition();
+  ASSERT_TRUE(storage_partition);
+  content::StoragePartitionConfig expected_config =
+      content::StoragePartitionConfig::Create(
+          browser()->GetProfile(), kContainersStoragePartitionDomain,
+          "test-container", browser()->GetProfile()->IsOffTheRecord());
+  EXPECT_EQ(expected_config, storage_partition->GetConfig());
 }
 
 IN_PROC_BROWSER_TEST_F(ContainersBrowserTest, TabTooltipShowsContainerName) {

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -1225,7 +1225,9 @@ void OpenTabUrlsInContainer(BrowserWindowInterface* browser_window,
 void OpenUrlInContainer(BrowserWindowInterface* browser_window,
                         const GURL& url,
                         const containers::mojom::ContainerPtr& container,
-                        bool is_link) {
+                        bool is_link,
+                        const std::optional<url::Origin>& initiator_origin,
+                        bool started_from_context_menu) {
   if (!url.is_valid()) {
     LOG(ERROR) << "Url is not valid";
     return;
@@ -1237,6 +1239,8 @@ void OpenUrlInContainer(BrowserWindowInterface* browser_window,
       browser_window, url,
       is_link ? ui::PAGE_TRANSITION_LINK : ui::PAGE_TRANSITION_TYPED);
   params.disposition = WindowOpenDisposition::NEW_FOREGROUND_TAB;
+  params.initiator_origin = initiator_origin;
+  params.started_from_context_menu = started_from_context_menu;
   params.storage_partition_config = content::StoragePartitionConfig::Create(
       browser_window->GetProfile(),
       containers::kContainersStoragePartitionDomain, container->id,
@@ -1261,7 +1265,9 @@ void OpenTabUrlsWithoutContainer(BrowserWindowInterface* browser_window,
 
 void OpenUrlWithoutContainer(BrowserWindowInterface* browser_window,
                              const GURL& url,
-                             bool is_link) {
+                             bool is_link,
+                             const std::optional<url::Origin>& initiator_origin,
+                             bool started_from_context_menu) {
   if (!url.is_valid()) {
     LOG(ERROR) << "Url is not valid";
     return;
@@ -1271,6 +1277,8 @@ void OpenUrlWithoutContainer(BrowserWindowInterface* browser_window,
       browser_window, url,
       is_link ? ui::PAGE_TRANSITION_LINK : ui::PAGE_TRANSITION_TYPED);
   params.disposition = WindowOpenDisposition::NEW_FOREGROUND_TAB;
+  params.initiator_origin = initiator_origin;
+  params.started_from_context_menu = started_from_context_menu;
   Navigate(&params);
 }
 
@@ -1285,9 +1293,12 @@ void CreateTemporaryContainerAndOpenTabUrls(
       containers_service->CreateAndPersistTemporaryContainer());
 }
 
-void CreateTemporaryContainerAndOpenUrl(BrowserWindowInterface* browser_window,
-                                        const GURL& url,
-                                        bool is_link) {
+void CreateTemporaryContainerAndOpenUrl(
+    BrowserWindowInterface* browser_window,
+    const GURL& url,
+    bool is_link,
+    const std::optional<url::Origin>& initiator_origin,
+    bool started_from_context_menu) {
   CHECK(browser_window);
   if (!url.is_valid()) {
     LOG(ERROR) << "Url is not valid";
@@ -1299,7 +1310,7 @@ void CreateTemporaryContainerAndOpenUrl(BrowserWindowInterface* browser_window,
   CHECK(containers_service);
   OpenUrlInContainer(browser_window, url,
                      containers_service->CreateAndPersistTemporaryContainer(),
-                     is_link);
+                     is_link, initiator_origin, started_from_context_menu);
 }
 
 void OpenContainerMenuOnPageActionView(BrowserWindowInterface* browser_window,

--- a/browser/ui/browser_commands.h
+++ b/browser/ui/browser_commands.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_BROWSER_UI_BROWSER_COMMANDS_H_
 #define BRAVE_BROWSER_UI_BROWSER_COMMANDS_H_
 
+#include <optional>
+
 #include "brave/components/brave_wallet/common/buildflags/buildflags.h"
 #include "brave/components/brave_wayback_machine/buildflags/buildflags.h"
 #include "brave/components/commander/common/buildflags/buildflags.h"
@@ -183,26 +185,35 @@ void OpenTabUrlsInContainer(BrowserWindowInterface* browser_window,
                             const std::vector<tabs::TabHandle>& tabs,
                             const containers::mojom::ContainerPtr& container);
 // Creates a new tab with the specified URL in the given container.
-void OpenUrlInContainer(BrowserWindowInterface* browser_window,
-                        const GURL& url,
-                        const containers::mojom::ContainerPtr& container,
-                        bool is_link = true);
+void OpenUrlInContainer(
+    BrowserWindowInterface* browser_window,
+    const GURL& url,
+    const containers::mojom::ContainerPtr& container,
+    bool is_link = true,
+    const std::optional<url::Origin>& initiator_origin = std::nullopt,
+    bool started_from_context_menu = false);
 
 // Creates new tabs with the given tabs' URLs without a container.
 void OpenTabUrlsWithoutContainer(BrowserWindowInterface* browser_window,
                                  const std::vector<tabs::TabHandle>& tabs);
-void OpenUrlWithoutContainer(BrowserWindowInterface* browser_window,
-                             const GURL& url,
-                             bool is_link = true);
+void OpenUrlWithoutContainer(
+    BrowserWindowInterface* browser_window,
+    const GURL& url,
+    bool is_link = true,
+    const std::optional<url::Origin>& initiator_origin = std::nullopt,
+    bool started_from_context_menu = false);
 
 // Creates a new temporary container and opens the given tabs' URLs in it.
 void CreateTemporaryContainerAndOpenTabUrls(
     BrowserWindowInterface* browser_window,
     const std::vector<tabs::TabHandle>& tabs);
 // Opens |url| in a new tab in a freshly created temporary container.
-void CreateTemporaryContainerAndOpenUrl(BrowserWindowInterface* browser_window,
-                                        const GURL& url,
-                                        bool is_link = true);
+void CreateTemporaryContainerAndOpenUrl(
+    BrowserWindowInterface* browser_window,
+    const GURL& url,
+    bool is_link = true,
+    const std::optional<url::Origin>& initiator_origin = std::nullopt,
+    bool started_from_context_menu = false);
 
 // Opens the container menu on the page action view if the active tab is in a
 // container.

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -778,7 +778,9 @@ void RenderViewContextMenu::OnContainerSelected(
     return;
   }
 
-  brave::OpenUrlInContainer(GetBrowser(), params_.link_url, container);
+  brave::OpenUrlInContainer(GetBrowser(), params_.link_url, container,
+                            /*is_link=*/true, params_.frame_origin,
+                            /*started_from_context_menu=*/true);
 }
 
 void RenderViewContextMenu::OnNoContainerSelected() {
@@ -786,7 +788,9 @@ void RenderViewContextMenu::OnNoContainerSelected() {
     return;
   }
 
-  brave::OpenUrlWithoutContainer(GetBrowser(), params_.link_url);
+  brave::OpenUrlWithoutContainer(GetBrowser(), params_.link_url,
+                                 /*is_link=*/true, params_.frame_origin,
+                                 /*started_from_context_menu=*/true);
 }
 
 void RenderViewContextMenu::OnNewTemporaryContainerSelected() {
@@ -794,7 +798,9 @@ void RenderViewContextMenu::OnNewTemporaryContainerSelected() {
     return;
   }
 
-  brave::CreateTemporaryContainerAndOpenUrl(GetBrowser(), params_.link_url);
+  brave::CreateTemporaryContainerAndOpenUrl(
+      GetBrowser(), params_.link_url, /*is_link=*/true, params_.frame_origin,
+      /*started_from_context_menu=*/true);
 }
 
 base::flat_set<std::string> RenderViewContextMenu::GetCurrentContainerIds() {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
"Open link in a container" omitted `initiator_origin`, so `Sec-Fetch-Site` was `none` instead of a site relation. Pass `frame_origin` from the link context menu so fetch metadata is correct.

- Resolves https://github.com/brave/brave-browser/issues/58230
- Resolves https://github.com/brave/internal/issues/1859

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
