### PR TITLE
[bots][infra] Adding `bots.py validate`

### DIFF
--- a/infra/PRESUBMIT.py
+++ b/infra/PRESUBMIT.py
@@ -42,3 +42,20 @@ def CheckBotsSnapshotOutput(input_api, output_api):
             message=output_api.PresubmitError,
         ),
     ])
+
+
+def CheckBotsValidateOutput(input_api, output_api):
+    """Sanity-checks infra/config/generated/builders/.
+
+    Mirrors upstream's `tools/mb/PRESUBMIT.py`'s `CheckMbValidate`: runs
+    `bots.py validate` and turns a non-zero exit into a presubmit error.
+    """
+    bots_py = os.path.join(input_api.PresubmitLocalPath(), 'bots', 'bots.py')
+    return input_api.RunTests([
+        input_api.Command(
+            name='bots.py validate',
+            cmd=[input_api.python3_executable, bots_py, 'validate'],
+            kwargs={},
+            message=output_api.PresubmitError,
+        ),
+    ])

--- a/infra/bots/bots.py
+++ b/infra/bots/bots.py
@@ -19,6 +19,7 @@ import gen
 import generated_output
 import lookup
 import snapshot
+import validate
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -28,6 +29,7 @@ def main(argv: list[str] | None = None) -> int:
     snapshot.add_subparser(subparsers)
     lookup.add_subparser(subparsers)
     gen.add_subparser(subparsers)
+    validate.add_subparser(subparsers)
 
     args = parser.parse_args(argv)
     try:

--- a/infra/bots/bots_test.py
+++ b/infra/bots/bots_test.py
@@ -28,6 +28,7 @@ import bots
 import gen
 import gen_paths
 import lookup
+import validate
 
 
 def _make_generated_output_dir(tmp_dir, builder_names):
@@ -173,6 +174,71 @@ class GenDispatchTest(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 2)
         self.assertIn('a-builder', buf.getvalue())
         self.assertIn('b-builder', buf.getvalue())
