### PR TITLE
[Android] Bottom UI elements are obscured by bottom nav bar in settings/modals

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -332,6 +332,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/set_default_browser/SetDefaultBrowserBottomSheetFragment.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/AppearancePreferences.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BackgroundImagesPreferences.java",
+  "../../brave/android/java/org/chromium/chrome/browser/settings/BottomInsetViewProvider.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveAccountPreference.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveAccountSectionController.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveDestructivePreference.java",

--- a/android/java/org/chromium/chrome/browser/settings/BottomInsetViewProvider.java
+++ b/android/java/org/chromium/chrome/browser/settings/BottomInsetViewProvider.java
@@ -1,0 +1,21 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.settings;
+
+import android.view.View;
+
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.build.annotations.Nullable;
+
+/**
+ * Implemented by Settings fragments whose content does not use the standard preference list.
+ *
+ * <p>Returns the view that should receive the bottom system-bar inset.
+ */
+@NullMarked
+public interface BottomInsetViewProvider {
+    @Nullable View getBottomInsetView(View fragmentView);
+}

--- a/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferencesDetails.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferencesDetails.java
@@ -57,7 +57,10 @@ import java.util.List;
 import java.util.Map;
 
 public class BraveNewsPreferencesDetails extends BravePreferenceFragment
