### PR TITLE
[Origin] Keep local AI component in sync with the master switch

### DIFF
--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -39,6 +39,7 @@
 #include "brave/components/debounce/core/browser/debounce_component_installer.h"
 #include "brave/components/debounce/core/common/features.h"
 #include "brave/components/https_upgrade_exceptions/browser/https_upgrade_exceptions_service.h"
+#include "brave/components/local_ai/buildflags/buildflags.h"
 #include "brave/components/ntp_background_images/browser/ntp_background_images_service.h"
 #include "brave/components/p3a/histograms_braveizer.h"
 #include "brave/components/p3a/p3a_config.h"
@@ -124,6 +125,10 @@
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
 #include "brave/browser/brave_wallet/wallet_data_files_installer_delegate_impl.h"
 #include "brave/components/brave_wallet/browser/wallet_data_files_installer.h"
+#endif
+
+#if BUILDFLAG(ENABLE_LOCAL_AI)
+#include "brave/components/local_ai/core/local_models_updater.h"
 #endif
 
 using brave_component_updater::BraveComponent;
@@ -267,6 +272,11 @@ void BraveBrowserProcessImpl::StartTearDown() {
   // component_updater::ComponentUpdateService::Observer, so it needs to be
   // reset before the CrxUpdateService is destroyed.
   brave_wallet::WalletDataFilesInstaller::GetInstance().Reset();
+#endif
+#if BUILDFLAG(ENABLE_LOCAL_AI)
+  // Drop the local models registrar's pointers to CrxUpdateService and
+  // local_state before either is destroyed.
+  local_ai::ShutdownLocalModelsComponentRegistration();
 #endif
   // Reset BraveOriginPolicyManager to prevent dangling pointer to local_state_
   brave_origin::BraveOriginPolicyManager::GetInstance()->Shutdown();

--- a/browser/history_embeddings/brave_passage_embeddings_service_controller.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service_controller.cc
@@ -72,6 +72,8 @@ bool BravePassageEmbeddingsServiceController::MaybeUpdateModelInfo(
 
 void BravePassageEmbeddingsServiceController::OnLocalModelsReady(
     const base::FilePath& install_dir) {
+  // Drop a load still in flight for the dir this one replaces.
+  weak_ptr_factory_.InvalidateWeakPtrs();
   // The component ships the LiteRT model in optimization guide's own layout:
   // model.tflite, model-info.pb, and the SentencePiece model listed in its
   // additional_files. Loading it here reads the version and the embedder
@@ -89,7 +91,14 @@ void BravePassageEmbeddingsServiceController::OnLocalModelsReady(
               ->GetEmbeddingGemmaLitertDir()),
       base::BindOnce(
           &BravePassageEmbeddingsServiceController::OnLitertModelInfoLoaded,
-          base::Unretained(this)));
+          weak_ptr_factory_.GetWeakPtr()));
+}
+
+void BravePassageEmbeddingsServiceController::OnLocalModelsUnavailable() {
+  // The files go with the component, so drop the model built from them.
+  // Cancelling first stops a load in flight republishing what it just read.
+  weak_ptr_factory_.InvalidateWeakPtrs();
+  PassageEmbeddingsServiceController::MaybeUpdateModelInfo(std::nullopt);
 }
 
 void BravePassageEmbeddingsServiceController::OnLitertModelInfoLoaded(

--- a/browser/history_embeddings/brave_passage_embeddings_service_controller.h
+++ b/browser/history_embeddings/brave_passage_embeddings_service_controller.h
@@ -9,6 +9,7 @@
 #include <optional>
 
 #include "base/files/file_path.h"
+#include "base/memory/weak_ptr.h"
 #include "base/no_destructor.h"
 #include "base/scoped_observation.h"
 #include "base/types/optional_ref.h"
@@ -55,6 +56,7 @@ class BravePassageEmbeddingsServiceController
 
   // local_ai::LocalModelsUpdaterState::Observer:
   void OnLocalModelsReady(const base::FilePath& install_dir) override;
+  void OnLocalModelsUnavailable() override;
 
   // Reply for the model dir load posted by OnLocalModelsReady. `model_info` is
   // empty when the component ships no usable model.
@@ -64,6 +66,12 @@ class BravePassageEmbeddingsServiceController
   base::ScopedObservation<local_ai::LocalModelsUpdaterState,
                           local_ai::LocalModelsUpdaterState::Observer>
       updater_state_observation_{this};
+
+  // Guards the in-flight model dir load. Invalidated whenever the install dir
+  // changes, so a load started for a dir that is no longer current cannot
+  // publish the model it read.
+  base::WeakPtrFactory<BravePassageEmbeddingsServiceController>
+      weak_ptr_factory_{this};
 };
 
 }  // namespace passage_embeddings

