### PR TITLE
[plaster] Fix unintentional base feature overrides

### DIFF
--- a/patches/chrome-browser-devtools-features.cc.patch
+++ b/patches/chrome-browser-devtools-features.cc.patch
@@ -1,24 +1,20 @@
 diff --git a/chrome/browser/devtools/features.cc b/chrome/browser/devtools/features.cc
-index 5af5dcc1cc92abe579d72e9c2ffa88181413991d..fb4df136de2fa83cb16796c10900e91741c3b5ca 100644
+index 5af5dcc1cc92abe579d72e9c2ffa88181413991d..2baf995af053ad2ca77c262ae1b73241f7aee9c1 100644
 --- a/chrome/browser/devtools/features.cc
 +++ b/chrome/browser/devtools/features.cc
-@@ -11,7 +11,14 @@ namespace features {
+@@ -11,7 +11,11 @@ namespace features {
  
  // Let the DevTools front-end query an AIDA endpoint for explanations and
  // insights regarding console (error) messages.
--BASE_FEATURE(kDevToolsConsoleInsights, base::FEATURE_ENABLED_BY_DEFAULT);
-+// kDevToolsConsoleInsights feature state is enforced via plaster rewrite.
-+BASE_FEATURE(kDevToolsConsoleInsights, 
 +#if BUILDFLAG(IS_ANDROID)
-+  base::FEATURE_ENABLED_BY_DEFAULT
+ BASE_FEATURE(kDevToolsConsoleInsights, base::FEATURE_ENABLED_BY_DEFAULT);
 +#else
-+  base::FEATURE_DISABLED_BY_DEFAULT
++BASE_FEATURE(kDevToolsConsoleInsights, base::FEATURE_DISABLED_BY_DEFAULT);
 +#endif
-+);
  const base::FeatureParam<std::string> kDevToolsConsoleInsightsModelId{
      &kDevToolsConsoleInsights, "aida_model_id", /*default_value=*/""};
  const base::FeatureParam<double> kDevToolsConsoleInsightsTemperature{
-@@ -116,7 +123,8 @@ BASE_FEATURE(kDevToolsAiAssistanceStorageAgent,
+@@ -116,7 +120,8 @@ BASE_FEATURE(kDevToolsAiAssistanceStorageAgent,
               base::FEATURE_DISABLED_BY_DEFAULT);
  
  // Whether the DevTools AI Code Completion is enabled.
@@ -28,7 +24,7 @@ index 5af5dcc1cc92abe579d72e9c2ffa88181413991d..fb4df136de2fa83cb16796c10900e917
  const base::FeatureParam<std::string> kDevToolsAiCodeCompletionModelId{
      &kDevToolsAiCodeCompletion, "aida_model_id",
      /*default_value=*/""};
-@@ -130,7 +138,8 @@ const base::FeatureParam<DevToolsFreestylerUserTier>
+@@ -130,7 +135,8 @@ const base::FeatureParam<DevToolsFreestylerUserTier>
          &devtools_freestyler_user_tier_options};
  
  // Whether the DevTools AI Code Generation is enabled.
@@ -38,7 +34,7 @@ index 5af5dcc1cc92abe579d72e9c2ffa88181413991d..fb4df136de2fa83cb16796c10900e917
  const base::FeatureParam<std::string> kDevToolsAiCodeGenerationModelId{
      &kDevToolsAiCodeGeneration, "aida_model_id",
      /*default_value=*/""};
-@@ -175,7 +184,8 @@ BASE_FEATURE(kDevToolsAiGeneratedTimelineLabels,
+@@ -175,7 +181,8 @@ BASE_FEATURE(kDevToolsAiGeneratedTimelineLabels,
               base::FEATURE_ENABLED_BY_DEFAULT);
  
  // Whether the DevTools AI generated annotation labels in timeline are enabled.
@@ -48,7 +44,7 @@ index 5af5dcc1cc92abe579d72e9c2ffa88181413991d..fb4df136de2fa83cb16796c10900e917
  
  // Whether DevTools drawer can be toggled to vertical orientation.
  BASE_FEATURE(kDevToolsVerticalDrawer, base::FEATURE_ENABLED_BY_DEFAULT);
-@@ -213,8 +223,9 @@ BASE_FEATURE(kDevToolsAcceptDebuggingConnections,
+@@ -213,8 +220,9 @@ BASE_FEATURE(kDevToolsAcceptDebuggingConnections,
  // TODO(crbug.com/442892562): Remove this flag once the feature is launched.
  BASE_FEATURE(kDevToolsShowPolicyDialog, base::FEATURE_ENABLED_BY_DEFAULT);
  
@@ -59,7 +55,7 @@ index 5af5dcc1cc92abe579d72e9c2ffa88181413991d..fb4df136de2fa83cb16796c10900e917
  
  // Whether Console Insights Teasers are enabled.
  BASE_FEATURE(kDevToolsConsoleInsightsTeasers,
-@@ -237,6 +248,7 @@ BASE_FEATURE(kDevToolsGeminiRebranding, base::FEATURE_DISABLED_BY_DEFAULT);
+@@ -237,6 +245,7 @@ BASE_FEATURE(kDevToolsGeminiRebranding, base::FEATURE_DISABLED_BY_DEFAULT);
  
  BASE_FEATURE(kDevToolsAiOriginTrialsApis, base::FEATURE_ENABLED_BY_DEFAULT);
  

--- a/patches/components-feed-feed_feature_list.cc.patch
+++ b/patches/components-feed-feed_feature_list.cc.patch
@@ -1,52 +1,40 @@
 diff --git a/components/feed/feed_feature_list.cc b/components/feed/feed_feature_list.cc
-index 4ef72a4b65288af7eddddd331d396c05dc72160c..00934c37aa1380b5b90111422c0425413be32124 100644
+index 4ef72a4b65288af7eddddd331d396c05dc72160c..9222fed043488ed6e858363e93cf3d679802272a 100644
 --- a/components/feed/feed_feature_list.cc
 +++ b/components/feed/feed_feature_list.cc
-@@ -21,7 +21,14 @@ namespace feed {
+@@ -21,7 +21,11 @@ namespace feed {
  // InterestFeedV2 takes precedence over InterestFeedContentSuggestions.
  // InterestFeedV2 is cached in ChromeCachedFlags. If the default value here is
  // changed, please update the cached one's default value in CachedFeatureFlags.
--BASE_FEATURE(kInterestFeedV2, base::FEATURE_ENABLED_BY_DEFAULT);
-+// kInterestFeedV2 feature state is enforced via plaster rewrite.
-+BASE_FEATURE(kInterestFeedV2, 
 +#if BUILDFLAG(IS_ANDROID)
-+  base::FEATURE_DISABLED_BY_DEFAULT
++BASE_FEATURE(kInterestFeedV2, base::FEATURE_DISABLED_BY_DEFAULT);
 +#else
-+  base::FEATURE_ENABLED_BY_DEFAULT
+ BASE_FEATURE(kInterestFeedV2, base::FEATURE_ENABLED_BY_DEFAULT);
 +#endif
-+);
  
  BASE_FEATURE(kDiscoFeedEndpoint, base::FEATURE_ENABLED_BY_DEFAULT);
  BASE_FEATURE(kXsurfaceMetricsReporting, base::FEATURE_DISABLED_BY_DEFAULT);
-@@ -48,7 +55,14 @@ BASE_FEATURE(kFeedSignedOutViewDemotion, base::FEATURE_DISABLED_BY_DEFAULT);
+@@ -48,7 +52,11 @@ BASE_FEATURE(kFeedSignedOutViewDemotion, base::FEATURE_DISABLED_BY_DEFAULT);
  
  BASE_FEATURE(kRefreshFeedOnRestart, base::FEATURE_DISABLED_BY_DEFAULT);
  
--BASE_FEATURE(kFeedContainment, base::FEATURE_ENABLED_BY_DEFAULT);
-+// kFeedContainment feature state is enforced via plaster rewrite.
-+BASE_FEATURE(kFeedContainment, 
 +#if BUILDFLAG(IS_ANDROID)
-+  base::FEATURE_DISABLED_BY_DEFAULT
++BASE_FEATURE(kFeedContainment, base::FEATURE_DISABLED_BY_DEFAULT);
 +#else
-+  base::FEATURE_ENABLED_BY_DEFAULT
+ BASE_FEATURE(kFeedContainment, base::FEATURE_ENABLED_BY_DEFAULT);
 +#endif
-+);
  
  BASE_FEATURE(kFeedRecyclerBinderUnmountOnDetach,
               base::FEATURE_DISABLED_BY_DEFAULT);
-@@ -57,7 +71,14 @@ BASE_FEATURE(kFeedStreaming, base::FEATURE_DISABLED_BY_DEFAULT);
+@@ -57,7 +65,11 @@ BASE_FEATURE(kFeedStreaming, base::FEATURE_DISABLED_BY_DEFAULT);
  
  BASE_FEATURE(kFeedAudioOverviews, base::FEATURE_DISABLED_BY_DEFAULT);
  
--BASE_FEATURE(kAndroidOpenIncognitoAsWindow, base::FEATURE_ENABLED_BY_DEFAULT);
-+// kAndroidOpenIncognitoAsWindow feature state is enforced via plaster rewrite.
-+BASE_FEATURE(kAndroidOpenIncognitoAsWindow, 
 +#if BUILDFLAG(IS_ANDROID)
-+  base::FEATURE_DISABLED_BY_DEFAULT
++BASE_FEATURE(kAndroidOpenIncognitoAsWindow, base::FEATURE_DISABLED_BY_DEFAULT);
 +#else
-+  base::FEATURE_ENABLED_BY_DEFAULT
+ BASE_FEATURE(kAndroidOpenIncognitoAsWindow, base::FEATURE_ENABLED_BY_DEFAULT);
 +#endif
-+);
  
  BASE_FEATURE(kWideScreenFeedForFoldables, base::FEATURE_DISABLED_BY_DEFAULT);
  

--- a/rewrite/chrome/browser/devtools/features.cc.yaml
+++ b/rewrite/chrome/browser/devtools/features.cc.yaml
@@ -21,14 +21,15 @@ substitutions:
 
   - description: |-
       Ship kDevToolsConsoleInsights disabled outside of Android.
-    set_feature_flag_default_state:
-      feature_name: kDevToolsConsoleInsights
-      value: |
-
+    regex:
+      pattern:
+        'BASE_FEATURE(kDevToolsConsoleInsights,
+        base::FEATURE_ENABLED_BY_DEFAULT);'
+      replace: |-
         #if BUILDFLAG(IS_ANDROID)
-          base::FEATURE_ENABLED_BY_DEFAULT
+        BASE_FEATURE(kDevToolsConsoleInsights, base::FEATURE_ENABLED_BY_DEFAULT);
         #else
-          base::FEATURE_DISABLED_BY_DEFAULT
+        BASE_FEATURE(kDevToolsConsoleInsights, base::FEATURE_DISABLED_BY_DEFAULT);
         #endif
 
   - description: 'Ship kDevToolsNewPermissionDialog disabled.'

--- a/rewrite/components/browser_actuator/internal/BUILD.gn.yaml
+++ b/rewrite/components/browser_actuator/internal/BUILD.gn.yaml
@@ -11,7 +11,8 @@ substitutions:
       feature flag Brave overrides, kBrowserActuatorProtoStreamTransport
       included, and that requires depending on this target directly.
     regex:
-      pattern: 'visibility = [ "//components/browser_actuator/*" ]'
+      re_pattern: '(source_set\("features"\)\s*\{[^}]*?visibility = \[[^\]]*\])'
+      re_flags: [DOTALL]
       replace: |-
-        visibility = [ "//components/browser_actuator/*" ]
+        \1
           visibility += [ "//brave/app:unit_tests" ]

--- a/rewrite/components/feed/feed_feature_list.cc.yaml
+++ b/rewrite/components/feed/feed_feature_list.cc.yaml
@@ -8,25 +8,26 @@
 
 substitutions:
   - description: 'Ship kAndroidOpenIncognitoAsWindow disabled on Android.'
-    set_feature_flag_default_state:
-      feature_name: kAndroidOpenIncognitoAsWindow
-      value: |
-
+    regex:
+      pattern:
+        'BASE_FEATURE(kAndroidOpenIncognitoAsWindow,
+        base::FEATURE_ENABLED_BY_DEFAULT);'
+      replace: |-
         #if BUILDFLAG(IS_ANDROID)
-          base::FEATURE_DISABLED_BY_DEFAULT
+        BASE_FEATURE(kAndroidOpenIncognitoAsWindow, base::FEATURE_DISABLED_BY_DEFAULT);
         #else
-          base::FEATURE_ENABLED_BY_DEFAULT
+        BASE_FEATURE(kAndroidOpenIncognitoAsWindow, base::FEATURE_ENABLED_BY_DEFAULT);
         #endif
 
   - description: 'Ship kFeedContainment disabled on Android.'
-    set_feature_flag_default_state:
-      feature_name: kFeedContainment
-      value: |
-
+    regex:
+      pattern:
+        'BASE_FEATURE(kFeedContainment, base::FEATURE_ENABLED_BY_DEFAULT);'
+      replace: |-
         #if BUILDFLAG(IS_ANDROID)
-          base::FEATURE_DISABLED_BY_DEFAULT
+        BASE_FEATURE(kFeedContainment, base::FEATURE_DISABLED_BY_DEFAULT);
         #else
-          base::FEATURE_ENABLED_BY_DEFAULT
+        BASE_FEATURE(kFeedContainment, base::FEATURE_ENABLED_BY_DEFAULT);
         #endif
 
   - description: |-
@@ -35,12 +36,12 @@ substitutions:
       InterestFeedV2 is cached in ChromeCachedFlags. If the default value
       here is changed, please update the cached one's default value in
       CachedFeatureFlags.
-    set_feature_flag_default_state:
-      feature_name: kInterestFeedV2
-      value: |
-
+    regex:
+      pattern:
+        'BASE_FEATURE(kInterestFeedV2, base::FEATURE_ENABLED_BY_DEFAULT);'
+      replace: |-
         #if BUILDFLAG(IS_ANDROID)
-          base::FEATURE_DISABLED_BY_DEFAULT
+        BASE_FEATURE(kInterestFeedV2, base::FEATURE_DISABLED_BY_DEFAULT);
         #else
-          base::FEATURE_ENABLED_BY_DEFAULT
+        BASE_FEATURE(kInterestFeedV2, base::FEATURE_ENABLED_BY_DEFAULT);
         #endif


### PR DESCRIPTION
This PR corrects a few cases where in the process of changing a
particular value for a given feature flag that had a platform-dependant
flag override, we ended up pinning the default value for the other
platforms that we didn't care about.

Additionally, the regex used in one of the `BUILD.gn` files is also
improved to be made more resilient.

Bug: https://github.com/brave/brave-browser/issues/45050
