### PR TITLE
Update design for Tool permission prompt in Leo

### DIFF
--- a/components/ai_chat/resources/untrusted_conversation_frame/components/tool_permission_challenge/tool_permission_challenge.module.scss
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/tool_permission_challenge/tool_permission_challenge.module.scss
@@ -4,18 +4,17 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 .container {
-  max-width: 400px;
-  border: 1px solid var(--leo-color-yellow-10);
-  border-radius: var(--leo-radius-m);
+  border: 1px solid var(--leo-color-yellow-20);
+  border-radius: var(--leo-radius-l);
   // Overflow: hidden ensures the border radius clips the header background
   overflow: hidden;
-  background: var(--leo-color-yellow-5);
+  background: var(--leo-color-container-background);
 }
 
 .header {
-  background: var(--leo-color-yellow-10);
+  background: var(--leo-color-yellow-20);
   padding: var(--leo-spacing-m) var(--leo-spacing-l);
-  color: var(--leo-color-yellow-50);
+  color: var(--leo-color-yellow-60);
   display: flex;
   align-items: center;
   gap: var(--leo-spacing-m);
@@ -35,7 +34,7 @@
   flex-direction: column;
   gap: var(--leo-spacing-l);
   font: var(--leo-font-default-regular);
-  color: var(--leo-color-yellow-60);
+  color: var(--leo-color-text-primary);
   p {
     margin: 0;
   }


### PR DESCRIPTION
Adjust visual tokens and layout for `tool_permission_challenge.module.scss`: use `var(--leo-color-yellow-20)` for borders/header, switch container background to `var(--leo-color-container-background)`, increase border-radius to `var(--leo-radius-l)`, remove fixed `max-width`, and set content color to `var(--leo-color-text-primary)` for better contrast and consistency with theme.

Resolves https://github.com/brave/brave-browser/issues/58265

### Previous
<img width="890" height="1000" alt="image" src="https://github.com/user-attachments/assets/4660e022-a307-422c-8667-9aebcae359d7" />

### Changed 
<img width="533" height="535" alt="image" src="https://github.com/user-attachments/assets/2559cc4f-afec-4fee-a6b7-77d607bdce9e" />