### PR TITLE
[bots] Delete `brave_services_key_id` checks

### DIFF
--- a/build/commands/lib/buildArgs.ts
+++ b/build/commands/lib/buildArgs.ts
@@ -13,7 +13,6 @@ const FORWARD_ENV_CONFIG_VARS_TO_GN_ARGS = [
   'brave_android_developer_options_code',
   'brave_google_api_key',
   'brave_safebrowsing_api_key',
-  'brave_services_key_id',
   'brave_services_key',
   'brave_stats_api_key',
   'brave_sync_endpoint',

--- a/components/brave_service_keys/BUILD.gn
+++ b/components/brave_service_keys/BUILD.gn
@@ -7,13 +7,6 @@ import("//brave/build/config.gni")
 import("//build/buildflag_header.gni")
 import("//testing/test.gni")
 
-declare_args() {
-  # TODO(https://github.com/brave/brave-browser/issues/56449): Remove this once
-  # a couple of releases have gone through and we've confirmed the derived value
-  # is correct.
-  brave_services_key_id = ""
-}
-
 if (target_os == "android") {
   _platform = "android"
 } else if (target_os == "ios") {
@@ -37,16 +30,6 @@ if (is_release_channel) {
 }
 
 _brave_services_key_id = "$_platform-$chromium_version_major-$_channel"
-
-# TODO(https://github.com/brave/brave-browser/issues/56449): Remove this once
-# a couple of releases have gone through and we've confirmed the derived value
-# is correct.
-if (is_official_build && brave_services_key_id != "") {
-  assert(
-      brave_services_key_id == _brave_services_key_id,
-      "brave_services_key_id mismatch: env='$brave_services_key_id' " +
-          "derived='$_brave_services_key_id'. Update your .env file to match")
-}
 
 buildflag_header("buildflags") {
   header = "buildflags.h"


### PR DESCRIPTION
This PR deletes the checks for `brave_services_key_id`, as this value is
not being provided in CI anymore, which means that all channels are now
relying on the value deduced as `_brave_services_key_id`.

Bug: https://github.com/brave/brave-browser/issues/56449