-        implements BraveNewsPreferencesListener, ConnectionErrorHandler, SearchViewProvider {
+        implements BraveNewsPreferencesListener,
+                ConnectionErrorHandler,
+                SearchViewProvider,
+                BottomInsetViewProvider {
     private RecyclerView mRecyclerView;
 
     private BraveNewsPreferencesTypeAdapter mAdapter;
@@ -73,6 +76,11 @@ public class BraveNewsPreferencesDetails extends BravePreferenceFragment
     public View onCreateView(
             LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         return inflater.inflate(R.layout.brave_news_settings_details, container, false);
+    }
+
+    @Override
+    public View getBottomInsetView(View fragmentView) {
+        return fragmentView.findViewById(R.id.recyclerview);
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/settings/BraveSettingsActivity.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSettingsActivity.java
@@ -39,12 +39,12 @@ public class BraveSettingsActivity extends SettingsActivity {
     private @Nullable View mContentView;
 
     /**
-     * Original bottom padding for each Settings fragment's RecyclerView.
+     * Original bottom padding for each Settings content view.
      *
      * <p>Used as the baseline when applying navigation-bar insets so repeated updates do not
      * accumulate padding.
      */
-    private final Map<RecyclerView, Integer> mOriginalRecyclerViewBottomPaddings = new HashMap<>();
+    private final Map<View, Integer> mOriginalContentBottomPaddings = new HashMap<>();
 
     private final FragmentManager.FragmentLifecycleCallbacks mSettingsFragmentLifecycleCallbacks =
             new FragmentManager.FragmentLifecycleCallbacks() {
@@ -63,10 +63,10 @@ public class BraveSettingsActivity extends SettingsActivity {
                     View fragmentView = fragment.getView();
                     if (fragmentView == null) return;
 
-                    RecyclerView recyclerView = fragmentView.findViewById(R.id.recycler_view);
-                    if (recyclerView == null) return;
+                    View insetView = getInsetView(fragment, fragmentView);
+                    if (insetView == null) return;
 
-                    mOriginalRecyclerViewBottomPaddings.remove(recyclerView);
+                    mOriginalContentBottomPaddings.remove(insetView);
                 }
             };
 
@@ -105,7 +105,7 @@ public class BraveSettingsActivity extends SettingsActivity {
             ViewCompat.setOnApplyWindowInsetsListener(mContentView, null);
             mContentView = null;
         }
-        mOriginalRecyclerViewBottomPaddings.clear();
+        mOriginalContentBottomPaddings.clear();
         super.onDestroy();
     }
 
@@ -152,12 +152,13 @@ public class BraveSettingsActivity extends SettingsActivity {
         if (!fragment.isAdded() || fragment.getView() != fragmentView) return;
         if (isFinishing() || isDestroyed()) return;
 
-        RecyclerView recyclerView = fragmentView.findViewById(R.id.recycler_view);
-        if (recyclerView == null) return;
+        View insetView = getInsetView(fragment, fragmentView);
+        if (insetView == null) return;
 
-        mOriginalRecyclerViewBottomPaddings.putIfAbsent(
-                recyclerView, recyclerView.getPaddingBottom());
-        recyclerView.setClipToPadding(false);
+        mOriginalContentBottomPaddings.putIfAbsent(insetView, insetView.getPaddingBottom());
+        if (insetView instanceof RecyclerView recyclerView) {
+            recyclerView.setClipToPadding(false);
+        }
 
         View contentView = mContentView;
         if (contentView == null) return;
@@ -169,8 +170,13 @@ public class BraveSettingsActivity extends SettingsActivity {
     }
 
     private WindowInsetsCompat updateSettingsContentInsets(
-            View contentView, WindowInsetsCompat rootWindowInsets) {
-        if (isFinishing() || isDestroyed()) return rootWindowInsets;
+            View contentView, WindowInsetsCompat windowInsets) {
+        if (isFinishing() || isDestroyed()) return windowInsets;
+
+        // The nested Settings content view can receive consumed insets. Read the root values so
+        // a later dispatch cannot clear the taskbar padding.
+        WindowInsetsCompat rootWindowInsets = ViewCompat.getRootWindowInsets(contentView);
+        if (rootWindowInsets == null) rootWindowInsets = windowInsets;
 
         setBottomPadding(
                 contentView, rootWindowInsets.getInsets(WindowInsetsCompat.Type.ime()).bottom);
@@ -181,11 +187,19 @@ public class BraveSettingsActivity extends SettingsActivity {
                 rootWindowInsets.getInsets(WindowInsetsCompat.Type.tappableElement());
         int navigationBarBottomInset =
                 Math.max(navigationBarInsets.bottom, tappableElementInsets.bottom);
-        for (Map.Entry<RecyclerView, Integer> entry :
-                mOriginalRecyclerViewBottomPaddings.entrySet()) {
+        for (Map.Entry<View, Integer> entry : mOriginalContentBottomPaddings.entrySet()) {
             setBottomPadding(entry.getKey(), entry.getValue() + navigationBarBottomInset);
         }
-        return rootWindowInsets;
+        return windowInsets;
+    }
+
+    private static @Nullable View getInsetView(Fragment fragment, View fragmentView) {
+        if (fragment instanceof BottomInsetViewProvider provider) {
+            return provider.getBottomInsetView(fragmentView);
+        }
+
+        RecyclerView recyclerView = fragmentView.findViewById(R.id.recycler_view);
+        return recyclerView;
     }
 
     private static void setBottomPadding(View view, int bottomPadding) {

--- a/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
@@ -83,6 +83,7 @@ import java.util.ArrayList;
 /** Settings fragment that allows to control Sync functionality. */
 public class BraveSyncScreensPreference extends BravePreferenceFragment
         implements View.OnClickListener,
+                BottomInsetViewProvider,
                 QRCodeCameraManager.Callback,
                 QRCodeCameraManager.HostProvider,
                 BraveSyncDevices.DeviceInfoChangedListener,
@@ -331,6 +332,11 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
 
         mInflater = inflater;
         return mInflater.inflate(R.layout.brave_sync_layout, container, false);
+    }
+
+    @Override
+    public View getBottomInsetView(View fragmentView) {
+        return fragmentView;
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/settings/BraveWalletAddNetworksFragment.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveWalletAddNetworksFragment.java
@@ -29,6 +29,8 @@ import org.chromium.brave_wallet.mojom.ProviderError;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.crypto_wallet.BraveWalletServiceFactory;
 import org.chromium.chrome.browser.crypto_wallet.util.AndroidUtils;
+import org.chromium.components.browser_ui.settings.SettingsFragment;
+import org.chromium.components.browser_ui.settings.SettingsFragment.AnimationType;
 import org.chromium.mojo.bindings.ConnectionErrorHandler;
 import org.chromium.mojo.system.MojoException;
 import org.chromium.url.mojom.Url;
@@ -36,7 +38,8 @@ import org.chromium.url.mojom.Url;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-public class BraveWalletAddNetworksFragment extends Fragment implements ConnectionErrorHandler {
+public class BraveWalletAddNetworksFragment extends Fragment
+        implements BottomInsetViewProvider, ConnectionErrorHandler, SettingsFragment {
 
     /**
      * Listener implemented by {@link BraveWalletNetworksPreferenceFragment} used to notify the
@@ -87,6 +90,18 @@ public class BraveWalletAddNetworksFragment extends Fragment implements Connecti
     public View onCreateView(
             @NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         return inflater.inflate(R.layout.brave_wallet_add_network, container, false);
+    }
+
+    @Override
+    public View getBottomInsetView(View fragmentView) {
+        return fragmentView;
+    }
+
+    @Override
+    public @AnimationType int getAnimationType() {
+        // Preserve SettingsActivity's legacy fallback until this fragment adopts property
+        // animations.
+        return AnimationType.TWEEN;
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/shields/AddCustomFilterListsFragment.java
+++ b/android/java/org/chromium/chrome/browser/shields/AddCustomFilterListsFragment.java
@@ -26,11 +26,13 @@ import org.chromium.base.supplier.ObservableSuppliers;
 import org.chromium.base.supplier.SettableMonotonicObservableSupplier;
 import org.chromium.brave_shields.mojom.FilterListAndroidHandler;
 import org.chromium.chrome.R;
+import org.chromium.chrome.browser.settings.BottomInsetViewProvider;
 import org.chromium.chrome.browser.settings.BravePreferenceFragment;
 import org.chromium.chrome.browser.theme.BraveDynamicColors;
 import org.chromium.url.mojom.Url;
 
-public class AddCustomFilterListsFragment extends BravePreferenceFragment {
+public class AddCustomFilterListsFragment extends BravePreferenceFragment
+        implements BottomInsetViewProvider {
     private FilterListAndroidHandler mFilterListAndroidHandler;
     private final SettableMonotonicObservableSupplier<String> mPageTitle =
             ObservableSuppliers.createMonotonic();
@@ -39,6 +41,11 @@ public class AddCustomFilterListsFragment extends BravePreferenceFragment {
     public View onCreateView(
             LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         return inflater.inflate(R.layout.fragment_add_custom_filter_lists, container, false);
+    }
+
+    @Override
+    public View getBottomInsetView(View fragmentView) {
+        return fragmentView;
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/shields/ContentFilteringFragment.java
+++ b/android/java/org/chromium/chrome/browser/shields/ContentFilteringFragment.java
@@ -28,6 +28,7 @@ import org.chromium.base.supplier.SettableMonotonicObservableSupplier;
 import org.chromium.brave_shields.mojom.FilterListAndroidHandler;
 import org.chromium.brave_shields.mojom.SubscriptionInfo;
 import org.chromium.chrome.R;
+import org.chromium.chrome.browser.settings.BottomInsetViewProvider;
 import org.chromium.chrome.browser.settings.BravePreferenceFragment;
 import org.chromium.chrome.browser.settings.BraveSettingsActivity;
 import org.chromium.components.browser_ui.settings.FragmentSettingsNavigation;
@@ -39,7 +40,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 public class ContentFilteringFragment extends BravePreferenceFragment
-        implements FragmentSettingsNavigation, BraveContentFilteringListener {
+        implements FragmentSettingsNavigation,
+                BraveContentFilteringListener,
+                BottomInsetViewProvider {
     private RecyclerView mRecyclerView;
 
     private ContentFilteringAdapter mAdapter;
@@ -62,6 +65,11 @@ public class ContentFilteringFragment extends BravePreferenceFragment
     public View onCreateView(
             LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         return inflater.inflate(R.layout.fragment_content_filtering, container, false);
+    }
+
+    @Override
+    public View getBottomInsetView(View fragmentView) {
+        return fragmentView;
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/shields/CreateCustomFiltersFragment.java
+++ b/android/java/org/chromium/chrome/browser/shields/CreateCustomFiltersFragment.java
@@ -30,13 +30,15 @@ import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.BraveRewardsHelper;
 import org.chromium.chrome.browser.customtabs.CustomTabActivity;
+import org.chromium.chrome.browser.settings.BottomInsetViewProvider;
 import org.chromium.chrome.browser.settings.BravePreferenceFragment;
 import org.chromium.chrome.browser.theme.BraveDynamicColors;
 import org.chromium.ui.text.ChromeClickableSpan;
 import org.chromium.ui.widget.Toast;
 
 @NullMarked
-public class CreateCustomFiltersFragment extends BravePreferenceFragment {
+public class CreateCustomFiltersFragment extends BravePreferenceFragment
+        implements BottomInsetViewProvider {
     public static final String BRAVE_ADBLOCK_FILTER_SYNTAX_PAGE =
             "https://support.brave.app/hc/en-us/articles/6449369961741";
 
@@ -51,6 +53,11 @@ public class CreateCustomFiltersFragment extends BravePreferenceFragment {
             @Nullable ViewGroup container,
             @Nullable Bundle savedInstanceState) {
         return inflater.inflate(R.layout.fragment_create_custom_filters, container, false);
+    }
+
+    @Override
+    public View getBottomInsetView(View fragmentView) {
+        return fragmentView;
     }
 
     @Override


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58222.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

### Changes


Fix settings elements displaying beneath tablet taskbar
- add BottomInsetViewProvider
- BraveSettingsActivity inset behavior can be configured via BottomInsetViewProvider
- update settings UI elements to implement and configure BottomInsetViewProvider

Fix wallet Add Networks button placement
- BraveWalletAddNetworksFragment implements BottomInsetViewProvider and SettingsFragment

## Screenshots

&nbsp; | 1.95.76 | Fixed
--|--|--
`Sync`|<img width="2560" height="1600" alt="Screenshot_1787110536" src="https://github.com/user-attachments/assets/b0ec7c92-f89a-4887-bc94-f0f03baa11f1" />|<img width="2560" height="1600" alt="Screenshot_1787110551" src="https://github.com/user-attachments/assets/2ebc0bd1-9b2d-43b2-b7d9-d13481982c43" />
`Brave News` -> `Channels` -> scroll to bottom |<img width="2560" height="1600" alt="Screenshot_1787110629" src="https://github.com/user-attachments/assets/1998b520-f253-4eb0-963b-4a59b0fe9aa4" />Note that `World News` was obscured |<img width="2560" height="1600" alt="Screenshot_1787110605" src="https://github.com/user-attachments/assets/8553f187-e0f8-463f-9e53-6f6f012c2208" />
`Brave Wallet` -> `Networks` -> `Add network` -> scroll to bottom|<img width="2560" height="1600" alt="Screenshot_1787110507" src="https://github.com/user-attachments/assets/45b26ed3-50c1-47a3-9709-dfe4c6313d8a" />|<img width="2560" height="1600" alt="Screenshot_1787110488" src="https://github.com/user-attachments/assets/8eb2cdca-afae-4ec2-b919-198eff20143e" />
`Brave Shields` -> `Content filtering` -> `Add custom filters list` -> dismiss keyboard|<img width="2560" height="1600" alt="Screenshot_1787114580" src="https://github.com/user-attachments/assets/03846219-3a04-47de-a178-7dd20ee7fcf0" />|<img width="2560" height="1600" alt="Screenshot_1787110392" src="https://github.com/user-attachments/assets/cc227998-cdc8-44a7-b04f-bcad4bd64503" />
`Brave Shields` -> `Content filtering` -> `Create custom filters` -> dismiss keyboard|<img width="2560" height="1600" alt="Screenshot_1787114603" src="https://github.com/user-attachments/assets/d71c1a20-9c72-46aa-b16d-f22016a28d5a" />|<img width="2560" height="1600" alt="Screenshot_1787110381" src="https://github.com/user-attachments/assets/29b94f6d-029e-47e7-83b6-984e3008e005" />


### Notes
Reproducing these issues required an emulator with a fixed Taskbar. Long pressing the divider line on a tablet emulator shows this option:

<img width="629" height="188" alt="Screenshot_2026-08-19 at 14 53 17" src="https://github.com/user-attachments/assets/9a4e652b-24da-4268-8263-2ead1ead8654" />
