### PR TITLE
Scope CloseTab/ReloadInternal to the active tab for tree-tab subtrees

### DIFF
--- a/browser/ui/tabs/brave_tab_strip_model.cc
+++ b/browser/ui/tabs/brave_tab_strip_model.cc
@@ -29,6 +29,7 @@
 #include "components/tabs/public/tab_strip_collection.h"
 #include "components/tabs/public/unpinned_tab_collection.h"
 #include "content/public/browser/web_contents.h"
+#include "ui/base/models/list_selection_model.h"
 
 BraveTabStripModel::BraveTabStripModel(
     TabStripModelDelegate* delegate,
@@ -114,6 +115,30 @@ std::vector<int> BraveTabStripModel::GetTreeTabDescendantIndices(int index) {
     }
   }
   return descendant_indices;
+}
+
+bool BraveTabStripModel::IsOnlyActiveTabAndTreeDescendantsSelected() {
+  const auto& selected_indices =
+      selection_model().GetListSelectionModel().selected_indices();
+  CHECK(!selected_indices.empty());
+
+  // When automatically selecting a tree tab, active index should be the
+  // smallest index of selected indices
+  if (active_index() != static_cast<int>(*selected_indices.begin())) {
+    return false;
+  }
+
+  const std::vector<int> descendant_indices =
+      GetTreeTabDescendantIndices(active_index());
+  if (descendant_indices.empty()) {
+    return false;
+  }
+
+  base::flat_set<size_t> expected_indices(descendant_indices.begin(),
+                                          descendant_indices.end());
+
+  expected_indices.insert(active_index());
+  return selected_indices == expected_indices;
 }
 
 void BraveTabStripModel::SelectMRUTab(TabRelativeDirection direction,

--- a/browser/ui/tabs/brave_tab_strip_model.h
+++ b/browser/ui/tabs/brave_tab_strip_model.h
@@ -72,6 +72,16 @@ class BraveTabStripModel : public TabStripModel {
   // a tree-tab parent to select its whole subtree.
   std::vector<int> GetTreeTabDescendantIndices(int index);
 
+  // Returns true iff the current selection consists of exactly the active
+  // tab and the tree tab descendants returned by
+  // GetTreeTabDescendantIndices() for it (no more, no fewer, no other
+  // tabs/trees). Always false when tree tabs are disabled or the active tab
+  // has no descendants. Used by chrome::CloseTab()/ReloadInternal() to
+  // detect an ordinary subtree-selection-on-activate so those commands can
+  // be scoped to just the active tab, mirroring how they already handle
+  // split tabs.
+  bool IsOnlyActiveTabAndTreeDescendantsSelected();
+
   // TabStripModel:
   void SelectRelativeTab(TabRelativeDirection direction,
                          TabStripUserGestureDetails detail) override;

--- a/browser/ui/tabs/test/tree_tabs_browsertest.cc
+++ b/browser/ui/tabs/test/tree_tabs_browsertest.cc
@@ -14,6 +14,7 @@
 #include "brave/browser/ui/tabs/tree_tab_model.h"
 #include "brave/components/tabs/public/tree_tab_node_id.h"
 #include "brave/components/tabs/public/tree_tab_node_tab_collection.h"
+#include "chrome/app/chrome_command_ids.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/tab_group_sync/tab_group_sync_service_factory.h"
 #include "chrome/browser/ui/browser.h"
@@ -42,12 +43,18 @@
 #include "components/tabs/public/tab_group_tab_collection.h"
 #include "components/tabs/public/tab_strip_collection.h"
 #include "components/tabs/public/unpinned_tab_collection.h"
+#include "content/public/browser/navigation_controller.h"
 #include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_contents_observer.h"
+#include "content/public/common/referrer.h"
 #include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/base/models/list_selection_model.h"
+#include "ui/base/page_transition_types.h"
 #include "ui/events/event.h"
+#include "url/gurl.h"
 
 namespace {
 
@@ -290,6 +297,24 @@ class TreeTabsBrowserTest : public InProcessBrowserTest {
     // Prerequisite for enabling tree tabs.
     profile()->GetPrefs()->SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
   }
+
+  // Counts DidStartLoading() calls on a WebContents, so tests can tell which
+  // tabs a reload command actually touched.
+  class ReloadObserver : public content::WebContentsObserver {
+   public:
+    ~ReloadObserver() override = default;
+
+    int load_count() const { return load_count_; }
+    void SetWebContents(content::WebContents* web_contents) {
+      Observe(web_contents);
+    }
+
+    // content::WebContentsObserver
+    void DidStartLoading() override { load_count_++; }
+
+   private:
+    int load_count_ = 0;
+  };
 
  private:
   base::test::ScopedFeatureList feature_list_;
@@ -3824,4 +3849,179 @@ IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest,
             tabs::TabCollection::Type::TREE_NODE);
 
   CloseBrowserSynchronously(new_browser);
+}
+
+// Activating a tree-tab parent selects its whole subtree (see the
+// SelectTab_* tests in this file), but IDC_CLOSE_TAB should still only close
+// the active tab in that case, mirroring OnlyCloseActiveTabInSplitView in
+// chrome/browser/ui/browser_commands_browsertest.cc for split tabs.
+IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest, OnlyCloseActiveTabInTreeSubtree) {
+  SetTreeTabsEnabled(true);
+
+  auto* parent_tab = tab_strip_model().GetTabAtIndex(0);
+  std::vector<content::WebContents*> child_contents;
+  for (int i = 0; i < 2; ++i) {
+    std::unique_ptr<content::WebContents> contents = CreateWebContents();
+    child_contents.push_back(contents.get());
+    auto child_interface = std::make_unique<tabs::TabModel>(std::move(contents),
+                                                            &tab_strip_model());
+    child_interface->set_opener(parent_tab);
+    tab_strip_model().AddTab(std::move(child_interface), -1,
+                             ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  }
+  ASSERT_EQ(3, tab_strip_model().count());
+
+  // Clicking the parent selects the parent and both children.
+  ClickTab(0);
+  ASSERT_TRUE(tab_strip_model().IsTabSelected(0));
+  ASSERT_TRUE(tab_strip_model().IsTabSelected(1));
+  ASSERT_TRUE(tab_strip_model().IsTabSelected(2));
+
+  EXPECT_TRUE(chrome::ExecuteCommand(browser(), IDC_CLOSE_TAB));
+
+  // Only the parent should have closed; both children remain.
+  EXPECT_EQ(2, tab_strip_model().count());
+  EXPECT_NE(tab_strip_model().GetIndexOfWebContents(child_contents[0]),
+            TabStripModel::kNoTab);
+  EXPECT_NE(tab_strip_model().GetIndexOfWebContents(child_contents[1]),
+            TabStripModel::kNoTab);
+}
+
+// Same as above but for IDC_RELOAD: only the active tab in the subtree
+// should reload.
+IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest, OnlyReloadActiveTabInTreeSubtree) {
+  SetTreeTabsEnabled(true);
+
+  auto* parent_tab = tab_strip_model().GetTabAtIndex(0);
+  for (int i = 0; i < 2; ++i) {
+    auto child_interface = std::make_unique<tabs::TabModel>(CreateWebContents(),
+                                                            &tab_strip_model());
+    child_interface->set_opener(parent_tab);
+    tab_strip_model().AddTab(std::move(child_interface), -1,
+                             ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  }
+  ASSERT_EQ(3, tab_strip_model().count());
+
+  // Give every tab a committed navigation entry so IDC_RELOAD has something
+  // to reload, then track reload starts per tab.
+  std::vector<ReloadObserver> reload_observers(3);
+  for (int i = 0; i < 3; ++i) {
+    content::WebContents* const contents =
+        tab_strip_model().GetWebContentsAt(i);
+    contents->GetController().LoadURL(GURL("about:blank"), content::Referrer(),
+                                      ui::PAGE_TRANSITION_TYPED, std::string());
+    EXPECT_TRUE(content::WaitForLoadStop(contents));
+    reload_observers[i].SetWebContents(contents);
+  }
+
+  ClickTab(0);
+  ASSERT_TRUE(tab_strip_model().IsTabSelected(0));
+  ASSERT_TRUE(tab_strip_model().IsTabSelected(1));
+  ASSERT_TRUE(tab_strip_model().IsTabSelected(2));
+
+  EXPECT_TRUE(chrome::ExecuteCommand(browser(), IDC_RELOAD));
+  EXPECT_TRUE(content::WaitForLoadStop(tab_strip_model().GetWebContentsAt(0)));
+
+  // Only the active (parent) tab should have reloaded; both children must be
+  // untouched.
+  EXPECT_EQ(1, reload_observers[0].load_count());
+  EXPECT_EQ(0, reload_observers[1].load_count());
+  EXPECT_EQ(0, reload_observers[2].load_count());
+}
+
+// If a tab outside the active tab's subtree is also selected, IDC_CLOSE_TAB
+// must close the whole selection, same as the existing
+// CloseAllTabsInSelectionModel split-tab behavior.
+IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest,
+                       CloseAllSelectedTabs_WhenExtraTabSelectedOutsideTree) {
+  SetTreeTabsEnabled(true);
+
+  auto* parent_tab = tab_strip_model().GetTabAtIndex(0);
+  auto child_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  child_interface->set_opener(parent_tab);
+  tab_strip_model().AddTab(std::move(child_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+
+  // An unrelated tab that gets selected alongside the subtree, and one more
+  // that stays unselected so the browser has a tab left after closing.
+  for (int i = 0; i < 2; ++i) {
+    auto other_tab_interface = std::make_unique<tabs::TabModel>(
+        CreateWebContents(), &tab_strip_model());
+    tab_strip_model().AddTab(std::move(other_tab_interface), -1,
+                             ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  }
+  ASSERT_EQ(4, tab_strip_model().count());
+
+  // Select the parent's subtree (indices 0, 1), then additionally select the
+  // unrelated tab at index 2 (leaving index 3 unselected).
+  ClickTab(0);
+  tab_strip_model().SelectTabAt(2);
+  ASSERT_TRUE(tab_strip_model().IsTabSelected(0));
+  ASSERT_TRUE(tab_strip_model().IsTabSelected(1));
+  ASSERT_TRUE(tab_strip_model().IsTabSelected(2));
+  ASSERT_FALSE(tab_strip_model().IsTabSelected(3));
+
+  EXPECT_TRUE(chrome::ExecuteCommand(browser(), IDC_CLOSE_TAB));
+
+  // The whole selection (subtree + the extra tab) should have closed,
+  // leaving only the untouched tab.
+  EXPECT_EQ(1, tab_strip_model().count());
+}
+
+// If a tab outside the active tab's subtree is also selected, IDC_RELOAD
+// must reload the whole selection, not just the active tab.
+IN_PROC_BROWSER_TEST_F(TreeTabsBrowserTest,
+                       ReloadAllSelectedTabs_WhenExtraTabSelectedOutsideTree) {
+  SetTreeTabsEnabled(true);
+
+  auto* parent_tab = tab_strip_model().GetTabAtIndex(0);
+  auto child_interface =
+      std::make_unique<tabs::TabModel>(CreateWebContents(), &tab_strip_model());
+  child_interface->set_opener(parent_tab);
+  tab_strip_model().AddTab(std::move(child_interface), -1,
+                           ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+
+  // An unrelated tab that gets selected alongside the subtree, and one more
+  // that stays unselected.
+  for (int i = 0; i < 2; ++i) {
+    auto other_tab_interface = std::make_unique<tabs::TabModel>(
+        CreateWebContents(), &tab_strip_model());
+    tab_strip_model().AddTab(std::move(other_tab_interface), -1,
+                             ui::PAGE_TRANSITION_AUTO_BOOKMARK, ADD_NONE);
+  }
+  ASSERT_EQ(4, tab_strip_model().count());
+
+  // Give every tab a committed navigation entry so IDC_RELOAD has something
+  // to reload, then track reload starts per tab.
+  std::vector<ReloadObserver> reload_observers(4);
+  for (int i = 0; i < 4; ++i) {
+    content::WebContents* const contents =
+        tab_strip_model().GetWebContentsAt(i);
+    contents->GetController().LoadURL(GURL("about:blank"), content::Referrer(),
+                                      ui::PAGE_TRANSITION_TYPED, std::string());
+    ASSERT_TRUE(content::WaitForLoadStop(contents));
+    reload_observers[i].SetWebContents(contents);
+  }
+
+  // Select the parent's subtree (indices 0, 1), then additionally select the
+  // unrelated tab at index 2 (leaving index 3 unselected).
+  ClickTab(0);
+  tab_strip_model().SelectTabAt(2);
+  ASSERT_TRUE(tab_strip_model().IsTabSelected(0));
+  ASSERT_TRUE(tab_strip_model().IsTabSelected(1));
+  ASSERT_TRUE(tab_strip_model().IsTabSelected(2));
+  ASSERT_FALSE(tab_strip_model().IsTabSelected(3));
+
+  EXPECT_TRUE(chrome::ExecuteCommand(browser(), IDC_RELOAD));
+  EXPECT_TRUE(content::WaitForLoadStop(tab_strip_model().GetWebContentsAt(0)));
+  EXPECT_TRUE(content::WaitForLoadStop(tab_strip_model().GetWebContentsAt(1)));
+  EXPECT_TRUE(content::WaitForLoadStop(tab_strip_model().GetWebContentsAt(2)));
+
+  // The whole selection (subtree + the extra tab) should have reloaded; the
+  // untouched tab must not.
+  EXPECT_EQ(1, reload_observers[0].load_count());
+  EXPECT_EQ(1, reload_observers[1].load_count());
+  EXPECT_EQ(1, reload_observers[2].load_count());
+  EXPECT_EQ(0, reload_observers[3].load_count());
 }

--- a/chromium_src/chrome/browser/ui/browser_commands.cc
+++ b/chromium_src/chrome/browser/ui/browser_commands.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/ui/browser_commands.h"
 
 #include "base/check.h"
+#include "brave/browser/ui/tabs/brave_tab_strip_model.h"
 #include "brave/components/commander/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "chrome/browser/profiles/profile.h"

--- a/patches/chrome-browser-ui-browser_commands.cc.patch
+++ b/patches/chrome-browser-ui-browser_commands.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/browser_commands.cc b/chrome/browser/ui/browser_commands.cc
-index 294487f7864795d9b004b83adb0880e6da03ac3b..7d781da8ed85ee76020ec2d02a135d69f743f403 100644
+index 294487f7864795d9b004b83adb0880e6da03ac3b..1b3a86c8febd3475fdcedb28867336c3d0a58dab 100644
 --- a/chrome/browser/ui/browser_commands.cc
 +++ b/chrome/browser/ui/browser_commands.cc
 @@ -459,7 +459,12 @@ void MoveTabsToWindowImpl(BrowserWindowInterface* source,
@@ -16,7 +16,19 @@ index 294487f7864795d9b004b83adb0880e6da03ac3b..7d781da8ed85ee76020ec2d02a135d69
                collection->get()->collection_)) {
          target_model->InsertDetachedTabGroupAt(std::move(*collection),
                                                 target_model->count());
-@@ -1068,7 +1073,7 @@ void Reload(BrowserWindowInterface* browser,
+@@ -635,6 +640,11 @@ void ReloadInternal(BrowserWindowInterface* browser,
+   bool multiple_ui_tabs_selected =
+       active_tab && tab_strip_model->selection_model().size() >
+                         (active_tab->IsSplit() ? 2 : 1);
++  if (multiple_ui_tabs_selected &&
++      static_cast<BraveTabStripModel*>(tab_strip_model)
++          ->IsOnlyActiveTabAndTreeDescendantsSelected()) {
++    multiple_ui_tabs_selected = false;
++  }
+ 
+   if (multiple_ui_tabs_selected) {
+     // Reloading a tab may change the selection (see crbug.com/339061099), so
+@@ -1068,7 +1078,7 @@ void Reload(BrowserWindowInterface* browser,
    ReloadInternal(browser, disposition, false);
  }
  
@@ -25,7 +37,18 @@ index 294487f7864795d9b004b83adb0880e6da03ac3b..7d781da8ed85ee76020ec2d02a135d69
                            WindowOpenDisposition disposition) {
    base::RecordAction(UserMetricsAction("ReloadBypassingCache"));
    ReloadInternal(browser, disposition, true);
-@@ -1381,6 +1386,7 @@ void CloseTab(BrowserWindowInterface* browser) {
+@@ -1361,7 +1371,9 @@ void CloseTab(BrowserWindowInterface* browser) {
+       active_tab->IsSplit() &&
+       browser->GetTabStripModel()->selection_model().size() == 2;
+ 
+-  if (only_active_split_tab_selected) {
++  if (only_active_split_tab_selected ||
++      static_cast<BraveTabStripModel*>(browser->GetTabStripModel())
++          ->IsOnlyActiveTabAndTreeDescendantsSelected()) {
+     RecordTabCloseCount(1);
+     active_tab->GetContents()->Close();
+     return;
+@@ -1381,6 +1393,7 @@ void CloseTab(BrowserWindowInterface* browser) {
  #endif
  
    ToastController* toast_controller = browser->GetFeatures().toast_controller();
@@ -33,7 +56,7 @@ index 294487f7864795d9b004b83adb0880e6da03ac3b..7d781da8ed85ee76020ec2d02a135d69
    if (!toast_controller) {
      CloseSelectedTabAndRecordTabCountMetric(browser);
      return;
-@@ -1685,7 +1691,7 @@ void NewSplitTab(BrowserWindowInterface* browser,
+@@ -1685,7 +1698,7 @@ void NewSplitTab(BrowserWindowInterface* browser,
    // the regular NTP which renders special content when in Incognito.
    const GURL new_tab_url = !browser->GetProfile()->IsIncognitoProfile() &&
                                     tab_strip_model->count() > 1

--- a/rewrite/chrome/browser/ui/browser_commands.cc.yaml
+++ b/rewrite/chrome/browser/ui/browser_commands.cc.yaml
@@ -43,3 +43,39 @@ substitutions:
                 target_model->InsertDetachedTreeTabNodeAt(std::move(*collection),
                                                           target_model->count());
               } else \1\n
+
+  - description: |-
+      Scope ReloadInternal() to the active tab when its whole tree-tab
+      subtree is selected.
+
+      When `multiple_ui_tabs_selected` is true, the reload will perform on all
+      selected tabs. So when the selected tabs represent a whole tree tab, mark
+      `multiple_ui_tabs_selected` as false to scope the reload to the active tab
+      only. This is to avoid reloading the whole tree tab.
+
+    regex:
+      re_pattern: (void ReloadInternal\(.*?bool multiple_ui_tabs_selected =.*?;)
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+          if (multiple_ui_tabs_selected &&
+              static_cast<BraveTabStripModel*>(tab_strip_model)
+                  ->IsOnlyActiveTabAndTreeDescendantsSelected()) {
+            multiple_ui_tabs_selected = false;
+          }
+
+  - description: |-
+      Scope CloseTab() to the active tab when its whole tree-tab subtree
+      is selected.
+
+      When `only_active_split_tab_selected` is true, the close will perform on
+      only the active tab of split view. Likewise, when the selected tabs
+      represent a whole tree tab, fallback to the active tab only closing.
+
+    regex:
+      re_pattern: (void CloseTab\(.*?if \(only_active_split_tab_selected)\) \{
+      re_flags: [DOTALL]
+      replace: |-
+        \1 ||
+              static_cast<BraveTabStripModel*>(browser->GetTabStripModel())
+                  ->IsOnlyActiveTabAndTreeDescendantsSelected()) {


### PR DESCRIPTION
Activating a tree-tab parent selects its whole subtree (see BraveBrowserTabStripController::SelectTab()), the same way activating a split tab selects both halves of the split. Upstream already narrows CloseTab()/ReloadInternal() to just the active tab when the selection is exactly a split pair, so those commands don't unexpectedly act on both split tabs. This applies the same treatment to tree-tab subtrees: closing or reloading a tree-tab parent now affects only the active tab, unless a tab or tree outside that subtree is also part of the selection, in which case the commands act on the whole selection as before.

Implemented via a plaster substitution on browser_commands.cc (mirroring the existing split-tab handling in the same functions), backed by a new BraveTabStripModel::IsOnlyActiveTabAndTreeDescendantsSelected() helper.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58294

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
