### PR TITLE
[1.93.x][uplift][plaster] Composite uplift for `add_to_public`

### DIFF
--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -136,6 +136,7 @@ introduce more rewriters. These are the ones we have supported for now.
 | `drop_final`            | AST  | Removes `final` from a C++ class declaration.     |
 | `preempt_function_impl` | AST  | Inserts at the top of a C++ function body.        |
 | `rename_class`          | AST  | Renames a C++ class.                              |
+| `add_to_protected`      | AST  | Adds a member to a class `protected:` section.    |
 
 Use `plaster --help` to discover rewriters and read their full docs:
 

--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -117,22 +117,6 @@ substitutions:
       re_flags: [] # traditional Python `re` flag names, e.g. [DOTALL]
 ```
 
-For backward compatibility, the `regex` fields may also be placed bare directly
-on the item, without the `regex:` key:
-
-```yaml
-substitutions:
-  - description: ''
-    re_pattern: '' # or `pattern:` for a literal, escaped match
-    replace: ''
-```
-
-> [!WARNING]
->
-> This bare form is deprecated (`TODO(brave.dev/bug/56854)`) and will be removed
-> once all plasters are migrated. Prefer the `regex:` form above for all new
-> plasters.
-
 Use YAML's `|` / `|-` block scalars when you need multi-line `replace` or
 `description` values — `|` keeps a trailing newline, `|-` strips it.
 Single-quoted YAML strings preserve backslashes literally, which is useful for

--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -135,6 +135,7 @@ introduce more rewriters. These are the ones we have supported for now.
 | `add_friend`            | AST  | Adds a `friend` declaration to a private section. |
 | `drop_final`            | AST  | Removes `final` from a C++ class declaration.     |
 | `preempt_function_impl` | AST  | Inserts at the top of a C++ function body.        |
+| `rename_class`          | AST  | Renames a C++ class.                              |
 
 Use `plaster --help` to discover rewriters and read their full docs:
 

--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -135,6 +135,7 @@ introduce more rewriters. These are the ones we have supported for now.
 | `add_friend`            | AST  | Adds a `friend` declaration to a private section. |
 | `drop_final`            | AST  | Removes `final` from a C++ class declaration.     |
 | `preempt_function_impl` | AST  | Inserts at the top of a C++ function body.        |
+| `after_function_impl`   | AST  | Wraps a C++ function body and runs code after.    |
 | `rename_class`          | AST  | Renames a C++ class.                              |
 | `add_to_protected`      | AST  | Adds a member to a class `protected:` section.    |
 

--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -138,6 +138,7 @@ introduce more rewriters. These are the ones we have supported for now.
 | `after_function_impl`   | AST  | Wraps a C++ function body and runs code after.    |
 | `rename_class`          | AST  | Renames a C++ class.                              |
 | `add_to_protected`      | AST  | Adds a member to a class `protected:` section.    |
+| `add_to_public`         | AST  | Appends a member to a class `public:` section.    |
 
 Use `plaster --help` to discover rewriters and read their full docs:
 

--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -128,12 +128,13 @@ YAML).
 The keyed rewrite (`regex:` above) is a **rewriter**. There is on-going work to
 introduce more rewriters. These are the ones we have supported for now.
 
-| Rewriter       | Kind | Description                                       |
-| -------------- | ---- | ------------------------------------------------- |
-| `regex`        | text | A Python `re.subn` substitution (the default).    |
-| `make_virtual` | AST  | Prepends `virtual ` to a C++ method declaration.  |
-| `add_friend`   | AST  | Adds a `friend` declaration to a private section. |
-| `drop_final`   | AST  | Removes `final` from a C++ class declaration.     |
+| Rewriter                | Kind | Description                                       |
+| ----------------------- | ---- | ------------------------------------------------- |
+| `regex`                 | text | A Python `re.subn` substitution (the default).    |
+| `make_virtual`          | AST  | Prepends `virtual ` to a C++ method declaration.  |
+| `add_friend`            | AST  | Adds a `friend` declaration to a private section. |
+| `drop_final`            | AST  | Removes `final` from a C++ class declaration.     |
+| `preempt_function_impl` | AST  | Inserts at the top of a C++ function body.        |
 
 Use `plaster --help` to discover rewriters and read their full docs:
 

--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -142,6 +142,15 @@ tools/cr/plaster.py --help                # overview of commands and rewriters
 tools/cr/plaster.py --help make_virtual   # full docs for a specific rewriter
 ```
 
+### File-wide options
+
+Besides `substitutions:`, a plaster file may set file-wide options at the top
+level:
+
+| Key                            | Default | Description                                                   |
+| ------------------------------ | ------- | ------------------------------------------------------------- |
+| `blank_macros_for_ast_parsing` | `false` | Blank parse-blocking macros/conditionals before AST matching. |
+
 ### Applying a plaster
 
 To apply this plaster file, just run `plaster.py`:

--- a/tools/cr/alias/follow_renames_test.py
+++ b/tools/cr/alias/follow_renames_test.py
@@ -460,8 +460,9 @@ class PlasterApplyTest(_Base):
 
     _SUBST_YAML = ('substitutions:\n'
                    '  - description: Replace old_func\n'
-                   '    pattern: old_func\n'
-                   '    replace: new_func\n')
+                   '    regex:\n'
+                   '      pattern: old_func\n'
+                   '      replace: new_func\n')
 
     def test_patch_created_at_new_location(self) -> None:
         """Plaster writes patches/B-foo.cc.patch after an upstream rename."""
@@ -599,8 +600,9 @@ class PatchFileRepairTest(_Base):
         """Patch deleted by _repair_plaster_files is not re-renamed here."""
         _SUBST_YAML = ('substitutions:\n'
                        '  - description: test\n'
-                       '    pattern: old_func\n'
-                       '    replace: new_func\n')
+                       '    regex:\n'
+                       '      pattern: old_func\n'
+                       '      replace: new_func\n')
         before = self._chromium_head()
         self._chromium_commit(self._OLD_REL, 'void old_func() {}\n')
         self._brave_commit('rewrite/A/foo.cc.yaml', _SUBST_YAML)

--- a/tools/cr/alias/mv_test.py
+++ b/tools/cr/alias/mv_test.py
@@ -615,8 +615,9 @@ class PlasterApplyTest(_Base):
 
     _SUBST_YAML = ('substitutions:\n'
                    '  - description: Replace old_func\n'
-                   '    pattern: old_func\n'
-                   '    replace: new_func\n')
+                   '    regex:\n'
+                   '      pattern: old_func\n'
+                   '      replace: new_func\n')
 
     def _commit_chromium(self, rel: str, content: str) -> None:
         self._repo.write_and_stage_file(rel, content, self._repo.chromium)

--- a/tools/cr/patchfile_test.py
+++ b/tools/cr/patchfile_test.py
@@ -707,8 +707,9 @@ class PatchfilePlasterApplyTest(unittest.TestCase):
     # count = 0 means "replace all matches, bypass count validation".
     _WORKING_YAML = ('substitutions:\n'
                      '  - description: Replace old_func\n'
-                     '    pattern: old_func\n'
-                     '    replace: new_func\n'
+                     '    regex:\n'
+                     '      pattern: old_func\n'
+                     '      replace: new_func\n'
                      '    count: 0\n')
 
     # No substitutions key → missing required key → PLASTER_BROKEN.

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -432,6 +432,11 @@ class Rewriter(abc.ABC):
         """Build a rewriter from its YAML body, validating its fields."""
 
     @classmethod
+    def validate_count(cls, count: int, description: str) -> None:
+        """Reject an unsupported `count:` for this rewriter.
+        """
+
+    @classmethod
     def help_text(cls) -> str:
         """The full, user-facing help for this rewriter as dedented Markdown."""
         return textwrap.dedent(cls.HELP or cls.__doc__ or '').strip('\n')
@@ -605,9 +610,11 @@ class Substitution:
                                  f'rewriter: '
                                  f'{", ".join(repr(k) for k in unknown)} '
                                  f'(in "{description}")')
-            # The chosen rewriter decides what an omitted `count:` means.
+            # The chosen rewriter decides what an omitted `count:` means, and
+            # may reject a count it does not support.
             expected_count = Substitution._parse_count(
                 data, description, _REWRITERS[name].DEFAULT_COUNT)
+            _REWRITERS[name].validate_count(expected_count, description)
             rewriter = _REWRITERS[name].parse(data[name],
                                               description=description)
             return Substitution(description=description,
@@ -1274,10 +1281,8 @@ class PreemptFunctionImpl(_AstGrepRewriter):
         return f'if ({condition}) return{value};'
 
 
-# A set with all the rewriters available in plaster.
 class RenameClass(_AstGrepRewriter):
-    """Rename a C++ class -- its declaration, type uses, `Class::` qualifiers
-    and con/destructor names -- via the ast-grep rewriters."""
+    """Rename a C++ class."""
 
     NAME: Final = 'rename_class'
     OP_ID: Final = 'cxx.rename_class'
@@ -1307,10 +1312,107 @@ class RenameClass(_AstGrepRewriter):
     """
 
 
+class AddToProtected(_AstGrepRewriter):
+    """Add a member declaration to a C++ class's `protected:` section"""
+
+    NAME: Final = 'add_to_protected'
+    # Two ops share the work (see `operations`); this names the language and a
+    # representative op for the base's helpers.
+    OP_ID: Final = 'cxx.add_to_protected'
+    SUMMARY: Final = 'Add code to a class protected section (creating one if '\
+                     'needed).'
+    # Authored in Markdown; `Help` renders it with rich.
+    HELP: Final = r"""
+        Adds code to a C++ class's `protected:` section. It will either use an
+        existing `protected:` section or create a new one.
+
+        Fields:
+
+        - `class_name` — the class to add to.
+        - `code` — free-form text to insert in the protected section, e.g. a
+          declaration like `virtual void OnFoo() = 0;`.
+
+        Example:
+
+        ```yaml
+        substitutions:
+          - description: Add a protected hook for the Brave subclass to override.
+            add_to_protected:
+              class_name: TestLauncher_ChromiumImpl
+              code: 'virtual const TestResult& OnTestResult(const TestResult& result) = 0;'
+        ```
+    """
+
+    # This rewriter uses composite operations that look for an existing
+    # protected section, or add one before `private:`.
+    _ADD_TO_EXISTING: Final = 'cxx.add_to_protected'
+    _CREATE_BEFORE_PRIVATE: Final = 'cxx.add_protected_before_private'
+
+    @classmethod
+    def validate_count(cls, count: int, description: str) -> None:
+        # The code is inserted once, into whichever placement applies, so a
+        # `count:` other than 1 is meaningless here.
+        if count != 1:
+            raise ValueError(f'{cls.NAME} adds the code exactly once and does '
+                             f'not accept a count other than 1 '
+                             f'(in "{description}")')
+
+    def __init__(self, *, class_name: str, code: str):
+        super().__init__()
+        self._class_name = class_name
+        self._code = code
+
+    def apply(self,
+              contents: str,
+              *,
+              count: int,
+              description: str,
+              blank_for_parse: bool = False) -> tuple[str, list[str]]:
+        # The code is inserted exactly once either in an existing protected
+        # section or in a new one created just before a private section.
+        del count, description
+        engine = AstRewriter(RewritersEval.load(),
+                             contents,
+                             blank_for_parse=blank_for_parse)
+        code = _indent_yaml(self._code).replace('\\', '\\\\')
+        inputs = {'class_name': self._class_name, 'code': code}
+        op = Operation(self._ADD_TO_EXISTING, inputs,
+                       MatchExpectation.exactly(1))
+        changes = engine.run(op)
+        if changes == 0:
+            op = Operation(self._CREATE_BEFORE_PRIVATE, inputs,
+                           MatchExpectation.exactly(1))
+            changes = engine.run(op)
+        error = op.expectation.error_for(changes)
+        return engine.content, [error] if error else []
+
+    @classmethod
+    def parse(cls, body: object, *, description: str) -> AddToProtected:
+        """Validate an `add_to_protected:` body of string args."""
+        if not isinstance(body, dict):
+            raise ValueError(
+                f'"{cls.NAME}" must be a mapping (in "{description}")')
+        required = {'class_name', 'code'}
+        unknown = sorted(set(body) - required)
+        if unknown:
+            raise ValueError(
+                f'Unrecognised {cls.NAME} arg(s): '
+                f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
+        missing = sorted(required - set(body))
+        if missing:
+            raise ValueError(f'{cls.NAME} requires arg(s): '
+                             f'{", ".join(missing)} (in "{description}")')
+        for key in sorted(required):
+            if not isinstance(body[key], str) or not body[key]:
+                raise ValueError(f'{cls.NAME} `{key}` must be a non-empty '
+                                 f'string (in "{description}")')
+        return cls(class_name=body['class_name'], code=body['code'])
+
+
 _REWRITERS: MappingProxyType[str, type[Rewriter]] = MappingProxyType({
     rewriter.NAME: rewriter
     for rewriter in (Regex, MakeVirtual, AddFriend, DropFinal,
-                     PreemptFunctionImpl, RenameClass)
+                     PreemptFunctionImpl, RenameClass, AddToProtected)
 })
 
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -398,6 +398,9 @@ class Rewriter(abc.ABC):
     # The `<name>:` key that selects this rewriter in a `substitutions:` entry.
     NAME: ClassVar[str] = ''
 
+    # A rewriter-specific override for the default value of `count:`.
+    DEFAULT_COUNT: ClassVar[int | None] = None
+
     # One-line summary shown in the `Rewriters` help index.
     SUMMARY: ClassVar[str] = ''
 
@@ -588,8 +591,6 @@ class Substitution:
         if not isinstance(description, str):
             raise ValueError('No description specified for substitution entry')
 
-        expected_count = Substitution._parse_count(data, description)
-
         rewriter_keys = sorted(keys & _REWRITERS.keys())
         if len(rewriter_keys) > 1:
             raise ValueError(
@@ -604,6 +605,9 @@ class Substitution:
                                  f'rewriter: '
                                  f'{", ".join(repr(k) for k in unknown)} '
                                  f'(in "{description}")')
+            # The chosen rewriter decides what an omitted `count:` means.
+            expected_count = Substitution._parse_count(
+                data, description, _REWRITERS[name].DEFAULT_COUNT)
             rewriter = _REWRITERS[name].parse(data[name],
                                               description=description)
             return Substitution(description=description,
@@ -630,8 +634,10 @@ class Substitution:
             f'{", ".join(sorted(_REWRITERS)) or "(none)"}')
 
     @staticmethod
-    def _parse_count(data: dict[str, object], description: str) -> int:
-        expected_count = data.get('count', 1)
+    def _parse_count(data: dict[str, object],
+                     description: str,
+                     default: int | None = None) -> int:
+        expected_count = data.get('count', 1 if default is None else default)
         # bool is a subclass of int; reject it explicitly.
         if (not isinstance(expected_count, int)
                 or isinstance(expected_count, bool)):
@@ -1269,10 +1275,42 @@ class PreemptFunctionImpl(_AstGrepRewriter):
 
 
 # A set with all the rewriters available in plaster.
+class RenameClass(_AstGrepRewriter):
+    """Rename a C++ class -- its declaration, type uses, `Class::` qualifiers
+    and con/destructor names -- via the ast-grep rewriters."""
+
+    NAME: Final = 'rename_class'
+    OP_ID: Final = 'cxx.rename_class'
+    SUMMARY: Final = 'Rename a class and every code token of its name.'
+    # For this rewriter we have less of a concerns about `count`.
+    DEFAULT_COUNT: Final = 0
+    # Authored in Markdown; `Help` renders it with rich.
+    HELP: Final = r"""
+        Renames a C++ class everywhere its name appears as a *code token*: the
+        class declaration, type positions (`Foo*`, `<Foo>`), the `Foo::`
+        qualifier on out-of-line members, and constructor/destructor names.
+
+        Fields:
+
+        - `class_name` — the current class name.
+        - `rename` — the name to rename it to (e.g. `Foo_ChromiumImpl`).
+
+        Example:
+
+        ```yaml
+        substitutions:
+          - description: Rename so the Brave subclass can reuse the name.
+            rename_class:
+              class_name: TestLauncher
+              rename: TestLauncher_ChromiumImpl
+        ```
+    """
+
+
 _REWRITERS: MappingProxyType[str, type[Rewriter]] = MappingProxyType({
     rewriter.NAME: rewriter
     for rewriter in (Regex, MakeVirtual, AddFriend, DropFinal,
-                     PreemptFunctionImpl)
+                     PreemptFunctionImpl, RenameClass)
 })
 
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -406,8 +406,12 @@ class Rewriter(abc.ABC):
     HELP: ClassVar[str] = ''
 
     @abc.abstractmethod
-    def apply(self, contents: str, *, count: int,
-              description: str) -> tuple[str, list[str]]:
+    def apply(self,
+              contents: str,
+              *,
+              count: int,
+              description: str,
+              blank_for_parse: bool = False) -> tuple[str, list[str]]:
         """Transform `contents`, returning (new_contents, validation_errors).
 
         `count` is the entry's `count:` (default 1, `0` meaning "one or more").
@@ -415,7 +419,8 @@ class Rewriter(abc.ABC):
         the expected number of matches. A composed rewriter may instead give
         each of its operations its own expectation. `errors` is the list of
         human-readable count/validation failures (empty when the entry applied
-        as expected).
+        as expected). `blank_for_parse` is the file-wide
+        `blank_macros_for_ast_parsing` flag used by AST rewriters.
         """
 
     @classmethod
@@ -427,6 +432,43 @@ class Rewriter(abc.ABC):
     def help_text(cls) -> str:
         """The full, user-facing help for this rewriter as dedented Markdown."""
         return textwrap.dedent(cls.HELP or cls.__doc__ or '').strip('\n')
+
+    def source_language(self) -> str | None:
+        """The source language this rewriter requires, or None if agnostic.
+
+        AST rewriters parse the target in a specific language (the `<lang>.`
+        prefix of their op id), so they may only be used on sources of that
+        language. Text rewriters are language-agnostic and return None.
+        """
+        return None
+
+
+# The file-wide plaster keys allowed at the top level of a YAML plaster.
+_TOP_LEVEL_KEYS: Final = frozenset(
+    {'substitutions', 'blank_macros_for_ast_parsing'})
+
+# Target-source suffixes plaster treats as C++. `blank_macros_for_ast_parsing`
+# blanks constructs for the tree-sitter C++ parser, so it is only meaningful for
+# these.
+_CXX_SOURCE_SUFFIXES: Final = frozenset(
+    {'.h', '.hpp', '.hxx', '.h++', '.cc', '.cpp', '.cxx', '.c++', '.mm'})
+
+
+def _is_cxx_source(plaster_path: Path) -> bool:
+    """True if the plaster's target source (its path minus `.yaml`) is C++."""
+    return plaster_path.with_suffix('').suffix in _CXX_SOURCE_SUFFIXES
+
+
+@dataclass(frozen=True)
+class PlasterSpec:
+    """A parsed plaster file: its substitutions plus its file-wide options."""
+
+    # The `substitutions:` entries, in order.
+    substitutions: list[Substitution]
+
+    # Indicates to the AST-rewriter that it needs to blank all cxx preprocessor
+    # directives that can interfere with parsing.
+    blank_macros_for_ast_parsing: bool = False
 
 
 @dataclass(frozen=True)
@@ -447,16 +489,16 @@ class Substitution:
     # The rewriter this entry composes; `apply` delegates to it.
     rewriter: Rewriter
 
-    def apply(self, contents: str) -> tuple[str, list[str]]:
+    def apply(self,
+              contents: str,
+              *,
+              blank_for_parse: bool = False) -> tuple[str, list[str]]:
         """Apply the composed rewriter, returning (new_contents, errors).
-
-        The envelope's `expected_count`/`description` are handed to the
-        rewriter, which owns count validation (per-operation for composed
-        rewriters) and reports any failures as error strings.
         """
         return self.rewriter.apply(contents,
                                    count=self.expected_count,
-                                   description=self.description)
+                                   description=self.description,
+                                   blank_for_parse=blank_for_parse)
 
     class _NoDupSafeLoader(yaml.SafeLoader):
         """`yaml.SafeLoader` that rejects duplicate mapping keys.
@@ -491,16 +533,27 @@ class Substitution:
         }
 
     @staticmethod
-    def from_yaml(contents: str) -> list[Substitution]:
-        """Parse all substitutions from the contents of a YAML plaster file.
+    def from_yaml(contents: str) -> PlasterSpec:
+        """Parse a YAML plaster file into a `PlasterSpec`.
 
-        YAML plasters use a top-level `substitutions:` list.
+        YAML plasters use a top-level `substitutions:` list, plus file-level
+        values.
         """
         data = yaml.load(contents, Loader=Substitution._NoDupSafeLoader)
         if data is None:
             data = {}
         if not isinstance(data, dict):
             raise ValueError('Plaster YAML must be a mapping at the top level')
+        unknown = sorted(set(data) - _TOP_LEVEL_KEYS)
+        if unknown:
+            raise ValueError('Unrecognised top-level plaster key(s): ' +
+                             ', '.join(repr(k)
+                                       for k in unknown) + '; allowed: ' +
+                             ', '.join(sorted(_TOP_LEVEL_KEYS)))
+        blank_for_parse = data.get('blank_macros_for_ast_parsing', False)
+        if not isinstance(blank_for_parse, bool):
+            raise ValueError(
+                '`blank_macros_for_ast_parsing` must be a boolean')
         raw = data.get('substitutions')
         if raw is None:
             raise ValueError(
@@ -511,7 +564,9 @@ class Substitution:
             raise ValueError(
                 'Plaster YAML `substitutions:` must contain at least one entry'
             )
-        return [Substitution._from_item(entry) for entry in raw]
+        return PlasterSpec(
+            substitutions=[Substitution._from_item(entry) for entry in raw],
+            blank_macros_for_ast_parsing=blank_for_parse)
 
     @staticmethod
     def _from_item(data: object) -> Substitution:
@@ -685,9 +740,14 @@ class Regex(Rewriter):
         self._replace = replace
         self._re_flags = re_flags
 
-    def apply(self, contents: str, *, count: int,
-              description: str) -> tuple[str, list[str]]:
+    def apply(self,
+              contents: str,
+              *,
+              count: int,
+              description: str,
+              blank_for_parse: bool = False) -> tuple[str, list[str]]:
         del description  # Only the count matters for the regex diagnostic.
+        del blank_for_parse  # Text substitution never parses; nothing to relax.
         # `count=0` here means "replace every match"; how many were expected is
         # validated afterwards against the entry's `count:`.
         content, matches = re.subn(self._re_pattern,
@@ -806,6 +866,14 @@ class _AstGrepRewriter(Rewriter):
         # subclasses hold their own parsed shape and leave this empty.
         self._inputs = inputs if inputs is not None else {}
 
+    def source_language(self) -> str:
+        """The `<lang>.` prefix for the op (e.g. `cxx` for `cxx.make_virtual`).
+
+        AST rewriters parse the target in this language, so they are only valid
+        on sources of it.
+        """
+        return self.OP_ID.split('.', 1)[0]
+
     def operations(self, count: int) -> list[Operation]:
         """The ordered ast-grep operations this rewriter expands to.
 
@@ -819,9 +887,15 @@ class _AstGrepRewriter(Rewriter):
                       MatchExpectation.from_count(count))
         ]
 
-    def apply(self, contents: str, *, count: int,
-              description: str) -> tuple[str, list[str]]:
-        engine = AstRewriter(RewritersEval.load(), contents)
+    def apply(self,
+              contents: str,
+              *,
+              count: int,
+              description: str,
+              blank_for_parse: bool = False) -> tuple[str, list[str]]:
+        engine = AstRewriter(RewritersEval.load(),
+                             contents,
+                             blank_for_parse=blank_for_parse)
         outcomes = [(op, engine.run(op)) for op in self.operations(count)]
         return engine.content, self.validate_outcomes(outcomes, description)
 
@@ -877,7 +951,9 @@ class MakeVirtual(_AstGrepRewriter):
     SUMMARY: Final = 'Prepend `virtual ` to a class method declaration.'
     # Authored in Markdown; `Help` renders it with rich.
     HELP: Final = r"""
-        Prepends `virtual ` to a C++ method declaration.
+        Adds `virtual ` to a C++ method declaration. A leading attribute like
+        `[[nodiscard]]` is kept first, so `virtual` lands after it
+        (`[[nodiscard]] virtual T Foo()`), as the grammar requires.
 
         Fields:
 
@@ -1114,18 +1190,30 @@ class PlasterFile:
 
         info = PatchinfoBuilder(self.path)
         if suffix == '.yaml':
-            substitutions = Substitution.from_yaml(info.plaster_contents)
+            doc = Substitution.from_yaml(info.plaster_contents)
+            is_cxx = _is_cxx_source(self.path)
+            if doc.blank_macros_for_ast_parsing and not is_cxx:
+                raise ValueError(
+                    '`blank_macros_for_ast_parsing` is only supported for C++ '
+                    f'sources (in {self.path})')
+            if not is_cxx:
+                for substitution in doc.substitutions:
+                    if substitution.rewriter.source_language() == 'cxx':
+                        raise ValueError(
+                            f'the `{substitution.rewriter.NAME}` rewriter is '
+                            f'only supported for C++ sources (in {self.path})')
         else:
             raise ValueError(f'Unsupported plaster file extension: {suffix}')
         contents = repository.chromium.read_file(info.source)
         errors = []
 
         try:
-            for substitution in substitutions:
+            for substitution in doc.substitutions:
                 # Each substitution owns its count validation (per-operation for
                 # composed rewriters) and reports any failures; we just attach
                 # the file being patched.
-                contents, sub_errors = substitution.apply(contents)
+                contents, sub_errors = substitution.apply(
+                    contents, blank_for_parse=doc.blank_macros_for_ast_parsing)
                 errors.extend(f'{error} in {self.path}'
                               for error in sub_errors)
 
@@ -1470,14 +1558,59 @@ class AstRewriter:
     operations to run.
     """
 
-    def __init__(self, rewriters: RewritersEval, content: str):
+    # Class-head export macro (e.g. `MODULES_EXPORT`, `COMPONENT_EXPORT(FOO)`):
+    # the keyword and its space, the macro, then the start of the real name.
+    # Used by `_prepare_cxx_for_parse`.
+    _EXPORT_MACRO_RE = re.compile(r'(\b(?:class|struct)\s+)'
+                                  r'([A-Z][A-Z0-9_]*_EXPORT(?:\s*\([^()]*\))?)'
+                                  r'(\s+[A-Za-z_])')
+
+    # A preprocessor conditional directive line (`#if`, `#ifdef` ...), matched
+    # without its trailing newline. Used by `_prepare_cxx_for_parse`.
+    _CXX_CONDITIONAL_RE = re.compile(
+        r'(?m)^[ \t]*#[ \t]*(?:if|ifdef|ifndef|elif|else|endif)\b.*$')
+
+    def __init__(self,
+                 rewriters: RewritersEval,
+                 content: str,
+                 *,
+                 blank_for_parse: bool = False):
         self._rewriters = rewriters
-        self._content = content
+        self._source = content
+        # When set, blank constructs tree-sitter cannot parse before matching
+        # (see `_prepare_cxx_for_parse`). Off by default. Opt-in per file.
+        self._blank_for_parse = blank_for_parse
 
     @property
     def content(self) -> str:
         """The current file contents, reflecting every applied rewrite."""
-        return self._content
+        return self._source
+
+    def _prepare_cxx_for_parse(self) -> str:
+        """Normalise C++ source for tree-sitter parsing
+
+        Two constructs are handled:
+
+        - A class-head export macro (`class MODULES_EXPORT Foo`): tree-sitter
+          has no macro definitions, so it reads the macro as the class name and
+          drops the real name, any `final`, and the body into an error node.
+          Blanking the macro leaves a plain `class Foo ...`.
+        - A preprocessor conditional (`#if`/`#endif`/...), most damaging inside
+          a base-specifier list (`#if defined(USE_AURA)`), which has no grammar
+          node and breaks the class head. Blanking the directive lines, keeping
+          the guarded code, makes the head parse.
+
+        Both substitutions only replace characters in place, so every byte
+        offset is preserved. Blanking every conditional file-wide is safe
+        because the caller opts in per file via `blank_macros_for_ast_parsing`,
+        and a directive guarding an alternative definition would leave two
+        matches that the count check flags.
+        """
+        source = self._EXPORT_MACRO_RE.sub(
+            lambda m: m.group(1) + ' ' * len(m.group(2)) + m.group(3),
+            self._source)
+        return self._CXX_CONDITIONAL_RE.sub(
+            lambda line: ' ' * len(line.group(0)), source)
 
     def run(self, op: Operation) -> int:
         """Run one bound `Operation`, mutate content, return the change count.
@@ -1500,9 +1633,14 @@ class AstRewriter:
         language = self._rewriters.language_of(op.op_id)
         rule_body = matcher['template'].format(**op.inputs)
 
+        # `_prepare_cxx_for_parse` blanks C++-specific constructs, so it only
+        # applies to `cxx.` ops.
+        blank = self._blank_for_parse and op.op_id.startswith('cxx.')
+        source_for_parse = (self._prepare_cxx_for_parse()
+                            if blank else self._source)
         matches = run_ast_grep(language=language,
                                rule_body=rule_body,
-                               source=self._content)
+                               source=source_for_parse)
         if rewriter.get('first_match'):
             matches = matches[:1]
 
@@ -1512,7 +1650,7 @@ class AstRewriter:
         before = replace.get('consume_before', '').encode('utf-8')
         after = replace.get('consume_after', '').encode('utf-8')
 
-        source = self._content.encode('utf-8')
+        source = self._source.encode('utf-8')
         edits = []
         total = 0
         for match in matches:
@@ -1533,7 +1671,7 @@ class AstRewriter:
         # Apply from the end so each splice leaves earlier offsets unchanged.
         for start, end, new_text in sorted(edits, reverse=True):
             source = source[:start] + new_text.encode('utf-8') + source[end:]
-        self._content = source.decode('utf-8')
+        self._source = source.decode('utf-8')
         return total
 
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -1509,20 +1509,39 @@ class AddToProtected(_AstGrepRewriter):
               description: str,
               blank_for_parse: bool = False) -> tuple[str, list[str]]:
         # The code is inserted exactly once either in an existing protected
