### PR TITLE
(Wallet) Use GetPrimaryFrame in ConnectAccount and RequestPermission

### DIFF
--- a/browser/permissions/connect_account_android.cc
+++ b/browser/permissions/connect_account_android.cc
@@ -56,11 +56,11 @@ static void JNI_ConnectAccountFragment_ConnectAccount(
   std::string account_address =
       base::android::ConvertJavaStringToUTF8(java_account_address);
 
-  // The connect screen names the primary main frame's origin (see
-  // BraveWalletServiceDelegateImpl::GetActiveOrigin), and so do the connected
+  // ConnectAccountFragment names the primary main frame's origin (see
+  // BraveWalletServiceDelegateImpl::GetActiveOrigin), and so do its connected
   // accounts list and Disconnect. Grant to that same frame: using the focused
   // frame would let a cross-origin subframe holding focus receive a durable
-  // permission the user was never shown and cannot revoke from this panel.
+  // permission the user was never shown and cannot revoke from that screen.
   content::RenderFrameHost* rfh = web_contents->GetPrimaryMainFrame();
 
   brave_wallet::mojom::CoinType coin =

--- a/browser/permissions/connect_account_android.cc
+++ b/browser/permissions/connect_account_android.cc
@@ -56,11 +56,12 @@ static void JNI_ConnectAccountFragment_ConnectAccount(
   std::string account_address =
       base::android::ConvertJavaStringToUTF8(java_account_address);
 
-  content::RenderFrameHost* rfh = web_contents->GetFocusedFrame();
-  if (rfh == nullptr) {
-    PlainCallConnectAccountCallback(env, java_callback, false);
-    return;
-  }
+  // The connect screen names the primary main frame's origin (see
+  // BraveWalletServiceDelegateImpl::GetActiveOrigin), and so do the connected
+  // accounts list and Disconnect. Grant to that same frame: using the focused
+  // frame would let a cross-origin subframe holding focus receive a durable
+  // permission the user was never shown and cannot revoke from this panel.
+  content::RenderFrameHost* rfh = web_contents->GetPrimaryMainFrame();
 
   brave_wallet::mojom::CoinType coin =
       static_cast<brave_wallet::mojom::CoinType>(account_id_coin);

--- a/browser/ui/webui/brave_wallet/wallet_panel/BUILD.gn
+++ b/browser/ui/webui/brave_wallet/wallet_panel/BUILD.gn
@@ -68,18 +68,31 @@ source_set("browser_tests") {
   testonly = true
   defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
 
-  sources = [ "wallet_panel_ui_browsertest.cc" ]
+  sources = [
+    "wallet_panel_handler_browsertest.cc",
+    "wallet_panel_ui_browsertest.cc",
+  ]
   deps = [
     ":wallet_panel",
     "//base/test:test_support",
     "//brave/browser/brave_wallet",
+    "//brave/browser/brave_wallet:tab_helper",
     "//brave/components/brave_wallet/browser",
     "//brave/components/brave_wallet/browser:utils",
+    "//brave/components/brave_wallet/common",
     "//brave/components/brave_wallet/common:common_constants",
+    "//brave/components/brave_wallet/common:mojom",
     "//chrome/browser:browser_process",
     "//chrome/test:test_support",
     "//chrome/test:test_support_ui",
+    "//components/permissions",
+    "//components/permissions:test_support",
+    "//content/public/browser",
     "//content/test:test_support",
+    "//mojo/public/cpp/bindings",
+    "//net:test_support",
     "//testing/gtest",
+    "//third_party/blink/public/common",
+    "//url",
   ]
 }

--- a/browser/ui/webui/brave_wallet/wallet_panel/wallet_panel_handler.cc
+++ b/browser/ui/webui/brave_wallet/wallet_panel/wallet_panel_handler.cc
@@ -89,7 +89,8 @@ void WalletPanelHandler::IsSolanaAccountConnected(
     const std::string& account,
     IsSolanaAccountConnectedCallback callback) {
   // Report the connection state of the frame the panel names, not of whichever
-  // frame happens to hold focus. See RequestPermission below.
+  // frame happens to hold focus. See WalletPanelHandler::RequestPermission for
+  // the rationale.
   content::RenderFrameHost* rfh = active_web_contents_->GetPrimaryMainFrame();
 
   auto* tab_helper =

--- a/browser/ui/webui/brave_wallet/wallet_panel/wallet_panel_handler.cc
+++ b/browser/ui/webui/brave_wallet/wallet_panel/wallet_panel_handler.cc
@@ -88,11 +88,9 @@ void WalletPanelHandler::Focus() {
 void WalletPanelHandler::IsSolanaAccountConnected(
     const std::string& account,
     IsSolanaAccountConnectedCallback callback) {
-  content::RenderFrameHost* rfh = nullptr;
-  if (!(rfh = active_web_contents_->GetFocusedFrame())) {
-    std::move(callback).Run(false);
-    return;
-  }
+  // Report the connection state of the frame the panel names, not of whichever
+  // frame happens to hold focus. See RequestPermission below.
+  content::RenderFrameHost* rfh = active_web_contents_->GetPrimaryMainFrame();
 
   auto* tab_helper =
       brave_wallet::BraveWalletTabHelper::FromWebContents(active_web_contents_);
@@ -108,11 +106,12 @@ void WalletPanelHandler::IsSolanaAccountConnected(
 void WalletPanelHandler::RequestPermission(
     brave_wallet::mojom::AccountIdPtr account_id,
     RequestPermissionCallback callback) {
-  content::RenderFrameHost* rfh = nullptr;
-  if (!(rfh = active_web_contents_->GetFocusedFrame())) {
-    std::move(callback).Run(false);
-    return;
-  }
+  // The panel names the primary main frame's origin (see
+  // BraveWalletServiceDelegateImpl::GetActiveOrigin), and so do the connected
+  // accounts list and Disconnect. Grant to that same frame: using the focused
+  // frame would let a cross-origin subframe holding focus receive a durable
+  // permission the user was never shown and cannot revoke from this panel.
+  content::RenderFrameHost* rfh = active_web_contents_->GetPrimaryMainFrame();
 
   auto request_type =
       brave_wallet::CoinTypeToPermissionRequestType(account_id->coin);

--- a/browser/ui/webui/brave_wallet/wallet_panel/wallet_panel_handler_browsertest.cc
+++ b/browser/ui/webui/brave_wallet/wallet_panel/wallet_panel_handler_browsertest.cc
@@ -1,0 +1,210 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/webui/brave_wallet/wallet_panel/wallet_panel_handler.h"
+
+#include <memory>
+#include <string>
+
+#include "base/memory/raw_ptr.h"
+#include "base/test/run_until.h"
+#include "base/test/test_future.h"
+#include "brave/browser/brave_wallet/brave_wallet_service_factory.h"
+#include "brave/browser/brave_wallet/brave_wallet_tab_helper.h"
+#include "brave/components/brave_wallet/browser/brave_wallet_service.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+#include "brave/components/brave_wallet/common/common_utils.h"
+#include "brave/components/permissions/contexts/brave_wallet_permission_context.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "components/permissions/test/permission_request_observer.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "net/dns/mock_host_resolver.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/blink/public/common/permissions/permission_utils.h"
+#include "url/gurl.h"
+#include "url/origin.h"
+
+namespace {
+
+constexpr char kTestEthAccount[] = "0xaf5Ad1E10926C0Ee4af4eDAC61DD60E853753f8A";
+constexpr char kTestSolAccount[] =
+    "BrG44HdsEhzapvs8bEqzvkq4egwevS3fRE6ze2ENo6S8";
+
+bool HasEthereumPermission(content::BrowserContext* context,
+                           const url::Origin& origin,
+                           const std::string& account) {
+  bool has_permission = false;
+  return permissions::BraveWalletPermissionContext::HasPermission(
+             blink::PermissionType::BRAVE_ETHEREUM, context, origin, account,
+             &has_permission) &&
+         has_permission;
+}
+
+}  // namespace
+
+// The panel names one origin and every control on it must act on that same
+// origin. These tests pin that down while a cross-origin subframe holds the
+// browser's frame focus.
+class WalletPanelHandlerBrowserTest : public InProcessBrowserTest {
+ public:
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+    host_resolver()->AddRule("*", "127.0.0.1");
+    embedded_test_server()->ServeFilesFromSourceDirectory(
+        GetChromeTestDataDir());
+    ASSERT_TRUE(embedded_test_server()->Start());
+
+    main_frame_url_ = embedded_test_server()->GetURL("a.test", "/iframe.html");
+    subframe_url_ = embedded_test_server()->GetURL("b.test", "/title1.html");
+  }
+
+  void TearDownOnMainThread() override {
+    subframe_ = nullptr;
+    InProcessBrowserTest::TearDownOnMainThread();
+  }
+
+  content::WebContents* web_contents() {
+    return browser()->tab_strip_model()->GetActiveWebContents();
+  }
+
+  content::RenderFrameHost* main_frame() {
+    return web_contents()->GetPrimaryMainFrame();
+  }
+
+  content::RenderFrameHost* subframe() { return subframe_; }
+
+  // Loads a.test embedding a cross-origin b.test iframe and moves the browser's
+  // frame focus into that iframe, which is the precondition the attack relies
+  // on. Call via ASSERT_NO_FATAL_FAILURE.
+  void LoadPageAndFocusSubframe() {
+    subframe_ = nullptr;
+    ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), main_frame_url_));
+    ASSERT_TRUE(
+        content::NavigateIframeToURL(web_contents(), "test", subframe_url_));
+
+    subframe_ = content::ChildFrameAt(main_frame(), 0);
+    ASSERT_TRUE(subframe_);
+    ASSERT_EQ(url::Origin::Create(subframe_url_),
+              subframe_->GetLastCommittedOrigin());
+    ASSERT_NE(main_frame()->GetLastCommittedOrigin(),
+              subframe_->GetLastCommittedOrigin());
+
+    // Focusing an element inside the subframe makes it the browser's focused
+    // frame, via RenderFrameHostImpl::DidFocusFrame. That is a renderer to
+    // browser message, so wait for the browser side state to catch up.
+    ASSERT_TRUE(content::ExecJs(subframe_, R"(
+        const input = document.createElement('input');
+        document.body.appendChild(input);
+        input.focus();
+    )"));
+    ASSERT_TRUE(base::test::RunUntil(
+        [&] { return web_contents()->GetFocusedFrame() == subframe_.get(); }));
+  }
+
+  // The origin the panel puts on screen for this tab.
+  std::string GetDisplayedOriginSpec() {
+    return brave_wallet::BraveWalletServiceFactory::GetServiceForContext(
+               browser()->GetProfile())
+        ->GetActiveOriginSync()
+        ->origin_spec;
+  }
+
+  // RequestPermission, ConnectToSite and IsSolanaAccountConnected never touch
+  // the WebUI controller, so the panel does not need to be instantiated to
+  // drive them.
+  std::unique_ptr<WalletPanelHandler> CreateHandler() {
+    return std::make_unique<WalletPanelHandler>(
+        handler_remote_.BindNewPipeAndPassReceiver(),
+        /*webui_controller=*/nullptr, web_contents());
+  }
+
+ protected:
+  GURL main_frame_url_;
+  GURL subframe_url_;
+
+ private:
+  raw_ptr<content::RenderFrameHost> subframe_ = nullptr;
+  mojo::Remote<brave_wallet::mojom::PanelHandler> handler_remote_;
+};
+
+// Connecting from the panel must grant to the origin the panel displays, even
+// though a cross-origin subframe holds the frame focus.
+IN_PROC_BROWSER_TEST_F(
+    WalletPanelHandlerBrowserTest,
+    RequestPermission_GrantsToDisplayedOriginWhileSubframeIsFocused) {
+  ASSERT_NO_FATAL_FAILURE(LoadPageAndFocusSubframe());
+
+  const url::Origin displayed_origin = url::Origin::Create(main_frame_url_);
+  const url::Origin focused_origin = url::Origin::Create(subframe_url_);
+  ASSERT_EQ(displayed_origin.Serialize(), GetDisplayedOriginSpec());
+
+  auto handler = CreateHandler();
+
+  permissions::PermissionRequestObserver prompt_observer(web_contents());
+  base::test::TestFuture<bool> granted;
+  handler->RequestPermission(
+      brave_wallet::MakeAccountId(brave_wallet::mojom::CoinType::ETH,
+                                  brave_wallet::mojom::KeyringId::kDefault,
+                                  brave_wallet::mojom::AccountKind::kDerived,
+                                  kTestEthAccount),
+      granted.GetCallback());
+  prompt_observer.Wait();
+  ASSERT_TRUE(prompt_observer.request_shown());
+
+  handler->ConnectToSite(
+      {kTestEthAccount},
+      brave_wallet::mojom::PermissionLifetimeOption::kForever);
+  EXPECT_TRUE(granted.Get());
+
+  auto* context = browser()->GetProfile();
+  EXPECT_TRUE(HasEthereumPermission(context, displayed_origin, kTestEthAccount))
+      << "the panel named " << displayed_origin << " but did not grant to it";
+  EXPECT_FALSE(HasEthereumPermission(context, focused_origin, kTestEthAccount))
+      << "granted to focused subframe " << focused_origin
+      << ", an origin the panel never named";
+}
+
+// The connected indicator must describe the origin the panel displays, not
+// whichever frame holds the focus.
+IN_PROC_BROWSER_TEST_F(WalletPanelHandlerBrowserTest,
+                       IsSolanaAccountConnected_ReportsMainFrameNotSubframe) {
+  ASSERT_NO_FATAL_FAILURE(LoadPageAndFocusSubframe());
+  ASSERT_EQ(url::Origin::Create(main_frame_url_).Serialize(),
+            GetDisplayedOriginSpec());
+
+  auto* tab_helper =
+      brave_wallet::BraveWalletTabHelper::FromWebContents(web_contents());
+  ASSERT_TRUE(tab_helper);
+  auto handler = CreateHandler();
+
+  auto is_connected = [&] {
+    base::test::TestFuture<bool> future;
+    handler->IsSolanaAccountConnected(kTestSolAccount, future.GetCallback());
+    return future.Get();
+  };
+
+  EXPECT_FALSE(is_connected());
+
+  // A connection held by the focused subframe is not a connection of the top
+  // level site the panel names.
+  tab_helper->AddSolanaConnectedAccount(subframe()->GetGlobalId(),
+                                        kTestSolAccount);
+  EXPECT_FALSE(is_connected());
+
+  // A main frame connection is still reported.
+  tab_helper->AddSolanaConnectedAccount(main_frame()->GetGlobalId(),
+                                        kTestSolAccount);
+  EXPECT_TRUE(is_connected());
+}


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/57608

The wallet panel names one origin and grants to another. The connect screen displays `GetActiveOrigin()`, which is the **primary main frame**, while `RequestPermission` wrote the durable `BRAVE_ETHEREUM` / `BRAVE_SOLANA` / `BRAVE_CARDANO` content setting for `GetFocusedFrame()`. A cross-origin iframe can hold that focus, so tapping Connect on a screen reading `trusted-dapp.com` could create a permanent permission for the iframe's origin instead. The attacker then loads that origin as an ordinary top level page and `eth_accounts` resolves with the user's account and no prompt.

Every other control on the same screen already routes through `delegate_->GetActiveOrigin()`: the connected accounts list, `isPermissionDenied`, and Disconnect / `resetPermission`. That is also why the grant could not be revoked from the panel that created it, since Disconnect looks at an origin where the grant does not appear.

On Android `BraveDappPermissionPromptDialog.initAccounts` picks up the pending request from `ConnectAccountFragment` and approves and dismisses itself before rendering, so a successful grant and a no-op looked identical to the user.

## Changes

`JNI_ConnectAccountFragment_ConnectAccount` and `WalletPanelHandler::RequestPermission` now use `GetPrimaryMainFrame()`, the same source `GetActiveOrigin()` uses, so the decision surface and the grant target cannot disagree. Note that passing the main frame origin while keeping the focused frame would not work: `BraveWalletPermissionContext::RequestWalletPermissions` rejects the request when `requesting_origin != rfh->GetLastCommittedOrigin()`. The frame and the origin had to move together.

`WalletPanelHandler::IsSolanaAccountConnected` gets the same treatment. It computed the connected indicator from the focused frame while the label above it named the main frame, so an iframe's Solana connection was displayed as a connection of the top level site. That one is display only and never created a grant.

The null checks on the old `GetFocusedFrame()` results are gone because `GetPrimaryMainFrame()` never returns null.

## Test Plan

1. Open `https://evil.poczephyrus.my.id/` on its own and confirm the wallet is not connected.
2. Open `https://site-trusted.vercel.app/?embed=https://evil.poczephyrus.my.id/`, which embeds `https://evil.poczephyrus.my.id/` as a cross-origin iframe.
3. Tap **Wake the wallet**. A wallet popup appears. Dismiss it with **Back**. This is what makes the toolbar wallet icon visible, and the icon is cleared on every page load, so steps 3 through 7 must happen within one page lifetime.
4. Tap the input field inside the iframe and type a letter. Confirm the letter renders. This gives the cross-origin subframe the browser's frame focus.
5. Open the wallet from the wallet icon in the address bar. Do not use the three dot menu.
6. Confirm the Connect screen names `https://site-trusted.vercel.app`, then tap **Connect**.
7. Open `https://evil.poczephyrus.my.id/verify.html` as a top level page and call `eth_accounts`.

**Expected after the fix:** step 7 returns an empty array. `eth_accounts` only returns already permitted accounts and can never raise a prompt, so an empty result means no permission was written for the embed origin.

8. Reopen `https://site-trusted.vercel.app/` and confirm the account shows as connected for that origin, and that Disconnect on the panel removes it. The grant must land where the panel can revoke it.
9. Regression pass: connect and disconnect on an ordinary dApp with no iframes and confirm nothing changed.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