--- a/browser/history_embeddings/brave_passage_embeddings_service_controller_unittest.cc
+++ b/browser/history_embeddings/brave_passage_embeddings_service_controller_unittest.cc
@@ -12,6 +12,9 @@
 #include "base/files/file_util.h"
 #include "base/files/scoped_temp_dir.h"
 #include "base/memory/raw_ptr.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/task/thread_pool/thread_pool_instance.h"
+#include "base/test/bind.h"
 #include "base/test/run_until.h"
 #include "brave/components/local_ai/core/local_models_updater.h"
 #include "components/optimization_guide/core/optimization_guide_proto_util.h"
@@ -145,6 +148,43 @@ TEST_F(BravePassageEmbeddingsServiceControllerTest,
   InstallComponent(CreateComponentDir("no-model-info"));
   EXPECT_TRUE(
       base::test::RunUntil([&] { return !controller_->IsModelAvailable(); }));
+}
+
+// Losing the component takes the model with it: the master switch turning off
+// unregisters the component and removes its files, so the paths published from
+// its install dir are gone.
+TEST_F(BravePassageEmbeddingsServiceControllerTest,
+       ClearedInstallDirClearsModel) {
+  const base::FilePath component = CreateComponentDir("with-model-info");
+  WriteModelInfo(component, /*version=*/13);
+  InstallComponent(component);
+  ASSERT_TRUE(
+      base::test::RunUntil([&] { return observer_.metadata().has_value(); }));
+  ASSERT_TRUE(controller_->IsModelAvailable());
+
+  InstallComponent(base::FilePath());
+  EXPECT_FALSE(controller_->IsModelAvailable());
+}
+
+// A load still in flight when the models go away must not publish what it
+// read: those paths are about to be removed with the component.
+TEST_F(BravePassageEmbeddingsServiceControllerTest,
+       StaleLoadDoesNotRepublishModel) {
+  const base::FilePath component = CreateComponentDir("going-away");
+  WriteModelInfo(component, /*version=*/14);
+  InstallComponent(component);
+  // Take the models away without waiting, so the load is still in flight.
+  InstallComponent(base::FilePath());
+
+  // Let the load finish - that posts its reply - then drain the reply behind a
+  // sentinel queued after it.
+  base::ThreadPoolInstance::Get()->FlushForTesting();
+  bool drained = false;
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE, base::BindLambdaForTesting([&] { drained = true; }));
+  ASSERT_TRUE(base::test::RunUntil([&] { return drained; }));
+
+  EXPECT_FALSE(controller_->IsModelAvailable());
 }
 
 }  // namespace passage_embeddings

--- a/components/local_ai/core/BUILD.gn
+++ b/components/local_ai/core/BUILD.gn
@@ -96,6 +96,7 @@ source_set("unit_tests") {
     "//components/component_updater:test_support",
     "//components/history_embeddings/core",
     "//components/prefs:test_support",
+    "//components/update_client",
     "//testing/gmock",
     "//testing/gtest",
   ]