-        # section or in a new one created just before a private section.
+        # section or in a new one created just before a private section. Each
+        # placement is indented to the anchor's real column (Chromium members
+        # sit one space in from their access specifier), so a nested class is
+        # indented correctly rather than at the top-level column.
         del count, description
         engine = AstRewriter(RewritersEval.load(),
                              contents,
                              blank_for_parse=blank_for_parse)
-        code = _indent_yaml(self._code).replace('\\', '\\\\')
-        inputs = {'class_name': self._class_name, 'code': code}
-        op = Operation(self._ADD_TO_EXISTING, inputs,
-                       MatchExpectation.exactly(1))
+        source = contents.encode('utf-8')
+        class_inputs = {'class_name': self._class_name}
+
+        anchor = engine.first_match(
+            Operation(self._ADD_TO_EXISTING, class_inputs))
+        if anchor is not None:
+            member = len(_leading_indent(source, anchor.start)) + 1
+            op = Operation(
+                self._ADD_TO_EXISTING, {
+                    'class_name': self._class_name,
+                    'code': _indent_code(self._code, member),
+                }, MatchExpectation.exactly(1))
+        else:
+            anchor = engine.first_match(
+                Operation(self._CREATE_BEFORE_PRIVATE, class_inputs))
+            # A missing anchor leaves the run to report the count shortfall.
+            indent = _leading_indent(source, anchor.start) if anchor else ''
+            op = Operation(
+                self._CREATE_BEFORE_PRIVATE, {
+                    'class_name': self._class_name,
+                    'code': _indent_code(self._code,
+                                         len(indent) + 1),
+                    'indent': indent,
+                }, MatchExpectation.exactly(1))
         changes = engine.run(op)
-        if changes == 0:
-            op = Operation(self._CREATE_BEFORE_PRIVATE, inputs,
-                           MatchExpectation.exactly(1))
-            changes = engine.run(op)
         error = op.expectation.error_for(changes)
         return engine.content, [error] if error else []
 
@@ -1549,11 +1568,130 @@ class AddToProtected(_AstGrepRewriter):
         return cls(class_name=body['class_name'], code=body['code'])
 
 
+class AddToPublic(_AstGrepRewriter):
+    """Append a member declaration to the end of a C++ class's `public:` section
+    """
+
+    NAME: Final = 'add_to_public'
+    # Two ops share the work (see `apply`); this names the language and a
+    # representative op for the base's helpers.
+    OP_ID: Final = 'cxx.append_to_public_before_section'
+    SUMMARY: Final = 'Append code to the end of a class public section.'
+    # Authored in Markdown; `Help` renders it with rich.
+    HELP: Final = r"""
+        Appends code to a C++ class's `public:` section, at the end of it.
+
+        Fields:
+
+        - `class_name` — the class to add to.
+        - `code` — free-form text to append to the public section, e.g. a
+          declaration like `virtual void OnFoo();`.
+
+        Example:
+
+        ```yaml
+        substitutions:
+          - description: Expose a Brave hook on the public interface.
+            add_to_public:
+              class_name: TestLauncher_ChromiumImpl
+              code: 'virtual const TestResult& OnTestResult(const TestResult& result);'
+        ```
+    """
+
+    # This rewriter appends either before the section that follows public, or
+    # -- when public is the last/only section -- before the class's closing
+    # brace.
+    _APPEND_BEFORE_SECTION: Final = 'cxx.append_to_public_before_section'
+    _APPEND_BEFORE_CLOSE: Final = 'cxx.append_to_public_before_close'
+
+    @classmethod
+    def validate_count(cls, count: int, description: str) -> None:
+        # The code is inserted once, into whichever placement applies, so a
+        # `count:` other than 1 is meaningless here.
+        if count != 1:
+            raise ValueError(f'{cls.NAME} adds the code exactly once and does '
+                             f'not accept a count other than 1 '
+                             f'(in "{description}")')
+
+    def __init__(self, *, class_name: str, code: str):
+        super().__init__()
+        self._class_name = class_name
+        self._code = code
+
+    def apply(self,
+              contents: str,
+              *,
+              count: int,
+              description: str,
+              blank_for_parse: bool = False) -> tuple[str, list[str]]:
+        # The code is appended exactly once, either just before the section
+        # that follows public or, when public is last, before the closing brace.
+        # Each placement is indented to the anchor's real column so a nested
+        # class is indented correctly rather than at the top-level column.
+        del count, description
+        engine = AstRewriter(RewritersEval.load(),
+                             contents,
+                             blank_for_parse=blank_for_parse)
+        source = contents.encode('utf-8')
+        class_inputs = {'class_name': self._class_name}
+
+        anchor = engine.first_match(
+            Operation(self._APPEND_BEFORE_SECTION, class_inputs))
+        if anchor is not None:
+            indent = _leading_indent(source, anchor.start)
+            op = Operation(
+                self._APPEND_BEFORE_SECTION, {
+                    'class_name': self._class_name,
+                    'code': _indent_code(self._code,
+                                         len(indent) + 1),
+                    'indent': indent,
+                }, MatchExpectation.exactly(1))
+        else:
+            anchor = engine.first_match(
+                Operation(self._APPEND_BEFORE_CLOSE, class_inputs))
+            # The closing brace is the last byte of the matched body; a missing
+            # anchor leaves the run to report the count shortfall.
+            indent = (_leading_indent(source, anchor.end -
+                                      1) if anchor else '')
+            op = Operation(
+                self._APPEND_BEFORE_CLOSE, {
+                    'class_name': self._class_name,
+                    'code': _indent_code(self._code,
+                                         len(indent) + 2),
+                    'indent': indent,
+                }, MatchExpectation.exactly(1))
+        changes = engine.run(op)
+        error = op.expectation.error_for(changes)
+        return engine.content, [error] if error else []
+
+    @classmethod
+    def parse(cls, body: object, *, description: str) -> AddToPublic:
+        """Validate an `add_to_public:` body of string args."""
+        if not isinstance(body, dict):
+            raise ValueError(
+                f'"{cls.NAME}" must be a mapping (in "{description}")')
+        required = {'class_name', 'code'}
+        unknown = sorted(set(body) - required)
+        if unknown:
+            raise ValueError(
+                f'Unrecognised {cls.NAME} arg(s): '
+                f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
+        missing = sorted(required - set(body))
+        if missing:
+            raise ValueError(f'{cls.NAME} requires arg(s): '
+                             f'{", ".join(missing)} (in "{description}")')
+        for key in sorted(required):
+            if not isinstance(body[key], str) or not body[key]:
+                raise ValueError(f'{cls.NAME} `{key}` must be a non-empty '
+                                 f'string (in "{description}")')
+        return cls(class_name=body['class_name'], code=body['code'])
+
+
 _REWRITERS: MappingProxyType[str, type[Rewriter]] = MappingProxyType({
     rewriter.NAME: rewriter
     for rewriter in (Regex, MakeVirtual, AddFriend, DropFinal,
                      PreemptFunctionImpl, AfterFunctionImpl, RenameClass,
-                     AddToProtected)
+                     AddToProtected, AddToPublic)
 })
 
 
