### PR TITLE
Disable PreventExtensionResourceFetchAcrossIsolatedWorlds (uplift to 1.93.x)

### DIFF
--- a/patches/third_party-blink-renderer-platform-loader-fetch-resource.cc.patch
+++ b/patches/third_party-blink-renderer-platform-loader-fetch-resource.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/third_party/blink/renderer/platform/loader/fetch/resource.cc b/third_party/blink/renderer/platform/loader/fetch/resource.cc
+index 6ffb8ce5eb080a967534fb478e20238eb4fa48f8..afcc206015a198f036441c968a6e54bd14f9228e 100644
+--- a/third_party/blink/renderer/platform/loader/fetch/resource.cc
++++ b/third_party/blink/renderer/platform/loader/fetch/resource.cc
+@@ -79,7 +79,7 @@ namespace blink {
+ // Feature that prevents an extension resource (chrome-extension://...) from
+ // being fetched across isolated worlds.
+ BASE_FEATURE(kPreventExtensionResourceFetchAcrossIsolatedWorlds,
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT);
+ 
+ // Feature that prevents resources fetched via a Service Worker from being
+ // reused across different script worlds.

--- a/patches/third_party-blink-renderer-platform-loader-fetch-resource.cc.patch
+++ b/patches/third_party-blink-renderer-platform-loader-fetch-resource.cc.patch
@@ -2,12 +2,12 @@ diff --git a/third_party/blink/renderer/platform/loader/fetch/resource.cc b/thir
 index 6ffb8ce5eb080a967534fb478e20238eb4fa48f8..afcc206015a198f036441c968a6e54bd14f9228e 100644
 --- a/third_party/blink/renderer/platform/loader/fetch/resource.cc
 +++ b/third_party/blink/renderer/platform/loader/fetch/resource.cc
-@@ -79,7 +79,7 @@ namespace blink {
- // Feature that prevents an extension resource (chrome-extension://...) from
- // being fetched across isolated worlds.
+@@ -73,7 +73,7 @@
+ // Feature that prevents an extension resource from being fetched across
+ // isolated worlds.
  BASE_FEATURE(kPreventExtensionResourceFetchAcrossIsolatedWorlds,
 -             base::FEATURE_ENABLED_BY_DEFAULT);
 +             base::FEATURE_DISABLED_BY_DEFAULT);
  
- // Feature that prevents resources fetched via a Service Worker from being
- // reused across different script worlds.
+ namespace blink {
+ 

--- a/patches/third_party-blink-renderer-platform-loader-fetch-resource.h.patch
+++ b/patches/third_party-blink-renderer-platform-loader-fetch-resource.h.patch
@@ -1,0 +1,24 @@
+diff --git a/third_party/blink/renderer/platform/loader/fetch/resource.h b/third_party/blink/renderer/platform/loader/fetch/resource.h
+index a6abed969b442b8122e3f4a0eb7eb9e1d7ae5f17..c0e823db6b20314e121cd680492235e1200674e3 100644
+--- a/third_party/blink/renderer/platform/loader/fetch/resource.h
++++ b/third_party/blink/renderer/platform/loader/fetch/resource.h
+@@ -30,6 +30,7 @@
+ 
+ #include "base/auto_reset.h"
+ #include "base/containers/span.h"
++#include "base/feature_list.h"
+ #include "base/gtest_prod_util.h"
+ #include "base/memory_coordinator/memory_consumer.h"
+ #include "base/task/single_thread_task_runner.h"
+@@ -72,6 +73,11 @@ class Clock;
+ 
+ namespace blink {
+ 
++PLATFORM_EXPORT BASE_DECLARE_FEATURE(
++    kPreventExtensionResourceFetchAcrossIsolatedWorlds);
++PLATFORM_EXPORT BASE_DECLARE_FEATURE(
++    kPreventCrossWorldServiceWorkerResourceReuse);
++
+ class BackgroundResponseProcessorFactory;
+ class BlobDataHandle;
+ class FetchParameters;

--- a/patches/third_party-blink-renderer-platform-loader-fetch-resource_fetcher_test.cc.patch
+++ b/patches/third_party-blink-renderer-platform-loader-fetch-resource_fetcher_test.cc.patch
@@ -1,0 +1,17 @@
+diff --git a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher_test.cc b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher_test.cc
+index 35ff0eeba4903a7fc7431b4bc4c6c5338c1d1275..c5c4aa5286be24c4c445c2a10c2f77d2e89d1720 100644
+--- a/third_party/blink/renderer/platform/loader/fetch/resource_fetcher_test.cc
++++ b/third_party/blink/renderer/platform/loader/fetch/resource_fetcher_test.cc
+@@ -2394,6 +2394,12 @@ TEST_P(TransparentPlaceholderResourceFetcherTest, InspectorNotAttached) {
+ // world) are not reused by requests originating from a different isolated
+ // world. Regression test for crbug.com/461167648.
+ TEST_P(ResourceFetcherTest, CrossWorldExtensionResourceMismatch) {
++  // Explicitly enable `kPreventExtensionResourceFetchAcrossIsolatedWorlds` for
++  // this test since the feature is disabled by default.
++  base::test::ScopedFeatureList scoped_feature_list;
++  scoped_feature_list.InitAndEnableFeature(
++      kPreventExtensionResourceFetchAcrossIsolatedWorlds);
++
+   // Register the scheme to ensure it's recognized as an extension.
+   CommonSchemeRegistry::RegisterURLSchemeAsExtension("chrome-extension");
+ 


### PR DESCRIPTION
Uplift of #39212
Resolves https://github.com/brave/brave-browser/issues/58248

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.