--- a/components/local_ai/core/local_models_updater.cc
+++ b/components/local_ai/core/local_models_updater.cc
@@ -14,19 +14,18 @@
 
 #include "base/feature_list.h"
 #include "base/files/file_path.h"
-#include "base/files/file_util.h"
 #include "base/functional/bind.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/no_destructor.h"
-#include "base/path_service.h"
 #include "base/values.h"
 #include "base/version.h"
 #include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
 #include "brave/components/local_ai/core/pref_names.h"
 #include "components/component_updater/component_installer.h"
-#include "components/component_updater/component_updater_paths.h"
 #include "components/component_updater/component_updater_service.h"
 #include "components/history_embeddings/core/history_embeddings_features.h"
+#include "components/prefs/pref_change_registrar.h"
 #include "components/prefs/pref_service.h"
 #include "components/update_client/update_client.h"
 #include "crypto/sha2.h"
@@ -45,21 +44,123 @@ constexpr uint8_t kPublicKeySHA256[32] = {
 static_assert(std::size(kPublicKeySHA256) == crypto::kSHA256Length,
               "Wrong hash length");
 
-base::FilePath GetComponentDir() {
-  base::FilePath components_dir =
-      base::PathService::CheckedGet(component_updater::DIR_COMPONENT_USER);
+// Keeps the component registration in sync with the `kBraveLocalAIEnabled`
+// master switch, which Brave Origin can flip long after startup.
+class LocalModelsComponentRegistrar {
+ public:
+  static LocalModelsComponentRegistrar* GetInstance() {
+    static base::NoDestructor<LocalModelsComponentRegistrar> instance;
+    return instance.get();
+  }
 
-  return components_dir.Append(kComponentInstallDir);
-}
+  LocalModelsComponentRegistrar(const LocalModelsComponentRegistrar&) = delete;
+  LocalModelsComponentRegistrar& operator=(
+      const LocalModelsComponentRegistrar&) = delete;
 
-void DeleteComponentDirectory() {
-  base::DeletePathRecursively(GetComponentDir());
-}
+  // Once per process, or once per Shutdown().
+  void Start(component_updater::ComponentUpdateService* cus,
+             PrefService* local_state) {
+    CHECK(pref_change_registrar_.IsEmpty() && !cus_);
+    cus_ = cus;
+    if (local_state) {
+      pref_change_registrar_.Init(local_state);
+      pref_change_registrar_.Add(
+          prefs::kBraveLocalAIEnabled,
+          base::BindRepeating(&LocalModelsComponentRegistrar::Sync,
+                              base::Unretained(this)));
+    }
+    Sync();
+  }
+
+  void Shutdown() {
+    pref_change_registrar_.Reset();
+    cus_ = nullptr;
+    installer_.reset();
+    registration_pending_ = false;
+  }
+
+ private:
+  friend base::NoDestructor<LocalModelsComponentRegistrar>;
+
+  LocalModelsComponentRegistrar() = default;
+  ~LocalModelsComponentRegistrar() = default;
+
+  bool IsEnabled() const {
+    const PrefService* local_state = pref_change_registrar_.prefs();
+    return cus_ && local_state &&
+           local_state->GetBoolean(prefs::kBraveLocalAIEnabled) &&
+           base::FeatureList::IsEnabled(history_embeddings::kHistoryEmbeddings);
+  }
+
+  void Sync() {
+    if (!IsEnabled()) {
+      Unregister();
+      return;
+    }
+    Register();
+  }
+
+  void Register() {
+    if (registration_pending_) {
+      return;
+    }
+    registration_pending_ = true;
+    EnsureInstaller();
+    installer_->Register(
+        cus_, base::BindOnce(&LocalModelsComponentRegistrar::OnRegistered,
+                             base::Unretained(this)));
+  }
+
+  // The switch can have turned off while the registration was in flight.
+  void OnRegistered() {
+    registration_pending_ = false;
+    if (!cus_) {
+      return;
+    }
+    if (!IsEnabled()) {
+      Unregister();
+      return;
+    }
+    brave_component_updater::BraveOnDemandUpdater::GetInstance()
+        ->EnsureInstalled(kComponentId);
+  }
+
+  void Unregister() {
+    // Only remove it ourselves when the service did not (it uninstalls what it
+    // had registered) and no registration in flight may still publish it.
+    const bool was_registered = cus_ && cus_->UnregisterComponent(kComponentId);
+    LocalModelsUpdaterState::GetInstance()->SetInstallDir(base::FilePath());
+    if (!was_registered && !registration_pending_) {
+      EnsureInstaller();
+      installer_->Uninstall();
+    }
+  }
+
+  void EnsureInstaller() {
+    if (!installer_) {
+      installer_ = base::MakeRefCounted<component_updater::ComponentInstaller>(
+          std::make_unique<LocalModelsComponentInstallerPolicy>(
+              pref_change_registrar_.prefs()));
+    }
+  }
+
+  raw_ptr<component_updater::ComponentUpdateService> cus_ = nullptr;
+  PrefChangeRegistrar pref_change_registrar_;
+  // True from Register() until OnRegistered(). The component is absent from
+  // the service for that whole window, so a second Register() would register
+  // it twice and an Unregister() would find nothing to unregister.
+  bool registration_pending_ = false;
+  // Reused: registration and uninstall share the installer's task runner, so a
+  // per-registration instance would let an uninstall delete what the next
+  // registration installed.
+  scoped_refptr<component_updater::ComponentInstaller> installer_;
+};
 
 }  // namespace
 
