### PR TITLE
[Android] Elide Shields panel site labels at the start

### DIFF
--- a/android/java/brave-res/layout/brave_report_broken_site_panel.xml
+++ b/android/java/brave-res/layout/brave_report_broken_site_panel.xml
@@ -79,7 +79,7 @@
                     android:layout_marginStart="16dp"
                     android:textColor="?attr/colorOnSurface"
                     android:maxLines="1"
-                    android:ellipsize="end"
+                    android:ellipsize="start"
                     tools:text="example.com"/>
 
             </LinearLayout>

--- a/android/java/brave-res/layout/brave_shields_tab_content.xml
+++ b/android/java/brave-res/layout/brave_shields_tab_content.xml
@@ -62,7 +62,7 @@
                     android:lineHeight="26sp"
                     android:fontFamily="sans-serif-medium"
                     android:maxLines="1"
-                    android:ellipsize="end"
+                    android:ellipsize="start"
                     tools:text="example.com"/>
 
                 <TextView


### PR DESCRIPTION
End-eliding a long hostname pushes the registrable domain out of view, so the panel no longer shows which site the user is on. The site name always ends at the host because the URL is formatted with
formatUrlForDisplayOmitSchemePathAndTrivialSubdomains, so start-eliding keeps the domain visible.

Restores the behaviour from https://github.com/brave/brave-core/pull/23927, which was dropped when the Shields UI was redesigned in https://github.com/brave/brave-core/pull/34451.

Resolves: https://github.com/brave/brave-browser/issues/58242

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

| Before | After |
| --- | --- |
| <img width="1344" height="2992" alt="Screenshot_20260818_135150" src="https://github.com/user-attachments/assets/6cf10736-5fc0-4a1f-af93-eb642216476d" /> | <img width="1344" height="2992" alt="Screenshot_20260818_134753" src="https://github.com/user-attachments/assets/04d21e44-4ed4-47bf-baf1-5b2870648223" /> |
| <img width="1344" height="2992" alt="Screenshot_20260818_140640" src="https://github.com/user-attachments/assets/f564a9c7-fc61-4e03-a45f-fc261d1308d8" /> | <img width="1344" height="2992" alt="Screenshot_20260818_141022" src="https://github.com/user-attachments/assets/42aab325-9b2e-40bc-83a7-3aa6d72b05ba" /> |