+
+
+def _make_valid_builder_dir(tmp_dir, name):
+    """Writes a builder's full, valid set of generated files under
+    `tmp_dir`, unlike `_make_generated_output_dir()`'s `gn-args.json`-only
+    fixture: `validate` reports the other two files as missing otherwise."""
+    builder_dir = Path(tmp_dir) / name
+    builder_dir.mkdir()
+    (builder_dir / 'gn-args.json').write_text(json.dumps(
+        {'gn_args': {
+            'target_os': 'linux',
+            'target_cpu': 'x64',
+        }}),
+                                              encoding='utf-8')
+    (builder_dir / 'sync.json').write_text(json.dumps({
+        'target_os': 'linux',
+        'target_cpu': 'x64',
+        'gclient_overrides': {},
+    }),
+                                           encoding='utf-8')
+    (builder_dir / 'targets.json').write_text(json.dumps({
+        'compile': ['brave:all'],
+        'tests': [],
+    }),
+                                              encoding='utf-8')
+
+
+class ValidateDispatchTest(unittest.TestCase):
+    """`bots.py validate`'s CLI wiring: dispatch to `validate.cmd_validate()`
+    and its success/failure exit codes. See validate_test.py for
+    `validate.py`'s own checks."""
+
+    def test_dispatches_to_validate_cmd(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        _make_valid_builder_dir(tmp.name, 'b')
+
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
+        try:
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                ret = bots.main(['validate'])
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original
+
+        self.assertEqual(ret, 0)
+        self.assertIn('looks ok', buf.getvalue())
+
+    def test_problems_return_1(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        _make_generated_output_dir(tmp.name, ['b'])  # gn-args.json only.
+
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
+        try:
+            buf = io.StringIO()
+            with contextlib.redirect_stderr(buf):
+                ret = bots.main(['validate'])
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original
+
+        self.assertEqual(ret, 1)
+        self.assertIn('missing', buf.getvalue())
 
 
 if __name__ == '__main__':

--- a/infra/bots/validate.py
+++ b/infra/bots/validate.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""bots validate: sanity-check `infra/config/generated/builders/`.
+
+This is an extra validation for the values found in the snapshot, run during
+the PRESUBMIT stage.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import gen_paths
+import generated_output
+
+_CHROMIUM_SRC_DIR = gen_paths.BOTS_DIR.parents[2]
+
+# The three files `bots.py snapshot` writes for every builder.
+_REQUIRED_FILES = ('gn-args.json', 'sync.json', 'targets.json')
+
+
+def _list_builder_dirs() -> list[Path]:
+    """Every immediate subdirectory of `generated/builders/`, sorted by
+    name."""
+    if not gen_paths.BUILDERS_OUTPUT_DIR.is_dir():
+        return []
+    return sorted(
+        (p for p in gen_paths.BUILDERS_OUTPUT_DIR.iterdir() if p.is_dir()),
+        key=lambda p: p.name)
+
+
+class _Validator:
+    """Runs every check over one snapshot of `generated/builders/`.
+
+    A plain function per check would need `errs` and, for the duplicate
+    check, every builder's raw file text threaded through as parameters;
+    both are just accumulated state, so they live on `self` instead and each
+    check appends to `self._errs` directly.
+    """
+
+    def __init__(self) -> None:
+        self._errs: list[str] = []
+        # Builder dir -> {filename: raw text}, for the duplicate-builder
+        # check to compare against without re-reading anything from disk.
+        self._raw_by_dir: dict[Path, dict[str, str]] = {}
+
+    def run(self) -> list[str]:
+        """Validates every generated builder.
+
+        Returns a list of human-readable errors. Empty means success.
+        """
+        builder_dirs = _list_builder_dirs()
+        if not builder_dirs:
+            self._errs.append(
+                'no generated builders found under %s; run `bots.py '
+                'snapshot` first.' % gen_paths.BUILDERS_OUTPUT_DIR)
+            return self._errs
+
+        for builder_dir in builder_dirs:
+            self._validate_builder(builder_dir)
+        self._check_no_duplicate_builders(builder_dirs)
+        return self._errs
+
+    def _validate_builder(self, builder_dir: Path) -> None:
+        raw = self._read_raw_files(builder_dir)
+        self._raw_by_dir[builder_dir] = raw
+
+        gn_args_path = builder_dir / 'gn-args.json'
+        gn_args_json = (self._parse_json(gn_args_path, raw['gn-args.json'])
+                        if 'gn-args.json' in raw else None)
+        if gn_args_json is not None:
+            self._check_gn_args_schema(gn_args_path, gn_args_json)
+            self._check_args_file_exists(gn_args_path, gn_args_json)
+            self._check_secrets_not_leaked(gn_args_path, gn_args_json)
+
+        sync_path = builder_dir / 'sync.json'
+        sync_json = (self._parse_json(sync_path, raw['sync.json'])
+                     if 'sync.json' in raw else None)
+        if sync_json is not None:
+            self._check_sync_schema(sync_path, sync_json)
+
+        targets_path = builder_dir / 'targets.json'
+        targets_json = (self._parse_json(targets_path, raw['targets.json'])
+                        if 'targets.json' in raw else None)
+        if targets_json is not None:
+            self._check_targets_schema(targets_path, targets_json)
+
+    def _read_raw_files(self, builder_dir: Path) -> dict[str, str]:
+        """Reads each of `_REQUIRED_FILES` present under `builder_dir` as
+        text.
+
+        A missing file is reported and simply absent from the result, so
+        callers can tell "present" from "missing" by dict membership.
+        """
+        raw = {}
+        for filename in _REQUIRED_FILES:
+            path = builder_dir / filename
+            if not path.is_file():
+                self._errs.append('%s: missing' % path)
+                continue
+            raw[filename] = path.read_bytes().decode('utf-8')
+        return raw
+
+    def _parse_json(self, path: Path, text: str) -> dict | None:
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as e:
+            self._errs.append('%s: invalid JSON (%s)' % (path, e))
+            return None
+        if not isinstance(parsed, dict):
+            self._errs.append('%s: expected a JSON object, got %s' %
+                              (path, type(parsed).__name__))
+            return None
+        return parsed
+
+    def _check_gn_args_schema(self, gn_args_path: Path,
+                              gn_args_json: dict) -> None:
+        """Checks `gn-args.json`'s `gn_args` carries what `gn gen`
+        requires."""
+        gn_args = gn_args_json.get('gn_args')
+        if not isinstance(gn_args, dict):
+            self._errs.append('%s: "gn_args" is missing or not an object' %
+                              gn_args_path)
+            return
+        for required in ('target_os', 'target_cpu'):
+            if required not in gn_args:
+                self._errs.append('%s: "gn_args" is missing %r' %
+                                  (gn_args_path, required))
+
+    def _check_args_file_exists(self, gn_args_path: Path,
+                                gn_args_json: dict) -> None:
+        """Checks a declared `args_file` is a source-absolute path that
+        exists.
+        """
+        args_file = gn_args_json.get('args_file')
+        if not args_file:
+            return
+        if not args_file.startswith('//'):
+            self._errs.append(
+                '%s: args_file %r is not a source-absolute ("//...") path' %
+                (gn_args_path, args_file))
+            return
+        if not (_CHROMIUM_SRC_DIR / args_file[2:]).is_file():
+            self._errs.append('%s: args_file %r does not exist' %
+                              (gn_args_path, args_file))
+
+    def _check_secrets_not_leaked(self, gn_args_path: Path,
+                                  gn_args_json: dict) -> None:
+        """Checks a declared secret's real value never made it into
+        `gn_args`.
+        """
+        secrets = gn_args_json.get('secrets') or {}
+        gn_args = gn_args_json.get('gn_args') or {}
+        for gn_arg_name, env_var_name in secrets.items():
+            value = os.environ.get(env_var_name)
+            if not value:
+                continue
+            for other_name, other_value in gn_args.items():
+                if isinstance(other_value, str) and value in other_value:
+                    self._errs.append(
+                        '%s: gn_args[%r] appears to contain the value of '
+                        'secret %r (from $%s); secret values must never be '
+                        'checked in' %
+                        (gn_args_path, other_name, gn_arg_name, env_var_name))
+
+    def _check_sync_schema(self, sync_path: Path, sync_json: dict) -> None:
+        for required in ('target_os', 'target_cpu', 'gclient_overrides'):
+            if required not in sync_json:
+                self._errs.append('%s: missing %r' % (sync_path, required))
+
+    def _check_targets_schema(self, targets_path: Path,
+                              targets_json: dict) -> None:
+        for required in ('compile', 'tests'):
+            value = targets_json.get(required)
+            if required not in targets_json:
+                self._errs.append('%s: missing %r' % (targets_path, required))
+            elif not isinstance(value, list):
+                self._errs.append('%s: %r is not a list' %
+                                  (targets_path, required))
+
+    def _check_no_duplicate_builders(self, builder_dirs: list[Path]) -> None:
+        """Flags duplicate builders that are identical."""
+        seen: dict[tuple[str, ...], str] = {}
+        for builder_dir in builder_dirs:
+            raw = self._raw_by_dir[builder_dir]
+            if len(raw) != len(_REQUIRED_FILES):
+                continue  # Already reported as missing/unreadable above.
+            key = tuple(raw[name] for name in _REQUIRED_FILES)
+            first_seen_as = seen.get(key)
+            if first_seen_as is None:
+                seen[key] = builder_dir.name
+            else:
+                self._errs.append(
+                    'builders %r and %r are exact duplicates (identical '
+                    'gn-args.json, sync.json and targets.json); consolidate '
+                    'them into one' % (first_seen_as, builder_dir.name))
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    errs = _Validator().run()
+    if errs:
+        raise generated_output.BotsError(
+            'infra/config/generated/builders/ has problems:\n  ' +
+            '\n  '.join(errs))
+    if not args.quiet:
+        print('infra/config/generated/builders/ looks ok (%d builder(s)).' %
+              len(_list_builder_dirs()))
+    return 0
+
+
+def add_subparser(subparsers) -> argparse.ArgumentParser:
+    """Registers the `validate` subcommand onto `bots.py`'s subparsers."""
+    validate_parser = subparsers.add_parser(
+        'validate',
+        description='Sanity-check infra/config/generated/builders/.')
+    validate_parser.add_argument('-q',
+                                 '--quiet',
+                                 action='store_true',
+                                 help="Don't print anything on success.")
+    validate_parser.set_defaults(func=cmd_validate)
+    return validate_parser

--- a/infra/bots/validate_test.py
+++ b/infra/bots/validate_test.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for validate.py's own logic: `_Validator.run()`'s checks over
+`generated/builders/` and `cmd_validate()`'s success/failure paths.
+`bots.py`'s CLI wiring for the `validate` subcommand is exercised in
+bots_test.py instead."""
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import gen_paths
+import generated_output
+import validate
+
+
+def _write_builder(output_dir,
+                   name,
+                   *,
+                   gn_args=None,
+                   sync=None,
+                   targets=None,
+                   omit=()):
+    """Writes a builder's three generated files under `output_dir`.
+
+    `gn_args`/`sync`/`targets` default to minimal-but-valid payloads. Pass
+    `omit`, a subset of `validate._REQUIRED_FILES`, to skip writing specific
+    files, for testing the missing-file path.
+    """
+    builder_dir = Path(output_dir) / name
+    builder_dir.mkdir(parents=True, exist_ok=True)
+    payloads = {
+        'gn-args.json': gn_args if gn_args is not None else {
+            'gn_args': {
+                'target_os': 'linux',
+                'target_cpu': 'x64',
+            },
+        },
+        'sync.json': sync if sync is not None else {
+            'target_os': 'linux',
+            'target_cpu': 'x64',
+            'gclient_overrides': {},
+        },
+        'targets.json': targets if targets is not None else {
+            'compile': ['brave:all'],
+            'tests': ['a_test'],
+        },
+    }
+    for filename, payload in payloads.items():
+        if filename in omit:
+            continue
+        (builder_dir / filename).write_text(json.dumps(payload),
+                                            encoding='utf-8')
+
+
+class _OutputDirTestCase(unittest.TestCase):
+    """Points `gen_paths.BUILDERS_OUTPUT_DIR` at a scratch directory for the
+    duration of each test."""
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.output_dir = Path(tmp.name)
+
+        original = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = self.output_dir
+        self.addCleanup(setattr, gen_paths, 'BUILDERS_OUTPUT_DIR', original)
+
+
+class ValidatorRunTest(_OutputDirTestCase):
+
+    def test_no_generated_builders_says_run_snapshot_first(self):
+        errs = validate._Validator().run()
+        self.assertEqual(len(errs), 1)
+        self.assertIn('bots.py snapshot', errs[0])
+
+    def test_single_valid_builder_has_no_errors(self):
+        _write_builder(self.output_dir, 'linux-x64-asan-brave')
+        self.assertEqual(validate._Validator().run(), [])
+
+    def test_two_builders_sharing_gn_args_but_not_targets_is_fine(self):
+        # The two real ASan builders resolve to identical gn_args by design
+        # and differ only in targets.json.
+        _write_builder(self.output_dir,
+                       'linux-x64-asan-brave',
+                       targets={
+                           'compile': ['brave:all'],
+                           'tests': ['brave_all_unit_tests'],
+                       })
+        _write_builder(self.output_dir,
+                       'linux-x64-asan-chromium',
+                       targets={
+                           'compile': ['brave:all'],
+                           'tests': ['chromium_unit_tests'],
+                       })
+        self.assertEqual(validate._Validator().run(), [])
+
+    def test_missing_file_is_reported(self):
+        _write_builder(self.output_dir, 'b', omit=('targets.json', ))
+        errs = validate._Validator().run()
+        self.assertEqual(len(errs), 1)
+        self.assertIn('targets.json', errs[0])
+        self.assertIn('missing', errs[0])
+
+    def test_invalid_json_is_reported(self):
+        _write_builder(self.output_dir, 'b')
+        (self.output_dir / 'b' / 'gn-args.json').write_text('not json',
+                                                            encoding='utf-8')
+        errs = validate._Validator().run()
+        self.assertEqual(len(errs), 1)
+        self.assertIn('gn-args.json', errs[0])
+        self.assertIn('invalid JSON', errs[0])
+
+    def test_gn_args_missing_target_os_is_reported(self):
+        _write_builder(self.output_dir,
+                       'b',
+                       gn_args={'gn_args': {
+                           'target_cpu': 'x64'
+                       }})
+        errs = validate._Validator().run()
+        self.assertEqual(len(errs), 1)
+        self.assertIn("'target_os'", errs[0])
+
+    def test_gn_args_not_an_object_is_reported(self):
+        _write_builder(self.output_dir, 'b', gn_args={'gn_args': 'nope'})
+        errs = validate._Validator().run()
+        self.assertEqual(len(errs), 1)
+        self.assertIn('not an object', errs[0])
+
+    def test_gn_args_json_that_parses_to_an_empty_object_is_reported(self):
+        # A JSON body of exactly `{}` is still a valid, parsed object -
+        # falling back to truthiness instead of an explicit `is not None`
+        # check would skip validating it entirely.
+        _write_builder(self.output_dir, 'b', gn_args={})
+        errs = validate._Validator().run()
+        self.assertEqual(len(errs), 1)
+        self.assertIn('missing or not an object', errs[0])
+
+    def test_args_file_missing_on_disk_is_reported(self):
+        _write_builder(self.output_dir,
+                       'b',
+                       gn_args={
+                           'gn_args': {
+                               'target_os': 'linux',
+                               'target_cpu': 'x64',
+                           },
+                           'args_file': '//build/args/does_not_exist.gni',
+                       })
+        errs = validate._Validator().run()
+        self.assertEqual(len(errs), 1)
+        self.assertIn('does_not_exist.gni', errs[0])
+        self.assertIn('does not exist', errs[0])
+
+    def test_args_file_present_on_disk_is_fine(self):
+        original_src_dir = validate._CHROMIUM_SRC_DIR
+        fake_src_root = tempfile.TemporaryDirectory()
+        self.addCleanup(fake_src_root.cleanup)
+        args_file_path = Path(fake_src_root.name) / 'build' / 'args' / 'x.gni'
+        args_file_path.parent.mkdir(parents=True)
+        args_file_path.write_text('', encoding='utf-8')
+        validate._CHROMIUM_SRC_DIR = Path(fake_src_root.name)
+        self.addCleanup(setattr, validate, '_CHROMIUM_SRC_DIR',
+                        original_src_dir)
+
+        _write_builder(self.output_dir,
+                       'b',
+                       gn_args={
+                           'gn_args': {
+                               'target_os': 'linux',
+                               'target_cpu': 'x64',
+                           },
+                           'args_file': '//build/args/x.gni',
+                       })
+        self.assertEqual(validate._Validator().run(), [])
+
+    def test_args_file_not_source_absolute_is_reported(self):
+        _write_builder(self.output_dir,
+                       'b',
+                       gn_args={
+                           'gn_args': {
+                               'target_os': 'linux',
+                               'target_cpu': 'x64',
+                           },
+                           'args_file': 'build/args/x.gni',
+                       })
+        errs = validate._Validator().run()
+        self.assertEqual(len(errs), 1)
+        self.assertIn('source-absolute', errs[0])
+
+    def test_leaked_secret_value_is_reported(self):
+        self.addCleanup(os.environ.pop, 'FAKE_SECRET_ENV_VAR', None)
+        os.environ['FAKE_SECRET_ENV_VAR'] = 'super-secret-value'
+        _write_builder(self.output_dir,
+                       'b',
+                       gn_args={
+                           'gn_args': {
+                               'target_os': 'linux',
+                               'target_cpu': 'x64',
+                               'brave_google_api_key': 'super-secret-value',
+                           },
+                           'secrets': {
+                               'brave_services_key': 'FAKE_SECRET_ENV_VAR',
+                           },
+                       })
+        errs = validate._Validator().run()
+        self.assertEqual(len(errs), 1)
+        self.assertIn('brave_google_api_key', errs[0])
+        self.assertIn('brave_services_key', errs[0])
+        self.assertNotIn('super-secret-value', errs[0])
+
+    def test_secret_declared_but_env_var_unset_is_fine(self):
+        self.addCleanup(os.environ.pop, 'FAKE_SECRET_ENV_VAR', None)
+        os.environ.pop('FAKE_SECRET_ENV_VAR', None)
+        _write_builder(self.output_dir,
+                       'b',
+                       gn_args={
+                           'gn_args': {
+                               'target_os': 'linux',
+                               'target_cpu': 'x64',
+                           },
+                           'secrets': {
+                               'brave_services_key': 'FAKE_SECRET_ENV_VAR',
+                           },
+                       })
+        self.assertEqual(validate._Validator().run(), [])
+
+    def test_sync_json_missing_field_is_reported(self):
+        _write_builder(self.output_dir, 'b', sync={'target_os': 'linux'})
+        errs = validate._Validator().run()
+        self.assertEqual(len(errs), 2)
+        self.assertTrue(
+            any("'target_cpu'" in e for e in errs)
+            and any("'gclient_overrides'" in e for e in errs))
+
+    def test_targets_json_field_not_a_list_is_reported(self):
+        _write_builder(self.output_dir,
+                       'b',
+                       targets={
+                           'compile': 'brave:all',
+                           'tests': [],
+                       })
+        errs = validate._Validator().run()
+        self.assertEqual(len(errs), 1)
+        self.assertIn("'compile'", errs[0])
+        self.assertIn('not a list', errs[0])
+
+    def test_exact_duplicate_builders_are_reported(self):
+        _write_builder(self.output_dir, 'b1')
+        _write_builder(self.output_dir, 'b2')
+        errs = validate._Validator().run()
+        self.assertEqual(len(errs), 1)
+        self.assertIn('b1', errs[0])
+        self.assertIn('b2', errs[0])
+        self.assertIn('duplicates', errs[0])
+
+
+class CmdValidateTest(_OutputDirTestCase):
+
+    def test_returns_0_and_prints_ok_message(self):
+        _write_builder(self.output_dir, 'linux-x64-asan-brave')
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            ret = validate.cmd_validate(argparse.Namespace(quiet=False))
+        self.assertEqual(ret, 0)
+        self.assertIn('looks ok', buf.getvalue())
+        self.assertIn('1 builder', buf.getvalue())
+
+    def test_quiet_suppresses_success_message(self):
+        _write_builder(self.output_dir, 'b')
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            ret = validate.cmd_validate(argparse.Namespace(quiet=True))
+        self.assertEqual(ret, 0)
+        self.assertEqual(buf.getvalue(), '')
+
+    def test_raises_bots_error_with_every_problem_when_invalid(self):
+        _write_builder(self.output_dir, 'b1')
+        _write_builder(self.output_dir, 'b2')
+        with self.assertRaises(generated_output.BotsError) as ctx:
+            validate.cmd_validate(argparse.Namespace(quiet=False))
+        self.assertIn('duplicates', str(ctx.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This command serves as a base for all types of checks based on the
contents of the generated path, and it is also being wired into
`PRESUBMIT.py`.

Bug: https://github.com/brave/brave-browser/issues/47912