@@ -1754,8 +1892,9 @@ _MATCHER_SCHEMA = {
 # A rewriter op: locates nodes through a matcher op and edits each via a regex
 # substitution. `inputs` is its public interface (validated against the
 # templates it feeds in `_check_cross_references`); `replace` may name adjacent
-# tokens to fold into each rewritten span. `first_match`, when true, rewrites
-# only the first match (in source order) and ignores any later ones.
+# tokens to fold into each rewritten span, which are `{input}`-formatted like
+# `replace` itself. `first_match`, when true, rewrites only the first match (in
+# source order) and ignores any later ones.
 _REWRITER_SCHEMA = {
     'matcher': _NON_EMPTY_STR,
     'inputs': [str],
@@ -1892,8 +2031,11 @@ class RewritersEval:
                     f'{ref!r} node {matcher_node!r}')
 
             declared = set(spec['inputs'])
+            replace = spec['replace']
             used = (_placeholders(matcher['template'])
-                    | _placeholders(spec['replace']['replace']))
+                    | _placeholders(replace['replace'])
+                    | _placeholders(replace.get('consume_before', ''))
+                    | _placeholders(replace.get('consume_after', '')))
             undeclared = sorted(used - declared)
             if undeclared:
                 raise RewritersSchemaError(
@@ -1953,6 +2095,27 @@ def _indent_yaml(text: str, spaces: int = 2) -> str:
     pad = ' ' * spaces
     return '\n'.join(pad + line if line.strip() else line
                      for line in text.splitlines())
+
+
+def _indent_code(text: str, spaces: int) -> str:
+    """Indent `code` to a member level and escape it for a `re.sub` replacement.
+
+    A member-level rewriter splices `code` into an ast-grep op's `re.sub`
+    replacement, so it is indented to the target column and its backslashes are
+    doubled (a backslash is special in a replacement string).
+    """
+    return _indent_yaml(text, spaces).replace('\\', '\\\\')
+
+
+def _leading_indent(source: bytes, pos: int) -> str:
+    """The leading whitespace of the line containing byte offset `pos`.
+
+    Used to anchor an insertion to the real indentation of a class member,
+    keyword or brace, rather than assuming the top-level column.
+    """
+    line_start = source.rfind(b'\n', 0, pos) + 1
+    line = source[line_start:pos]
+    return line[:len(line) - len(line.lstrip(b' \t'))].decode('utf-8')
 
 
 def run_ast_grep(*, language: str, rule_body: str,
@@ -2057,21 +2220,8 @@ class AstRewriter:
         return self._CXX_CONDITIONAL_RE.sub(
             lambda line: ' ' * len(line.group(0)), source)
 
-    def run(self, op: Operation) -> int:
-        """Run one bound `Operation`, mutate content, return the change count.
-
-        Locates nodes via the op's matcher template, applies the op's `replace`
-        regex substitution (with `op.inputs` filled into the replacement
-        template) to each matched node, and splices the results back into the
-        held contents from the end so earlier byte offsets stay valid. Returns
-        the total number of substitutions made.
-
-        An op's `replace` may name `consume_before` / `consume_after` literals
-        that sit immediately before / after each matched node; they are folded
-        into the rewritten span when the node kind stops short of an adjacent
-        token (e.g. the `:` after an access_specifier, or the space before a
-        `final` specifier). An op that sets `first_match` rewrites only the
-        first match (in source order), leaving any later matches untouched.
+    def _locate(self, op: Operation) -> list[AstMatch]:
+        """Every match for `op`'s matcher, in source order.
         """
         rewriter = self._rewriters.rewriter(op.op_id)
         matcher = self._rewriters.matcher(rewriter['matcher'])
@@ -2083,17 +2233,49 @@ class AstRewriter:
         blank = self._blank_for_parse and op.op_id.startswith('cxx.')
         source_for_parse = (self._prepare_cxx_for_parse()
                             if blank else self._source)
-        matches = run_ast_grep(language=language,
-                               rule_body=rule_body,
-                               source=source_for_parse)
+        return run_ast_grep(language=language,
+                            rule_body=rule_body,
+                            source=source_for_parse)
+
+    def first_match(self, op: Operation) -> AstMatch | None:
+        """The first match for `op`'s matcher, or None. Does not mutate content.
+
+        Parse-normalisation preserves byte offsets, so a caller can read the
+        real source (e.g. to derive an insertion's indentation) at the returned
+        offsets before running the op.
+        """
+        matches = self._locate(op)
+        return matches[0] if matches else None
+
+    def run(self, op: Operation) -> int:
+        """Run one bound `Operation`, mutate content, return the change count.
+
+        Locates nodes via the op's matcher template, applies the op's `replace`
+        regex substitution (with `op.inputs` filled into the replacement
+        template) to each matched node, and splices the results back into the
+        held contents from the end so earlier byte offsets stay valid. Returns
+        the total number of substitutions made.
+
+        An op's `replace` may name `consume_before` / `consume_after` tokens
+        (themselves `op.inputs`-formatted) that sit immediately before / after
+        each matched node; they are folded into the rewritten span when the node
+        kind stops short of an adjacent token (e.g. the `:` after an
+        access_specifier, or the space before a `final` specifier). An op that
+        sets `first_match` rewrites only the first match (in source order),
+        leaving any later matches untouched.
+        """
+        rewriter = self._rewriters.rewriter(op.op_id)
+        matches = self._locate(op)
         if rewriter.get('first_match'):
             matches = matches[:1]
 
         replace = rewriter['replace']
         pattern = replace['re_pattern']
         replacement = replace['replace'].format(**op.inputs)
-        before = replace.get('consume_before', '').encode('utf-8')
-        after = replace.get('consume_after', '').encode('utf-8')
+        before = replace.get('consume_before',
+                             '').format(**op.inputs).encode('utf-8')
+        after = replace.get('consume_after',
+                            '').format(**op.inputs).encode('utf-8')
 
         source = self._source.encode('utf-8')
         edits = []

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -1105,10 +1105,174 @@ class DropFinal(_AstGrepRewriter):
     """
 
 
+class PreemptFunctionImpl(_AstGrepRewriter):
+    """Insert a statement block at the top of a C++ function body, via the
+    ast-grep rewriters.
+    """
+
+    NAME: Final = 'preempt_function_impl'
+    OP_ID: Final = 'cxx.preempt_function_impl'
+    SUMMARY: Final = 'Insert a statement block at the top of a function body.'
+    # Authored in Markdown; `Help` renders it with rich.
+    HELP: Final = r"""
+        Inserts a statement block as the first thing in a C++ function's body,
+        right after the opening brace. Use it to preempt the implementation of
+        an upstream function, rather than renaming it to an inner
+        `_ChromiumImpl`.
+
+        Fields:
+
+        - `function_name` — the function's name exactly as its definition
+          writes it: a qualified `Class::Method` for a member, or the bare name
+          for a free function.
+
+        Exactly one of the following selects what to insert:
+
+        - `return_if` — a boolean condition that expands to `if (<condition>)
+          return;`, or `if (<condition>) return <return_value>;` when
+          `return_value` is also given.
+        - `code` — a free-form statement block. Write it flush-left; the whole
+          block is indented to the body's first-statement level for you.
+
+        - `return_value` — optional, only valid with `return_if`: the value the
+          generated early return yields.
+
+        Each overload sharing the name is one match, so an overloaded method
+        needs a matching `count`.
+
+        Examples:
+
+        ```yaml
+        substitutions:
+          - description: Skip autocomplete when Brave has it disabled.
+            preempt_function_impl:
+              function_name: OmniboxController::StartAutocomplete
+              return_if: '!IsAutocompleteEnabled(client_->GetPrefs())'
+
+          - description: Never expose the feedback buttons; return false early.
+            preempt_function_impl:
+              function_name: OmniboxResultView::IsFeedbackButtonVisible
+              return_if: 'true'
+              return_value: 'false'
+
+          - description: Pin Brave-managed actions before the upstream body.
+            preempt_function_impl:
+              function_name: CustomizeToolbarHandler::PinAction
+              code: |-
+                if (PinBraveAction(action_id, prefs(), pin)) {
+                  return;
+                }
+        ```
+
+        The last entry turns this upstream definition:
+
+        ```cpp
+        void CustomizeToolbarHandler::PinAction(int action_id, bool pin) {
+          // ... upstream body ...
+        }
+        ```
+
+        into (note the flush-left `code` block indented to the body level):
+
+        ```cpp
+        void CustomizeToolbarHandler::PinAction(int action_id, bool pin) {
+          if (PinBraveAction(action_id, prefs(), pin)) {
+            return;
+          }
+          // ... upstream body ...
+        }
+        ```
+    """
+
+    # The keys that select what to insert; exactly one must be present.
+    _MODE_KEYS: Final = frozenset({'code', 'return_if'})
+
+    def __init__(self, *, function_name: str, prologue: str):
+        # This rewriter holds its own parsed shape (the resolved prologue text)
+        # and builds its operation from it, so the base's flat inputs stay
+        # empty.
+        super().__init__()
+        self._function_name = function_name
+        self._prologue = prologue
+
+    def operations(self, count: int) -> list[Operation]:
+        # A function body is matched once per overload, so the entry's `count:`
+        # carries through unchanged (an overloaded method needs a matching
+        # count).
+        #
+        # The prologue lands as the body's first statement, so indent every
+        # non-blank line to the body's first level -- two spaces, which is where
+        # an out-of-line `Class::Method` definition always sits (file/namespace
+        # scope). Escape backslashes last, since the text is spliced into a
+        # `re.sub` replacement where a backslash is special.
+        prologue = _indent_yaml(self._prologue).replace('\\', '\\\\')
+        return [
+            Operation(self.OP_ID, {
+                'function_name': self._function_name,
+                'prologue': prologue,
+            }, MatchExpectation.from_count(count))
+        ]
+
+    @classmethod
+    def parse(cls, body: object, *, description: str) -> PreemptFunctionImpl:
+        """Validate a `preempt_function_impl:` body and resolve what to insert.
+
+        Requires `function_name`, plus exactly one of `code` or `return_if`;
+        `return_value` is optional and only valid with `return_if`.
+        """
+        if not isinstance(body, dict):
+            raise ValueError(
+                f'"{cls.NAME}" must be a mapping (in "{description}")')
+        allowed = {'function_name', 'return_value'} | cls._MODE_KEYS
+        unknown = sorted(set(body) - allowed)
+        if unknown:
+            raise ValueError(
+                f'Unrecognised {cls.NAME} arg(s): '
+                f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
+        if not isinstance(body.get('function_name'),
+                          str) or not body['function_name']:
+            raise ValueError(f'{cls.NAME} `function_name` must be a non-empty '
+                             f'string (in "{description}")')
+        prologue = cls._resolve_prologue(body, description)
+        return cls(function_name=body['function_name'], prologue=prologue)
+
+    @classmethod
+    def _resolve_prologue(cls, body: dict, description: str) -> str:
+        """Build the text to insert from the `code`/`return_if` fields."""
+        modes = sorted(cls._MODE_KEYS & set(body))
+        if len(modes) != 1:
+            raise ValueError(
+                f'{cls.NAME} requires exactly one of `code` or `return_if` '
+                f'(in "{description}")')
+        mode = modes[0]
+        if mode == 'code':
+            if 'return_value' in body:
+                raise ValueError(
+                    f'{cls.NAME} `return_value` is only valid with `return_if` '
+                    f'(in "{description}")')
+            code = body['code']
+            if not isinstance(code, str) or not code:
+                raise ValueError(
+                    f'{cls.NAME} `code` must be a non-empty string '
+                    f'(in "{description}")')
+            return code
+        condition = body['return_if']
+        if not isinstance(condition, str) or not condition:
+            raise ValueError(f'{cls.NAME} `return_if` must be a non-empty '
+                             f'string (in "{description}")')
+        return_value = body.get('return_value', '')
+        if not isinstance(return_value, str):
+            raise ValueError(f'{cls.NAME} `return_value` must be a string '
+                             f'(in "{description}")')
+        value = f' {return_value}' if return_value else ''
+        return f'if ({condition}) return{value};'
+
+
 # A set with all the rewriters available in plaster.
 _REWRITERS: MappingProxyType[str, type[Rewriter]] = MappingProxyType({
     rewriter.NAME: rewriter
-    for rewriter in (Regex, MakeVirtual, AddFriend, DropFinal)
+    for rewriter in (Regex, MakeVirtual, AddFriend, DropFinal,
+                     PreemptFunctionImpl)
 })
 
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -1281,6 +1281,146 @@ class PreemptFunctionImpl(_AstGrepRewriter):
         return f'if ({condition}) return{value};'
 
 
+class AfterFunctionImpl(_AstGrepRewriter):
+    """Wrap a function body in a lambda and run a code block after it.
+
+    The upstream body runs first, then our code. The idea of this rewriter is to
+    eliminate the need for certain cases where we either rename a function in
+    upstream to an inner `_ChromiumImpl` and call it, or when we subclass a
+    function to override it and call the base.
+
+    This rewriter offers a third option: wrap the upstream body in a lambda and
+    run a code block after it.
+    """
+
+    NAME: Final = 'after_function_impl'
+    OP_ID: Final = 'cxx.after_function_impl'
+    SUMMARY: Final = 'Run a statement block after a function body, wrapped so '\
+                     'it always runs.'
+    # Authored in Markdown; `Help` renders it with rich.
+    HELP: Final = r"""
+        Wraps a C++ function's whole body in an immediately-invoked `[&]` lambda
+        and runs a statement block after it, so that code always runs before the
+        function ends. This is an alternative to renaming the function to an
+        inner `_ChromiumImpl`, or to subclassing and calling the base, when you
+        want to run code after the upstream body.
+
+        The upstream body becomes `[&]() { ... }();`: a lambda capturing
+        everything (including `this`) by reference and invoked immediately.
+
+        Fields:
+
+        - `function_name` — the function's name exactly as its definition
+          writes it: a qualified `Class::Method` for a member, or the bare name
+          for a free function.
+        - `code` — the statement block to append.
+        - `result_var` — optional. For a non-void function, names a variable
+          bound to the wrapped body's return value (`auto <result_var> = [&]()
+          { ... }();`) so the appended `code` can use it. When set, the appended
+          `code` owns the function's final `return`.
+
+        Each overload sharing the name is one match, so an overloaded method
+        needs a matching `count`.
+
+        Examples:
+
+        ```yaml
+        substitutions:
+          - description: Record a metric after the upstream body always runs.
+            after_function_impl:
+              function_name: DownloadDisplayController::OnButtonPressed
+              code: |-
+                RecordBraveDownloadInteraction();
+
+          - description: Let Brave adjust the computed value before returning.
+            after_function_impl:
+              function_name: OmniboxController::ComputeScore
+              result_var: score
+              code: |-
+                return ComputeScore_BraveImpl(score);
+        ```
+
+        The second entry turns this upstream definition:
+
+        ```cpp
+        int OmniboxController::ComputeScore() {
+          // ... upstream body with its own returns ...
+        }
+        ```
+
+        into (the upstream body is wrapped, not reindented):
+
+        ```cpp
+        int OmniboxController::ComputeScore() {
+          auto score = [&]() {
+          // ... upstream body with its own returns ...
+          }();
+          return ComputeScore_BraveImpl(score);
+        }
+        ```
+    """
+
+    def __init__(self, *, function_name: str, capture: str, epilogue: str):
+        super().__init__()
+        self._function_name = function_name
+        self._capture = capture
+        self._epilogue = epilogue
+
+    def operations(self, count: int) -> list[Operation]:
+        # Escape backslashes last in both spliced values, since they are spliced
+        # into a `re.sub` replacement where a backslash is special.
+        epilogue = _indent_yaml(self._epilogue).replace('\\', '\\\\')
+        capture = self._capture.replace('\\', '\\\\')
+        return [
+            Operation(
+                self.OP_ID, {
+                    'function_name': self._function_name,
+                    'capture': capture,
+                    'epilogue': epilogue,
+                }, MatchExpectation.from_count(count))
+        ]
+
+    @classmethod
+    def parse(cls, body: object, *, description: str) -> AfterFunctionImpl:
+        """Validate an `after_function_impl:` body and resolve what to append.
+
+        Requires `function_name` and `code`. `result_var` is optional and, when
+        given, binds the wrapped body's value to `auto <result_var>`.
+        """
+        if not isinstance(body, dict):
+            raise ValueError(
+                f'"{cls.NAME}" must be a mapping (in "{description}")')
+        allowed = {'function_name', 'code', 'result_var'}
+        unknown = sorted(set(body) - allowed)
+        if unknown:
+            raise ValueError(
+                f'Unrecognised {cls.NAME} arg(s): '
+                f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
+        if not isinstance(body.get('function_name'),
+                          str) or not body['function_name']:
+            raise ValueError(f'{cls.NAME} `function_name` must be a non-empty '
+                             f'string (in "{description}")')
+        code = body.get('code')
+        if not isinstance(code, str) or not code:
+            raise ValueError(f'{cls.NAME} `code` must be a non-empty string '
+                             f'(in "{description}")')
+        capture = cls._resolve_capture(body, description)
+        return cls(function_name=body['function_name'],
+                   capture=capture,
+                   epilogue=code)
+
+    @classmethod
+    def _resolve_capture(cls, body: dict, description: str) -> str:
+        """Build the `auto <result_var> = ` lead, or empty for a void wrap."""
+        if 'result_var' not in body:
+            return ''
+        result_var = body['result_var']
+        if not isinstance(result_var, str) or not result_var:
+            raise ValueError(f'{cls.NAME} `result_var` must be a non-empty '
+                             f'string (in "{description}")')
+        return f'auto {result_var} = '
+
+
 class RenameClass(_AstGrepRewriter):
     """Rename a C++ class."""
 
@@ -1412,7 +1552,8 @@ class AddToProtected(_AstGrepRewriter):
 _REWRITERS: MappingProxyType[str, type[Rewriter]] = MappingProxyType({
     rewriter.NAME: rewriter
     for rewriter in (Regex, MakeVirtual, AddFriend, DropFinal,
-                     PreemptFunctionImpl, RenameClass, AddToProtected)
+                     PreemptFunctionImpl, AfterFunctionImpl, RenameClass,
+                     AddToProtected)
 })
 
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -2321,7 +2321,15 @@ def get_plaster_files(filepaths: list[str] | None = None) -> list[PlasterFile]:
               and filepath.endswith(PLASTER_EXTENSION)):
             expected_plaster_files.add(filepath)
         else:
-            raise ValueError(f'Unexpected file path: {filepath}')
+            hint = ''
+            # Control characters mean the shell interpreted unquoted
+            # backslash escapes (e.g. '\a' -> bell) before we saw the path,
+            # mangling it beyond recovery. Guide the user to quote it.
+            if any(ord(c) < 0x20 for c in filepath):
+                hint = ('\nThe path contains control characters, likely '
+                        'because an unquoted backslash path was escaped by '
+                        'the shell. Quote the path or use forward slashes.')
+            raise PlasterError(f'Unexpected file path: {filepath!r}{hint}')
 
     plaster_parent = Path(PLASTER_FILES_PATH).parent
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -517,12 +517,12 @@ class Substitution:
     def _from_item(data: object) -> Substitution:
         """Validate one `substitutions:` entry and build its rewriter.
 
-        An entry names a rewriter when it carries one of `_REWRITERS` as a key.
-        `description` and the optional `count` are item-level for every form.
+        An entry names a rewriter by carrying one of `_REWRITERS` as a key,
+        alongside the item-level `description` and optional `count`.
 
         Raises:
-            ValueError: on a malformed entry (missing/typo'd keys, mixed
-                forms, or invalid rewriter-specific fields).
+            ValueError: on a malformed entry (missing/typo'd keys, a missing
+                or unknown rewriter, or invalid rewriter-specific fields).
         """
         if not isinstance(data, dict):
             raise ValueError(f'substitution entry must be a mapping, got '
@@ -540,13 +540,6 @@ class Substitution:
             raise ValueError(
                 f'Only one rewriter allowed per entry, got '
                 f'{", ".join(rewriter_keys)} (in "{description}")')
-        # TODO(brave.dev/bug/56854): the bare regex form (regex fields placed
-        # directly on the item, without a `regex:` key) is deprecated. Once all
-        # plasters are migrated, delete this mixing check -- with no bare form
-        # there is nothing to mix.
-        if rewriter_keys and (keys & Regex._FIELD_KEYS):
-            raise ValueError(f'Cannot mix the "{rewriter_keys[0]}" rewriter '
-                             f'with bare regex fields (in "{description}")')
 
         if rewriter_keys:
             name = rewriter_keys[0]
@@ -562,32 +555,24 @@ class Substitution:
                                 expected_count=expected_count,
                                 rewriter=rewriter)
 
-        # No rewriter key: tolerated bare regex (the legacy form).
-        #
-        # TODO(brave.dev/bug/56854): the bare regex form (regex fields placed
-        # directly on the item, without a `regex:` key) is deprecated. Once all
-        # plasters are migrated, delete this whole block and require a rewriter
-        # key above, so an entry with no rewriter key becomes an error.
-        unknown = sorted(keys - ({'description', 'count'} | Regex._FIELD_KEYS))
+        # Every entry must name a rewriter. Surface the most helpful error we
+        # can: a mapping-valued stray key is almost certainly an attempt to use
+        # a rewriter that is not registered -- point the user at the ones that
+        # are; anything else is an unrecognised key.
+        unknown = sorted(keys - {'description', 'count'})
+        bad_rewriters = [k for k in unknown if isinstance(data[k], dict)]
+        if bad_rewriters:
+            available = ', '.join(sorted(_REWRITERS)) or '(none)'
+            raise ValueError(
+                f'Unknown rewriter(s): '
+                f'{", ".join(repr(k) for k in bad_rewriters)}; available '
+                f'rewriters: {available} (in "{description}")')
         if unknown:
-            # Every rewriter body is a mapping, so an unknown key carrying one
-            # is almost certainly an attempt to use a rewriter that is not
-            # registered -- point the user at the ones that are.
-            bad_rewriters = [k for k in unknown if isinstance(data[k], dict)]
-            if bad_rewriters:
-                available = ', '.join(sorted(_REWRITERS)) or '(none)'
-                raise ValueError(
-                    f'Unknown rewriter(s): '
-                    f'{", ".join(repr(k) for k in bad_rewriters)}; available '
-                    f'rewriters: {available} (in "{description}")')
             raise ValueError('Unrecognised substitution key(s): '
                              f'{", ".join(repr(k) for k in unknown)}')
-        # Compose a `regex:` body from the bare fields and hand it to Regex.
-        fields = {k: data[k] for k in keys & Regex._FIELD_KEYS}
-        rewriter = Regex.parse(fields, description=description)
-        return Substitution(description=description,
-                            expected_count=expected_count,
-                            rewriter=rewriter)
+        raise ValueError(
+            f'No rewriter specified (in "{description}"); expected one of: '
+            f'{", ".join(sorted(_REWRITERS)) or "(none)"}')
 
     @staticmethod
     def _parse_count(data: dict[str, object], description: str) -> int:
@@ -692,12 +677,7 @@ class Regex(Rewriter):
         ```
     """
 
-    # The pattern/replacement fields, valid either bare on the item or nested
-    # under a `regex:` op key.
-    #
-    # TODO(brave.dev/bug/56854): the bare placement is deprecated; this set
-    # stays for the `regex:` form, but once all plasters are migrated its bare
-    # use in `Substitution._from_item` should go.
+    # The pattern/replacement fields, nested under the `regex:` op key.
     _FIELD_KEYS = frozenset(('pattern', 're_pattern', 'replace', 're_flags'))
 
     def __init__(self, *, re_pattern: str, replace: str, re_flags: int = 0):
@@ -720,7 +700,7 @@ class Regex(Rewriter):
 
     @classmethod
     def parse(cls, body: object, *, description: str) -> Regex:
-        """Build from a regex field mapping (a `regex:` body or bare keys)."""
+        """Build from a `regex:` body (a mapping of the regex fields)."""
         if not isinstance(body, dict):
             raise ValueError(f'"regex" must be a mapping (in "{description}")')
         unknown = sorted(set(body) - cls._FIELD_KEYS)

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -1241,10 +1241,12 @@ _MATCHER_SCHEMA = {
 # A rewriter op: locates nodes through a matcher op and edits each via a regex
 # substitution. `inputs` is its public interface (validated against the
 # templates it feeds in `_check_cross_references`); `replace` may name adjacent
-# tokens to fold into each rewritten span.
+# tokens to fold into each rewritten span. `first_match`, when true, rewrites
+# only the first match (in source order) and ignores any later ones.
 _REWRITER_SCHEMA = {
     'matcher': _NON_EMPTY_STR,
     'inputs': [str],
+    schema.Optional('first_match'): bool,
     'replace': {
         schema.Optional('consume_before'): str,
         schema.Optional('consume_after'): str,
@@ -1510,7 +1512,8 @@ class AstRewriter:
         that sit immediately before / after each matched node; they are folded
         into the rewritten span when the node kind stops short of an adjacent
         token (e.g. the `:` after an access_specifier, or the space before a
-        `final` specifier).
+        `final` specifier). An op that sets `first_match` rewrites only the
+        first match (in source order), leaving any later matches untouched.
         """
         rewriter = self._rewriters.rewriter(op.op_id)
         matcher = self._rewriters.matcher(rewriter['matcher'])
@@ -1520,6 +1523,8 @@ class AstRewriter:
         matches = run_ast_grep(language=language,
                                rule_body=rule_body,
                                source=self._content)
+        if rewriter.get('first_match'):
+            matches = matches[:1]
 
         replace = rewriter['replace']
         pattern = replace['re_pattern']

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -406,8 +406,17 @@ class Rewriter(abc.ABC):
     HELP: ClassVar[str] = ''
 
     @abc.abstractmethod
-    def apply(self, contents: str) -> tuple[str, int]:
-        """Transform `contents`, returning (new_contents, num_changes)."""
+    def apply(self, contents: str, *, count: int,
+              description: str) -> tuple[str, list[str]]:
+        """Transform `contents`, returning (new_contents, validation_errors).
+
+        `count` is the entry's `count:` (default 1, `0` meaning "one or more").
+        Each rewriter decides how it applies. For a single-site rewriter it is
+        the expected number of matches. A composed rewriter may instead give
+        each of its operations its own expectation. `errors` is the list of
+        human-readable count/validation failures (empty when the entry applied
+        as expected).
+        """
 
     @classmethod
     @abc.abstractmethod
@@ -438,9 +447,16 @@ class Substitution:
     # The rewriter this entry composes; `apply` delegates to it.
     rewriter: Rewriter
 
-    def apply(self, contents: str) -> tuple[str, int]:
-        """Apply the composed rewriter, returning (new_contents, changes)."""
-        return self.rewriter.apply(contents)
+    def apply(self, contents: str) -> tuple[str, list[str]]:
+        """Apply the composed rewriter, returning (new_contents, errors).
+
+        The envelope's `expected_count`/`description` are handed to the
+        rewriter, which owns count validation (per-operation for composed
+        rewriters) and reports any failures as error strings.
+        """
+        return self.rewriter.apply(contents,
+                                   count=self.expected_count,
+                                   description=self.description)
 
     class _NoDupSafeLoader(yaml.SafeLoader):
         """`yaml.SafeLoader` that rejects duplicate mapping keys.
@@ -583,6 +599,64 @@ class Substitution:
         return expected_count
 
 
+@dataclass(frozen=True)
+class MatchExpectation:
+    """How many matches an operation must make to count as correctly applied.
+
+    A closed range `[minimum, maximum]`; `maximum is None` means unbounded. The
+    canonical forms cover every case plaster needs:
+
+    - `exactly(n)`   — precisely `n` matches (the default, `exactly(1)`).
+    - `at_least_one` — one or more (the `count: 0` form).
+    - `optional`     — any number including zero; never fails on its own. Use
+      for an operation that may legitimately find nothing, leaving a
+      cross-operation rule (e.g. "at least one of these") to a rewriter's own
+      validation.
+    """
+
+    minimum: int
+    maximum: int | None
+
+    @classmethod
+    def exactly(cls, n: int) -> MatchExpectation:
+        return cls(n, n)
+
+    @classmethod
+    def at_least_one(cls) -> MatchExpectation:
+        return cls(1, None)
+
+    @classmethod
+    def optional(cls) -> MatchExpectation:
+        return cls(0, None)
+
+    @classmethod
+    def from_count(cls, count: int) -> MatchExpectation:
+        """Map an entry's `count:` to an expectation (`0` -> one-or-more)."""
+        return cls.at_least_one() if count == 0 else cls.exactly(count)
+
+    def accepts(self, matches: int) -> bool:
+        """True if `matches` satisfies this expectation."""
+        return matches >= self.minimum and (self.maximum is None
+                                            or matches <= self.maximum)
+
+    def error_for(self, matches: int) -> str | None:
+        """A failure message if `matches` is unacceptable, else None.
+
+        The `exactly`/`at_least_one` wordings match plaster's historical count
+        errors so existing diagnostics are unchanged.
+        """
+        if self.accepts(matches):
+            return None
+        if self.minimum == 1 and self.maximum is None:
+            return 'Expected at least one match but found none'
+        if self.minimum == self.maximum:
+            return (f'Unexpected number of matches ({matches} vs '
+                    f'{self.minimum})')
+        upper = 'any' if self.maximum is None else self.maximum
+        return (f'Unexpected number of matches ({matches} vs '
+                f'{self.minimum}..{upper})')
+
+
 class Regex(Rewriter):
     """A regex substitution applied with `re.subn` (the native rewriter).
     """
@@ -631,14 +705,18 @@ class Regex(Rewriter):
         self._replace = replace
         self._re_flags = re_flags
 
-    def apply(self, contents: str) -> tuple[str, int]:
-        # `count=0` is provided here so all substitutions are applied, and then
-        # the number of them gets validated by the callers.
-        return re.subn(self._re_pattern,
-                       self._replace,
-                       contents,
-                       flags=self._re_flags,
-                       count=0)
+    def apply(self, contents: str, *, count: int,
+              description: str) -> tuple[str, list[str]]:
+        del description  # Only the count matters for the regex diagnostic.
+        # `count=0` here means "replace every match"; how many were expected is
+        # validated afterwards against the entry's `count:`.
+        content, matches = re.subn(self._re_pattern,
+                                   self._replace,
+                                   contents,
+                                   flags=self._re_flags,
+                                   count=0)
+        error = MatchExpectation.from_count(count).error_for(matches)
+        return content, [error] if error else []
 
     @classmethod
     def parse(cls, body: object, *, description: str) -> Regex:
@@ -694,58 +772,121 @@ class Regex(Rewriter):
         return re_flags
 
 
+@dataclass(frozen=True)
+class Operation:
+    """One planned ast-grep op invocation: the whole contract to the engine.
+
+    `op_id` names an `ast.rewriter` in `rewriters.pyl`; `inputs` binds each of
+    that op's declared `inputs` to a concrete string. Everything else the engine
+    needs -- which matcher to run, which adjacent tokens to consume, the
+    replacement template -- lives in the op spec, so a frontend `Rewriter`
+    composes purely by emitting `Operation`s (one, several of the same op, or a
+    mix of different ops) and never touches engine internals.
+
+    `expectation` is how many matches this operation must make to be considered
+    correctly applied; it is validation metadata that `AstRewriter.run` ignores
+    (the engine just reports how many matches it made) and the composing
+    `Rewriter` checks. A composed rewriter sets a per-operation expectation --
+    e.g. `add_friend` expects each friend inserted exactly once regardless of
+    how many friends there are -- rather than folding everything into one total.
+    """
+
+    # The `rewriters.pyl` rewriter op id this invokes (e.g. `cxx.make_virtual`).
+    op_id: str
+
+    # Values bound to the op's declared `inputs`, injected into its templates.
+    inputs: dict[str, str]
+
+    # How many matches this operation must make (default: exactly one).
+    expectation: MatchExpectation = MatchExpectation.exactly(1)
+
+
 class _AstGrepRewriter(Rewriter):
     """Base for rewriters backed by an ast-grep op declared in `rewriters.pyl`.
 
     A concrete subclass sets the usual `NAME`/`SUMMARY`/`HELP` metadata plus the
-    `OP_ID` it resolves to, the string arguments its body accepts (`_ARG_KEYS`),
-    and any adjacent tokens the op consumes (`_CONSUME_BEFORE`/`_CONSUME_AFTER`,
-    engine details -- see `AstRewriter.apply`). `parse` validates the body as a
-    mapping of exactly those string args and `apply` runs the op, so subclasses
-    are pure declarations.
+    `OP_ID` it resolves to. `apply` runs whatever `operations` returns against
+    the engine, so a subclass expresses itself entirely by *composing*
+    operations rather than by driving the engine.
+
+    The default `operations`/`parse` cover the common 1:1 case: the YAML body is
+    a flat mapping of exactly the op's declared `inputs` (read from the spec,
+    the single source of truth), producing a single operation whose expectation
+    is the entry's `count:`. Subclasses that take a richer body (e.g. a list-
+    valued field expanding to several operations) override `parse` and
+    `operations`, and may override `validate_outcomes` to add cross-operation
+    rules (e.g. "at least one of these optional operations must apply").
     """
 
     # The `rewriters.pyl` op id this resolves to (e.g. `cxx.make_virtual`).
     OP_ID: ClassVar[str] = ''
 
-    # The string argument names the op body must supply.
-    _ARG_KEYS: ClassVar[frozenset[str]] = frozenset()
+    def __init__(self, inputs: dict[str, str] | None = None):
+        # The flat default binds these to the op's single operation; composing
+        # subclasses hold their own parsed shape and leave this empty.
+        self._inputs = inputs if inputs is not None else {}
 
-    # Literals the op assumes sit immediately before / after each matched node.
-    _CONSUME_BEFORE: ClassVar[str] = ''
-    _CONSUME_AFTER: ClassVar[str] = ''
+    def operations(self, count: int) -> list[Operation]:
+        """The ordered ast-grep operations this rewriter expands to.
 
-    def __init__(self, args: dict[str, str]):
-        self._args = args
+        `count` is the entry's `count:`; the default single operation adopts it
+        as its expectation, so a flat rewriter keeps plaster's original count
+        semantics. Composed rewriters typically ignore it in favour of a
+        per-operation expectation.
+        """
+        return [
+            Operation(self.OP_ID, self._inputs,
+                      MatchExpectation.from_count(count))
+        ]
 
-    def apply(self, contents: str) -> tuple[str, int]:
-        rewriter = AstRewriter(RewritersEval.load(), contents)
-        count = rewriter.apply(self.OP_ID,
-                               self._args,
-                               consume_before=self._CONSUME_BEFORE,
-                               consume_after=self._CONSUME_AFTER)
-        return rewriter.content, count
+    def apply(self, contents: str, *, count: int,
+              description: str) -> tuple[str, list[str]]:
+        engine = AstRewriter(RewritersEval.load(), contents)
+        outcomes = [(op, engine.run(op)) for op in self.operations(count)]
+        return engine.content, self.validate_outcomes(outcomes, description)
+
+    def validate_outcomes(self, outcomes: list[tuple[Operation, int]],
+                          description: str) -> list[str]:
+        """Errors for `(operation, matches)` outcomes; empty when all applied.
+
+        The default checks each operation against its own `expectation`.
+        Override to add cross-operation rules -- an override typically calls
+        `super().validate_outcomes(...)` first, then appends group checks.
+        """
+        del description  # Historical count diagnostics do not name the entry.
+        errors = []
+        for op, matches in outcomes:
+            error = op.expectation.error_for(matches)
+            if error:
+                errors.append(error)
+        return errors
+
+    @classmethod
+    def declared_inputs(cls) -> frozenset[str]:
+        """The op's declared `inputs`, read from the `rewriters.pyl` spec."""
+        return frozenset(RewritersEval.load().rewriter(cls.OP_ID)['inputs'])
 
     @classmethod
     def parse(cls, body: object, *, description: str) -> _AstGrepRewriter:
         """Validate a `<NAME>:` body of string args and build the rewriter."""
+        keys = cls.declared_inputs()
         if not isinstance(body, dict):
             raise ValueError(
                 f'"{cls.NAME}" must be a mapping (in "{description}")')
-        unknown = sorted(set(body) - cls._ARG_KEYS)
+        unknown = sorted(set(body) - keys)
         if unknown:
             raise ValueError(
                 f'Unrecognised {cls.NAME} arg(s): '
                 f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
-        missing = sorted(cls._ARG_KEYS - set(body))
+        missing = sorted(keys - set(body))
         if missing:
             raise ValueError(f'{cls.NAME} requires arg(s): '
                              f'{", ".join(missing)} (in "{description}")')
-        for key in sorted(cls._ARG_KEYS):
+        for key in sorted(keys):
             if not isinstance(body[key], str):
                 raise ValueError(f'{cls.NAME} `{key}` must be a string '
                                  f'(in "{description}")')
-        return cls({key: body[key] for key in cls._ARG_KEYS})
+        return cls({key: body[key] for key in keys})
 
 
 class MakeVirtual(_AstGrepRewriter):
@@ -754,7 +895,6 @@ class MakeVirtual(_AstGrepRewriter):
     NAME: Final = 'make_virtual'
     OP_ID: Final = 'cxx.make_virtual'
     SUMMARY: Final = 'Prepend `virtual ` to a class method declaration.'
-    _ARG_KEYS: Final = frozenset(('class_name', 'method_name'))
     # Authored in Markdown; `Help` renders it with rich.
     HELP: Final = r"""
         Prepends `virtual ` to a C++ method declaration.
@@ -781,26 +921,23 @@ class MakeVirtual(_AstGrepRewriter):
 
 
 class AddFriend(_AstGrepRewriter):
-    """Add a `friend` declaration to a C++ class's private section, via the
-    ast-grep rewriters."""
+    """Add one or more `friend` declarations to a C++ class's private section,
+    via the ast-grep rewriters."""
 
     NAME: Final = 'add_friend'
     OP_ID: Final = 'cxx.add_friend'
-    SUMMARY: Final = 'Add a `friend` declaration to a class private section.'
-    _ARG_KEYS: Final = frozenset(('class_name', 'friend_type'))
-    # The matcher stops at the `private` keyword; the op re-emits the `:` that
-    # follows, so consume the original one.
-    _CONSUME_AFTER: Final = ':'
+    SUMMARY: Final = 'Add `friend` declaration(s) to a class private section.'
     # Authored in Markdown; `Help` renders it with rich.
     HELP: Final = r"""
-        Inserts a `friend` declaration as the first line of a class's private
-        section. The class must have a `private:` section.
+        Inserts one or more `friend` declarations as the first lines of a
+        class's private section. The class must have a `private:` section.
 
         Fields:
 
         - `class_name` — the class to befriend from.
         - `friend_type` — the friend's declaration body, e.g. `class BraveFoo`
-          becomes `friend class BraveFoo;`.
+          becomes `friend class BraveFoo;`. May be a single string, or a list
+          of them.
 
         Example:
 
@@ -810,8 +947,78 @@ class AddFriend(_AstGrepRewriter):
             add_friend:
               class_name: MultiContentsView
               friend_type: class BraveMultiContentsView
+
+          - description: Friend the Brave worker and its test.
+            add_friend:
+              class_name: DataTypeWorker
+              friend_type:
+                - class BraveDataTypeWorker
+                - class BraveDataTypeWorkerTest
         ```
     """
+
+    def __init__(self, *, class_name: str, friend_types: list[str]):
+        # This rewriter holds its own parsed shape and builds operations from
+        # it, so the base's flat inputs stay empty.
+        super().__init__()
+        self._class_name = class_name
+        self._friend_types = friend_types
+
+    def operations(self, count: int) -> list[Operation]:
+        # Each friend targets the class's single private section, so it is
+        # expected exactly once -- independent of how many friends are listed,
+        # which is why the entry's `count:` is not used here.
+        #
+        # `add_friend` inserts each friend as the *first* private line, so a
+        # later insertion ends up above an earlier one. Emit in reverse so the
+        # friends land in the order the user listed them.
+        del count
+        return [
+            Operation(self.OP_ID, {
+                'class_name': self._class_name,
+                'friend_type': friend_type,
+            }, MatchExpectation.exactly(1))
+            for friend_type in reversed(self._friend_types)
+        ]
+
+    @classmethod
+    def parse(cls, body: object, *, description: str) -> AddFriend:
+        """Validate an `add_friend:` body, accepting a single friend or a list.
+
+        `friend_type` may be a string (one friend) or a non-empty list of
+        strings (several); everything else matches the flat-args form.
+        """
+        if not isinstance(body, dict):
+            raise ValueError(
+                f'"{cls.NAME}" must be a mapping (in "{description}")')
+        required = {'class_name', 'friend_type'}
+        unknown = sorted(set(body) - required)
+        if unknown:
+            raise ValueError(
+                f'Unrecognised {cls.NAME} arg(s): '
+                f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
+        missing = sorted(required - set(body))
+        if missing:
+            raise ValueError(f'{cls.NAME} requires arg(s): '
+                             f'{", ".join(missing)} (in "{description}")')
+        if not isinstance(body['class_name'], str):
+            raise ValueError(f'{cls.NAME} `class_name` must be a string '
+                             f'(in "{description}")')
+        return cls(class_name=body['class_name'],
+                   friend_types=cls._parse_friend_types(
+                       body['friend_type'], description))
+
+    @staticmethod
+    def _parse_friend_types(value: object, description: str) -> list[str]:
+        """Normalise `friend_type` to a non-empty list of strings."""
+        if isinstance(value, str):
+            return [value]
+        if (isinstance(value, list) and value
+                and all(isinstance(item, str) for item in value)):
+            return list(value)
+        raise ValueError(
+            f'{AddFriend.NAME} `friend_type` must be a string or a non-empty '
+            f'list of strings (in "{description}")')
 
 
 class DropFinal(_AstGrepRewriter):
@@ -821,10 +1028,6 @@ class DropFinal(_AstGrepRewriter):
     NAME: Final = 'drop_final'
     OP_ID: Final = 'cxx.drop_final'
     SUMMARY: Final = 'Remove the `final` specifier from a class declaration.'
-    _ARG_KEYS: Final = frozenset(('class_name', ))
-    # The matcher stops at the `final` keyword; consume the space before it so
-    # dropping `final` leaves no doubled space.
-    _CONSUME_BEFORE: Final = ' '
     # Authored in Markdown; `Help` renders it with rich.
     HELP: Final = r"""
         Removes the `final` specifier from a C++ class declaration, so the class
@@ -939,19 +1142,12 @@ class PlasterFile:
 
         try:
             for substitution in substitutions:
-                contents, num_changes = substitution.apply(contents)
-
-                # count == 0 means "one or more matches", but zero matches still
-                # result in a failure.
-                if substitution.expected_count == 0:
-                    if num_changes == 0:
-                        errors.append(
-                            'Expected at least one match but found none in '
-                            f'{self.path}')
-                elif num_changes != substitution.expected_count:
-                    errors.append(
-                        f'Unexpected number of matches ({num_changes} vs '
-                        f'{substitution.expected_count}) in {self.path}')
+                # Each substitution owns its count validation (per-operation for
+                # composed rewriters) and reports any failures; we just attach
+                # the file being patched.
+                contents, sub_errors = substitution.apply(contents)
+                errors.extend(f'{error} in {self.path}'
+                              for error in sub_errors)
 
         except re.error as e:
             errors.append(f'Invalid regex: {e} in {self.path}')
@@ -1012,28 +1208,12 @@ def _is_op_id(op_id: str) -> bool:
     return bool(name) and prefix in _LANGUAGE_BY_PREFIX
 
 
-def _template_args_match(spec: dict) -> dict:
-    """schema validator: a matcher's template uses exactly its declared args.
-
-    Returns the spec unchanged on success or raises schema.SchemaError if the
-    template references a placeholder that is not a declared arg, or declares
-    an arg the template never uses, catching any typos.
-    """
-    placeholders = {
+def _placeholders(template: str) -> set[str]:
+    """The set of named `{placeholder}` fields referenced in `template`."""
+    return {
         name
-        for _, name, _, _ in string.Formatter().parse(spec['template']) if name
+        for _, name, _, _ in string.Formatter().parse(template) if name
     }
-    declared = set(spec['args'])
-    undeclared = sorted(placeholders - declared)
-    if undeclared:
-        raise schema.SchemaError(
-            f'template uses undeclared placeholder(s): {", ".join(undeclared)}'
-        )
-    unused = sorted(declared - placeholders)
-    if unused:
-        raise schema.SchemaError(
-            f'declared arg(s) never used in template: {", ".join(unused)}')
-    return spec
 
 
 # Reusable leaf schemas.
@@ -1051,19 +1231,23 @@ _RESULT_SCHEMA = {
     'node': _NON_EMPTY_STR,
 }
 
-# A matcher op: a templated ast-grep query plus its result shape.
-_MATCHER_SCHEMA = schema.And(
-    {
-        'args': [str],
-        'template': _NON_EMPTY_STR,
-        'result': _RESULT_SCHEMA,
-    }, _template_args_match)
+# A matcher op: a templated ast-grep query plus its result shape. Its inputs
+# are the template's `{placeholder}`s, inferred rather than declared.
+_MATCHER_SCHEMA = {
+    'template': _NON_EMPTY_STR,
+    'result': _RESULT_SCHEMA,
+}
 
 # A rewriter op: locates nodes through a matcher op and edits each via a regex
-# substitution.
+# substitution. `inputs` is its public interface (validated against the
+# templates it feeds in `_check_cross_references`); `replace` may name adjacent
+# tokens to fold into each rewritten span.
 _REWRITER_SCHEMA = {
     'matcher': _NON_EMPTY_STR,
+    'inputs': [str],
     'replace': {
+        schema.Optional('consume_before'): str,
+        schema.Optional('consume_after'): str,
         're_pattern': _REGEX_STR,
         'replace': str,
     },
@@ -1171,9 +1355,12 @@ class RewritersEval:
     def _check_cross_references(self) -> None:
         """Validate rules that span records, which schema cannot express.
 
-        Each rewriter must reference a matcher that exists, and must declare the
+        Each rewriter must reference a matcher that exists, must declare the
         same result node as that matcher (it replaces the node the matcher
-        locates, so the two must agree).
+        locates, so the two must agree), and its declared `inputs` must be
+        exactly the `{placeholder}`s used across the matcher template and the
+        `replace` template -- so the op's advertised interface never drifts from
+        what its templates actually consume.
         """
         for op_id, spec in self._rewriters.items():
             ref = spec['matcher']
@@ -1181,12 +1368,27 @@ class RewritersEval:
                 raise RewritersSchemaError(
                     f'{self._source}: rewriter {op_id!r} references unknown '
                     f'matcher {ref!r}')
-            matcher_node = self._matchers[ref]['result']['node']
+            matcher = self._matchers[ref]
+            matcher_node = matcher['result']['node']
             if spec['result']['node'] != matcher_node:
                 raise RewritersSchemaError(
                     f'{self._source}: rewriter {op_id!r} result node '
                     f'{spec["result"]["node"]!r} does not match matcher '
                     f'{ref!r} node {matcher_node!r}')
+
+            declared = set(spec['inputs'])
+            used = (_placeholders(matcher['template'])
+                    | _placeholders(spec['replace']['replace']))
+            undeclared = sorted(used - declared)
+            if undeclared:
+                raise RewritersSchemaError(
+                    f'{self._source}: rewriter {op_id!r} templates use '
+                    f'undeclared input(s): {", ".join(undeclared)}')
+            unused = sorted(declared - used)
+            if unused:
+                raise RewritersSchemaError(
+                    f'{self._source}: rewriter {op_id!r} declares input(s) '
+                    f'never used in its templates: {", ".join(unused)}')
 
 
 def _ast_grep_platform_dir() -> str:
@@ -1278,11 +1480,12 @@ class AstRewriter:
     """Applies ast-grep rewriter ops to the contents of a single file.
 
     Constructed with an already-parsed `RewritersEval` and the target file's
-    contents. `apply` runs one rewriter op (by id) over the current contents,
+    contents. `run` executes one bound `Operation` over the current contents,
     mutating them in place and returning how many places changed; call it
-    repeatedly to accumulate edits. Op-specific conveniences (which op id and
-    which adjacent tokens to consume) belong with the `Rewriter` classes that
-    drive this engine, not here.
+    repeatedly to accumulate edits. The engine is fully self-contained: an op's
+    matcher, replacement, and any adjacent tokens to consume all come from the
+    op spec, so the `Rewriter` classes that drive it only choose which
+    operations to run.
     """
 
     def __init__(self, rewriters: RewritersEval, content: str):
@@ -1294,40 +1497,35 @@ class AstRewriter:
         """The current file contents, reflecting every applied rewrite."""
         return self._content
 
-    def apply(self,
-              op_id: str,
-              args: dict[str, str],
-              *,
-              consume_before: str = '',
-              consume_after: str = '') -> int:
-        """Run rewriter `op_id` with `args`, mutate content, return count.
+    def run(self, op: Operation) -> int:
+        """Run one bound `Operation`, mutate content, return the change count.
 
         Locates nodes via the op's matcher template, applies the op's `replace`
-        regex substitution (with `args` filled into the replacement template)
-        to each matched node, and splices the results back into the held
-        contents from the end so earlier byte offsets stay valid. Returns the
-        total number of substitutions made.
+        regex substitution (with `op.inputs` filled into the replacement
+        template) to each matched node, and splices the results back into the
+        held contents from the end so earlier byte offsets stay valid. Returns
+        the total number of substitutions made.
 
-        `consume_before` / `consume_after` are literals the op assumes
-        immediately precede / follow each matched node. They are folded into the
-        rewritten span used when the node kind stops short of an adjacent
+        An op's `replace` may name `consume_before` / `consume_after` literals
+        that sit immediately before / after each matched node; they are folded
+        into the rewritten span when the node kind stops short of an adjacent
         token (e.g. the `:` after an access_specifier, or the space before a
-        `final` specifier). They are engine details, not part of the rewriters
-        spec.
+        `final` specifier).
         """
-        rewriter = self._rewriters.rewriter(op_id)
+        rewriter = self._rewriters.rewriter(op.op_id)
         matcher = self._rewriters.matcher(rewriter['matcher'])
-        language = self._rewriters.language_of(op_id)
-        rule_body = matcher['template'].format(**args)
+        language = self._rewriters.language_of(op.op_id)
+        rule_body = matcher['template'].format(**op.inputs)
 
         matches = run_ast_grep(language=language,
                                rule_body=rule_body,
                                source=self._content)
 
-        pattern = rewriter['replace']['re_pattern']
-        replacement = rewriter['replace']['replace'].format(**args)
-        before = consume_before.encode('utf-8')
-        after = consume_after.encode('utf-8')
+        replace = rewriter['replace']
+        pattern = replace['re_pattern']
+        replacement = replace['replace'].format(**op.inputs)
+        before = replace.get('consume_before', '').encode('utf-8')
+        after = replace.get('consume_after', '').encode('utf-8')
 
         source = self._content.encode('utf-8')
         edits = []

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -2083,6 +2083,241 @@ class RewriterFormsTest(unittest.TestCase):
             '      code: virtual void Bar() = 0;\n',
             'does not accept a count other than 1')
 
+    def test_add_to_protected_creates_section_in_nested_class(self):
+        # A nested class is indented to its own column: the new protected
+        # section and its member follow the nested class's indentation, not the
+        # top-level one.
+        result = self._apply(
+            'prot_nested_class.h', 'class Outer {\n public:\n  class C {\n'
+            '   public:\n    void Foo();\n   private:\n    int x_;\n'
+            '  };\n};\n', 'substitutions:\n'
+            '  - description: add a protected hook to the nested class\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar() = 0;\n')
+        self.assertEqual(
+            result, 'class Outer {\n public:\n  class C {\n'
+            '   public:\n    void Foo();\n'
+            '   protected:\n    virtual void Bar() = 0;\n\n'
+            '   private:\n    int x_;\n  };\n};\n')
+
+    def test_add_to_protected_reuses_section_in_nested_class(self):
+        # Reusing an existing protected section in a nested class indents the
+        # inserted member to the nested member column.
+        result = self._apply(
+            'prot_nested_reuse.h', 'class Outer {\n public:\n  class C {\n'
+            '   protected:\n    void Existing();\n   private:\n    int x_;\n'
+            '  };\n};\n', 'substitutions:\n'
+            '  - description: reuse the nested protected section\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar() = 0;\n')
+        self.assertEqual(
+            result, 'class Outer {\n public:\n  class C {\n'
+            '   protected:\n    virtual void Bar() = 0;\n    void Existing();\n'
+            '   private:\n    int x_;\n  };\n};\n')
+
+    # -- add_to_public op (real ast-grep binary) --------------------
+
+    def test_add_to_public_appends_before_following_section(self):
+        # The code becomes the last public member, right before the private
+        # section that follows public -- not the first public line.
+        result = self._apply(
+            'pub_before_priv.h',
+            'class C {\n public:\n  void Foo();\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: expose a public hook\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            '  virtual void Bar();\n\n private:\n  int x_;\n};\n')
+
+    def test_add_to_public_appends_before_first_following_section(self):
+        # With both a protected and a private section, the append lands before
+        # the first one after public (protected) -- the end of public.
+        result = self._apply(
+            'pub_before_prot.h',
+            'class C {\n public:\n  void Foo();\n protected:\n  void P();\n'
+            ' private:\n  int x_;\n};\n', 'substitutions:\n'
+            '  - description: expose a public hook\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            '  virtual void Bar();\n\n protected:\n  void P();\n'
+            ' private:\n  int x_;\n};\n')
+
+    def test_add_to_public_appends_before_closing_brace(self):
+        # A pure interface (only a public section): with no following specifier
+        # to anchor on, the code lands just before the class's closing brace.
+        result = self._apply(
+            'pub_only.h', 'class C {\n public:\n  void Foo();\n};\n',
+            'substitutions:\n'
+            '  - description: expose a public hook\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            '  virtual void Bar();\n};\n')
+
+    def test_add_to_public_reordered_sections_use_closing_brace(self):
+        # `public:` is the last section (private declared first): nothing
+        # follows public, so the append falls back to the closing brace.
+        result = self._apply(
+            'pub_last.h',
+            'class C {\n private:\n  int x_;\n public:\n  void Foo();\n};\n',
+            'substitutions:\n'
+            '  - description: expose a public hook\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n')
+        self.assertEqual(
+            result,
+            'class C {\n private:\n  int x_;\n public:\n  void Foo();\n'
+            '  virtual void Bar();\n};\n')
+
+    def test_add_to_public_scoped_to_named_class(self):
+        # Only the named class is touched; a sibling class is left alone.
+        result = self._apply(
+            'pub_scope.h', 'class C {\n public:\n  void Foo();\n'
+            ' private:\n  int c_;\n};\n\n'
+            'class D {\n public:\n  void Baz();\n private:\n  int d_;\n};\n',
+            'substitutions:\n'
+            '  - description: add only to C\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            '  virtual void Bar();\n\n private:\n  int c_;\n};\n\n'
+            'class D {\n public:\n  void Baz();\n private:\n  int d_;\n};\n')
+
+    def test_add_to_public_multiline_code(self):
+        # A multi-line `code` block appends several declarations, each indented
+        # to the member level.
+        result = self._apply(
+            'pub_multi.h',
+            'class C {\n public:\n  void Foo();\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: add two public hooks\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: |-\n'
+            '        virtual void A();\n'
+            '        virtual void B();\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            '  virtual void A();\n  virtual void B();\n\n'
+            ' private:\n  int x_;\n};\n')
+
+    def test_add_to_public_first_of_multiple_public_sections(self):
+        # A reopened `public:` appends to the *first* public section (the append
+        # anchors on the first following section, here the private one).
+        result = self._apply(
+            'pub_reopen.h', 'class C {\n public:\n  void A();\n'
+            ' private:\n  int x_;\n public:\n  void B();\n};\n',
+            'substitutions:\n'
+            '  - description: append to the first public section\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void A();\n'
+            '  virtual void Bar();\n\n private:\n  int x_;\n public:\n'
+            '  void B();\n};\n')
+
+    def test_add_to_public_no_public_fails(self):
+        # A class with no public section has nothing to append to.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'pub_none.h', 'class C {\n private:\n  int x_;\n};\n',
+                'substitutions:\n'
+                '  - description: no public section\n'
+                '    add_to_public:\n'
+                '      class_name: C\n'
+                '      code: virtual void Bar();\n')
+
+    def test_add_to_public_unknown_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: typo arg\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      cod: virtual void Bar();\n',
+            'Unrecognised add_to_public arg')
+
+    def test_add_to_public_missing_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing code\n'
+            '    add_to_public:\n'
+            '      class_name: C\n', 'add_to_public requires arg')
+
+    def test_add_to_public_count_other_than_one_rejected(self):
+        # It always adds exactly once, so any other count is a config error.
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: bogus count\n'
+            '    count: 2\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n',
+            'does not accept a count other than 1')
+
+    def test_add_to_public_appends_before_section_in_nested_class(self):
+        # A nested class is indented to its own column: the appended member sits
+        # at the nested member column and the following section keeps its own.
+        result = self._apply(
+            'pub_nested_section.h', 'class Outer {\n public:\n  class C {\n'
+            '   public:\n    void Foo();\n   private:\n    int x_;\n'
+            '  };\n};\n', 'substitutions:\n'
+            '  - description: expose a public hook on the nested class\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n')
+        self.assertEqual(
+            result, 'class Outer {\n public:\n  class C {\n'
+            '   public:\n    void Foo();\n    virtual void Bar();\n\n'
+            '   private:\n    int x_;\n  };\n};\n')
+
+    def test_add_to_public_appends_before_close_in_nested_class(self):
+        # A nested pure-interface class: the appended member sits at the nested
+        # member column and the closing brace keeps its own indentation.
+        result = self._apply(
+            'pub_nested_close.h', 'class Outer {\n public:\n  class C {\n'
+            '   public:\n    void Foo();\n  };\n};\n', 'substitutions:\n'
+            '  - description: expose a public hook on the nested interface\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar();\n')
+        self.assertEqual(
+            result, 'class Outer {\n public:\n  class C {\n'
+            '   public:\n    void Foo();\n    virtual void Bar();\n'
+            '  };\n};\n')
+
+    def test_add_to_public_multiline_indents_uniformly_when_nested(self):
+        # Every appended line lands at the same nested member column -- the
+        # first line is not indented differently from the rest.
+        result = self._apply(
+            'pub_nested_multi.h', 'class Outer {\n public:\n  class C {\n'
+            '   public:\n    void Foo();\n   private:\n    int x_;\n'
+            '  };\n};\n', 'substitutions:\n'
+            '  - description: add two nested public hooks\n'
+            '    add_to_public:\n'
+            '      class_name: C\n'
+            '      code: |-\n'
+            '        virtual void A();\n'
+            '        virtual void B();\n')
+        self.assertEqual(
+            result, 'class Outer {\n public:\n  class C {\n'
+            '   public:\n    void Foo();\n'
+            '    virtual void A();\n    virtual void B();\n\n'
+            '   private:\n    int x_;\n  };\n};\n')
+
     # -- after_function_impl op (real ast-grep binary) -------------------------
 
     def test_after_function_impl_void(self):
@@ -2800,6 +3035,24 @@ class RewritersEvalTest(unittest.TestCase):
         replace = rewriters.rewriter('cxx.make_virtual')['replace']
         self.assertEqual(replace['consume_before'], ' ')
         self.assertEqual(replace['consume_after'], ':')
+
+    def test_rewriter_consume_placeholder_must_be_declared(self):
+        # A `{placeholder}` used only in a consume token is an input like any
+        # other, so it must appear in `inputs`.
+        self._assert_invalid(
+            lambda s: s['ast.rewriter']['cxx.make_virtual']['replace'].
+            __setitem__('consume_before', '{indent}'), 'undeclared input')
+
+    def test_rewriter_consume_placeholder_declared_is_valid(self):
+        # Declaring the consume token's placeholder in `inputs` makes it valid.
+        spec = self._valid_spec()
+        spec['ast.rewriter']['cxx.make_virtual']['replace'][
+            'consume_before'] = '{indent}'
+        spec['ast.rewriter']['cxx.make_virtual']['inputs'].append('indent')
+        rewriters = plaster.RewritersEval(repr(spec))
+        self.assertEqual(
+            rewriters.rewriter('cxx.make_virtual')['replace']
+            ['consume_before'], '{indent}')
 
     def test_rewriter_first_match_is_optional_bool(self):
         # `first_match` is an optional flag; when present it must be a bool and

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1761,6 +1761,44 @@ class RewriterFormsTest(unittest.TestCase):
             result, 'Foo_ChromiumImpl::Foo_ChromiumImpl() {}\n'
             'void Foo_ChromiumImpl::Bar() {}\n')
 
+    def test_rename_class_renames_forwarding_constructor(self):
+        # A forwarding (delegating) constructor names the class again in its
+        # member initializer list -- `: Foo(...)` -- which tree-sitter parses as
+        # a field_identifier, not the identifier/type_identifier the other uses
+        # are. That token must be renamed along with the rest (the real-world
+        # miss was `CookieMonster::CookieMonster(...) : CookieMonster(...)`).
+        result = self._apply(
+            'rename_fwd_ctor.cc', 'Foo::Foo(int a)\n'
+            '    : Foo(base::PassKey<Foo>(), a) {}\n'
+            '\n'
+            'Foo::Foo(base::PassKey<Foo>, int a) {}\n', 'substitutions:\n'
+            '  - description: rename Foo, forwarding ctor included\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result, 'Foo_ChromiumImpl::Foo_ChromiumImpl(int a)\n'
+            '    : Foo_ChromiumImpl(base::PassKey<Foo_ChromiumImpl>(), a) {}\n'
+            '\n'
+            'Foo_ChromiumImpl::Foo_ChromiumImpl('
+            'base::PassKey<Foo_ChromiumImpl>, int a) {}\n')
+
+    def test_rename_class_leaves_member_access_in_initializer_untouched(self):
+        # The forwarding-ctor fix only claims the *name* slot of a member
+        # initializer (`: Foo(...)`). A same-spelled member access passed as an
+        # argument (`other.Foo`) is not that slot and must survive, or the fix
+        # would over-match member accesses that merely share the class name.
+        result = self._apply(
+            'rename_init_member.cc', 'Foo::Foo(const Other& other)\n'
+            '    : value_(other.Foo) {}\n', 'substitutions:\n'
+            '  - description: rename Foo but keep the member access\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result, 'Foo_ChromiumImpl::Foo_ChromiumImpl(const Other& other)\n'
+            '    : value_(other.Foo) {}\n')
+
     def test_rename_class_leaves_string_literal_untouched(self):
         # The whole point of matching AST identifier nodes: a same-spelled
         # string literal survives. The exact-quote-adjacent form (`"Foo"`) is

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -2045,6 +2045,177 @@ class RewriterFormsTest(unittest.TestCase):
             '      code: virtual void Bar() = 0;\n',
             'does not accept a count other than 1')
 
+    # -- after_function_impl op (real ast-grep binary) -------------------------
+
+    def test_after_function_impl_void(self):
+        # A void function: the body is wrapped in a bare IIFE lambda and the
+        # appended code runs after it, unconditionally.
+        result = self._apply(
+            'append.cc', 'void C::Foo() {\n  Upstream();\n}\n',
+            'substitutions:\n'
+            '  - description: always run Brave code after the body\n'
+            '    after_function_impl:\n'
+            '      function_name: C::Foo\n'
+            '      code: |-\n'
+            '        RecordBraveMetric();\n')
+        self.assertEqual(
+            result, 'void C::Foo() {\n  [&]() {\n  Upstream();\n  }();\n'
+            '  RecordBraveMetric();\n}\n')
+
+    def test_after_function_impl_captures_result(self):
+        # A non-void function: `result_var` binds the wrapped body's value so
+        # the appended code can use it and own the final return.
+        result = self._apply(
+            'append_result.cc', 'int C::Compute() {\n  return real_;\n}\n',
+            'substitutions:\n'
+            '  - description: adjust the computed value for Brave\n'
+            '    after_function_impl:\n'
+            '      function_name: C::Compute\n'
+            '      result_var: score\n'
+            '      code: |-\n'
+            '        return BraveAdjust(score);\n')
+        self.assertEqual(
+            result, 'int C::Compute() {\n  auto score = [&]() {\n'
+            '  return real_;\n  }();\n  return BraveAdjust(score);\n}\n')
+
+    def test_after_function_impl_wraps_early_returns(self):
+        # Every `return` in the upstream body only returns from the lambda, so
+        # the appended code still runs. The body's own lines are untouched.
+        source = ('void C::Foo() {\n'
+                  '  if (!ready_) {\n'
+                  '    return;\n'
+                  '  }\n'
+                  '  Work();\n'
+                  '}\n')
+        result = self._apply(
+            'append_early.cc', source, 'substitutions:\n'
+            '  - description: guarantee cleanup runs\n'
+            '    after_function_impl:\n'
+            '      function_name: C::Foo\n'
+            '      code: |-\n'
+            '        BraveCleanup();\n')
+        self.assertEqual(
+            result, 'void C::Foo() {\n  [&]() {\n'
+            '  if (!ready_) {\n    return;\n  }\n  Work();\n  }();\n'
+            '  BraveCleanup();\n}\n')
+
+    def test_after_function_impl_free_function(self):
+        result = self._apply(
+            'append_free.cc', 'void FreeFunc(int x) {\n  Upstream(x);\n}\n',
+            'substitutions:\n'
+            '  - description: append to a free function\n'
+            '    after_function_impl:\n'
+            '      function_name: FreeFunc\n'
+            '      code: |-\n'
+            '        AfterFree(x);\n')
+        self.assertEqual(
+            result, 'void FreeFunc(int x) {\n  [&]() {\n  Upstream(x);\n'
+            '  }();\n  AfterFree(x);\n}\n')
+
+    def test_after_function_impl_multiline_code_indented(self):
+        # A multi-line `code` block is authored flush-left and indented to the
+        # body level as a whole; a blank line stays empty.
+        result = self._apply(
+            'append_block.cc', 'void C::Foo() {\n  Upstream();\n}\n',
+            'substitutions:\n'
+            '  - description: append a two-statement block\n'
+            '    after_function_impl:\n'
+            '      function_name: C::Foo\n'
+            '      code: |-\n'
+            '        Prepare();\n'
+            '\n'
+            '        Track();\n')
+        self.assertEqual(
+            result, 'void C::Foo() {\n  [&]() {\n  Upstream();\n  }();\n'
+            '  Prepare();\n\n  Track();\n}\n')
+
+    def test_after_function_impl_targets_named_function_only(self):
+        # Only the named function's body is wrapped, not a sibling.
+        result = self._apply(
+            'append_siblings.cc',
+            'void C::A() {\n  a();\n}\n\nvoid C::B() {\n  b();\n}\n',
+            'substitutions:\n'
+            '  - description: append only to B\n'
+            '    after_function_impl:\n'
+            '      function_name: C::B\n'
+            '      code: |-\n'
+            '        after_b();\n')
+        self.assertEqual(
+            result, 'void C::A() {\n  a();\n}\n\n'
+            'void C::B() {\n  [&]() {\n  b();\n  }();\n  after_b();\n}\n')
+
+    def test_after_function_impl_overloads_need_count(self):
+        result = self._apply(
+            'append_overloads.cc',
+            'void C::F() {\n  a();\n}\n\nvoid C::F(int x) {\n  b();\n}\n',
+            'substitutions:\n'
+            '  - description: append to both overloads\n'
+            '    count: 2\n'
+            '    after_function_impl:\n'
+            '      function_name: C::F\n'
+            '      code: |-\n'
+            '        done();\n')
+        self.assertEqual(
+            result,
+            'void C::F() {\n  [&]() {\n  a();\n  }();\n  done();\n}\n\n'
+            'void C::F(int x) {\n  [&]() {\n  b();\n  }();\n  done();\n}\n')
+
+    def test_after_function_impl_overload_count_mismatch_fails(self):
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'append_overloads_bad.cc',
+                'void C::F() {\n  a();\n}\n\nvoid C::F(int x) {\n  b();\n}\n',
+                'substitutions:\n'
+                '  - description: forgot the count\n'
+                '    after_function_impl:\n'
+                '      function_name: C::F\n'
+                '      code: |-\n'
+                '        done();\n')
+
+    def test_after_function_impl_absent_function_fails(self):
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'append_missing.cc', 'void C::Foo() {\n}\n', 'substitutions:\n'
+                '  - description: no such function\n'
+                '    after_function_impl:\n'
+                '      function_name: C::Nope\n'
+                '      code: |-\n'
+                '        x();\n')
+
+    def test_after_function_impl_missing_code_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing code\n'
+            '    after_function_impl:\n'
+            '      function_name: C::F\n',
+            'after_function_impl `code` must be a non-empty string')
+
+    def test_after_function_impl_missing_function_name_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing function_name\n'
+            '    after_function_impl:\n'
+            '      code: x();\n',
+            'after_function_impl `function_name` must be a non-empty string')
+
+    def test_after_function_impl_empty_result_var_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: empty result_var\n'
+            '    after_function_impl:\n'
+            '      function_name: C::F\n'
+            '      result_var: \'\'\n'
+            '      code: x();\n',
+            'after_function_impl `result_var` must be a non-empty string')
+
+    def test_after_function_impl_unknown_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: typo arg\n'
+            '    after_function_impl:\n'
+            '      function_name: C::F\n'
+            '      cod: x();\n', 'Unrecognised after_function_impl arg')
+
     # -- export-macro classes (real ast-grep binary) ----------------------
     #
     # tree-sitter cannot parse `class MACRO_EXPORT Name`, so the engine blanks

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1508,6 +1508,225 @@ class RewriterFormsTest(unittest.TestCase):
             '  - description: missing arg\n'
             '    drop_final: {}\n', 'drop_final requires arg')
 
+    # -- preempt_function_impl op (real ast-grep binary) --------------------------
+
+    def test_preempt_function_impl_return_if(self):
+        result = self._apply(
+            'guard.cc', 'void C::Foo() {\n  Upstream();\n}\n',
+            'substitutions:\n'
+            '  - description: skip upstream when Brave has it disabled\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::Foo\n'
+            "      return_if: '!Enabled()'\n")
+        self.assertEqual(
+            result, 'void C::Foo() {\n  if (!Enabled()) return;\n'
+            '  Upstream();\n}\n')
+
+    def test_preempt_function_impl_free_function(self):
+        # A free function is named without a class qualifier -- just the bare
+        # declarator name.
+        result = self._apply(
+            'free.cc', 'void FreeFunc(int x) {\n  Upstream(x);\n}\n',
+            'substitutions:\n'
+            '  - description: guard a free function\n'
+            '    preempt_function_impl:\n'
+            '      function_name: FreeFunc\n'
+            "      return_if: '!Enabled()'\n")
+        self.assertEqual(
+            result, 'void FreeFunc(int x) {\n  if (!Enabled()) return;\n'
+            '  Upstream(x);\n}\n')
+
+    def test_preempt_function_impl_ignores_forward_declaration(self):
+        # A forward declaration is a bodyless `declaration`, not a
+        # `function_definition`, so the matcher skips it (count stays 1) and the
+        # guard lands only in the definition.
+        source = ('void FreeFunc(int x);\n\n'
+                  'void FreeFunc(int x) {\n  Upstream(x);\n}\n')
+        result = self._apply(
+            'forward.cc', source, 'substitutions:\n'
+            '  - description: guard the definition, not the declaration\n'
+            '    preempt_function_impl:\n'
+            '      function_name: FreeFunc\n'
+            "      return_if: '!Enabled()'\n")
+        self.assertEqual(
+            result,
+            source.replace('{\n  Upstream(x);',
+                           '{\n  if (!Enabled()) return;\n  Upstream(x);'))
+
+    def test_preempt_function_impl_anonymous_namespace_function(self):
+        # A function inside an anonymous namespace is named by its bare
+        # declarator -- the enclosing `namespace {}` is contextual, not part of
+        # the name.
+        source = ('namespace {\n\n'
+                  'bool ShouldProceed(int x) {\n  return x > 0;\n}\n\n'
+                  '}  // namespace\n')
+        result = self._apply(
+            'anon.cc', source, 'substitutions:\n'
+            '  - description: guard a function in an anonymous namespace\n'
+            '    preempt_function_impl:\n'
+            '      function_name: ShouldProceed\n'
+            "      return_if: '!Enabled()'\n")
+        self.assertEqual(
+            result,
+            source.replace('{\n  return x > 0;',
+                           '{\n  if (!Enabled()) return;\n  return x > 0;'))
+
+    def test_preempt_function_impl_return_if_with_value(self):
+        result = self._apply(
+            'guard_value.cc', 'bool C::IsVisible() {\n  return real_;\n}\n',
+            'substitutions:\n'
+            '  - description: force the answer for Brave\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::IsVisible\n'
+            "      return_if: 'true'\n"
+            "      return_value: 'false'\n")
+        self.assertEqual(
+            result, 'bool C::IsVisible() {\n  if (true) return false;\n'
+            '  return real_;\n}\n')
+
+    def test_preempt_function_impl_code_block(self):
+        # The `code` block is authored flush-left; the engine indents the whole
+        # block to the body's first-statement level (two spaces).
+        result = self._apply(
+            'code.cc', 'void C::Pin(int id) {\n  Upstream();\n}\n',
+            'substitutions:\n'
+            '  - description: pin Brave actions before the upstream body\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::Pin\n'
+            '      code: |-\n'
+            '        if (PinBraveAction(id)) {\n'
+            '          return;\n'
+            '        }\n')
+        self.assertEqual(
+            result, 'void C::Pin(int id) {\n  if (PinBraveAction(id)) {\n'
+            '    return;\n  }\n  Upstream();\n}\n')
+
+    def test_preempt_function_impl_code_block_blank_line_not_indented(self):
+        # A blank line inside the block stays empty -- no trailing whitespace.
+        result = self._apply(
+            'code_blank.cc', 'void C::Pin(int id) {\n  Upstream();\n}\n',
+            'substitutions:\n'
+            '  - description: two guarded statements split by a blank line\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::Pin\n'
+            '      code: |-\n'
+            '        Prepare(id);\n'
+            '\n'
+            '        Track(id);\n')
+        self.assertEqual(
+            result, 'void C::Pin(int id) {\n  Prepare(id);\n\n'
+            '  Track(id);\n  Upstream();\n}\n')
+
+    def test_preempt_function_impl_survives_braced_default_argument(self):
+        # A `= {}` default argument and a multi-line signature both defeat a
+        # naive `\\(.*?{` regex, which would stop at the argument's brace. The
+        # AST matcher lands on the real body brace regardless.
+        source = ('void C::Tricky(const Options& opts = {},\n'
+                  '               int flags = 0) {\n  Upstream();\n}\n')
+        result = self._apply(
+            'tricky.cc', source, 'substitutions:\n'
+            '  - description: guard a function with a braced default arg\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::Tricky\n'
+            "      return_if: '!ok'\n")
+        self.assertEqual(
+            result,
+            source.replace('{\n  Upstream();', '{\n  if (!ok) return;\n'
+                           '  Upstream();'))
+
+    def test_preempt_function_impl_targets_named_function_only(self):
+        # Only the named function's body is touched, not a sibling in the same
+        # file.
+        result = self._apply(
+            'siblings.cc',
+            'void C::A() {\n  a();\n}\n\nvoid C::B() {\n  b();\n}\n',
+            'substitutions:\n'
+            '  - description: guard only B\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::B\n'
+            "      return_if: 'g()'\n")
+        self.assertEqual(
+            result, 'void C::A() {\n  a();\n}\n\n'
+            'void C::B() {\n  if (g()) return;\n  b();\n}\n')
+
+    def test_preempt_function_impl_overloads_need_count(self):
+        result = self._apply(
+            'overloads.cc',
+            'void C::F() {\n  a();\n}\n\nvoid C::F(int x) {\n  b();\n}\n',
+            'substitutions:\n'
+            '  - description: guard both overloads\n'
+            '    count: 2\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::F\n'
+            "      return_if: 'g()'\n")
+        self.assertEqual(
+            result, 'void C::F() {\n  if (g()) return;\n  a();\n}\n\n'
+            'void C::F(int x) {\n  if (g()) return;\n  b();\n}\n')
+
+    def test_preempt_function_impl_overload_count_mismatch_fails(self):
+        # Two overloads match, but the default count is 1.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'overloads_bad.cc',
+                'void C::F() {\n  a();\n}\n\nvoid C::F(int x) {\n  b();\n}\n',
+                'substitutions:\n'
+                '  - description: forgot the count\n'
+                '    preempt_function_impl:\n'
+                '      function_name: C::F\n'
+                "      return_if: 'g()'\n")
+
+    def test_preempt_function_impl_absent_function_fails(self):
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'missing.cc', 'void C::Foo() {\n}\n', 'substitutions:\n'
+                '  - description: no such function\n'
+                '    preempt_function_impl:\n'
+                '      function_name: C::Nope\n'
+                "      return_if: 'g()'\n")
+
+    def test_preempt_function_impl_both_modes_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: two modes\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::F\n'
+            '      code: x;\n'
+            "      return_if: 'g()'\n", 'exactly one of `code` or `return_if`')
+
+    def test_preempt_function_impl_no_mode_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: no mode\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::F\n',
+            'exactly one of `code` or `return_if`')
+
+    def test_preempt_function_impl_return_value_requires_return_if(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: return_value with code\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::F\n'
+            '      code: x;\n'
+            "      return_value: 'false'\n",
+            '`return_value` is only valid with `return_if`')
+
+    def test_preempt_function_impl_unknown_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: typo arg\n'
+            '    preempt_function_impl:\n'
+            '      function_name: C::F\n'
+            '      cod: x;\n', 'Unrecognised preempt_function_impl arg')
+
+    def test_preempt_function_impl_missing_function_name_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing function_name\n'
+            '    preempt_function_impl:\n'
+            "      return_if: 'g()'\n",
+            'preempt_function_impl `function_name` must be a non-empty string')
+
     # -- export-macro classes (real ast-grep binary) ----------------------
     #
     # tree-sitter cannot parse `class MACRO_EXPORT Name`, so the engine blanks

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1727,6 +1727,152 @@ class RewriterFormsTest(unittest.TestCase):
             "      return_if: 'g()'\n",
             'preempt_function_impl `function_name` must be a non-empty string')
 
+    # -- rename_class op (real ast-grep binary) -----------------------------
+
+    # `count` is omitted throughout: rename_class defaults to `count: 0` (one or
+    # more), unlike every other rewriter (which defaults to exactly one).
+
+    def test_rename_class_renames_declaration_and_type_uses(self):
+        # The class declaration and a type-position use are both renamed; a
+        # different class that merely shares a prefix is left alone.
+        result = self._apply(
+            'rename.h',
+            'class Foo {\n};\n\nclass FooBar {\n  Foo* foo_;\n};\n',
+            'substitutions:\n'
+            '  - description: rename Foo to Foo_ChromiumImpl\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result, 'class Foo_ChromiumImpl {\n};\n\n'
+            'class FooBar {\n  Foo_ChromiumImpl* foo_;\n};\n')
+
+    def test_rename_class_renames_qualifiers_and_ctor(self):
+        # The `Foo::` qualifier and the out-of-line constructor name are both
+        # renamed.
+        result = self._apply(
+            'rename_ctor.cc', 'Foo::Foo() {}\nvoid Foo::Bar() {}\n',
+            'substitutions:\n'
+            '  - description: rename Foo\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result, 'Foo_ChromiumImpl::Foo_ChromiumImpl() {}\n'
+            'void Foo_ChromiumImpl::Bar() {}\n')
+
+    def test_rename_class_leaves_string_literal_untouched(self):
+        # The whole point of matching AST identifier nodes: a same-spelled
+        # string literal survives. The exact-quote-adjacent form (`"Foo"`) is
+        # the case a `#define`/regex token rename would wrongly rewrite.
+        result = self._apply(
+            'rename_str.cc', 'void Foo::Run() {\n  Register("Foo");\n}\n',
+            'substitutions:\n'
+            '  - description: rename Foo but keep the string\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result, 'void Foo_ChromiumImpl::Run() {\n  Register("Foo");\n}\n')
+
+    def test_rename_class_leaves_token_inside_a_larger_string_untouched(self):
+        # `Foo` sits in the *middle* of a string, not adjacent to a quote -- the
+        # case a `(?<!")...(?!")` regex guard would still rewrite, but an AST
+        # match never can (the whole literal is one string node).
+        result = self._apply(
+            'rename_midstr.cc',
+            'void Foo::Log() {\n  LOG(INFO) << "start Foo done";\n}\n',
+            'substitutions:\n'
+            '  - description: rename Foo, keep it inside the message string\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result, 'void Foo_ChromiumImpl::Log() {\n'
+            '  LOG(INFO) << "start Foo done";\n}\n')
+
+    def test_rename_class_leaves_line_and_block_comments_untouched(self):
+        # Neither a `//` line comment nor a `/* */` block comment mentioning the
+        # name is rewritten -- comments are not identifier nodes.
+        result = self._apply(
+            'rename_comment.cc', '// Foo does things.\n'
+            '/* Foo again, and Foo. */\n'
+            'void Foo::Run() {\n}\n', 'substitutions:\n'
+            '  - description: rename Foo but keep both comments\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result, '// Foo does things.\n'
+            '/* Foo again, and Foo. */\n'
+            'void Foo_ChromiumImpl::Run() {\n}\n')
+
+    def test_rename_class_default_count_renames_all_occurrences(self):
+        # With the default `count: 0`, omitting `count` renames every occurrence
+        # (here four tokens across two lines) instead of demanding exactly one.
+        result = self._apply(
+            'rename_many.cc', 'Foo::Foo() {}\nvoid Foo::Bar() {}\n',
+            'substitutions:\n'
+            '  - description: rename Foo everywhere, no count needed\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result, 'Foo_ChromiumImpl::Foo_ChromiumImpl() {}\n'
+            'void Foo_ChromiumImpl::Bar() {}\n')
+
+    def test_rename_class_explicit_count_still_asserts_exact(self):
+        # An explicit `count` overrides the default and asserts an exact number;
+        # here two tokens match the stated two.
+        result = self._apply(
+            'rename_exact.h', 'class Foo {\n  Foo* self_;\n};\n',
+            'substitutions:\n'
+            '  - description: rename the two Foo tokens\n'
+            '    count: 2\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      rename: Foo_ChromiumImpl\n')
+        self.assertEqual(
+            result,
+            'class Foo_ChromiumImpl {\n  Foo_ChromiumImpl* self_;\n};\n')
+
+    def test_rename_class_explicit_count_mismatch_fails(self):
+        # Two tokens match, but the entry asserts one.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'rename_bad_count.h', 'class Foo {\n  Foo* self_;\n};\n',
+                'substitutions:\n'
+                '  - description: wrong explicit count\n'
+                '    count: 1\n'
+                '    rename_class:\n'
+                '      class_name: Foo\n'
+                '      rename: Foo_ChromiumImpl\n')
+
+    def test_rename_class_absent_fails(self):
+        # The default `count: 0` is "one or more", so zero matches still fails.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'rename_absent.h', 'class Bar {\n};\n', 'substitutions:\n'
+                '  - description: no such class\n'
+                '    rename_class:\n'
+                '      class_name: Foo\n'
+                '      rename: Foo_ChromiumImpl\n')
+
+    def test_rename_class_unknown_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: typo arg\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n'
+            '      renam: Bar\n', 'Unrecognised rename_class arg')
+
+    def test_rename_class_missing_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing rename\n'
+            '    rename_class:\n'
+            '      class_name: Foo\n', 'rename_class requires arg')
+
     # -- export-macro classes (real ast-grep binary) ----------------------
     #
     # tree-sitter cannot parse `class MACRO_EXPORT Name`, so the engine blanks

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -108,21 +108,18 @@ class PlasterTest(unittest.TestCase):
         self.assertEqual(patchinfo_from_disk['schemaVersion'], 1)
         self.assertEqual(
             patchinfo_from_disk['patchChecksum'],
-            hashlib.sha256(
-                patchinfo.patch.path.read_text().encode()).hexdigest())
+            hashlib.sha256(patchinfo.patch.path.read_bytes()).hexdigest())
         self.assertEqual(patchinfo_from_disk['appliesTo'][0]['path'],
                          str(test_file_chromium))
         self.assertEqual(
             patchinfo_from_disk['appliesTo'][0]['checksum'],
-            hashlib.sha256(
-                (self.fake_chromium_src.chromium /
-                 test_file_chromium).read_text().encode()).hexdigest())
+            hashlib.sha256((self.fake_chromium_src.chromium /
+                            test_file_chromium).read_bytes()).hexdigest())
         # PatchinfoBuilder normalizes plaster path to be relative to brave root.
         self.assertEqual(patchinfo_from_disk['plaster']['path'],
                          str(patchinfo.plaster_file))
-        self.assertEqual(
-            patchinfo_from_disk['plaster']['checksum'],
-            hashlib.sha256(plaster_path.read_text().encode()).hexdigest())
+        self.assertEqual(patchinfo_from_disk['plaster']['checksum'],
+                         hashlib.sha256(plaster_path.read_bytes()).hexdigest())
 
         self.assertEqual(patchinfo_from_disk['patchChecksum'],
                          patchinfo.patch.checksum)

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1873,6 +1873,178 @@ class RewriterFormsTest(unittest.TestCase):
             '    rename_class:\n'
             '      class_name: Foo\n', 'rename_class requires arg')
 
+    # -- add_to_protected op (real ast-grep binary) -----------------
+
+    def test_add_to_protected_creates_section_before_private(self):
+        # No existing protected section: a fresh `protected:` is created just
+        # before `private:`.
+        result = self._apply(
+            'prot_new.h',
+            'class C {\n public:\n  void Foo();\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: add a protected hook\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar() = 0;\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            ' protected:\n  virtual void Bar() = 0;\n\n'
+            ' private:\n  int x_;\n};\n')
+
+    def test_add_to_protected_reuses_existing_protected(self):
+        # An existing protected section is reused: the code becomes its first
+        # line, and no second protected section is created before private.
+        result = self._apply(
+            'prot_reuse.h', 'class C {\n protected:\n  void Existing();\n'
+            ' private:\n  int x_;\n};\n', 'substitutions:\n'
+            '  - description: reuse the protected section\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar() = 0;\n')
+        self.assertEqual(
+            result, 'class C {\n protected:\n  virtual void Bar() = 0;\n'
+            '  void Existing();\n private:\n  int x_;\n};\n')
+
+    def test_add_to_protected_scoped_to_named_class(self):
+        # Only the named class is touched; a sibling class with its own private
+        # section is left alone (the matchers are scoped by class_name).
+        result = self._apply(
+            'prot_scope.h', 'class C {\n private:\n  int c_;\n};\n\n'
+            'class D {\n private:\n  int d_;\n};\n', 'substitutions:\n'
+            '  - description: add only to C\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar() = 0;\n')
+        self.assertEqual(
+            result, 'class C {\n protected:\n  virtual void Bar() = 0;\n\n'
+            ' private:\n  int c_;\n};\n\n'
+            'class D {\n private:\n  int d_;\n};\n')
+
+    def test_add_to_protected_multiline_code(self):
+        # A multi-line `code` block inserts several declarations, each indented
+        # to the member level.
+        result = self._apply(
+            'prot_multi.h', 'class C {\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: add two protected hooks\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: |-\n'
+            '        virtual void A() = 0;\n'
+            '        virtual void B() = 0;\n')
+        self.assertEqual(
+            result, 'class C {\n'
+            ' protected:\n  virtual void A() = 0;\n  virtual void B() = 0;\n\n'
+            ' private:\n  int x_;\n};\n')
+
+    def test_add_to_protected_indents_flush_left_nested_code(self):
+        # A flush-left `code` block is indented to the member level (two spaces),
+        # and its own relative indentation is preserved (the nested `DoStuff();`
+        # ends up two spaces deeper) -- like preempt_function_impl's `code`.
+        result = self._apply(
+            'prot_nested.h', 'class C {\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: add a hook with an inline body\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: |-\n'
+            '        void OnFoo() {\n'
+            '          DoStuff();\n'
+            '        }\n')
+        self.assertEqual(
+            result, 'class C {\n'
+            ' protected:\n  void OnFoo() {\n    DoStuff();\n  }\n\n'
+            ' private:\n  int x_;\n};\n')
+
+    def test_add_to_protected_blank_line_in_code_stays_empty(self):
+        # A blank line inside the `code` block stays empty -- no trailing
+        # whitespace from the member-level indentation.
+        result = self._apply(
+            'prot_blank.h', 'class C {\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: two declarations split by a blank line\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: |-\n'
+            '        virtual void A() = 0;\n'
+            '\n'
+            '        virtual void B() = 0;\n')
+        self.assertEqual(
+            result, 'class C {\n'
+            ' protected:\n  virtual void A() = 0;\n\n  virtual void B() = 0;\n\n'
+            ' private:\n  int x_;\n};\n')
+
+    def test_add_to_protected_reused_section_indents_code(self):
+        # Indentation is applied the same way when reusing an existing protected
+        # section: the multi-line block lands at the member level above the
+        # existing members.
+        result = self._apply(
+            'prot_reuse_multi.h',
+            'class C {\n protected:\n  void Existing();\n'
+            ' private:\n  int x_;\n};\n', 'substitutions:\n'
+            '  - description: add two hooks to the existing protected section\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: |-\n'
+            '        void A();\n'
+            '        void B();\n')
+        self.assertEqual(
+            result, 'class C {\n protected:\n  void A();\n  void B();\n'
+            '  void Existing();\n private:\n  int x_;\n};\n')
+
+    def test_add_to_protected_no_anchor_fails(self):
+        # A class with neither a protected nor a private section has nothing to
+        # anchor on.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'prot_none.h', 'class C {\n public:\n  void Foo();\n};\n',
+                'substitutions:\n'
+                '  - description: no anchor\n'
+                '    add_to_protected:\n'
+                '      class_name: C\n'
+                '      code: virtual void Bar() = 0;\n')
+
+    def test_add_to_protected_unknown_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: typo arg\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      cod: virtual void Bar() = 0;\n',
+            'Unrecognised add_to_protected arg')
+
+    def test_add_to_protected_missing_arg_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing code\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n', 'add_to_protected requires arg')
+
+    def test_add_to_protected_explicit_count_one_ok(self):
+        # An explicit `count: 1` is the only count accepted; it applies normally.
+        result = self._apply(
+            'prot_count_ok.h', 'class C {\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: explicit count of one\n'
+            '    count: 1\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar() = 0;\n')
+        self.assertEqual(
+            result, 'class C {\n protected:\n  virtual void Bar() = 0;\n\n'
+            ' private:\n  int x_;\n};\n')
+
+    def test_add_to_protected_count_other_than_one_rejected(self):
+        # It always adds exactly once, so any other count is a config error.
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: bogus count\n'
+            '    count: 2\n'
+            '    add_to_protected:\n'
+            '      class_name: C\n'
+            '      code: virtual void Bar() = 0;\n',
+            'does not accept a count other than 1')
+
     # -- export-macro classes (real ast-grep binary) ----------------------
     #
     # tree-sitter cannot parse `class MACRO_EXPORT Name`, so the engine blanks

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1508,6 +1508,181 @@ class RewriterFormsTest(unittest.TestCase):
             '  - description: missing arg\n'
             '    drop_final: {}\n', 'drop_final requires arg')
 
+    # -- export-macro classes (real ast-grep binary) ----------------------
+    #
+    # tree-sitter cannot parse `class MACRO_EXPORT Name`, so the engine blanks
+    # the macro before matching. These confirm the AST rewriters reach a class
+    # declared with an export macro while leaving the macro itself in place.
+
+    def test_drop_final_on_export_macro_class(self):
+        result = self._apply(
+            'exp_final.h',
+            'class MODULES_EXPORT C final : public Base {\n};\n',
+            'blank_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: drop final on an exported class\n'
+            '    drop_final:\n'
+            '      class_name: C\n')
+        self.assertEqual(result,
+                         'class MODULES_EXPORT C : public Base {\n};\n')
+
+    def test_make_virtual_on_export_macro_class(self):
+        result = self._apply(
+            'exp_virt.h', 'class MODULES_EXPORT C {\n  void Foo();\n};\n',
+            'blank_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: make Foo virtual on an exported class\n'
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            '      method_name: Foo\n')
+        self.assertEqual(
+            result, 'class MODULES_EXPORT C {\n  virtual void Foo();\n};\n')
+
+    def test_add_friend_on_parenthesised_export_macro_class(self):
+        # The parenthesised `COMPONENT_EXPORT(FOO)` form is blanked too.
+        result = self._apply(
+            'exp_friend.h',
+            'class COMPONENT_EXPORT(FOO) C {\n private:\n  int x_;\n};\n',
+            'blank_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: friend an exported class\n'
+            '    add_friend:\n'
+            '      class_name: C\n'
+            '      friend_type: class BraveC\n')
+        self.assertEqual(
+            result, 'class COMPONENT_EXPORT(FOO) C {\n'
+            ' private:\n  friend class BraveC;\n  int x_;\n};\n')
+
+    # -- classes with base-list preprocessor conditionals -----------------
+    #
+    # A `#if` in the base-specifier list stops tree-sitter from resolving the
+    # class; the engine blanks it before matching. These confirm the AST
+    # rewriters reach such a class while the conditional survives in the output.
+
+    _AURA_CLASS = ('class C : public A\n'
+                   '#if defined(USE_AURA)\n'
+                   '    ,\n'
+                   '         public D\n'
+                   '#endif  // defined(USE_AURA)\n'
+                   '{\n'
+                   ' public:\n'
+                   '  void Foo();\n'
+                   ' private:\n'
+                   '  int x_;\n'
+                   '};\n')
+
+    def test_make_virtual_through_base_list_conditional(self):
+        result = self._apply(
+            'aura_virt.h', self._AURA_CLASS,
+            'blank_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: make Foo virtual despite the aura base\n'
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            '      method_name: Foo\n')
+        self.assertEqual(
+            result,
+            self._AURA_CLASS.replace('  void Foo();', '  virtual void Foo();'))
+
+    def test_add_friend_through_base_list_conditional(self):
+        result = self._apply(
+            'aura_friend.h', self._AURA_CLASS,
+            'blank_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: friend despite the aura base\n'
+            '    add_friend:\n'
+            '      class_name: C\n'
+            '      friend_type: class BraveC\n')
+        self.assertEqual(
+            result,
+            self._AURA_CLASS.replace(' private:\n',
+                                     ' private:\n  friend class BraveC;\n'))
+
+    def test_blanking_is_off_by_default(self):
+        # Without `blank_macros_for_ast_parsing`, the export-macro class is
+        # unparseable, so the rewriter matches nothing and the apply fails.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'no_blank.h', 'class MODULES_EXPORT C final {\n};\n',
+                'substitutions:\n'
+                '  - description: no blanking, so final is invisible\n'
+                '    drop_final:\n'
+                '      class_name: C\n')
+
+    def test_blank_flag_false_does_not_blank(self):
+        # Explicit `false` behaves like the default: still unparseable.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'blank_false.h', 'class MODULES_EXPORT C final {\n};\n',
+                'blank_macros_for_ast_parsing: false\n'
+                'substitutions:\n'
+                '  - description: blanking explicitly off\n'
+                '    drop_final:\n'
+                '      class_name: C\n')
+
+    def test_blank_flag_must_be_boolean(self):
+        self._expect_value_error(
+            'blank_macros_for_ast_parsing: yes please\n'
+            'substitutions:\n'
+            '  - description: bad flag type\n'
+            '    drop_final:\n'
+            '      class_name: C\n',
+            '`blank_macros_for_ast_parsing` must be a boolean')
+
+    def test_unknown_top_level_key_rejected(self):
+        self._expect_value_error(
+            'blank_macros: true\n'
+            'substitutions:\n'
+            '  - description: typo in the top-level flag\n'
+            '    drop_final:\n'
+            '      class_name: C\n', 'Unrecognised top-level plaster key')
+
+    def test_blank_flag_rejected_for_non_cxx_source(self):
+        # `_expect_value_error` targets a `.idl` source; the flag only applies
+        # to C++ files, so it is rejected there.
+        self._expect_value_error(
+            'blank_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: flag on a non-C++ source\n'
+            '    regex:\n'
+            "      re_pattern: 'x'\n"
+            "      replace: 'y'\n",
+            '`blank_macros_for_ast_parsing` is only supported for C++ sources')
+
+    def test_blank_flag_allowed_for_cxx_source(self):
+        # The same flag is accepted for a `.h` source (here with no AST work to
+        # do, so it just applies the regex).
+        result = self._apply(
+            'cxx_flag.h', 'A Chromium thing.\n',
+            'blank_macros_for_ast_parsing: true\n'
+            'substitutions:\n'
+            '  - description: flag on a C++ source\n'
+            '    regex:\n'
+            "      re_pattern: 'Chromium'\n"
+            "      replace: 'Brave'\n")
+        self.assertEqual(result, 'A Brave thing.\n')
+
+    def test_ast_rewriter_rejected_for_non_cxx_source(self):
+        # AST rewriters (cxx.* ops) only work on C++ sources; the `.idl` target
+        # of `_expect_value_error` is not one.
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: AST rewriter on a non-C++ source\n'
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            '      method_name: Foo\n',
+            'the `make_virtual` rewriter is only supported for C++ sources')
+
+    def test_regex_rewriter_allowed_for_non_cxx_source(self):
+        # Text rewriters are language-agnostic, so they work on any source.
+        result = self._apply(
+            'plain.idl', 'A Chromium thing.\n', 'substitutions:\n'
+            '  - description: regex on a non-C++ source\n'
+            '    regex:\n'
+            "      re_pattern: 'Chromium'\n"
+            "      replace: 'Brave'\n")
+        self.assertEqual(result, 'A Brave thing.\n')
+
     # -- validation ---------------------------------------------------------
 
     def test_two_op_keys_rejected(self):
@@ -1992,6 +2167,94 @@ _SYNTHETIC_SPEC = {
         },
     },
 }
+
+
+class PrepareForParseTest(unittest.TestCase):
+    """Unit tests for AstRewriter._prepare_cxx_for_parse (no ast-grep binary)."""
+
+    def _prepared(self, source: str) -> str:
+        """Return the parse-prepared source, asserting length is preserved.
+
+        `_prepare_cxx_for_parse` only reads the held source and the class regexes,
+        so the rewriters registry is irrelevant and left as None here.
+        """
+        result = plaster.AstRewriter(None, source)._prepare_cxx_for_parse()
+        # The whole point is that offsets are preserved for byte-for-byte
+        # remapping onto the untouched source.
+        self.assertEqual(len(result.encode('utf-8')),
+                         len(source.encode('utf-8')))
+        return result
+
+    def _assert_blanks(self, source: str, macro: str):
+        """Assert `macro` is replaced by equal-length spaces, nothing else."""
+        self.assertEqual(self._prepared(source),
+                         source.replace(macro, ' ' * len(macro), 1))
+
+    # -- export macros ----------------------------------------------------
+
+    def test_blanks_simple_export_macro(self):
+        self._assert_blanks('class MODULES_EXPORT Foo final {};',
+                            'MODULES_EXPORT')
+
+    def test_blanks_parenthesised_export_macro(self):
+        self._assert_blanks('class COMPONENT_EXPORT(BASE) Foo {};',
+                            'COMPONENT_EXPORT(BASE)')
+
+    def test_blanks_struct_and_multiline_head(self):
+        self._assert_blanks('struct NET_EXPORT\n    Foo {};', 'NET_EXPORT')
+
+    def test_leaves_plain_class_untouched(self):
+        for src in ('class Foo final {};', 'class Foo : public Base {};',
+                    'class FooBar {};'):
+            self.assertEqual(self._prepared(src), src)
+
+    def test_leaves_all_caps_class_name_untouched(self):
+        # An all-caps name without an `_EXPORT` suffix is not a macro.
+        self.assertEqual(self._prepared('class URL final {};'),
+                         'class URL final {};')
+
+    def test_only_touches_class_head_macro(self):
+        # An `_EXPORT`-suffixed token elsewhere (a member, a value) is left be.
+        result = self._prepared(
+            'class MODULES_EXPORT Foo {\n  int MY_EXPORT = 1;\n};')
+        self.assertIn('int MY_EXPORT = 1;', result)
+        self.assertNotIn('MODULES_EXPORT', result)
+
+    # -- preprocessor conditionals ----------------------------------------
+
+    def test_blanks_conditionals_anywhere(self):
+        # Directives are blanked wherever they sit -- base list or class body --
+        # while the code they guarded stays put.
+        result = self._prepared('class C : public A\n'
+                                '#if defined(USE_AURA)\n'
+                                '    ,\n'
+                                '         public D\n'
+                                '#endif  // defined(USE_AURA)\n'
+                                '{\n'
+                                ' public:\n'
+                                '#ifdef FOO\n'
+                                '  void OnFoo();\n'
+                                '#else\n'
+                                '  void OnBar();\n'
+                                '#endif\n'
+                                '};\n')
+        for directive in ('#if', '#ifdef', '#else', '#endif'):
+            self.assertNotIn(directive, result)
+        # Guarded code survives.
+        for kept in ('public D', 'void OnFoo();', 'void OnBar();'):
+            self.assertIn(kept, result)
+
+    def test_blanks_every_directive_kind(self):
+        for directive in ('#if X', '#ifdef X', '#ifndef X', '#elif X', '#else',
+                          '#endif'):
+            self.assertEqual(self._prepared(f'a\n{directive}\nb\n'),
+                             f'a\n{" " * len(directive)}\nb\n')
+
+    def test_leaves_non_conditional_directives_untouched(self):
+        # `#include` / `#define` are not conditionals and must be preserved.
+        for src in ('#include <memory>\n', '#define FOO 1\n',
+                    '#pragma once\n'):
+            self.assertEqual(self._prepared(src), src)
 
 
 class RunAstGrepTest(unittest.TestCase):

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1300,6 +1300,65 @@ class RewriterFormsTest(unittest.TestCase):
             '      class_name: C\n'
             '      freind: class BraveC\n', 'Unrecognised add_friend arg')
 
+    def test_add_friend_list_inserts_in_authored_order(self):
+        # A list-valued `friend_type` befriends several types in one entry. Each
+        # is inserted once into the single private section, so no `count:` is
+        # needed; they land in the source in the order listed here even though
+        # each is inserted as the first line.
+        result = self._apply(
+            'friends.h',
+            'class C {\n public:\n  void Foo();\n private:\n  int x_;\n};\n',
+            'substitutions:\n'
+            '  - description: friend the Brave subclass and its test\n'
+            '    add_friend:\n'
+            '      class_name: C\n'
+            '      friend_type:\n'
+            '        - class BraveC\n'
+            '        - class BraveCTest\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            ' private:\n  friend class BraveC;\n  friend class BraveCTest;\n'
+            '  int x_;\n};\n')
+
+    def test_add_friend_list_fails_when_private_section_absent(self):
+        # Each friend is validated on its own: with no private section every
+        # per-friend operation matches nothing and fails.
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'friends2.h', 'class C {\n public:\n  void Foo();\n};\n',
+                'substitutions:\n'
+                '  - description: no private section for the friends\n'
+                '    add_friend:\n'
+                '      class_name: C\n'
+                '      friend_type:\n'
+                '        - class BraveC\n'
+                '        - class BraveCTest\n')
+
+    def test_add_friend_friend_type_must_be_string_or_list(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: bad friend_type\n'
+            '    add_friend:\n'
+            '      class_name: C\n'
+            '      friend_type: 42\n',
+            'friend_type` must be a string or a non-empty list')
+
+    def test_add_friend_friend_type_empty_list_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: empty friend list\n'
+            '    add_friend:\n'
+            '      class_name: C\n'
+            '      friend_type: []\n',
+            'friend_type` must be a string or a non-empty list')
+
+    def test_add_friend_missing_class_name_rejected(self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: missing class\n'
+            '    add_friend:\n'
+            '      friend_type: class BraveC\n', 'add_friend requires arg')
+
     # -- drop_final op (real ast-grep binary) -----------------------------
 
     def test_drop_final_op(self):
@@ -1406,6 +1465,69 @@ class RewriterRegistryTest(unittest.TestCase):
             self.assertTrue(cls.help_text(), f'{name} is missing help text')
 
 
+class AstGrepCompositionTest(unittest.TestCase):
+    """Frontend rewriters compose into `Operation`s fed to the engine.
+
+    These exercise the parse -> `operations()` seam directly (no ast-grep run),
+    against the shipped rewriters.pyl so `declared_inputs()` reads real specs.
+    """
+
+    def test_declared_inputs_read_from_spec(self):
+        # The accepted arg keys come from the op spec, not a duplicated class
+        # constant.
+        self.assertEqual(plaster.MakeVirtual.declared_inputs(),
+                         frozenset({'class_name', 'method_name'}))
+        self.assertEqual(plaster.DropFinal.declared_inputs(),
+                         frozenset({'class_name'}))
+
+    def test_flat_rewriter_expands_to_one_operation(self):
+        rewriter = plaster.MakeVirtual.parse(
+            {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            }, description='d')
+        self.assertEqual(rewriter.operations(1), [
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            })
+        ])
+
+    def test_add_friend_single_expands_to_one_operation(self):
+        rewriter = plaster.AddFriend.parse(
+            {
+                'class_name': 'C',
+                'friend_type': 'class BraveC'
+            },
+            description='d')
+        self.assertEqual(rewriter.operations(1), [
+            plaster.Operation('cxx.add_friend', {
+                'class_name': 'C',
+                'friend_type': 'class BraveC'
+            })
+        ])
+
+    def test_add_friend_list_expands_reversed_to_preserve_order(self):
+        # Each insertion goes to the top of the private section, so the ops are
+        # emitted in reverse of the authored list to land them in order.
+        rewriter = plaster.AddFriend.parse(
+            {
+                'class_name': 'C',
+                'friend_type': ['class BraveC', 'class BraveCTest'],
+            },
+            description='d')
+        self.assertEqual(rewriter.operations(1), [
+            plaster.Operation('cxx.add_friend', {
+                'class_name': 'C',
+                'friend_type': 'class BraveCTest'
+            }),
+            plaster.Operation('cxx.add_friend', {
+                'class_name': 'C',
+                'friend_type': 'class BraveC'
+            }),
+        ])
+
+
 class RewritersEvalTest(unittest.TestCase):
     """Schema evaluation and access tests for plaster.RewritersEval."""
 
@@ -1421,7 +1543,6 @@ class RewritersEvalTest(unittest.TestCase):
         return {
             'ast.matcher': {
                 'cxx.find_class_method_decl': {
-                    'args': ['class_name', 'method_name'],
                     'template': ('kind: field_declaration\n'
                                  'has:\n'
                                  '  regex: ^{method_name}$\n'
@@ -1435,6 +1556,7 @@ class RewritersEvalTest(unittest.TestCase):
             'ast.rewriter': {
                 'cxx.make_virtual': {
                     'matcher': 'cxx.find_class_method_decl',
+                    'inputs': ['class_name', 'method_name'],
                     'replace': {
                         're_pattern': '^',
                         'replace': 'virtual '
@@ -1478,11 +1600,14 @@ class RewritersEvalTest(unittest.TestCase):
     def test_accessors_return_specs(self):
         rewriters = self._eval_valid()
         self.assertEqual(
-            rewriters.matcher('cxx.find_class_method_decl')['args'],
-            ['class_name', 'method_name'])
+            rewriters.matcher('cxx.find_class_method_decl')['result']['node'],
+            'field_declaration')
         self.assertEqual(
             rewriters.rewriter('cxx.make_virtual')['matcher'],
             'cxx.find_class_method_decl')
+        self.assertEqual(
+            rewriters.rewriter('cxx.make_virtual')['inputs'],
+            ['class_name', 'method_name'])
 
     def test_unknown_op_access_raises(self):
         rewriters = self._eval_valid()
@@ -1566,23 +1691,6 @@ class RewritersEvalTest(unittest.TestCase):
             lambda s: s['ast.matcher']['cxx.find_class_method_decl'].update(
                 {'language': 'cpp'}), 'Wrong keys')
 
-    def test_matcher_args_not_list_of_strings(self):
-        self._assert_invalid(
-            lambda s: s['ast.matcher']['cxx.find_class_method_decl'].
-            __setitem__('args', 'class_name'), "should be instance of 'list'")
-
-    def test_matcher_undeclared_placeholder(self):
-        self._assert_invalid(
-            lambda s: s['ast.matcher']
-            ['cxx.find_class_method_decl'].__setitem__(
-                'template', 'regex: ^{class_name}$ ^{method_name}$ ^{bogus}$'),
-            'undeclared placeholder')
-
-    def test_matcher_unused_arg(self):
-        self._assert_invalid(
-            lambda s: s['ast.matcher']['cxx.find_class_method_decl']['args'].
-            append('unused'), 'never used')
-
     def test_matcher_bad_result(self):
         self._assert_invalid(
             lambda s: s['ast.matcher']['cxx.find_class_method_decl']['result'].
@@ -1614,6 +1722,36 @@ class RewritersEvalTest(unittest.TestCase):
         self._assert_invalid(
             lambda s: s['ast.rewriter']['cxx.make_virtual'].update(
                 {'append': '!'}), 'Wrong keys')
+
+    def test_rewriter_inputs_not_list_of_strings(self):
+        self._assert_invalid(
+            lambda s: s['ast.rewriter']['cxx.make_virtual'].__setitem__(
+                'inputs', 'class_name'), "should be instance of 'list'")
+
+    def test_rewriter_undeclared_input(self):
+        # The templates reference `method_name`, but it is dropped from the
+        # declared `inputs`, so the op's interface no longer covers them.
+        self._assert_invalid(
+            lambda s: s['ast.rewriter']['cxx.make_virtual'].__setitem__(
+                'inputs', ['class_name']), 'undeclared input')
+
+    def test_rewriter_unused_input(self):
+        self._assert_invalid(
+            lambda s: s['ast.rewriter']['cxx.make_virtual']['inputs'].append(
+                'unused'), 'never used')
+
+    def test_rewriter_replace_consume_tokens_are_optional(self):
+        # `consume_before` / `consume_after` are optional; adding them keeps the
+        # spec valid (and they must be strings).
+        spec = self._valid_spec()
+        spec['ast.rewriter']['cxx.make_virtual']['replace'].update({
+            'consume_before': ' ',
+            'consume_after': ':',
+        })
+        rewriters = plaster.RewritersEval(repr(spec))
+        replace = rewriters.rewriter('cxx.make_virtual')['replace']
+        self.assertEqual(replace['consume_before'], ' ')
+        self.assertEqual(replace['consume_after'], ':')
 
 
 # ast-grep matcher templates used to build synthetic RewritersEval specs for
@@ -1656,21 +1794,18 @@ _FINAL_RULE = ('kind: virtual_specifier\n'
 _SYNTHETIC_SPEC = {
     'ast.matcher': {
         'cxx.find_class_method_decl': {
-            'args': ['class_name', 'method_name'],
             'template': _METHOD_DECL_RULE,
             'result': {
                 'node': 'field_declaration'
             },
         },
         'cxx.find_class_private_section': {
-            'args': ['class_name'],
             'template': _PRIVATE_SECTION_RULE,
             'result': {
                 'node': 'access_specifier'
             },
         },
         'cxx.find_class_final': {
-            'args': ['class_name'],
             'template': _FINAL_RULE,
             'result': {
                 'node': 'virtual_specifier'
@@ -1680,6 +1815,7 @@ _SYNTHETIC_SPEC = {
     'ast.rewriter': {
         'cxx.make_virtual': {
             'matcher': 'cxx.find_class_method_decl',
+            'inputs': ['class_name', 'method_name'],
             'replace': {
                 're_pattern': '^',
                 'replace': 'virtual '
@@ -1690,7 +1826,9 @@ _SYNTHETIC_SPEC = {
         },
         'cxx.add_friend': {
             'matcher': 'cxx.find_class_private_section',
+            'inputs': ['class_name', 'friend_type'],
             'replace': {
+                'consume_after': ':',
                 're_pattern': '$',
                 'replace': ':\\n  friend {friend_type};'
             },
@@ -1700,7 +1838,9 @@ _SYNTHETIC_SPEC = {
         },
         'cxx.drop_final': {
             'matcher': 'cxx.find_class_final',
+            'inputs': ['class_name'],
             'replace': {
+                'consume_before': ' ',
                 're_pattern': '^final$',
                 'replace': ''
             },
@@ -1755,8 +1895,10 @@ class RunAstGrepTest(unittest.TestCase):
 class AstRewriterTest(unittest.TestCase):
     """Integration tests for plaster.AstRewriter (real ast-grep binary).
 
-    Driven with a synthetic RewritersEval built from `_SYNTHETIC_SPEC`, since
-    the shipped rewriters.pyl carries no ops yet.
+    Driven with a synthetic RewritersEval built from `_SYNTHETIC_SPEC`, so the
+    engine is exercised in isolation from whatever the shipped rewriters.pyl
+    currently carries. Each op is invoked through a bound `Operation`; the
+    consume tokens now live in the spec, not in the call.
     """
 
     _SRC = 'class C {\n  void Foo();\n  void Bar();\n};\n'
@@ -1767,10 +1909,11 @@ class AstRewriterTest(unittest.TestCase):
 
     def test_make_virtual_single(self):
         rewriter = self._rewriter()
-        count = rewriter.apply('cxx.make_virtual', {
-            'class_name': 'C',
-            'method_name': 'Foo'
-        })
+        count = rewriter.run(
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            }))
         self.assertEqual(count, 1)
         self.assertEqual(
             rewriter.content,
@@ -1780,10 +1923,11 @@ class AstRewriterTest(unittest.TestCase):
         # Destructors parse as `declaration` with a `destructor_name`, not the
         # `field_declaration`/`field_identifier` of a regular method.
         rewriter = self._rewriter('class C {\n public:\n  ~C();\n};\n')
-        count = rewriter.apply('cxx.make_virtual', {
-            'class_name': 'C',
-            'method_name': '~C'
-        })
+        count = rewriter.run(
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': '~C'
+            }))
         self.assertEqual(count, 1)
         self.assertEqual(rewriter.content,
                          'class C {\n public:\n  virtual ~C();\n};\n')
@@ -1791,10 +1935,11 @@ class AstRewriterTest(unittest.TestCase):
     def test_make_virtual_overloads_count_each(self):
         rewriter = self._rewriter(
             'class C {\n  void Foo();\n  void Foo(int x);\n};\n')
-        count = rewriter.apply('cxx.make_virtual', {
-            'class_name': 'C',
-            'method_name': 'Foo'
-        })
+        count = rewriter.run(
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            }))
         self.assertEqual(count, 2)
         # Splicing from the end keeps the earlier overload's offset valid.
         self.assertEqual(
@@ -1804,22 +1949,25 @@ class AstRewriterTest(unittest.TestCase):
     def test_no_match_leaves_content_unchanged(self):
         rewriter = self._rewriter()
         self.assertEqual(
-            rewriter.apply('cxx.make_virtual', {
-                'class_name': 'C',
-                'method_name': 'Nope'
-            }), 0)
+            rewriter.run(
+                plaster.Operation('cxx.make_virtual', {
+                    'class_name': 'C',
+                    'method_name': 'Nope'
+                })), 0)
         self.assertEqual(rewriter.content, self._SRC)
 
     def test_content_accumulates_across_calls(self):
         rewriter = self._rewriter()
-        rewriter.apply('cxx.make_virtual', {
-            'class_name': 'C',
-            'method_name': 'Foo'
-        })
-        rewriter.apply('cxx.make_virtual', {
-            'class_name': 'C',
-            'method_name': 'Bar'
-        })
+        rewriter.run(
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            }))
+        rewriter.run(
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': 'Bar'
+            }))
         self.assertEqual(
             rewriter.content,
             'class C {\n  virtual void Foo();\n  virtual void Bar();\n};\n')
@@ -1827,11 +1975,11 @@ class AstRewriterTest(unittest.TestCase):
     def test_add_friend_inserts_after_private_colon(self):
         rewriter = self._rewriter(
             'class C {\n public:\n  void Foo();\n private:\n  int x_;\n};\n')
-        count = rewriter.apply('cxx.add_friend', {
-            'class_name': 'C',
-            'friend_type': 'class BraveC'
-        },
-                               consume_after=':')
+        count = rewriter.run(
+            plaster.Operation('cxx.add_friend', {
+                'class_name': 'C',
+                'friend_type': 'class BraveC'
+            }))
         self.assertEqual(count, 1)
         # The friend lands as the first private line; the `:` is not duplicated.
         self.assertEqual(
@@ -1841,11 +1989,11 @@ class AstRewriterTest(unittest.TestCase):
     def test_add_friend_no_private_section(self):
         rewriter = self._rewriter('class C {\n public:\n  void Foo();\n};\n')
         self.assertEqual(
-            rewriter.apply('cxx.add_friend', {
-                'class_name': 'C',
-                'friend_type': 'class BraveC'
-            },
-                           consume_after=':'), 0)
+            rewriter.run(
+                plaster.Operation('cxx.add_friend', {
+                    'class_name': 'C',
+                    'friend_type': 'class BraveC'
+                })), 0)
         self.assertEqual(rewriter.content,
                          'class C {\n public:\n  void Foo();\n};\n')
 
@@ -1855,24 +2003,246 @@ class AstRewriterTest(unittest.TestCase):
         rewriter = self._rewriter(
             'class C final : public Base {\n  void f() final;\n};\n')
         self.assertEqual(
-            rewriter.apply('cxx.drop_final', {'class_name': 'C'},
-                           consume_before=' '), 1)
+            rewriter.run(
+                plaster.Operation('cxx.drop_final', {'class_name': 'C'})), 1)
         self.assertEqual(rewriter.content,
                          'class C : public Base {\n  void f() final;\n};\n')
 
     def test_drop_final_no_base(self):
         rewriter = self._rewriter('class C final {\n};\n')
         self.assertEqual(
-            rewriter.apply('cxx.drop_final', {'class_name': 'C'},
-                           consume_before=' '), 1)
+            rewriter.run(
+                plaster.Operation('cxx.drop_final', {'class_name': 'C'})), 1)
         self.assertEqual(rewriter.content, 'class C {\n};\n')
 
     def test_drop_final_absent(self):
         rewriter = self._rewriter('class C {\n};\n')
         self.assertEqual(
-            rewriter.apply('cxx.drop_final', {'class_name': 'C'},
-                           consume_before=' '), 0)
+            rewriter.run(
+                plaster.Operation('cxx.drop_final', {'class_name': 'C'})), 0)
         self.assertEqual(rewriter.content, 'class C {\n};\n')
+
+
+class _FlatAstGrepRewriter(plaster._AstGrepRewriter):
+    """Minimal `_AstGrepRewriter` subclass: inherits the base parse/operations.
+
+    Bound to `cxx.make_virtual` purely so the base's default 1:1 behaviour has a
+    real op to resolve against; it adds nothing of its own.
+    """
+
+    NAME = 'flat_test_op'
+    OP_ID = 'cxx.make_virtual'
+
+
+class _ComposingAstGrepRewriter(plaster._AstGrepRewriter):
+    """`_AstGrepRewriter` subclass that expands one body into several ops.
+
+    Exists only to prove the base's `apply` drives and accumulates across an
+    arbitrary `operations()` list -- the composition seam itself, with no
+    concrete rewriter (MakeVirtual/AddFriend/DropFinal) in the picture.
+    """
+
+    NAME = 'composing_test_op'
+    OP_ID = 'cxx.make_virtual'
+
+    def __init__(self, class_name: str, method_names: list[str]):
+        super().__init__()
+        self._class_name = class_name
+        self._method_names = method_names
+
+    def operations(self, count: int) -> list[plaster.Operation]:
+        del count  # Each method is its own exactly-once operation.
+        return [
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': self._class_name,
+                'method_name': method_name,
+            }) for method_name in self._method_names
+        ]
+
+
+class _OptionalPairAstGrepRewriter(plaster._AstGrepRewriter):
+    """Two optional ops plus a group rule: at least one must apply.
+
+    Mirrors the shape of a hypothetical `make_class_overridable` (drop `final`
+    or override the dtor -- either may be absent, but not both), to exercise
+    per-op optionality and a cross-operation check via `validate_outcomes`.
+    """
+
+    NAME = 'optional_pair_test_op'
+    OP_ID = 'cxx.make_virtual'
+
+    def __init__(self, method_names: list[str]):
+        super().__init__()
+        self._method_names = method_names
+
+    def operations(self, count: int) -> list[plaster.Operation]:
+        del count
+        return [
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': method_name,
+            }, plaster.MatchExpectation.optional())
+            for method_name in self._method_names
+        ]
+
+    def validate_outcomes(self, outcomes, description):
+        errors = super().validate_outcomes(outcomes, description)
+        if outcomes and all(matches == 0 for _, matches in outcomes):
+            errors.append('at least one operation must apply')
+        return errors
+
+
+class AstGrepRewriterBaseTest(unittest.TestCase):
+    """Unit tests for the `_AstGrepRewriter` base class on its own.
+
+    The base is exercised through the two synthetic subclasses above, with a
+    `RewritersEval` built from `_SYNTHETIC_SPEC` injected as the process
+    singleton so `apply`/`declared_inputs` resolve against it instead of the
+    shipped rewriters.pyl. Nothing here touches the concrete rewriters.
+    """
+
+    _SRC = 'class C {\n  void Foo();\n  void Bar();\n};\n'
+
+    def setUp(self):
+        plaster.RewritersEval._instance = plaster.RewritersEval(
+            repr(_SYNTHETIC_SPEC))
+        self.addCleanup(setattr, plaster.RewritersEval, '_instance', None)
+
+    # -- declared_inputs (reads the spec, not a class constant) -------------
+
+    def test_declared_inputs_read_from_injected_spec(self):
+        self.assertEqual(_FlatAstGrepRewriter.declared_inputs(),
+                         frozenset({'class_name', 'method_name'}))
+
+    # -- default parse (flat body validation) -------------------------------
+
+    def test_parse_builds_from_declared_inputs(self):
+        rewriter = _FlatAstGrepRewriter.parse(
+            {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            }, description='d')
+        self.assertIsInstance(rewriter, _FlatAstGrepRewriter)
+
+    def test_parse_rejects_non_mapping_body(self):
+        with self.assertRaises(ValueError) as ctx:
+            _FlatAstGrepRewriter.parse('nope', description='d')
+        self.assertIn('must be a mapping', str(ctx.exception))
+
+    def test_parse_rejects_unknown_arg(self):
+        with self.assertRaises(ValueError) as ctx:
+            _FlatAstGrepRewriter.parse(
+                {
+                    'class_name': 'C',
+                    'method_name': 'Foo',
+                    'bogus': 'x'
+                },
+                description='d')
+        self.assertIn('Unrecognised flat_test_op arg', str(ctx.exception))
+
+    def test_parse_rejects_missing_arg(self):
+        with self.assertRaises(ValueError) as ctx:
+            _FlatAstGrepRewriter.parse({'class_name': 'C'}, description='d')
+        message = str(ctx.exception)
+        self.assertIn('flat_test_op requires arg', message)
+        self.assertIn('method_name', message)
+
+    def test_parse_rejects_non_string_arg(self):
+        with self.assertRaises(ValueError) as ctx:
+            _FlatAstGrepRewriter.parse({
+                'class_name': 'C',
+                'method_name': 5
+            },
+                                       description='d')
+        self.assertIn('`method_name` must be a string', str(ctx.exception))
+
+    # -- default operations -------------------------------------------------
+
+    def test_default_operations_is_a_single_operation(self):
+        rewriter = _FlatAstGrepRewriter.parse(
+            {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            }, description='d')
+        self.assertEqual(rewriter.operations(1), [
+            plaster.Operation('cxx.make_virtual', {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            })
+        ])
+
+    def test_default_operation_adopts_entry_count(self):
+        # The flat single operation takes the entry's `count:` as its
+        # expectation, preserving plaster's original count semantics.
+        rewriter = _FlatAstGrepRewriter.parse(
+            {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            }, description='d')
+        self.assertEqual(
+            rewriter.operations(2)[0].expectation,
+            plaster.MatchExpectation.exactly(2))
+        self.assertEqual(
+            rewriter.operations(0)[0].expectation,
+            plaster.MatchExpectation.at_least_one())
+
+    # -- apply: drives the engine, then validates per operation -------------
+
+    def test_apply_runs_a_single_operation(self):
+        rewriter = _FlatAstGrepRewriter.parse(
+            {
+                'class_name': 'C',
+                'method_name': 'Foo'
+            }, description='d')
+        content, errors = rewriter.apply(self._SRC, count=1, description='d')
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            content, 'class C {\n  virtual void Foo();\n  void Bar();\n};\n')
+
+    def test_apply_runs_every_composed_operation(self):
+        # The whole point of the base: `apply` runs every op `operations()`
+        # yields against the same engine, so the edits from each land in the
+        # final content.
+        rewriter = _ComposingAstGrepRewriter('C', ['Foo', 'Bar'])
+        content, errors = rewriter.apply(self._SRC, count=1, description='d')
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            content,
+            'class C {\n  virtual void Foo();\n  virtual void Bar();\n};\n')
+
+    def test_apply_validates_each_operation_independently(self):
+        # A composed op that matches nothing fails its own expectation (exactly
+        # one), while the matching one still applies to the content.
+        rewriter = _ComposingAstGrepRewriter('C', ['Foo', 'Nope'])
+        content, errors = rewriter.apply(self._SRC, count=1, description='d')
+        self.assertEqual(errors, ['Unexpected number of matches (0 vs 1)'])
+        self.assertEqual(
+            content, 'class C {\n  virtual void Foo();\n  void Bar();\n};\n')
+
+    def test_apply_with_no_operations_is_a_noop(self):
+        rewriter = _ComposingAstGrepRewriter('C', [])
+        content, errors = rewriter.apply(self._SRC, count=1, description='d')
+        self.assertEqual(errors, [])
+        self.assertEqual(content, self._SRC)
+
+    # -- optional operations and cross-operation (group) rules -------------
+
+    def test_optional_operation_never_fails_on_its_own(self):
+        # 'Foo' matches; the optional 'Nope' matches nothing but, being
+        # optional, contributes no error, and the group rule is satisfied.
+        rewriter = _OptionalPairAstGrepRewriter(['Foo', 'Nope'])
+        content, errors = rewriter.apply(self._SRC, count=1, description='d')
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            content, 'class C {\n  virtual void Foo();\n  void Bar();\n};\n')
+
+    def test_group_rule_fails_when_no_optional_operation_applies(self):
+        # Neither optional op matches, so the cross-operation rule fires even
+        # though no individual op reported a count error.
+        rewriter = _OptionalPairAstGrepRewriter(['Nope1', 'Nope2'])
+        content, errors = rewriter.apply(self._SRC, count=1, description='d')
+        self.assertEqual(errors, ['at least one operation must apply'])
+        self.assertEqual(content, self._SRC)
 
 
 class HelpTest(unittest.TestCase):

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1282,6 +1282,74 @@ class RewriterFormsTest(unittest.TestCase):
             result, 'class C {\n public:\n  void Foo();\n'
             ' private:\n  friend class BraveC;\n  int x_;\n};\n')
 
+    def test_add_friend_inserts_into_first_private_section_only(self):
+        # A class may reopen `private:` more than once. The friend must land in
+        # the first private section only; the later one is left untouched.
+        result = self._apply(
+            'twoprivate.h', 'class C {\n public:\n  void Foo();\n'
+            ' private:\n  int x_;\n'
+            ' private:\n  int y_;\n};\n', 'substitutions:\n'
+            '  - description: friend the Brave subclass\n'
+            '    add_friend:\n'
+            '      class_name: C\n'
+            '      friend_type: class BraveC\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            ' private:\n  friend class BraveC;\n  int x_;\n'
+            ' private:\n  int y_;\n};\n')
+
+    def test_add_friend_list_into_first_private_section_only(self):
+        # The same holds for a list of friends: all of them go into the first
+        # private section, in the order listed, and the later one is untouched.
+        result = self._apply(
+            'twoprivate_list.h', 'class C {\n public:\n  void Foo();\n'
+            ' private:\n  int x_;\n'
+            ' private:\n  int y_;\n};\n', 'substitutions:\n'
+            '  - description: friend the Brave subclass and its test\n'
+            '    add_friend:\n'
+            '      class_name: C\n'
+            '      friend_type:\n'
+            '        - class BraveC\n'
+            '        - class BraveCTest\n')
+        self.assertEqual(
+            result, 'class C {\n public:\n  void Foo();\n'
+            ' private:\n  friend class BraveC;\n  friend class BraveCTest;\n'
+            '  int x_;\n private:\n  int y_;\n};\n')
+
+    def test_add_friend_ignores_nested_class_private_after(self):
+        # A nested class has its own private section. When befriending the outer
+        # class, the friend must land in the outer class's private section, never
+        # the nested one -- here the nested `private:` comes *after* the outer's.
+        result = self._apply(
+            'nested_after.h', 'class Foo {\n private:\n  int x_;\n'
+            '  class Bar {\n   private:\n    int y_;\n  };\n};\n',
+            'substitutions:\n'
+            '  - description: friend the Brave subclass of the outer class\n'
+            '    add_friend:\n'
+            '      class_name: Foo\n'
+            '      friend_type: class BraveFoo\n')
+        self.assertEqual(
+            result, 'class Foo {\n private:\n  friend class BraveFoo;\n'
+            '  int x_;\n'
+            '  class Bar {\n   private:\n    int y_;\n  };\n};\n')
+
+    def test_add_friend_ignores_nested_class_private_before(self):
+        # As above, but the nested class (and so its `private:`) appears *before*
+        # the outer class's own private section. The nested section is earlier in
+        # source order, so this guards against naively taking the first match.
+        result = self._apply(
+            'nested_before.h', 'class Foo {\n public:\n'
+            '  class Bar {\n   private:\n    int y_;\n  };\n'
+            ' private:\n  int x_;\n};\n', 'substitutions:\n'
+            '  - description: friend the Brave subclass of the outer class\n'
+            '    add_friend:\n'
+            '      class_name: Foo\n'
+            '      friend_type: class BraveFoo\n')
+        self.assertEqual(
+            result, 'class Foo {\n public:\n'
+            '  class Bar {\n   private:\n    int y_;\n  };\n'
+            ' private:\n  friend class BraveFoo;\n  int x_;\n};\n')
+
     def test_add_friend_no_private_section_fails(self):
         with self.assertRaises(plaster.PlasterApplyError):
             self._apply(
@@ -1753,6 +1821,19 @@ class RewritersEvalTest(unittest.TestCase):
         self.assertEqual(replace['consume_before'], ' ')
         self.assertEqual(replace['consume_after'], ':')
 
+    def test_rewriter_first_match_is_optional_bool(self):
+        # `first_match` is an optional flag; when present it must be a bool and
+        # is exposed on the rewriter spec.
+        spec = self._valid_spec()
+        spec['ast.rewriter']['cxx.make_virtual']['first_match'] = True
+        rewriters = plaster.RewritersEval(repr(spec))
+        self.assertIs(
+            rewriters.rewriter('cxx.make_virtual')['first_match'], True)
+
+    def test_rewriter_first_match_must_be_bool(self):
+        self._assert_invalid(lambda spec: spec['ast.rewriter'][
+            'cxx.make_virtual'].update({'first_match': 'yes'}))
+
 
 # ast-grep matcher templates used to build synthetic RewritersEval specs for
 # the engine tests below. The shipped rewriters.pyl is empty until the ops that
@@ -1777,11 +1858,12 @@ _METHOD_DECL_RULE = ('any:\n'
 _PRIVATE_SECTION_RULE = ('kind: access_specifier\n'
                          'regex: ^private$\n'
                          'inside:\n'
-                         '  kind: class_specifier\n'
-                         '  stopBy: end\n'
-                         '  has:\n'
-                         '    field: name\n'
-                         '    regex: ^{class_name}$\n')
+                         '  kind: field_declaration_list\n'
+                         '  inside:\n'
+                         '    kind: class_specifier\n'
+                         '    has:\n'
+                         '      field: name\n'
+                         '      regex: ^{class_name}$\n')
 
 _FINAL_RULE = ('kind: virtual_specifier\n'
                'regex: ^final$\n'
@@ -1827,6 +1909,7 @@ _SYNTHETIC_SPEC = {
         'cxx.add_friend': {
             'matcher': 'cxx.find_class_private_section',
             'inputs': ['class_name', 'friend_type'],
+            'first_match': True,
             'replace': {
                 'consume_after': ':',
                 're_pattern': '$',

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -87,8 +87,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Simple test substitution
-              re_pattern: 'Chromium'
-              replace: 'Plaster'
+              regex:
+                re_pattern: 'Chromium'
+                replace: 'Plaster'
         ''')
 
         # Use PlasterFile to apply the .yaml file to the committed file.
@@ -198,8 +199,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.parent.mkdir(parents=True, exist_ok=True)
         plaster_path.write_text('substitutions:\n'
                                 '  - description: Simple yaml substitution\n'
-                                "    re_pattern: 'Chromium'\n"
-                                "    replace: 'Plaster'\n")
+                                '    regex:\n'
+                                "      re_pattern: 'Chromium'\n"
+                                "      replace: 'Plaster'\n")
 
         plaster.PlasterFile(plaster_path).apply()
 
@@ -227,16 +229,19 @@ class PlasterTest(unittest.TestCase):
         cases = [
             ('substitutions:\n'
              '  - description: Both patterns specified\n'
-             "    pattern: 'Chromium'\n"
-             "    re_pattern: 'Chromium'\n"
-             "    replace: 'Plaster'\n",
+             '    regex:\n'
+             "      pattern: 'Chromium'\n"
+             "      re_pattern: 'Chromium'\n"
+             "      replace: 'Plaster'\n",
              'Please specify either pattern or re_pattern'),
             ('substitutions:\n'
              '  - description: No pattern specified\n'
-             "    replace: 'Plaster'\n", 'No pattern specified'),
+             '    regex:\n'
+             "      replace: 'Plaster'\n", 'No pattern specified'),
             ('substitutions:\n'
              '  - description: No replace specified\n'
-             "    pattern: 'Chromium'\n", 'No replace value specified'),
+             '    regex:\n'
+             "      pattern: 'Chromium'\n", 'No replace value specified'),
         ]
 
         for yaml_content, expected_error in cases:
@@ -335,8 +340,9 @@ class PlasterTest(unittest.TestCase):
             rewrite_path.write_text(f'''
               substitutions:
                 - description: Replace {orig} with {repl}
-                  re_pattern: '{orig}'
-                  replace: '{repl}'
+                  regex:
+                    re_pattern: '{orig}'
+                    replace: '{repl}'
             ''')
             # Apply the rewrite so files are up-to-date
             plaster_file = plaster.PlasterFile(rewrite_path)
@@ -373,8 +379,9 @@ class PlasterTest(unittest.TestCase):
             rewrite_path.write_text(f'''
               substitutions:
                 - description: Replace {orig} with {repl}
-                  re_pattern: '{orig}'
-                  replace: '{repl}'
+                  regex:
+                    re_pattern: '{orig}'
+                    replace: '{repl}'
             ''')
             plaster_file = plaster.PlasterFile(rewrite_path)
             plaster_file.apply()
@@ -394,8 +401,9 @@ class PlasterTest(unittest.TestCase):
         changed_path.write_text('''
           substitutions:
             - description: Break the rule
-              re_pattern: 'foo2'
-              replace: 'DIFFERENT'
+              regex:
+                re_pattern: 'foo2'
+                replace: 'DIFFERENT'
         ''')
         # Now check should raise PlasterFileNeedsRegen with the path included.
         with self.assertRaises(plaster.PlasterFileNeedsRegen) as context:
@@ -421,9 +429,10 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Test multiple flags in array work
-              re_pattern: 'chromium'
-              replace: 'Brave'
-              re_flags: ['IGNORECASE', 'MULTILINE']
+              regex:
+                re_pattern: 'chromium'
+                replace: 'Brave'
+                re_flags: ['IGNORECASE', 'MULTILINE']
         ''')
 
         plaster_file = plaster.PlasterFile(plaster_path)
@@ -464,9 +473,10 @@ class PlasterTest(unittest.TestCase):
                 plaster_path.write_text(f'''
                   substitutions:
                     - description: Test invalid flag rejection
-                      re_pattern: 'Chromium'
-                      replace: 'Brave'
-                      re_flags: ['{invalid_flag}']
+                      regex:
+                        re_pattern: 'Chromium'
+                        replace: 'Brave'
+                        re_flags: ['{invalid_flag}']
                 ''')
 
                 plaster_file = plaster.PlasterFile(plaster_path)
@@ -495,9 +505,10 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Test empty flags list
-              re_pattern: 'chromium'
-              replace: 'Brave'
-              re_flags: []
+              regex:
+                re_pattern: 'chromium'
+                replace: 'Brave'
+                re_flags: []
         ''')
 
         plaster_file = plaster.PlasterFile(plaster_path)
@@ -538,8 +549,9 @@ class PlasterTest(unittest.TestCase):
                 plaster_path.write_text(f'''
                   substitutions:
                     - description: Test invalid regex rejection
-                      re_pattern: '{invalid_pattern}'
-                      replace: 'Brave'
+                      regex:
+                        re_pattern: '{invalid_pattern}'
+                        replace: 'Brave'
                 ''')
 
                 plaster_file = plaster.PlasterFile(plaster_path)
@@ -567,19 +579,22 @@ class PlasterTest(unittest.TestCase):
             ('''
               substitutions:
                 - description: Both patterns specified
-                  pattern: 'Chromium'
-                  re_pattern: 'Chromium'
-                  replace: 'Plaster'
+                  regex:
+                    pattern: 'Chromium'
+                    re_pattern: 'Chromium'
+                    replace: 'Plaster'
             ''', 'Please specify either pattern or re_pattern'),
             ('''
               substitutions:
                 - description: No pattern specified
-                  replace: 'Plaster'
+                  regex:
+                    replace: 'Plaster'
             ''', 'No pattern specified'),
             ('''
               substitutions:
                 - description: No replace specified
-                  pattern: 'Chromium'
+                  regex:
+                    pattern: 'Chromium'
             ''', 'No replace value specified'),
         ]
 
@@ -617,8 +632,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Replace exact pattern
-              pattern: 'Chromium++'
-              replace: 'Brave++'
+              regex:
+                pattern: 'Chromium++'
+                replace: 'Brave++'
         ''')
 
         # Apply the plaster file
@@ -651,8 +667,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Replace regex pattern
-              re_pattern: 'Chromium\\w+'
-              replace: 'Brave'
+              regex:
+                re_pattern: 'Chromium\\w+'
+                replace: 'Brave'
               count: 2
         ''')
 
@@ -685,8 +702,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path1.write_text('''
           substitutions:
             - description: Replace exact brackets
-              pattern: '[brackets]'
-              replace: '{braces}'
+              regex:
+                pattern: '[brackets]'
+                replace: '{braces}'
         ''')
 
         plaster_file1 = plaster.PlasterFile(plaster_path1)
@@ -711,8 +729,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path2.write_text('''
           substitutions:
             - description: Replace using regex
-              re_pattern: '\\[\\w+\\]'
-              replace: '{braces}'
+              regex:
+                re_pattern: '\\[\\w+\\]'
+                replace: '{braces}'
         ''')
 
         plaster_file2 = plaster.PlasterFile(plaster_path2)
@@ -742,8 +761,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Test count mismatch
-              re_pattern: 'Chromium'
-              replace: 'Brave'
+              regex:
+                re_pattern: 'Chromium'
+                replace: 'Brave'
               count: 2
         ''')
 
@@ -773,8 +793,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path_correct.write_text('''
           substitutions:
             - description: Test default count with 1 match
-              re_pattern: 'Chromium'
-              replace: 'Brave'
+              regex:
+                re_pattern: 'Chromium'
+                replace: 'Brave'
         ''')
 
         # Should succeed because there's exactly 1 match (matches default)
@@ -801,8 +822,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path_incorrect.write_text('''
           substitutions:
             - description: Test default count with 2 matches
-              re_pattern: 'Chromium'
-              replace: 'Brave'
+              regex:
+                re_pattern: 'Chromium'
+                replace: 'Brave'
         ''')
 
         # Should fail because there are 2 matches but default expects 1
@@ -838,8 +860,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Test count 0 replaces all
-              re_pattern: 'Chromium'
-              replace: 'Brave'
+              regex:
+                re_pattern: 'Chromium'
+                replace: 'Brave'
               count: 0
         ''')
 
@@ -876,8 +899,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: replace a pattern that is absent
-              re_pattern: 'DoesNotAppear'
-              replace: 'X'
+              regex:
+                re_pattern: 'DoesNotAppear'
+                replace: 'X'
               count: 0
         ''')
 
@@ -912,12 +936,14 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Replace single Chromium
-              re_pattern: 'Chromium'
-              replace: 'Brave'
+              regex:
+                re_pattern: 'Chromium'
+                replace: 'Brave'
               count: 1
             - description: Replace all browsers
-              re_pattern: 'browser'
-              replace: 'application'
+              regex:
+                re_pattern: 'browser'
+                replace: 'application'
               count: 3
         ''')
 
@@ -946,8 +972,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.write_text('''
           substitutions:
             - description: Replace Chromium with Brave
-              re_pattern: 'Chromium'
-              replace: 'Brave'
+              regex:
+                re_pattern: 'Chromium'
+                replace: 'Brave'
         ''')
         plaster_file = plaster.PlasterFile(plaster_path)
         plaster_file.apply()
@@ -982,8 +1009,9 @@ class PlasterTest(unittest.TestCase):
         plaster_file.path.write_text('''
           substitutions:
             - description: A different rule
-              re_pattern: 'Brave'
-              replace: 'Lion'
+              regex:
+                re_pattern: 'Brave'
+                replace: 'Lion'
         ''')
         os.utime(plaster_file.path, (later, later))
         self.assertTrue(plaster_file.needs_apply())
@@ -1117,8 +1145,9 @@ class PlasterTest(unittest.TestCase):
         plaster_path.parent.mkdir(parents=True, exist_ok=True)
         plaster_path.write_text('substitutions:\n'
                                 '  - description: Touch the destructor body\n'
-                                "    pattern: 'MARKER_LINE;'\n"
-                                "    replace: 'MARKER_LINE_CHANGED;'\n")
+                                '    regex:\n'
+                                "      pattern: 'MARKER_LINE;'\n"
+                                "      replace: 'MARKER_LINE_CHANGED;'\n")
 
         plaster.PlasterFile(plaster_path).apply()
 
@@ -1179,9 +1208,9 @@ class RewriterFormsTest(unittest.TestCase):
             self._apply('validation.idl', 'dummy', yaml_body)
         self.assertIn(substr, str(ctx.exception))
 
-    # -- regex op (explicit form of the legacy bare regex) ------------------
+    # -- regex op -----------------------------------------------------------
 
-    def test_regex_op_matches_bare_form(self):
+    def test_regex_op_applies(self):
         result = self._apply(
             'regex_op.idl', 'A Chromium thing.', 'substitutions:\n'
             '  - description: explicit regex op\n'
@@ -1200,13 +1229,15 @@ class RewriterFormsTest(unittest.TestCase):
             '      re_flags: [IGNORECASE, MULTILINE]\n')
         self.assertEqual(result, 'foo\nbaz\n')
 
-    def test_bare_regex_still_applies(self):
-        result = self._apply(
-            'bare.idl', 'A Chromium thing.', 'substitutions:\n'
+    def test_bare_regex_is_rejected(self):
+        # The bare regex form (regex fields directly on the item, without a
+        # `regex:` key) is no longer supported: with no rewriter key it is an
+        # entry that names no rewriter.
+        self._expect_value_error(
+            'substitutions:\n'
             '  - description: legacy bare regex\n'
             "    re_pattern: 'Chromium'\n"
-            "    replace: 'Brave'\n")
-        self.assertEqual(result, 'A Brave thing.')
+            "    replace: 'Brave'\n", 'Unrecognised substitution key')
 
     # -- make_virtual op (real ast-grep binary) -----------------------------
 
@@ -1490,14 +1521,16 @@ class RewriterFormsTest(unittest.TestCase):
             '      class_name: C\n'
             '      method_name: Foo\n', 'Only one rewriter')
 
-    def test_cannot_mix_op_and_bare_regex(self):
+    def test_stray_field_alongside_rewriter_rejected(self):
+        # A stray item-level field next to a rewriter key is an unrecognised
+        # key for that rewriter.
         self._expect_value_error(
             'substitutions:\n'
-            '  - description: mixed\n'
+            '  - description: stray field\n'
             '    regex:\n'
             "      re_pattern: 'x'\n"
             "      replace: 'y'\n"
-            "    re_pattern: 'z'\n", 'Cannot mix')
+            "    re_pattern: 'z'\n", 'Unrecognised key(s) for the "regex"')
 
     def test_unknown_regex_field_rejected(self):
         self._expect_value_error(
@@ -1529,11 +1562,12 @@ class RewriterFormsTest(unittest.TestCase):
         self.assertIn('make_virtual', message)
 
     def test_stray_scalar_key_is_unrecognised(self):
-        # A non-mapping stray key is a bare-field typo, not a rewriter attempt,
-        # so it keeps the generic "Unrecognised substitution key" error.
+        # Non-mapping stray keys name no rewriter, so they get the generic
+        # "Unrecognised substitution key" error rather than the unknown-rewriter
+        # one (which is reserved for mapping-valued keys).
         self._expect_value_error(
             'substitutions:\n'
-            '  - description: typo bare field\n'
+            '  - description: stray fields\n'
             "    re_pattern: 'x'\n"
             "    replace: 'y'\n"
             '    re_flag: [DOTALL]\n', 'Unrecognised substitution key')

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -1219,6 +1219,31 @@ class RewriterFormsTest(unittest.TestCase):
             '      method_name: Foo\n')
         self.assertEqual(result, 'class C {\n  virtual void Foo();\n};\n')
 
+    def test_make_virtual_after_leading_attribute(self):
+        # `virtual` must land after a leading attribute, not before it.
+        result = self._apply(
+            'attr.h', 'class C {\n  [[nodiscard]] bool Foo();\n};\n',
+            'substitutions:\n'
+            '  - description: make Foo virtual, keeping the attribute first\n'
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            '      method_name: Foo\n')
+        self.assertEqual(
+            result, 'class C {\n  [[nodiscard]] virtual bool Foo();\n};\n')
+
+    def test_make_virtual_after_multiple_leading_attributes(self):
+        result = self._apply(
+            'attrs.h',
+            'class C {\n  [[nodiscard]] [[maybe_unused]] bool Foo();\n};\n',
+            'substitutions:\n'
+            '  - description: keep both attributes before virtual\n'
+            '    make_virtual:\n'
+            '      class_name: C\n'
+            '      method_name: Foo\n')
+        self.assertEqual(
+            result, 'class C {\n'
+            '  [[nodiscard]] [[maybe_unused]] virtual bool Foo();\n};\n')
+
     def test_make_virtual_destructor_quoted(self):
         result = self._apply(
             'dtor.h', 'class C {\n public:\n  ~C();\n};\n', 'substitutions:\n'
@@ -1899,8 +1924,8 @@ _SYNTHETIC_SPEC = {
             'matcher': 'cxx.find_class_method_decl',
             'inputs': ['class_name', 'method_name'],
             'replace': {
-                're_pattern': '^',
-                'replace': 'virtual '
+                're_pattern': r'^((?:\[\[.*?\]\]\s*)*)',
+                'replace': r'\1virtual '
             },
             'result': {
                 'node': 'field_declaration'

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -21,10 +21,11 @@
 #                 can be rendered.
 #       replace:  { re_pattern, replace }, re.sub'd over each match's source;
 #                 `replace` is {input}-formatted first (literal braces: {{ }}).
-#                 Optional `consume_before` / `consume_after` literals are
-#                 folded into the rewritten span when the matched node stops
-#                 short of an adjacent token (e.g. the `:` after an
-#                 access_specifier, or the space before a `final` specifier).
+#                 Optional `consume_before` / `consume_after` tokens (also
+#                 {input}-formatted) are folded into the rewritten span when the
+#                 matched node stops short of an adjacent token (e.g. the `:`
+#                 after an access_specifier, the space before a `final`
+#                 specifier, or a class member's leading indentation).
 #       first_match: optional bool; when true only the first match (in source
 #                 order) is rewritten and any later matches are ignored. Use it
 #                 when the matcher can legitimately find several nodes but the
@@ -108,6 +109,47 @@ inside:
 """,
             "result": {
                 "node": "access_specifier",
+            },
+        },
+
+        # Finds the first access specifier after the `public:` section, the
+        # first match being the boundary of the `public:` section.
+        "cxx.find_section_after_public": {
+            "template": """\
+kind: access_specifier
+regex: ^(private|protected)$
+follows:
+  kind: access_specifier
+  regex: ^public$
+  stopBy: end
+inside:
+  kind: field_declaration_list
+  inside:
+    kind: class_specifier
+    has:
+      field: name
+      regex: ^{class_name}$
+""",
+            "result": {
+                "node": "access_specifier",
+            },
+        },
+
+        # The body of a class after the `public:` section is found.
+        "cxx.find_class_body_with_public": {
+            "template": """\
+kind: field_declaration_list
+has:
+  kind: access_specifier
+  regex: ^public$
+inside:
+  kind: class_specifier
+  has:
+    field: name
+    regex: ^{class_name}$
+""",
+            "result": {
+                "node": "field_declaration_list",
             },
         },
 
@@ -307,17 +349,59 @@ regex: ^{class_name}$
         },
 
         # Inserts a fresh `protected:` section just before an existing
-        # `private:` one, and adds `code` under it.
+        # `private:` one, and adds `code` under it. The matched `private`
+        # keyword's own leading whitespace prefixes the new `protected:`, so it
+        # inherits the class's indentation; `code` arrives at the member level
+        # and `indent` re-emits the `private` keyword at its original column.
         "cxx.add_protected_before_private": {
             "matcher": "cxx.find_class_private_section",
-            "inputs": ["class_name", "code"],
+            "inputs": ["class_name", "code", "indent"],
             "first_match": True,
             "replace": {
                 "re_pattern": "^private$",
-                "replace": "protected:\\n{code}\\n\\n private",
+                "replace": "protected:\\n{code}\\n\\n{indent}private",
             },
             "result": {
                 "node": "access_specifier",
+            },
+        },
+
+        # Appends `code` at the end of `class_name`'s public section, just
+        # before the section that follows it. `consume_before` folds the
+        # keyword's entire leading indentation (`indent`) into the span so the
+        # replacement controls all whitespace: `code` (already member-indented)
+        # becomes the last public line(s), a blank line separates it, then the
+        # boundary keyword (`\1`) is re-emitted at that same `indent`.
+        "cxx.append_to_public_before_section": {
+            "matcher": "cxx.find_section_after_public",
+            "inputs": ["class_name", "code", "indent"],
+            "first_match": True,
+            "replace": {
+                "consume_before": "{indent}",
+                "re_pattern": "^(private|protected)$",
+                "replace": "{code}\\n\\n{indent}\\1",
+            },
+            "result": {
+                "node": "access_specifier",
+            },
+        },
+
+        # Appends `code` at the end of `class_name`'s public section when it is
+        # the last (or only) section, inserting it just before the body's
+        # closing brace. The pattern consumes the final `}` together with the
+        # newline and indentation on its line, so inline method bodies earlier
+        # in the class are left alone and the brace is re-emitted at its
+        # original column (`indent`) after the appended, member-indented `code`.
+        "cxx.append_to_public_before_close": {
+            "matcher": "cxx.find_class_body_with_public",
+            "inputs": ["class_name", "code", "indent"],
+            "first_match": True,
+            "replace": {
+                "re_pattern": "\\n[ \\t]*\\}$",
+                "replace": "\\n{code}\\n{indent}}}",
+            },
+            "result": {
+                "node": "field_declaration_list",
             },
         },
     },

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -25,6 +25,11 @@
 #                 folded into the rewritten span when the matched node stops
 #                 short of an adjacent token (e.g. the `:` after an
 #                 access_specifier, or the space before a `final` specifier).
+#       first_match: optional bool; when true only the first match (in source
+#                 order) is rewritten and any later matches are ignored. Use it
+#                 when the matcher can legitimately find several nodes but the
+#                 rewrite belongs to only the first (e.g. a class that reopens
+#                 `private:` more than once).
 #       result:   { node: <kind> } being replaced.
 #
 # An op yields every match in source order; the caller (plaster) decides how
@@ -65,17 +70,23 @@ inside:
 
         # The `private` access specifier opening `class_name`'s private section.
         # The node is the `private` keyword; the `:` that follows is a separate
-        # token immediately after it.
+        # token immediately after it. The specifier must be a *direct* member of
+        # `class_name`: its immediate parent is the class body
+        # (field_declaration_list), whose immediate parent is the class. Nesting
+        # through the body with the default (neighbor) `stopBy` -- rather than an
+        # `stopBy: end` ancestor search -- keeps a nested class's own `private:`
+        # from matching the enclosing class.
         "cxx.find_class_private_section": {
             "template": """\
 kind: access_specifier
 regex: ^private$
 inside:
-  kind: class_specifier
-  stopBy: end
-  has:
-    field: name
-    regex: ^{class_name}$
+  kind: field_declaration_list
+  inside:
+    kind: class_specifier
+    has:
+      field: name
+      regex: ^{class_name}$
 """,
             "result": {
                 "node": "access_specifier",
@@ -117,12 +128,15 @@ inside:
             },
         },
 
-        # The class's `private:` section with a `friend` declaration inserted as
-        # its first line. The matcher stops at the `private` keyword, so the op
-        # consumes the original `:` and re-emits it.
+        # The class's first `private:` section with a `friend` declaration
+        # inserted as its first line. The matcher stops at the `private`
+        # keyword, so the op consumes the original `:` and re-emits it. A class
+        # may reopen `private:` more than once, so `first_match` keeps the
+        # friend in the first section only.
         "cxx.add_friend": {
             "matcher": "cxx.find_class_private_section",
             "inputs": ["class_name", "friend_type"],
+            "first_match": True,
             "replace": {
                 "consume_after": ":",
                 "re_pattern": "$",

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -111,6 +111,34 @@ inside:
                 "node": "virtual_specifier",
             },
         },
+
+        # The body (compound_statement) of the definition of `function_name`.
+        # The match is the whole `{ ... }` block of the function_definition
+        # whose declarator text is exactly `function_name` -- a qualified
+        # `Class::Method` for a member, or the bare name for a free function.
+        # The function_declarator is reached with `stopBy: end`, so
+        # return-type wrappers (pointer/reference declarators, a trailing return
+        # type) between it and the definition do not matter. Anchoring on the
+        # AST body -- rather than a regex from the signature to the first `{` --
+        # is immune to braces in the parameter list (a `= {}` default argument),
+        # a multi-line signature, or an earlier overload. Each overload sharing
+        # the name yields its own match.
+        "cxx.find_function_body": {
+            "template": """\
+kind: compound_statement
+inside:
+  kind: function_definition
+  has:
+    kind: function_declarator
+    stopBy: end
+    has:
+      field: declarator
+      regex: ^{function_name}$
+""",
+            "result": {
+                "node": "compound_statement",
+            },
+        },
     },
     "ast.rewriter": {
 
@@ -161,6 +189,24 @@ inside:
             },
             "result": {
                 "node": "virtual_specifier",
+            },
+        },
+
+        # The function body with `prologue` inserted as its first statement,
+        # right after the opening brace. The matcher lands on the whole
+        # compound_statement, so anchoring the replace on `^{` inserts after the
+        # brace and leaves the rest of the body untouched. The caller passes
+        # `prologue` already indented to the body's first-statement level and
+        # with backslashes escaped for the `re.sub` replacement.
+        "cxx.preempt_function_impl": {
+            "matcher": "cxx.find_function_body",
+            "inputs": ["function_name", "prologue"],
+            "replace": {
+                "re_pattern": "^\\{",
+                "replace": "{{\\n{prologue}",
+            },
+            "result": {
+                "node": "compound_statement",
             },
         },
     },

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -10,18 +10,25 @@
 # resolved in code):
 #
 #   "ast.matcher" — a structural query:
-#       args:     arg names the caller supplies; each is a {placeholder}.
-#       template: ast-grep rule body (the part under `rule:`); {arg}s filled.
+#       template: ast-grep rule body (the part under `rule:`). Its {placeholder}
+#                 fields are the matcher's inputs; they are inferred from the
+#                 template, not declared.
 #       result:   { node: <tree-sitter kind> } each match is.
 #
 #   "ast.rewriter" — edits each node a matcher finds:
 #       matcher:  id of the "ast.matcher" op locating the node(s).
+#       inputs:   the interface the rewriter requires, so the template it uses
+#                 can be rendered.
 #       replace:  { re_pattern, replace }, re.sub'd over each match's source;
-#                 `replace` is {arg}-formatted first (literal braces: {{ }}).
+#                 `replace` is {input}-formatted first (literal braces: {{ }}).
+#                 Optional `consume_before` / `consume_after` literals are
+#                 folded into the rewritten span when the matched node stops
+#                 short of an adjacent token (e.g. the `:` after an
+#                 access_specifier, or the space before a `final` specifier).
 #       result:   { node: <kind> } being replaced.
 #
 # An op yields every match in source order; the caller (plaster) decides how
-# many it expects. Arg values are injected verbatim into the rule's `regex:`
+# many it expects. Input values are injected verbatim into the rule's `regex:`
 # fields, so the caller escapes any regex metacharacters.
 
 {
@@ -34,7 +41,6 @@
         # sharing the name each produce their own match. The result node is a
         # field_declaration for methods and a declaration for con/destructors.
         "cxx.find_class_method_decl": {
-            "args": ["class_name", "method_name"],
             "template": """\
 any:
   - kind: field_declaration
@@ -61,7 +67,6 @@ inside:
         # The node is the `private` keyword; the `:` that follows is a separate
         # token immediately after it.
         "cxx.find_class_private_section": {
-            "args": ["class_name"],
             "template": """\
 kind: access_specifier
 regex: ^private$
@@ -82,7 +87,6 @@ inside:
         # class-head `final` matches; a method's trailing `final` is nested
         # under its declaration, not directly inside the class.
         "cxx.find_class_final": {
-            "args": ["class_name"],
             "template": """\
 kind: virtual_specifier
 regex: ^final$
@@ -103,6 +107,7 @@ inside:
         # semicolon included) with `virtual ` prepended.
         "cxx.make_virtual": {
             "matcher": "cxx.find_class_method_decl",
+            "inputs": ["class_name", "method_name"],
             "replace": {
                 "re_pattern": "^",
                 "replace": "virtual ",
@@ -113,10 +118,13 @@ inside:
         },
 
         # The class's `private:` section with a `friend` declaration inserted as
-        # its first line.
+        # its first line. The matcher stops at the `private` keyword, so the op
+        # consumes the original `:` and re-emits it.
         "cxx.add_friend": {
             "matcher": "cxx.find_class_private_section",
+            "inputs": ["class_name", "friend_type"],
             "replace": {
+                "consume_after": ":",
                 "re_pattern": "$",
                 "replace": ":\\n  friend {friend_type};",
             },
@@ -126,11 +134,13 @@ inside:
         },
 
         # `class_name`'s declaration with its `final` specifier removed, so the
-        # class can be subclassed. The drop_final engine also consumes the
-        # leading space before `final` so no doubled space is left behind.
+        # class can be subclassed. `consume_before` also drops the leading space
+        # before `final` so no doubled space is left behind.
         "cxx.drop_final": {
             "matcher": "cxx.find_class_final",
+            "inputs": ["class_name"],
             "replace": {
+                "consume_before": " ",
                 "re_pattern": "^final$",
                 "replace": "",
             },

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -158,17 +158,24 @@ inside:
             },
         },
 
-        # Every identifier-family token whose text is exactly `class_name`: the
-        # name in the class declaration and in type positions (type_identifier),
-        # the `Class::` qualifier on out-of-line members (namespace_identifier),
-        # and the constructor/destructor name plus any other bare use
-        # (identifier).
+        # Every identifier-family token whose text is exactly `class_name`:
+        # type positions (type_identifier), the `Class::` qualifier
+        # (namespace_identifier), the ctor/dtor name and bare uses (identifier),
+        # and the delegating/base name in a member initializer (`: Class(...)`,
+        # a field_identifier). The last is scoped to the name slot (first child
+        # of a field_initializer), so a member access like `other.Class` in the
+        # argument list is left untouched.
         "cxx.find_class_name_tokens": {
             "template": """\
 any:
   - kind: type_identifier
   - kind: namespace_identifier
   - kind: identifier
+  - all:
+      - kind: field_identifier
+      - nthChild: 1
+      - inside:
+          kind: field_initializer
 regex: ^{class_name}$
 """,
             "result": {

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -93,6 +93,24 @@ inside:
             },
         },
 
+        # Finds the protected section in a given class.
+        "cxx.find_class_protected_section": {
+            "template": """\
+kind: access_specifier
+regex: ^protected$
+inside:
+  kind: field_declaration_list
+  inside:
+    kind: class_specifier
+    has:
+      field: name
+      regex: ^{class_name}$
+""",
+            "result": {
+                "node": "access_specifier",
+            },
+        },
+
         # The `final` specifier on `class_name`'s declaration (the
         # virtual_specifier node holding the `final` keyword). Only the
         # class-head `final` matches; a method's trailing `final` is nested
@@ -240,6 +258,36 @@ regex: ^{class_name}$
             },
             "result": {
                 "node": "identifier",
+            },
+        },
+
+        # Inserts `code` under an existing `protected:` specifier for the class.
+        "cxx.add_to_protected": {
+            "matcher": "cxx.find_class_protected_section",
+            "inputs": ["class_name", "code"],
+            "first_match": True,
+            "replace": {
+                "consume_after": ":",
+                "re_pattern": "$",
+                "replace": ":\\n{code}",
+            },
+            "result": {
+                "node": "access_specifier",
+            },
+        },
+
+        # Inserts a fresh `protected:` section just before an existing
+        # `private:` one, and adds `code` under it.
+        "cxx.add_protected_before_private": {
+            "matcher": "cxx.find_class_private_section",
+            "inputs": ["class_name", "code"],
+            "first_match": True,
+            "replace": {
+                "re_pattern": "^private$",
+                "replace": "protected:\\n{code}\\n\\n private",
+            },
+            "result": {
+                "node": "access_specifier",
             },
         },
     },

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -246,6 +246,29 @@ regex: ^{class_name}$
             },
         },
 
+        # The function body wrapped in an immediately-invoked `[&]` lambda, with
+        # `epilogue` appended after it. The matcher lands on the whole
+        # compound_statement; a DOTALL `^{ ... }$` capture folds the entire
+        # upstream body (`\1`) between a lambda prefix and its `}();`
+        # invocation, so the body's own lines are re-emitted verbatim, then
+        # appends `epilogue` as the body's trailing statements.
+        # `capture` is empty (a void wrap: `[&]() {...}();`) or an
+        # `auto <var> =` lead so the epilogue can read the wrapped body's return
+        # value. The caller passes `epilogue` indented to the body level and
+        # both spliced values with backslashes escaped for the `re.sub`
+        # replacement.
+        "cxx.after_function_impl": {
+            "matcher": "cxx.find_function_body",
+            "inputs": ["function_name", "capture", "epilogue"],
+            "replace": {
+                "re_pattern": "(?s)^\\{(.*)\\}$",
+                "replace": "{{\\n  {capture}[&]() {{\\1  }}();\\n{epilogue}\\n}}",
+            },
+            "result": {
+                "node": "compound_statement",
+            },
+        },
+
         # Each matched name token replaced with `rename`. The matcher already
         # pinned every match's text to exactly `class_name`, so the whole token
         # (`^.+$`) is swapped for the new name.

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -139,6 +139,24 @@ inside:
                 "node": "compound_statement",
             },
         },
+
+        # Every identifier-family token whose text is exactly `class_name`: the
+        # name in the class declaration and in type positions (type_identifier),
+        # the `Class::` qualifier on out-of-line members (namespace_identifier),
+        # and the constructor/destructor name plus any other bare use
+        # (identifier).
+        "cxx.find_class_name_tokens": {
+            "template": """\
+any:
+  - kind: type_identifier
+  - kind: namespace_identifier
+  - kind: identifier
+regex: ^{class_name}$
+""",
+            "result": {
+                "node": "identifier",
+            },
+        },
     },
     "ast.rewriter": {
 
@@ -207,6 +225,21 @@ inside:
             },
             "result": {
                 "node": "compound_statement",
+            },
+        },
+
+        # Each matched name token replaced with `rename`. The matcher already
+        # pinned every match's text to exactly `class_name`, so the whole token
+        # (`^.+$`) is swapped for the new name.
+        "cxx.rename_class": {
+            "matcher": "cxx.find_class_name_tokens",
+            "inputs": ["class_name", "rename"],
+            "replace": {
+                "re_pattern": "^.+$",
+                "replace": "{rename}",
+            },
+            "result": {
+                "node": "identifier",
             },
         },
     },

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -115,13 +115,14 @@ inside:
     "ast.rewriter": {
 
         # The whole method declaration (multi-line signature and trailing
-        # semicolon included) with `virtual ` prepended.
+        # semicolon included) with `virtual ` inserted before the type. Any
+        # attributes are re-emitted.
         "cxx.make_virtual": {
             "matcher": "cxx.find_class_method_decl",
             "inputs": ["class_name", "method_name"],
             "replace": {
-                "re_pattern": "^",
-                "replace": "virtual ",
+                "re_pattern": "^((?:\\[\\[.*?\\]\\]\\s*)*)",
+                "replace": "\\1virtual ",
             },
             "result": {
                 "node": "field_declaration",

--- a/tools/cr/terminal.py
+++ b/tools/cr/terminal.py
@@ -191,7 +191,7 @@ class Terminal:
             env: dict[str, str] | None = None,
             cwd=None,
             interactive: bool = False,
-            stdin: str | None = None):
+            stdin: str | bytes | None = None):
         """Runs a command on the terminal.
 
         When `interactive=True`, the subprocess inherits the parent's
@@ -205,10 +205,12 @@ class Terminal:
         add a few keys on top of `os.environ`, copy it first
         (`env={**os.environ, ...}`).
 
-                Pass `stdin=` to feed data into the subprocess's stdin. Captured
-        (non-interactive) mode encodes it with utf-8 to match the
-        captured streams; interactive mode rejects `stdin=` because the
-        subprocess owns the tty.
+                Pass `stdin=` to feed data into the subprocess's stdin. A `str`
+        is encoded as utf-8; `bytes` are sent as-is. Either way the stdin pipe
+        runs in binary mode so the child reads back exactly the bytes passed,
+        with no line-ending translation (see the note below on why this
+        matters). Interactive mode rejects `stdin=` because the subprocess owns
+        the tty.
         """
         # Convert all arguments to strings, to avoid issues with `PurePath`
         # being passed arguments
@@ -247,20 +249,35 @@ class Terminal:
             if resolved != cmd[0]:
                 cmd = [resolved] + cmd[1:]
 
-        # Captured mode pairs `capture_output` with text decoding so the
-        # `.stdout` / `.stderr` strings on the result are usable directly.
-        # Interactive mode skips both -- stdio is inherited from the parent,
-        # nothing is captured, and `text` / `encoding` are irrelevant.
-        capture_kwargs: dict[str, object] = {}
-        if not interactive:
-            capture_kwargs.update(capture_output=True,
-                                  text=True,
-                                  encoding='utf-8')
-
         if interactive and stdin is not None:
             raise ValueError(
                 'terminal.run(): `stdin=` is not supported with '
                 '`interactive=True` (the subprocess owns the tty).')
+
+        # Captured mode records stdout/stderr on the result. We normally let
+        # subprocess decode them as UTF-8 text, which also folds CRLF into LF
+        # (universal newlines).
+        #
+        # When feeding `stdin`, we run the pipes in binary mode instead. Binary
+        # pipes perform no newline translation at any layer, so the bytes flow
+        # through untouched in both directions.
+        feed_stdin = stdin is not None
+        stdin_bytes = None
+        if feed_stdin:
+            stdin_bytes = (stdin.encode('utf-8')
+                           if isinstance(stdin, str) else stdin)
+
+        capture_kwargs: dict[str, object] = {}
+        if not interactive:
+            capture_kwargs.update(capture_output=True)
+            if not feed_stdin:
+                capture_kwargs.update(text=True, encoding='utf-8')
+
+        def decode_stream(data):
+            """UTF-8 decode a binary captured stream, preserving newlines."""
+            if data is None or isinstance(data, str):
+                return data
+            return data.decode('utf-8')
 
         # The status spinner has to be stopped before running any commands in
         # interactive mode, to not interfere with that process's output.
@@ -273,9 +290,14 @@ class Terminal:
                                     check=True,
                                     env=env,
                                     cwd=cwd,
-                                    input=stdin,
+                                    input=stdin_bytes,
                                     **capture_kwargs)
         except subprocess.CalledProcessError as e:
+            if feed_stdin:
+                # Streams were captured as bytes; decode for logging and for
+                # the caller's own exception handling.
+                e.stdout = decode_stream(e.stdout)
+                e.stderr = decode_stream(e.stderr)
             if e.stderr:
                 # Only captured in non-interactive mode.
                 logging.debug('❯ %s', e.stderr.strip())
@@ -287,6 +309,9 @@ class Terminal:
                 self.current_command_start_time = None
                 self.running_command = None
 
+        if feed_stdin:
+            result.stdout = decode_stream(result.stdout)
+            result.stderr = decode_stream(result.stderr)
         return result
 
     def run_git(self,

--- a/tools/cr/terminal_test.py
+++ b/tools/cr/terminal_test.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import unittest
+
+from terminal import terminal
+
+
+class TerminalStdinTest(unittest.TestCase):
+    """`terminal.run(stdin=...)` must round-trip bytes untouched.
+
+    The stdin path runs the child's pipes in binary mode, so no layer -- OS or
+    Python -- translates newlines in either direction. `plaster.run_ast_grep`
+    maps ast-grep's byte offsets back onto the source it sent, so any rewrite
+    (e.g. text mode adding '\\r' on Windows) would shift every offset and
+    corrupt the resulting edits. These tests guard the byte-exact contract on
+    every platform.
+    """
+
+    def test_str_stdin_round_trips_verbatim(self):
+        source = 'line1\nline2\nline3\n'
+        result = terminal.run(['cat'], stdin=source)
+        self.assertIsInstance(result.stdout, str)
+        self.assertEqual(result.stdout, source)
+
+    def test_crlf_is_preserved_verbatim(self):
+        # CRLF in must be CRLF out -- never folded to LF -- and LF-only input
+        # must never gain a '\r'. Cover CRLF, a lone CR, and LF together.
+        for source in ('a\r\nb\r\nc\r\n', 'x\ry\r\nz\n', 'a\nb\n'):
+            with self.subTest(source=source):
+                result = terminal.run(['cat'], stdin=source)
+                self.assertEqual(result.stdout, source)
+
+    def test_no_byte_count_change_on_stdin(self):
+        # The child sees exactly the bytes we passed, so its byte count matches
+        # the source's, regardless of the host platform's line separator.
+        source = 'a\nb\nc\n'
+        result = terminal.run(['wc', '-c'], stdin=source)
+        self.assertEqual(result.stdout.strip(),
+                         str(len(source.encode('utf-8'))))
+
+    def test_bytes_stdin_is_sent_as_is(self):
+        result = terminal.run(['cat'], stdin=b'raw\r\nbytes\n')
+        self.assertEqual(result.stdout, 'raw\r\nbytes\n')
+
+    def test_stdin_rejected_in_interactive_mode(self):
+        with self.assertRaises(ValueError):
+            terminal.run(['cat'], interactive=True, stdin='data')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/cr/test/fake_chromium_repo.py
+++ b/tools/cr/test/fake_chromium_repo.py
@@ -132,6 +132,7 @@ class FakeChromiumRepo:
         """
         path.mkdir(parents=True, exist_ok=True)
         self._run_git_command(['init'], path)
+        self._run_git_command(['config', 'core.autocrlf', 'false'], path)
         (path / 'README.md').write_text(f'# Fake {path.name} repo\n')
         self._run_git_command(['add', 'README.md'], path)
         self._run_git_command(['config', 'user.name', 'Fake User'], path)
@@ -269,7 +270,7 @@ class FakeChromiumRepo:
         """
         file_path = repo_path / relative_path
         file_path.parent.mkdir(parents=True, exist_ok=True)
-        file_path.write_text(content)
+        file_path.write_text(content, newline='\n')
         self._run_git_command(['add', str(file_path)], repo_path)
 
     def delete_file(self, relative_path: str, repo_path: Path) -> None:

--- a/tools/cr/test/plasters/add_header_after_line.cc.yaml
+++ b/tools/cr/test/plasters/add_header_after_line.cc.yaml
@@ -5,7 +5,8 @@
 
 substitutions:
   - description: Test for adding a header after another line
-    re_pattern: '#include "extensions/buildflags/buildflags.h"'
-    replace: |-
-      #include "extensions/buildflags/buildflags.h"
-      #include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"
+    regex:
+      re_pattern: '#include "extensions/buildflags/buildflags.h"'
+      replace: |-
+        #include "extensions/buildflags/buildflags.h"
+        #include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"

--- a/tools/cr/test/plasters/simple_replacement.cc.yaml
+++ b/tools/cr/test/plasters/simple_replacement.cc.yaml
@@ -5,5 +5,6 @@
 
 substitutions:
   - description: Test for indiscriminte replacements
-    re_pattern: ChromeAutocompleteSchemeClassifier
-    replace: BraveAutocompleteSchemeClassifier
+    regex:
+      re_pattern: ChromeAutocompleteSchemeClassifier
+      replace: BraveAutocompleteSchemeClassifier


### PR DESCRIPTION
- **[plaster] Make rewriters composable (#38094)**
- **[plaster][ast-grep] Fix `add_friend` mismatches (#38123)**
- **[ast-grep][plaster] `make_virtual` supporting C++ attributes (#38128)**
- **[plaster] Remove deprecated regex format (#38083)**
- **[plaster][ast-grep] Blank C++ macros for `ast-grep` parsing (#38129)**
- **[plaster][ast-grep] `preempt_function_impl` rewriter (#38170)**
- **[plaster][ast-grep] Add a `rename_class` rewriter (#38175)**
- **[ast-grep][plaster] `add_to_protected` rewriter (#38183)**
- **[plaster][ast-grep] Add `after_function_impl` (#38197)**
- **[plaster] Fix `rename_class` on forwarding constructors (#38207)**
- **[plaster][ast-grep] `add_to_public` rewriter (#38231)**
- **[plaster] Fix Windows line-ending stdin mismatch (#38312)**
