### PR TITLE
[recipes] Disable `gevent` tracebacks on tests

### DIFF
--- a/tools/recipes/recipe_test_runner.py
+++ b/tools/recipes/recipe_test_runner.py
@@ -35,6 +35,8 @@ import sys
 import time
 from typing import TYPE_CHECKING
 
+import gevent
+
 import config_types
 import engine
 from engine_types import PerGreenletStateRegistry
@@ -477,6 +479,11 @@ def main(argv: list[str] | None = None) -> int:
                         action='store_true',
                         help='enable step/debug logging (noisy)')
     args = parser.parse_args(argv)
+
+    # We disable gevent's exception stream because it prints tracebacks for
+    # every exception thrown, when actually the exception is still caught and
+    # returned by the Future.
+    gevent.get_hub().exception_stream = None
 
     # Keep step logging quiet by default so test output is just the report.
     logging.basicConfig(


### PR DESCRIPTION
This PR disables `gevent` tracebacks when running tests, as that was
allowing tracebacks to be printed for exceptions that were still being
handled by a `Future`.

```
╰─λ vpython3 tools/recipes/engine.py test run
....................................................Traceback (most recent call last):
  File "src/gevent/greenlet.py", line 908, in gevent._gevent_cgreenlet.Greenlet.run
  File "/home/redacted/dev/brave-browser/src/brave/tools/recipes/recipe_modules/futures/api.py", line 251, in _runner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/redacted/dev/brave-browser/src/brave/tools/recipes/recipe_modules/step/api.py", line 341, in __call__
    raise subprocess.CalledProcessError(retcode,
subprocess.CalledProcessError: Command '['false']' returned non-zero exit status 1.
2026-08-18T15:24:51Z <Greenlet "Future-11" at 0x76936bd1d4e0: _runner> failed with CalledProcessError

.........................................................
----------------------------------------------------------------------
Ran 109 tests in 0.404s

recipe tests: 109 passed, 0 failed
```

With this change the handling of test failures stays the same, however
these noisy tracebacks are now suppressed.

Bug: https://github.com/brave/brave-browser/issues/56748