-LocalModelsComponentInstallerPolicy::LocalModelsComponentInstallerPolicy() =
-    default;
+LocalModelsComponentInstallerPolicy::LocalModelsComponentInstallerPolicy(
+    PrefService* local_state)
+    : local_state_(local_state) {}
 LocalModelsComponentInstallerPolicy::~LocalModelsComponentInstallerPolicy() =
     default;
 
@@ -92,6 +193,11 @@ void LocalModelsComponentInstallerPolicy::ComponentReady(
     const base::FilePath& install_dir,
     base::DictValue manifest) {
   if (install_dir.empty()) {
+    return;
+  }
+  // Unregistration is deferred behind an in-flight update, so this still fires
+  // for a download that started before the switch turned off.
+  if (local_state_ && !local_state_->GetBoolean(prefs::kBraveLocalAIEnabled)) {
     return;
   }
   LocalModelsUpdaterState::GetInstance()->SetInstallDir(install_dir);
@@ -148,6 +254,7 @@ void LocalModelsUpdaterState::SetInstallDir(const base::FilePath& install_dir) {
   install_dir_ = install_dir;
   if (install_dir.empty()) {
     embeddinggemma_litert_dir_ = base::FilePath();
+    observers_.Notify(&Observer::OnLocalModelsUnavailable);
     return;
   }
   embeddinggemma_litert_dir_ = install_dir_.AppendASCII(kEmbeddingGemmaModelDir)
@@ -171,23 +278,11 @@ LocalModelsUpdaterState::~LocalModelsUpdaterState() = default;
 void ManageLocalModelsComponentRegistration(
     component_updater::ComponentUpdateService* cus,
     PrefService* local_state) {
-  const bool local_ai_enabled =
-      local_state &&
-      local_state->GetBoolean(local_ai::prefs::kBraveLocalAIEnabled);
-  if (!local_ai_enabled || !cus ||
-      !base::FeatureList::IsEnabled(history_embeddings::kHistoryEmbeddings)) {
-    DeleteComponentDirectory();
-    return;
-  }
+  LocalModelsComponentRegistrar::GetInstance()->Start(cus, local_state);
+}
 
-  auto installer = base::MakeRefCounted<component_updater::ComponentInstaller>(
-      std::make_unique<LocalModelsComponentInstallerPolicy>());
-  installer->Register(
-      // After Register, run the callback with component id.
-      cus, base::BindOnce([]() {
-        brave_component_updater::BraveOnDemandUpdater::GetInstance()
-            ->EnsureInstalled(kComponentId);
-      }));
+void ShutdownLocalModelsComponentRegistration() {
+  LocalModelsComponentRegistrar::GetInstance()->Shutdown();
 }
 
 }  // namespace local_ai

--- a/components/local_ai/core/local_models_updater.h
+++ b/components/local_ai/core/local_models_updater.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "base/files/file_path.h"
+#include "base/memory/raw_ptr.h"
 #include "base/no_destructor.h"
 #include "base/observer_list.h"
 #include "base/observer_list_types.h"
@@ -43,7 +44,9 @@ inline constexpr char kEmbeddingGemmaLitertDir[] = "litert";
 class LocalModelsComponentInstallerPolicy
     : public component_updater::ComponentInstallerPolicy {
  public:
-  LocalModelsComponentInstallerPolicy();
+  // `local_state` gates ComponentReady() on the `kBraveLocalAIEnabled` master
+  // switch.
+  explicit LocalModelsComponentInstallerPolicy(PrefService* local_state);
   ~LocalModelsComponentInstallerPolicy() override;
 
   LocalModelsComponentInstallerPolicy(
@@ -68,6 +71,9 @@ class LocalModelsComponentInstallerPolicy
   std::string GetName() const override;
   update_client::InstallerAttributes GetInstallerAttributes() const override;
   bool IsBraveComponent() const override;
+
+ private:
+  raw_ptr<PrefService> local_state_ = nullptr;
 };
 
 class LocalModelsUpdaterState {
@@ -76,6 +82,10 @@ class LocalModelsUpdaterState {
    public:
     // Called when the local models are ready (component installed)
     virtual void OnLocalModelsReady(const base::FilePath& install_dir) = 0;
+
+    // Called when the local models are gone. Observers must drop anything
+    // they derived from the install dir: those files no longer exist.
+    virtual void OnLocalModelsUnavailable() = 0;
   };
 
   static LocalModelsUpdaterState* GetInstance();
@@ -106,9 +116,17 @@ class LocalModelsUpdaterState {
   SEQUENCE_CHECKER(sequence_checker_);
 };
 
+// Registers or unregisters the local models component to match the
+// `kBraveLocalAIEnabled` master switch, and keeps it in sync for the rest of
+// the session. The switch is managed by Brave Origin, whose purchase check is
+// asynchronous, so its value can land after components are registered.
 void ManageLocalModelsComponentRegistration(
     component_updater::ComponentUpdateService* cus,
     PrefService* local_state);
+
+// Drops the references taken by ManageLocalModelsComponentRegistration(). Must
+// run before `cus` and `local_state` are destroyed.
+void ShutdownLocalModelsComponentRegistration();
 
 }  // namespace local_ai
 

--- a/components/local_ai/core/local_models_updater_unittest.cc
+++ b/components/local_ai/core/local_models_updater_unittest.cc
@@ -6,6 +6,7 @@
 #include "brave/components/local_ai/core/local_models_updater.h"
 
 #include <memory>
+#include <vector>
 
 #include "base/feature_list.h"
 #include "base/files/file_path.h"
@@ -22,9 +23,11 @@
 #include "brave/components/brave_component_updater/browser/mock_on_demand_updater.h"
 #include "brave/components/local_ai/core/pref_names.h"
 #include "components/component_updater/component_updater_paths.h"
+#include "components/component_updater/component_updater_service.h"
 #include "components/component_updater/mock_component_updater_service.h"
 #include "components/history_embeddings/core/history_embeddings_features.h"
 #include "components/prefs/testing_pref_service.h"
+#include "components/update_client/update_client.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -34,6 +37,18 @@ namespace {
 constexpr base::FilePath::CharType kComponentInstallDir[] =
     FILE_PATH_LITERAL("BraveLocalAIModels");
 constexpr char kComponentId[] = "ejhejjmaoaohpghnblcdcjilndkangfe";
+
+class TestUpdaterStateObserver : public LocalModelsUpdaterState::Observer {
+ public:
+  void OnLocalModelsReady(const base::FilePath& install_dir) override {
+    ++ready_count;
+  }
+  void OnLocalModelsUnavailable() override { ++unavailable_count; }
+
+  int ready_count = 0;
+  int unavailable_count = 0;
+};
+
 }  // namespace
 
 class LocalModelsUpdaterUnitTest : public testing::Test {
@@ -57,7 +72,9 @@ class LocalModelsUpdaterUnitTest : public testing::Test {
   }
 
   void TearDown() override {
-    // Clear singleton state to avoid polluting other test suites.
+    // Clear singleton state to avoid polluting other test suites, and to drop
+    // the registrar's pointers to the per-test cus and local state.
+    ShutdownLocalModelsComponentRegistration();
     LocalModelsUpdaterState::GetInstance()->SetInstallDir(base::FilePath());
   }
 
@@ -99,7 +116,7 @@ TEST_F(LocalModelsUpdaterUnitTest, Register) {
 
 // Tests that ComponentReady sets up the install directory and the model dir.
 TEST_F(LocalModelsUpdaterUnitTest, ComponentReady) {
-  LocalModelsComponentInstallerPolicy policy;
+  LocalModelsComponentInstallerPolicy policy(local_state_.get());
   policy.ComponentReady(base::Version("1.0.0"), install_dir_,
                         base::DictValue());
 
@@ -120,6 +137,10 @@ TEST_F(LocalModelsUpdaterUnitTest, DeleteComponent) {
   base::test::ScopedFeatureList feature_list;
   feature_list.InitAndDisableFeature(history_embeddings::kHistoryEmbeddings);
   EXPECT_CALL(*cus_, RegisterComponent(testing::_)).Times(0);
+  // Nothing was registered, so the directory is ours to remove.
+  EXPECT_CALL(*cus_, UnregisterComponent(kComponentId))
+      .Times(1)
+      .WillOnce(testing::Return(false));
   EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
       .Times(0);
   ManageLocalModelsComponentRegistration(cus_.get(), local_state_.get());
@@ -134,6 +155,9 @@ TEST_F(LocalModelsUpdaterUnitTest, NoRegisterWhenFeatureDisabled) {
   feature_list.InitAndDisableFeature(history_embeddings::kHistoryEmbeddings);
 
   EXPECT_CALL(*cus_, RegisterComponent(testing::_)).Times(0);
+  EXPECT_CALL(*cus_, UnregisterComponent(kComponentId))
+      .Times(1)
+      .WillOnce(testing::Return(false));
   EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
       .Times(0);
   ManageLocalModelsComponentRegistration(cus_.get(), local_state_.get());
@@ -155,11 +179,184 @@ TEST_F(LocalModelsUpdaterUnitTest, NoRegisterWhenMasterSwitchOff) {
 
   local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
   EXPECT_CALL(*cus_, RegisterComponent(testing::_)).Times(0);
+  EXPECT_CALL(*cus_, UnregisterComponent(kComponentId))
+      .Times(1)
+      .WillOnce(testing::Return(false));
   EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
       .Times(0);
   ManageLocalModelsComponentRegistration(cus_.get(), local_state_.get());
   ASSERT_TRUE(
       base::test::RunUntil([&]() { return !PathExists(install_dir_); }));
+}
+
+// Unregistration is deferred behind an in-flight update, so that update still
+// installs and reports ready after the switch turned off.
+TEST_F(LocalModelsUpdaterUnitTest, ComponentReadyIgnoredWhenMasterSwitchOff) {
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+
+  LocalModelsComponentInstallerPolicy policy(local_state_.get());
+  policy.ComponentReady(base::Version("1.0.0"), install_dir_,
+                        base::DictValue());
+  EXPECT_TRUE(LocalModelsUpdaterState::GetInstance()->GetInstallDir().empty());
+}
+
+// Tests that observers are told when the models go away, so they can drop
+// anything derived from the install dir.
+TEST_F(LocalModelsUpdaterUnitTest, ObserverNotifiedWhenModelsGoAway) {
+  auto* state = LocalModelsUpdaterState::GetInstance();
+  TestUpdaterStateObserver observer;
+  state->AddObserver(&observer);
+
+  state->SetInstallDir(install_dir_);
+  EXPECT_EQ(observer.ready_count, 1);
+  EXPECT_EQ(observer.unavailable_count, 0);
+
+  state->SetInstallDir(base::FilePath());
+  EXPECT_EQ(observer.ready_count, 1);
+  EXPECT_EQ(observer.unavailable_count, 1);
+
+  state->RemoveObserver(&observer);
+}
+
+// The switch reaches its managed value only after components are registered,
+// so turning off has to tear an already-registered component back down.
+TEST_F(LocalModelsUpdaterUnitTest, UnregisterWhenMasterSwitchTurnsOff) {
+  base::RunLoop run_loop;
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
+      .Times(1)
+      .WillOnce([quit = run_loop.QuitClosure()]() { quit.Run(); });
+  ManageLocalModelsComponentRegistration(cus_.get(), local_state_.get());
+  run_loop.Run();
+
+  LocalModelsUpdaterState::GetInstance()->SetInstallDir(install_dir_);
+
+  // The component was registered, so ComponentInstaller::Uninstall() owns
+  // removing the files; we only drop the recorded install dir.
+  EXPECT_CALL(*cus_, UnregisterComponent(kComponentId))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+
+  EXPECT_TRUE(LocalModelsUpdaterState::GetInstance()->GetInstallDir().empty());
+}
+
+// Tests that a registration abandoned because the master switch turned off
+// before it landed still cleans the component directory up.
+TEST_F(LocalModelsUpdaterUnitTest, AbandonedRegistrationCleansUpDirectory) {
+  CreateDirectory(install_dir_);
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  // Twice: the pref change finds a registration pending and leaves the
+  // directory alone, then the abandoned registration cleans up.
+  EXPECT_CALL(*cus_, UnregisterComponent(kComponentId))
+      .Times(2)
+      .WillRepeatedly(testing::Return(false));
+  EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
+      .Times(0);
+  ManageLocalModelsComponentRegistration(cus_.get(), local_state_.get());
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+
+  ASSERT_TRUE(
+      base::test::RunUntil([&]() { return !PathExists(install_dir_); }));
+}
+
+// The switch can turn off between RegisterComponent() and our callback, when
+// there is nothing yet to unregister, so the teardown has to happen again.
+TEST_F(LocalModelsUpdaterUnitTest,
+       UnregisterWhenMasterSwitchTurnsOffWhileRegistering) {
+  int unregister_count = 0;
+  EXPECT_CALL(*cus_, UnregisterComponent(kComponentId))
+      .WillRepeatedly([&unregister_count]() {
+        ++unregister_count;
+        return true;
+      });
+  // ComponentInstaller::FinishRegistration() registers before it runs our
+  // callback, so this is the moment the switch can turn off unnoticed.
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_)).WillOnce([this]() {
+    local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+    return true;
+  });
+  EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
+      .Times(0);
+  ManageLocalModelsComponentRegistration(cus_.get(), local_state_.get());
+
+  // One from the pref change, one from the registration landing afterwards.
+  ASSERT_TRUE(base::test::RunUntil([&]() { return unregister_count == 2; }));
+}
+
+// Toggling while a registration is in flight must not remove the directory it
+// may still publish, nor start a second registration.
+TEST_F(LocalModelsUpdaterUnitTest, SwitchTogglesWhileRegistrationPending) {
+  CreateDirectory(install_dir_);
+  base::RunLoop run_loop;
+  // Nothing is registered for the whole toggle: the registration only reaches
+  // the service once ComponentInstaller finishes reading the manifest.
+  EXPECT_CALL(*cus_, UnregisterComponent(kComponentId))
+      .WillRepeatedly(testing::Return(false));
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
+      .Times(1)
+      .WillOnce([quit = run_loop.QuitClosure()]() { quit.Run(); });
+
+  ManageLocalModelsComponentRegistration(cus_.get(), local_state_.get());
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, true);
+  run_loop.Run();
+
+  EXPECT_TRUE(PathExists(install_dir_));
+}
+
+// Registration and uninstall share the installer's task runner. A fresh
+// instance per registration would let a queued uninstall run afterwards and
+// delete what was just installed.
+TEST_F(LocalModelsUpdaterUnitTest, ReusesInstallerAcrossReregistration) {
+  std::vector<scoped_refptr<update_client::CrxInstaller>> installers;
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .WillRepeatedly(
+          [&installers](
+              const component_updater::ComponentRegistration& registration) {
+            installers.push_back(registration.installer);
+            return true;
+          });
+  EXPECT_CALL(*cus_, UnregisterComponent(kComponentId))
+      .WillRepeatedly(testing::Return(true));
+  EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
+      .Times(testing::AnyNumber());
+
+  ManageLocalModelsComponentRegistration(cus_.get(), local_state_.get());
+  ASSERT_TRUE(base::test::RunUntil([&]() { return installers.size() == 1u; }));
+
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, true);
+  ASSERT_TRUE(base::test::RunUntil([&]() { return installers.size() == 2u; }));
+
+  EXPECT_EQ(installers[0], installers[1]);
+}
+
+// Tests that the component is registered when the local AI master switch is
+// turned on after startup.
+TEST_F(LocalModelsUpdaterUnitTest, RegisterWhenMasterSwitchTurnsOn) {
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+  EXPECT_CALL(*cus_, UnregisterComponent(kComponentId))
+      .Times(1)
+      .WillOnce(testing::Return(false));
+  ManageLocalModelsComponentRegistration(cus_.get(), local_state_.get());
+
+  base::RunLoop run_loop;
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
+      .Times(1)
+      .WillOnce([quit = run_loop.QuitClosure()]() { quit.Run(); });
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, true);
+  run_loop.Run();
 }
 
 }  // namespace local_ai


### PR DESCRIPTION
`RegisterComponentsForUpdate()` ran a one-shot check of `kBraveLocalAIEnabled`, but Brave Origin verifies the purchase asynchronously, so the switch only reaches its managed value after components are registered. On builds upgraded to Origin the component was registered and downloaded with "On-Device AI" off, and nothing unregistered it afterwards.

Observe the pref instead, and unregister plus remove the component whenever the switch is off. It can also turn off mid-registration or behind an in-flight update, so re-check it when a registration lands and in `ComponentReady()`. Clearing the install dir now notifies observers, so passage embeddings drops the model built from files that are going away.

## Test plan
### Switch disabled should not download component
- STR in the issue
### Enable switch should download component
1. follow the STR
2. Now enable the switch of  `On-Device AI`
3. After pressing prompted relaunch
4. Navigate to brave://components
5. We should see `Brave Local AI Models Updater` component downloaded or being downloaded

### Fast off and on
1. follow `Enable switch should download component`
2. Fast disable and then enable the switch of  `On-Device AI`
3. Navigate to brave://components
4. We should see `Brave Local AI Models Updater` is still there
5. And `BraveLocalAIModels` folder in the profile is still there

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58235

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

