### PR TITLE
Disable kNetworkQualityEstimatorAsyncNotifyHeadersReceived (uplift to 1.94.x)

### DIFF
--- a/patches/net-nqe-network_quality_estimator.cc.patch
+++ b/patches/net-nqe-network_quality_estimator.cc.patch
@@ -1,0 +1,22 @@
+diff --git a/net/nqe/network_quality_estimator.cc b/net/nqe/network_quality_estimator.cc
+index cae75078b455220646cfb29b2798e0fa3d642e1e..a42a504caef106bc99ace802c81749aacf6a8e0c 100644
+--- a/net/nqe/network_quality_estimator.cc
++++ b/net/nqe/network_quality_estimator.cc
+@@ -52,7 +52,7 @@ BASE_FEATURE(kNetworkQualityEstimatorAsyncNotifyStartTransaction,
+              base::FEATURE_ENABLED_BY_DEFAULT);
+ 
+ BASE_FEATURE(kNetworkQualityEstimatorAsyncNotifyHeadersReceived,
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT);
+ 
+ namespace {
+ 
+@@ -70,7 +70,7 @@ BASE_FEATURE_PARAM(bool,
+                    kDeferHeadersReceivedUntilNextStep,
+                    &kNetworkQualityEstimatorAsyncNotifyHeadersReceived,
+                    "defer_notify_headers_until_next_step",
+-                   true);
++                   false);
+ 
+ #if BUILDFLAG(IS_CHROMEOS)
+ // SequencedTaskRunner to get the network id. A SequencedTaskRunner is used


### PR DESCRIPTION
Uplift of #39155
Resolves https://github.com/brave/brave-browser/issues/58244

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.