### PR TITLE
[WebPanel] Fixed web panel's tab is not activated

### DIFF
--- a/browser/ui/sidebar/BUILD.gn
+++ b/browser/ui/sidebar/BUILD.gn
@@ -192,14 +192,21 @@ source_set("interactive_ui_tests") {
   testonly = true
   defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
 
-  sources = [ "sidebar_interactive_ui_tests.cc" ]
+  sources = [
+    "sidebar_interactive_ui_tests.cc",
+    "web_panel_interactive_ui_tests.cc",
+  ]
 
   deps = [
+    ":sidebar",
     ":sidebar_impl",
     ":test_support",
     "//base",
+    "//brave/browser/ui/views/frame",
+    "//brave/browser/ui/views/frame/split_view",
     "//brave/components/brave_wallet/common/buildflags",
     "//brave/components/sidebar/browser",
+    "//brave/components/sidebar/common",
     "//chrome/browser/ui",
     "//chrome/browser/ui/browser_window",
     "//chrome/browser/ui/tabs:tab_strip",
@@ -208,6 +215,7 @@ source_set("interactive_ui_tests") {
     "//content/public/browser",
     "//content/test:test_support",
     "//ui/base",
+    "//ui/views",
     "//url",
   ]
 

--- a/browser/ui/sidebar/sidebar_utils.cc
+++ b/browser/ui/sidebar/sidebar_utils.cc
@@ -162,22 +162,11 @@ bool IsWebPanelFeatureEnabled() {
   return base::FeatureList::IsEnabled(features::kSidebarWebPanel);
 }
 
-bool IsWebPanelRelatedFocusChange(BrowserWindowInterface* browser,
-                                  content::WebContents* focused_contents) {
-  if (!IsWebPanelFeatureEnabled()) {
-    return false;
-  }
-
-  auto* sidebar_controller = browser->GetFeatures().sidebar_controller();
-  if (!sidebar_controller) {
-    return false;
-  }
-
-  auto* web_panel_controller = sidebar_controller->GetWebPanelController();
-  if (!web_panel_controller) {
-    return false;
-  }
-
+bool IsWebPanelRelatedFocusChange(
+    SidebarWebPanelController* web_panel_controller,
+    TabStripModel* tab_strip_model,
+    content::WebContents* focused_contents) {
+  CHECK(web_panel_controller);
   const content::WebContents* panel_contents =
       web_panel_controller->panel_contents();
   if (!panel_contents) {
@@ -188,8 +177,7 @@ bool IsWebPanelRelatedFocusChange(BrowserWindowInterface* browser,
     return true;
   }
 
-  return browser->tab_strip_model()->GetActiveTab()->GetContents() ==
-         panel_contents;
+  return tab_strip_model->GetActiveTab()->GetContents() == panel_contents;
 }
 
 SidePanelEntryId SidePanelIdFromSideBarItemType(BuiltInItemType type) {

--- a/browser/ui/sidebar/sidebar_utils.cc
+++ b/browser/ui/sidebar/sidebar_utils.cc
@@ -15,6 +15,7 @@
 #include "brave/browser/ui/sidebar/sidebar_controller.h"
 #include "brave/browser/ui/sidebar/sidebar_model.h"
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
+#include "brave/browser/ui/sidebar/sidebar_web_panel_controller.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
 #include "brave/components/brave_origin/buildflags/buildflags.h"
@@ -159,6 +160,36 @@ bool CanAddCurrentActiveTabToSidebar(Browser* browser) {
 
 bool IsWebPanelFeatureEnabled() {
   return base::FeatureList::IsEnabled(features::kSidebarWebPanel);
+}
+
+bool IsWebPanelRelatedFocusChange(BrowserWindowInterface* browser,
+                                  content::WebContents* focused_contents) {
+  if (!IsWebPanelFeatureEnabled()) {
+    return false;
+  }
+
+  auto* sidebar_controller = browser->GetFeatures().sidebar_controller();
+  if (!sidebar_controller) {
+    return false;
+  }
+
+  auto* web_panel_controller = sidebar_controller->GetWebPanelController();
+  if (!web_panel_controller) {
+    return false;
+  }
+
+  const content::WebContents* panel_contents =
+      web_panel_controller->panel_contents();
+  if (!panel_contents) {
+    return false;
+  }
+
+  if (panel_contents == focused_contents) {
+    return true;
+  }
+
+  return browser->tab_strip_model()->GetActiveTab()->GetContents() ==
+         panel_contents;
 }
 
 SidePanelEntryId SidePanelIdFromSideBarItemType(BuiltInItemType type) {

--- a/browser/ui/sidebar/sidebar_utils.h
+++ b/browser/ui/sidebar/sidebar_utils.h
@@ -18,6 +18,8 @@ class BrowserWindowInterface;
 class GURL;
 class PrefService;
 class Profile;
+class SidebarWebPanelController;
+class TabStripModel;
 enum class SidePanelEntryId;
 
 namespace content {
@@ -33,8 +35,10 @@ bool IsWebPanelFeatureEnabled();
 // True if `focused_contents`'s focus event is web-panel-related: either its own
 // contents area was clicked/focused, or focus is moving from the panel back
 // to a normal tab.
-bool IsWebPanelRelatedFocusChange(BrowserWindowInterface* browser,
-                                  content::WebContents* focused_contents);
+bool IsWebPanelRelatedFocusChange(
+    SidebarWebPanelController* web_panel_conteroller,
+    TabStripModel* tab_strip_model,
+    content::WebContents* focused_contents);
 
 // Exported for testing.
 bool HiddenDefaultSidebarItemsContains(SidebarService* service,

--- a/browser/ui/sidebar/sidebar_utils.h
+++ b/browser/ui/sidebar/sidebar_utils.h
@@ -20,11 +20,21 @@ class PrefService;
 class Profile;
 enum class SidePanelEntryId;
 
+namespace content {
+class WebContents;
+}  // namespace content
+
 namespace sidebar {
 
 bool CanUseSidebar(Browser* browser);
 bool CanAddCurrentActiveTabToSidebar(Browser* browser);
 bool IsWebPanelFeatureEnabled();
+
+// True if `focused_contents`'s focus event is web-panel-related: either its own
+// contents area was clicked/focused, or focus is moving from the panel back
+// to a normal tab.
+bool IsWebPanelRelatedFocusChange(BrowserWindowInterface* browser,
+                                  content::WebContents* focused_contents);
 
 // Exported for testing.
 bool HiddenDefaultSidebarItemsContains(SidebarService* service,

--- a/browser/ui/sidebar/web_panel_interactive_ui_tests.cc
+++ b/browser/ui/sidebar/web_panel_interactive_ui_tests.cc
@@ -1,0 +1,114 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/test/bind.h"
+#include "base/test/scoped_feature_list.h"
+#include "brave/browser/ui/sidebar/sidebar_browsertest_base.h"
+#include "brave/browser/ui/sidebar/sidebar_controller.h"
+#include "brave/browser/ui/sidebar/sidebar_model.h"
+#include "brave/browser/ui/sidebar/sidebar_utils.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/frame/split_view/brave_multi_contents_view.h"
+#include "brave/components/sidebar/browser/pref_names.h"
+#include "brave/components/sidebar/browser/sidebar_item.h"
+#include "brave/components/sidebar/common/features.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/browser/ui/views/frame/multi_contents_view.h"
+#include "chrome/test/base/interactive_test_utils.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "chrome/test/interaction/interactive_browser_test.h"
+#include "components/prefs/pref_service.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "ui/base/interaction/state_observer.h"
+#include "ui/views/view.h"
+#include "url/gurl.h"
+
+namespace sidebar {
+
+class SidebarWebPanelInteractiveUITest
+    : public InteractiveBrowserTestMixin<SidebarBrowserTest> {
+ public:
+  SidebarWebPanelInteractiveUITest() {
+    scoped_features_.InitAndEnableFeature(sidebar::features::kSidebarWebPanel);
+  }
+  ~SidebarWebPanelInteractiveUITest() override = default;
+
+  BraveMultiContentsView* GetBraveMultiContentsView() {
+    return browser_view()->GetBraveMultiContentsView();
+  }
+
+  auto WaitForActiveTabChange(int index) {
+    DEFINE_LOCAL_STATE_IDENTIFIER_VALUE(ui::test::PollingStateObserver<int>,
+                                        kActiveTabIndexObserver);
+    return Steps(PollState(kActiveTabIndexObserver,
+                           base::BindRepeating(
+                               &TabStripModel::active_index,
+                               base::Unretained(browser()->tab_strip_model()))),
+                 WaitForState(kActiveTabIndexObserver, index),
+                 StopObservingState(kActiveTabIndexObserver));
+  }
+
+ private:
+  base::test::ScopedFeatureList scoped_features_;
+};
+
+// Verifies that a real mouse click actually activates the clicked pane's tab,
+// in both directions (into the panel, and back out to the normal tab).
+IN_PROC_BROWSER_TEST_F(SidebarWebPanelInteractiveUITest,
+                       ClickActivatesWebPanelAndNormalTab) {
+  // Ensure the browser window is actually the OS-level active/key window
+  // before sending any real synthetic clicks -- it may not be by
+  // default depending on the environment.
+  ASSERT_TRUE(ui_test_utils::BringBrowserWindowToFront(browser()));
+
+  // Use about:blank (rather than a real external site) so navigation never
+  // depends on network access and always commits as a normal page.
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), GURL("about:blank")));
+  ASSERT_TRUE(CanAddCurrentActiveTabToSidebar(browser()));
+  // To prevent the item-added feedback bubble from launching and stealing
+  // the clicks this test sends.
+  browser()->GetProfile()->GetPrefs()->SetInteger(
+      sidebar::kSidebarItemAddedFeedbackBubbleShowCount, 3);
+  controller()->AddItemWithCurrentTab();
+  const int web_panel_item_index =
+      static_cast<int>(model()->GetAllSidebarItems().size()) - 1;
+  controller()->ActivateItemAt(web_panel_item_index);
+  ASSERT_TRUE(GetBraveMultiContentsView()->IsWebPanelVisible());
+
+  ASSERT_EQ(2, browser()->tab_strip_model()->count());
+  ASSERT_EQ(1, browser()->tab_strip_model()->active_index());
+
+  // The panel's pinned tab was just created and is still navigating; make
+  // sure it's actually ready to receive input before clicking it.
+  ASSERT_TRUE(content::WaitForLoadStop(
+      browser()->tab_strip_model()->GetWebContentsAt(0)));
+
+  views::View* web_panel_contents_view =
+      GetBraveMultiContentsView()->GetWebPanelContentsViewForTesting();
+  views::View* normal_tab_contents_view = GetBraveMultiContentsView()
+                                              ->contents_container_views()[0]
+                                              ->contents_view();
+
+  constexpr char kWebPanelContentsViewId[] = "WebPanelContentsView";
+  constexpr char kNormalTabContentsViewId[] = "NormalTabView";
+
+  RunTestSequence(
+      NameView(kWebPanelContentsViewId, web_panel_contents_view),
+      MoveMouseTo(kWebPanelContentsViewId), ClickMouse(),
+      WaitForActiveTabChange(0), Check([this]() {
+        return GetBraveMultiContentsView()->is_web_panel_active_for_testing();
+      }),
+
+      NameView(kNormalTabContentsViewId, normal_tab_contents_view),
+      MoveMouseTo(kNormalTabContentsViewId), ClickMouse(),
+      WaitForActiveTabChange(1), Check([this]() {
+        return !GetBraveMultiContentsView()->is_web_panel_active_for_testing();
+      }));
+}
+
+}  // namespace sidebar

--- a/browser/ui/sidebar/web_panel_interactive_ui_tests.cc
+++ b/browser/ui/sidebar/web_panel_interactive_ui_tests.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <string_view>
+
 #include "base/test/bind.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/sidebar/sidebar_browsertest_base.h"
@@ -14,10 +16,12 @@
 #include "brave/components/sidebar/browser/pref_names.h"
 #include "brave/components/sidebar/browser/sidebar_item.h"
 #include "brave/components/sidebar/common/features.h"
+#include "build/build_config.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/views/frame/multi_contents_view.h"
+#include "chrome/browser/ui/views/frame/multi_contents_view_delegate.h"
 #include "chrome/test/base/interactive_test_utils.h"
 #include "chrome/test/base/ui_test_utils.h"
 #include "chrome/test/interaction/interactive_browser_test.h"
@@ -51,6 +55,22 @@ class SidebarWebPanelInteractiveUITest
                                base::Unretained(browser()->tab_strip_model()))),
                  WaitForState(kActiveTabIndexObserver, index),
                  StopObservingState(kActiveTabIndexObserver));
+  }
+
+  // Call delegate code path directly as sending click event makes this test
+  // flaky on macOS CI.
+  auto ActivatePane([[maybe_unused]] std::string_view view_id,
+                    [[maybe_unused]] views::View* target_view,
+                    content::WebContents* target_contents) {
+#if BUILDFLAG(IS_MAC)
+    return Steps(Do([this, target_contents]() {
+      GetBraveMultiContentsView()->delegate_for_testing()->WebContentsFocused(
+          target_contents);
+    }));
+#else
+    return Steps(NameView(view_id, target_view), MoveMouseTo(view_id),
+                 ClickMouse());
+#endif
   }
 
  private:
@@ -97,15 +117,20 @@ IN_PROC_BROWSER_TEST_F(SidebarWebPanelInteractiveUITest,
   constexpr char kWebPanelContentsViewId[] = "WebPanelContentsView";
   constexpr char kNormalTabContentsViewId[] = "NormalTabView";
 
+  content::WebContents* web_panel_contents =
+      browser()->tab_strip_model()->GetWebContentsAt(0);
+  content::WebContents* normal_tab_contents =
+      browser()->tab_strip_model()->GetWebContentsAt(1);
+
   RunTestSequence(
-      NameView(kWebPanelContentsViewId, web_panel_contents_view),
-      MoveMouseTo(kWebPanelContentsViewId), ClickMouse(),
+      ActivatePane(kWebPanelContentsViewId, web_panel_contents_view,
+                   web_panel_contents),
       WaitForActiveTabChange(0), Check([this]() {
         return GetBraveMultiContentsView()->is_web_panel_active_for_testing();
       }),
 
-      NameView(kNormalTabContentsViewId, normal_tab_contents_view),
-      MoveMouseTo(kNormalTabContentsViewId), ClickMouse(),
+      ActivatePane(kNormalTabContentsViewId, normal_tab_contents_view,
+                   normal_tab_contents),
       WaitForActiveTabChange(1), Check([this]() {
         return !GetBraveMultiContentsView()->is_web_panel_active_for_testing();
       }));

--- a/browser/ui/views/frame/split_view/BUILD.gn
+++ b/browser/ui/views/frame/split_view/BUILD.gn
@@ -18,6 +18,7 @@ source_set("split_view") {
   ]
 
   deps = [
+    "//brave/browser/ui/sidebar",
     "//brave/browser/ui/tabs:tab_model",
     "//brave/browser/ui/views/frame",
     "//brave/components/vector_icons",

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
@@ -110,6 +110,14 @@ bool BraveMultiContentsView::IsWebPanelVisible() const {
   return contents_container_view_for_web_panel_->GetVisible();
 }
 
+views::View*
+BraveMultiContentsView::GetWebPanelContentsViewForTesting()  // IN-TEST
+    const {
+  return contents_container_view_for_web_panel_
+             ? contents_container_view_for_web_panel_->contents_view()
+             : nullptr;
+}
+
 void BraveMultiContentsView::SetWebPanelWidth(int width) {
   web_panel_width_ = width;
   InvalidateLayout();

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view.h
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view.h
@@ -43,6 +43,8 @@ class BraveMultiContentsView : public MultiContentsView {
   void SetWebPanelOnLeft(bool left);
 
   void set_web_panel_active(bool active) { is_web_panel_active_ = active; }
+  bool is_web_panel_active_for_testing() const { return is_web_panel_active_; }
+  views::View* GetWebPanelContentsViewForTesting() const;
 
   // Notifies the multi-contents view that the browser's active content domain
   // display state has changed.

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view_delegate_impl.cc
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view_delegate_impl.cc
@@ -8,27 +8,27 @@
 #include "base/types/to_address.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "components/tabs/public/tab_interface.h"
 
 BraveMultiContentsViewDelegateImpl::BraveMultiContentsViewDelegateImpl(
     Browser& browser)
-    : MultiContentsViewDelegateImpl(browser),
-      browser_(browser),
-      tab_strip_model_(*browser.tab_strip_model()) {}
+    : MultiContentsViewDelegateImpl(browser), bwi_(browser) {}
 
 BraveMultiContentsViewDelegateImpl::~BraveMultiContentsViewDelegateImpl() =
     default;
 
 void BraveMultiContentsViewDelegateImpl::WebContentsFocused(
     content::WebContents* contents) {
+  TabStripModel* model = bwi_->tab_strip_model();
   // https://github.com/brave/brave-browser/issues/53121
   // On macOS, closing a split view detaches a web contents native view, which
   // can synchronously trigger a focus change (via AppKit first responder
   // transfer). This focus event propagates to ActivateTabAt(), but if we're
   // already inside CloseAllTabs(), the TabStripModel reentrancy guard fires.
   // Skip the activation when tabs are being closed.
-  if (tab_strip_model_->closing_all()) {
+  if (model->closing_all()) {
     return;
   }
 
@@ -37,12 +37,11 @@ void BraveMultiContentsViewDelegateImpl::WebContentsFocused(
   // its contents area is clicked/focused. Likewise, it never reactivates
   // the normal tab that gets clicked back into after the panel became
   // active. Activate directly in both cases.
-  if (sidebar::IsWebPanelRelatedFocusChange(base::to_address(browser_),
-                                            contents)) {
+  if (sidebar::IsWebPanelRelatedFocusChange(base::to_address(bwi_), contents)) {
     if (tabs::TabInterface* tab =
             tabs::TabInterface::MaybeGetFromContents(contents);
-        tab && tab_strip_model_->GetActiveTab() != tab) {
-      tab_strip_model_->ActivateTabAt(tab_strip_model_->GetIndexOfTab(tab));
+        tab && model->GetActiveTab() != tab) {
+      model->ActivateTabAt(model->GetIndexOfTab(tab));
     }
     return;
   }
@@ -57,7 +56,7 @@ void BraveMultiContentsViewDelegateImpl::ResizeWebContents(double ratio,
   // TODO(https://github.com/brave/brave-browser/issues/33533):
   // Need to handle split view resize when web panel is active.
   // If not skip, crash happened now due to above reason.
-  if (!tab_strip_model_->GetActiveTab()->GetSplit()) {
+  if (!bwi_->tab_strip_model()->GetActiveTab()->GetSplit()) {
     return;
   }
 

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view_delegate_impl.cc
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view_delegate_impl.cc
@@ -6,8 +6,10 @@
 #include "brave/browser/ui/views/frame/split_view/brave_multi_contents_view_delegate_impl.h"
 
 #include "base/types/to_address.h"
+#include "brave/browser/ui/sidebar/sidebar_controller.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "components/tabs/public/tab_interface.h"
@@ -37,7 +39,10 @@ void BraveMultiContentsViewDelegateImpl::WebContentsFocused(
   // its contents area is clicked/focused. Likewise, it never reactivates
   // the normal tab that gets clicked back into after the panel became
   // active. Activate directly in both cases.
-  if (sidebar::IsWebPanelRelatedFocusChange(base::to_address(bwi_), contents)) {
+  if (sidebar::IsWebPanelFeatureEnabled() &&
+      sidebar::IsWebPanelRelatedFocusChange(
+          bwi_->GetFeatures().sidebar_controller()->GetWebPanelController(),
+          model, contents)) {
     if (tabs::TabInterface* tab =
             tabs::TabInterface::MaybeGetFromContents(contents);
         tab && model->GetActiveTab() != tab) {

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view_delegate_impl.cc
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view_delegate_impl.cc
@@ -5,12 +5,16 @@
 
 #include "brave/browser/ui/views/frame/split_view/brave_multi_contents_view_delegate_impl.h"
 
+#include "base/types/to_address.h"
+#include "brave/browser/ui/sidebar/sidebar_utils.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "components/tabs/public/tab_interface.h"
 
 BraveMultiContentsViewDelegateImpl::BraveMultiContentsViewDelegateImpl(
     Browser& browser)
     : MultiContentsViewDelegateImpl(browser),
+      browser_(browser),
       tab_strip_model_(*browser.tab_strip_model()) {}
 
 BraveMultiContentsViewDelegateImpl::~BraveMultiContentsViewDelegateImpl() =
@@ -25,6 +29,21 @@ void BraveMultiContentsViewDelegateImpl::WebContentsFocused(
   // already inside CloseAllTabs(), the TabStripModel reentrancy guard fires.
   // Skip the activation when tabs are being closed.
   if (tab_strip_model_->closing_all()) {
+    return;
+  }
+
+  // Web panel's tab is a plain pinned tab, not part of a split, so
+  // upstream's split-only activation logic never activates it when
+  // its contents area is clicked/focused. Likewise, it never reactivates
+  // the normal tab that gets clicked back into after the panel became
+  // active. Activate directly in both cases.
+  if (sidebar::IsWebPanelRelatedFocusChange(base::to_address(browser_),
+                                            contents)) {
+    if (tabs::TabInterface* tab =
+            tabs::TabInterface::MaybeGetFromContents(contents);
+        tab && tab_strip_model_->GetActiveTab() != tab) {
+      tab_strip_model_->ActivateTabAt(tab_strip_model_->GetIndexOfTab(tab));
+    }
     return;
   }
 

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view_delegate_impl.h
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view_delegate_impl.h
@@ -21,6 +21,7 @@ class BraveMultiContentsViewDelegateImpl
   void ResizeWebContents(double ratio, bool done_resizing) override;
 
  private:
+  const raw_ref<Browser> browser_;
   const raw_ref<TabStripModel> tab_strip_model_;
 };
 

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view_delegate_impl.h
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view_delegate_impl.h
@@ -8,7 +8,7 @@
 
 #include "chrome/browser/ui/views/frame/multi_contents_view_delegate.h"
 
-class TabStripModel;
+class BrowserWindowInterface;
 
 class BraveMultiContentsViewDelegateImpl
     : public MultiContentsViewDelegateImpl {
@@ -21,8 +21,7 @@ class BraveMultiContentsViewDelegateImpl
   void ResizeWebContents(double ratio, bool done_resizing) override;
 
  private:
-  const raw_ref<Browser> browser_;
-  const raw_ref<TabStripModel> tab_strip_model_;
+  const raw_ref<BrowserWindowInterface> bwi_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_SPLIT_VIEW_BRAVE_MULTI_CONTENTS_VIEW_DELEGATE_IMPL_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Issue: https://github.com/brave/brave-browser/issues/33533

It's regressed by upstream. Upstream updated `MultiContentsViewDelegateImpl::WebContentsFocused()` to make tab activate only for split tab. So, web panel's tab activation is skipped.

https://github.com/user-attachments/assets/7b8f0baa-47a4-42c9-b523-6767a33e5994



TEST=SidebarWebPanelInteractiveUITest.ClickActivatesWebPanelAndNormalTab

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
