### PR TITLE
[VPN 2.0] Add browser-side agent IPC client for BraveVPN v2

### DIFF
--- a/components/brave_vpn/browser/v2/BUILD.gn
+++ b/components/brave_vpn/browser/v2/BUILD.gn
@@ -26,14 +26,30 @@ static_library("browser") {
   } else if (is_linux || is_mac || is_win) {
     sources += [ "brave_vpn_service_impl_desktop.cc" ]
   }
+  if (enable_brave_vpn_v2_apps) {
+    sources += [
+      "agent_client.cc",
+      "agent_client.h",
+      "browser_endpoint_impl.cc",
+      "browser_endpoint_impl.h",
+    ]
+  }
 
   public_deps = [
     "//brave/components/brave_vpn/browser",
+    "//brave/components/brave_vpn/common/buildflags",
     "//brave/components/brave_vpn/common/mojom",
     "//brave/components/skus/browser",
     "//brave/components/skus/common:mojom",
     "//mojo/public/cpp/bindings",
+    "//net",
   ]
+  if (enable_brave_vpn_v2_apps) {
+    public_deps += [
+      "//brave/components/brave_vpn/common/mojom:agent",
+      "//mojo/public/cpp/platform",
+    ]
+  }
 
   deps = [
     "api",
@@ -41,12 +57,41 @@ static_library("browser") {
     "//brave/components/brave_vpn/common",
     "//brave/components/resources:strings",
     "//components/prefs",
-    "//net",
     "//services/network/public/cpp",
     "//third_party/icu",
     "//ui/base",
     "//url",
   ]
+  if (enable_brave_vpn_v2_apps) {
+    deps += [
+      "//brave/components/brave_vpn/common/v2:common",
+      "//components/named_mojo_ipc_server",
+      "//mojo/public/cpp/system",
+    ]
+  }
+}
+
+source_set("test_support") {
+  testonly = true
+
+  sources = []
+  public_deps = []
+
+  if (enable_brave_vpn_v2_apps) {
+    sources += [
+      "test/fake_agent.cc",
+      "test/fake_agent.h",
+    ]
+
+    public_deps += [
+      ":browser",
+      "//base",
+      "//brave/components/brave_vpn/common/mojom",
+      "//mojo/public/cpp/bindings",
+      "//mojo/public/cpp/platform",
+      "//mojo/public/cpp/system",
+    ]
+  }
 }
 
 source_set("unit_tests") {
@@ -62,8 +107,13 @@ source_set("unit_tests") {
     "skus_service_client_unittest.cc",
   ]
 
+  if (enable_brave_vpn_v2_apps) {
+    sources += [ "agent_client_unittest.cc" ]
+  }
+
   deps = [
     ":browser",
+    ":test_support",
     "api",
     "//base",
     "//base:i18n",

--- a/components/brave_vpn/browser/v2/BUILD.gn
+++ b/components/brave_vpn/browser/v2/BUILD.gn
@@ -26,14 +26,6 @@ static_library("browser") {
   } else if (is_linux || is_mac || is_win) {
     sources += [ "brave_vpn_service_impl_desktop.cc" ]
   }
-  if (enable_brave_vpn_v2_apps) {
-    sources += [
-      "agent_client.cc",
-      "agent_client.h",
-      "browser_endpoint_impl.cc",
-      "browser_endpoint_impl.h",
-    ]
-  }
 
   public_deps = [
     "//brave/components/brave_vpn/browser",
@@ -44,12 +36,6 @@ static_library("browser") {
     "//mojo/public/cpp/bindings",
     "//net",
   ]
-  if (enable_brave_vpn_v2_apps) {
-    public_deps += [
-      "//brave/components/brave_vpn/common/mojom:agent",
-      "//mojo/public/cpp/platform",
-    ]
-  }
 
   deps = [
     "api",
@@ -62,7 +48,20 @@ static_library("browser") {
     "//ui/base",
     "//url",
   ]
+
   if (enable_brave_vpn_v2_apps) {
+    sources += [
+      "agent_client.cc",
+      "agent_client.h",
+      "browser_endpoint_impl.cc",
+      "browser_endpoint_impl.h",
+    ]
+
+    public_deps += [
+      "//brave/components/brave_vpn/common/mojom:agent",
+      "//mojo/public/cpp/platform",
+    ]
+
     deps += [
       "//brave/components/brave_vpn/common/v2:common",
       "//components/named_mojo_ipc_server",

--- a/components/brave_vpn/browser/v2/DEPS
+++ b/components/brave_vpn/browser/v2/DEPS
@@ -2,6 +2,7 @@ include_rules = [
   "-brave/components/brave_vpn/browser",
   "-brave/components/brave_vpn/common",
   "+brave/components/brave_vpn/browser/v2",
+  "+brave/components/brave_vpn/common/v2",
   "+brave/components/brave_vpn/browser/brave_vpn_service.h",
   "+brave/components/brave_vpn/common/brave_vpn_constants.h",
   "+brave/components/brave_vpn/common/brave_vpn_utils.h",
@@ -9,4 +10,5 @@ include_rules = [
   "+brave/components/brave_vpn/common/pref_names.h",
   "+brave/components/brave_vpn/common/buildflags",
   "+brave/components/brave_vpn/common/mojom",
+  "+components/named_mojo_ipc_server",
 ]

--- a/components/brave_vpn/browser/v2/agent_client.cc
+++ b/components/brave_vpn/browser/v2/agent_client.cc
@@ -1,0 +1,393 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/agent_client.h"
+
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <utility>
+
+#include "base/check.h"
+#include "base/functional/bind.h"
+#include "base/location.h"
+#include "base/logging.h"
+#include "base/memory/ptr_util.h"
+#include "base/task/task_traits.h"
+#include "base/task/thread_pool.h"
+#include "base/time/time.h"
+#include "brave/components/brave_vpn/browser/v2/browser_endpoint_impl.h"
+#include "brave/components/brave_vpn/common/v2/agent_utils.h"
+#include "components/named_mojo_ipc_server/named_mojo_ipc_server_client_util.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/platform/platform_channel_endpoint.h"
+#include "mojo/public/cpp/system/invitation.h"
+#include "mojo/public/cpp/system/message_pipe.h"
+
+namespace brave_vpn::v2 {
+namespace {
+// Back off policy for the connection to an agent. The common first-time failure
+// is "no agent running", which an immediate retry will not fix. Jitter is
+// load-bearing: one agent serves every profile of every browser instance the
+// user has open, and they fail together, so an agent restart would otherwise be
+// answered by all of them reconnecting in lockstep, repeatedly, on a schedule
+// they all derived the same way.
+constexpr net::BackoffEntry::Policy kBackoffPolicy = {
+    .num_errors_to_ignore = 0,
+    .initial_delay_ms = 1000,
+    .multiply_factor = 1.5,
+    .jitter_factor = 0.5,
+    .maximum_backoff_ms = 60 * 1000,
+    .entry_lifetime_ms = -1,
+    .always_use_initial_delay = false,
+};
+
+// How long the agent gets to answer BindBrowserHost() before the connection is
+// treated as failed.
+constexpr base::TimeDelta kHandshakeTimeout = base::Seconds(10);
+
+// A helper that establishes the transport to the agent's IPC server and returns
+// the pipe its BrowserHostProvider is bound to.
+mojo::ScopedMessagePipeHandle ConnectToAgentServer(
+    const mojo::NamedPlatformChannel::ServerName& server_name) {
+  mojo::PlatformChannelEndpoint endpoint =
+      named_mojo_ipc_server::ConnectToServer(server_name);
+  if (!endpoint.is_valid()) {
+    // The ordinary case on a cold browser: nothing is listening yet.
+    return mojo::ScopedMessagePipeHandle();
+  }
+  mojo::ScopedMessagePipeHandle pipe =
+      mojo::IncomingInvitation::AcceptIsolated(std::move(endpoint));
+  if (!pipe.is_valid()) {
+    // Reached the agent's channel but couldn't turn it into a connection, which
+    // is not something a retry usually fixes. Logged here because this is the
+    // only place that can tell the two failures apart.
+    LOG(ERROR) << "Agent did not accept an isolated invitation";
+  }
+  return pipe;
+}
+
+}  // namespace
+
+AgentClient::AgentClient()
+    : AgentClient(base::BindRepeating(&GetAgentServerName),
+                  base::BindRepeating(&ConnectToAgentServer)) {}
+
+AgentClient::AgentClient(ServerNameProvider server_name_provider,
+                         Connector connector,
+                         const base::TickClock* tick_clock)
+    : server_name_provider_(std::move(server_name_provider)),
+      connector_(std::move(connector)),
+      backoff_(&kBackoffPolicy, tick_clock) {
+  CHECK(server_name_provider_);
+  CHECK(connector_);
+}
+
+AgentClient::~AgentClient() = default;
+
+// static
+std::unique_ptr<AgentClient> AgentClient::CreateForTesting(  // IN-TEST
+    ServerNameProvider server_name_provider,
+    Connector connector,
+    const base::TickClock* tick_clock) {
+  return base::WrapUnique(new AgentClient(std::move(server_name_provider),
+                                          std::move(connector), tick_clock));
+}
+
+void AgentClient::EnsureConnected() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  switch (state_) {
+    case State::kConnecting:
+    case State::kConnected:
+    case State::kWaitingToRetry:
+      break;
+    case State::kUnavailable:
+      VLOG(1) << "Agent is unavailable to this browser; not reconnecting";
+      break;
+    case State::kDisconnected:
+      StartConnect();
+      break;
+  }
+}
+
+void AgentClient::Reset() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  const bool was_connected = state_ == State::kConnected;
+  retry_timer_.Stop();
+  weak_factory_.InvalidateWeakPtrs();
+  ResetConnection();
+  ClearFailureRun();
+  state_ = State::kDisconnected;
+  if (was_connected) {
+    observers_.Notify(&Observer::OnAgentDisconnected);
+  }
+}
+
+mojom::BrowserHost* AgentClient::browser_host() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  // The host pipe is bound before the handshake completes, so gate on the state
+  // rather than on the remote: sending to an unauthenticated host would just be
+  // queued into a pipe the agent is about to close.
+  return state_ == State::kConnected ? host_.get() : nullptr;
+}
+
+AgentClient::State AgentClient::state() const {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  return state_;
+}
+
+bool AgentClient::is_connected() const {
+  return state() == State::kConnected;
+}
+
+void AgentClient::AddObserver(Observer* observer) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  observers_.AddObserver(observer);
+}
+
+void AgentClient::RemoveObserver(Observer* observer) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  observers_.RemoveObserver(observer);
+}
+
+// static
+AgentClient::ConnectResult AgentClient::ConnectBlocking(
+    ServerNameProvider server_name_provider,
+    Connector connector) {
+  std::optional<mojo::NamedPlatformChannel::ServerName> server_name =
+      server_name_provider.Run();
+  if (!server_name) {
+    // Already logged by the resolver.
+    return base::unexpected(ConnectError::kNoServerName);
+  }
+
+  // TODO(https://github.com/brave/brave-browser/issues/54608)
+  // Verify the agent server's identity here, before the endpoint is
+  // handed to mojo. The agent verifies the browser after BindBrowserHost()
+  // arrives, but this direction is unchecked: a malicious process in the
+  // session can create a pipe with the agent's name, and the name is
+  // enumerable. The handle is still a plain pipe at this point, so the server
+  // pid can be fetched and fed to the same signature check the agent uses to
+  // verify the browser. Until then, treat everything reachable through this
+  // connection as talking to a peer we have not authenticated.
+
+  mojo::ScopedMessagePipeHandle pipe = connector.Run(*server_name);
+  if (!pipe.is_valid()) {
+    return base::unexpected(ConnectError::kNoAgentRunning);
+  }
+  return pipe;
+}
+
+void AgentClient::StartConnect() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  CHECK(!provider_.is_bound());
+  state_ = State::kConnecting;
+
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE,
+      {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
+       base::TaskShutdownBehavior::CONTINUE_ON_SHUTDOWN},
+      base::BindOnce(&AgentClient::ConnectBlocking, server_name_provider_,
+                     connector_),
+      base::BindOnce(&AgentClient::OnTransportConnected,
+                     weak_factory_.GetWeakPtr()));
+}
+
+void AgentClient::OnTransportConnected(ConnectResult result) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  CHECK(state_ == State::kConnecting);
+
+  if (!result.has_value()) {
+    if (result.error() == ConnectError::kNoServerName) {
+      // Terminal rather than retried: the session id, runtime dir, and temp dir
+      // this is derived from are fixed for the life of the process, so every
+      // later attempt would fail identically.
+      EnterUnavailable("no agent server name for this session", std::nullopt);
+      return;
+    }
+    TeardownAndRetry("couldn't reach the agent");
+    ReportNotRunningIfNeeded();
+    return;
+  }
+
+  // The pipe the transport was established on is what the agent bound its
+  // BrowserHostProvider to. Dropping it later drops the transport with it. Pass
+  // 0 as version as we don't support [MinVersion]-based versioning yet.
+  provider_.Bind(mojo::PendingRemote<mojom::BrowserHostProvider>(
+      std::move(result.value()), /*version=*/0));
+
+  provider_.set_disconnect_handler(base::BindOnce(
+      &AgentClient::OnProviderDisconnected, weak_factory_.GetWeakPtr()));
+
+  browser_endpoint_ = std::make_unique<BrowserEndpointImpl>(
+      base::BindOnce(&AgentClient::OnSessionPipeDisconnected,
+                     weak_factory_.GetWeakPtr(), "endpoint pipe closed"));
+  mojo::PendingRemote<mojom::BrowserEndpoint> endpoint_remote =
+      browser_endpoint_->BindNewPipeAndPassRemote();
+
+  mojo::PendingReceiver<mojom::BrowserHost> host_receiver =
+      host_.BindNewPipeAndPassReceiver();
+  host_.set_disconnect_handler(
+      base::BindOnce(&AgentClient::OnSessionPipeDisconnected,
+                     weak_factory_.GetWeakPtr(), "host pipe closed"));
+
+  handshake_timer_.Start(FROM_HERE, kHandshakeTimeout,
+                         base::BindOnce(&AgentClient::OnHandshakeTimeout,
+                                        weak_factory_.GetWeakPtr()));
+
+  provider_->BindBrowserHost(
+      mojom::kProtocolVersion, std::move(endpoint_remote),
+      std::move(host_receiver),
+      base::BindOnce(&AgentClient::OnAuthResult, weak_factory_.GetWeakPtr()));
+}
+
+void AgentClient::OnAuthResult(mojom::BrowserAuthResult result) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  CHECK(state_ == State::kConnecting);
+  handshake_timer_.Stop();
+
+  // This value came off the wire from a peer that has not been verified, so it
+  // decides policy but never invariants: no CHECK on any branch below.
+  switch (result) {
+    case mojom::BrowserAuthResult::kAccepted:
+      if (session_pipe_dropped_) {
+        // Accepted, but one of the pipes the session runs on is already gone.
+        // Treat it as a failed attempt rather than publishing a host that
+        // cannot deliver anything.
+        TeardownAndRetry("session pipe closed during handshake");
+        return;
+      }
+      ClearFailureRun();
+      state_ = State::kConnected;
+      observers_.Notify(&Observer::OnAgentConnected);
+      return;
+
+    case mojom::BrowserAuthResult::kVersionMismatch:
+      // The agent accepts a range ending at the version it was built with, so
+      // this is usually a browser that updated ahead of the agent it is talking
+      // to. Retrying against this agent cannot help; a replacement can.
+      EnterUnavailable("protocol version outside the agent's accepted range",
+                       result);
+      return;
+
+    case mojom::BrowserAuthResult::kRejected:
+      // The agent ran its peer check on us and said no. That verdict is about
+      // this binary, which does not change while it runs, so back off entirely.
+      EnterUnavailable("agent rejected this browser", result);
+      return;
+
+    case mojom::BrowserAuthResult::kHostAlreadyRequested:
+      // The agent scopes this to one BindBrowserHost() per connection, and this
+      // is a connection we have just opened and called once, so either this is
+      // a bug or the peer is not the agent.
+      LOG(ERROR) << "Agent reports this connection is already authenticated";
+      EnterUnavailable("connection already authenticated", result);
+      return;
+  }
+}
+
+void AgentClient::OnHandshakeTimeout() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  TeardownAndRetry("agent did not answer the handshake");
+}
+
+void AgentClient::OnProviderDisconnected() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (state_ == State::kUnavailable) {
+    // The agent that refused us is gone. Its replacement is a different binary
+    // with a potentially different answer, so this is not a failure to back off
+    // from. Connect as if for the first time. This is how a browser that
+    // outlives an agent update recovers without being restarted.
+    ClearFailureRun();
+    ResetConnection();
+    state_ = State::kDisconnected;
+    StartConnect();
+    return;
+  }
+  TeardownAndRetry("provider pipe closed");
+}
+
+void AgentClient::OnSessionPipeDisconnected(std::string_view reason) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (state_ == State::kConnecting) {
+    // The reply decides the outcome, and the provider pipe's own handler covers
+    // the case where no reply is coming.
+    VLOG(1) << "Session pipe dropped during the handshake (" << reason << ")";
+    session_pipe_dropped_ = true;
+    return;
+  }
+  TeardownAndRetry(reason);
+}
+
+void AgentClient::TeardownAndRetry(std::string_view reason) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  const bool was_connected = state_ == State::kConnected;
+  ResetConnection();
+  if (was_connected) {
+    ClearFailureRun();
+  }
+  backoff_.InformOfRequest(/*succeeded=*/false);
+
+  const base::TimeDelta delay = backoff_.GetTimeUntilRelease();
+  VLOG(1) << "Agent connection failed (" << reason << "); retrying in "
+          << delay;
+
+  state_ = State::kWaitingToRetry;
+  retry_timer_.Start(
+      FROM_HERE, delay,
+      base::BindOnce(&AgentClient::StartConnect, weak_factory_.GetWeakPtr()));
+
+  if (was_connected) {
+    observers_.Notify(&Observer::OnAgentDisconnected);
+  }
+}
+
+void AgentClient::EnterUnavailable(
+    std::string_view reason,
+    std::optional<mojom::BrowserAuthResult> result) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  const bool was_connected = state_ == State::kConnected;
+
+  retry_timer_.Stop();
+  ResetSession();
+  state_ = State::kUnavailable;
+  VLOG(1) << "Agent unavailable to this browser: " << reason;
+
+  if (was_connected) {
+    observers_.Notify(&Observer::OnAgentDisconnected);
+  }
+  observers_.Notify(&Observer::OnAgentUnavailable, result);
+}
+
+void AgentClient::ReportNotRunningIfNeeded() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (std::exchange(not_running_reported_, true)) {
+    return;
+  }
+  observers_.Notify(&Observer::OnAgentNotRunning);
+}
+
+void AgentClient::ClearFailureRun() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  backoff_.Reset();
+  not_running_reported_ = false;
+}
+
+void AgentClient::ResetSession() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  handshake_timer_.Stop();
+  session_pipe_dropped_ = false;
+  host_.reset();
+  browser_endpoint_.reset();
+}
+
+void AgentClient::ResetConnection() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  ResetSession();
+  provider_.reset();
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/agent_client.cc
+++ b/components/brave_vpn/browser/v2/agent_client.cc
@@ -192,11 +192,11 @@ void AgentClient::StartConnect() {
        base::TaskShutdownBehavior::CONTINUE_ON_SHUTDOWN},
       base::BindOnce(&AgentClient::ConnectBlocking, server_name_provider_,
                      connector_),
-      base::BindOnce(&AgentClient::OnTransportConnected,
+      base::BindOnce(&AgentClient::OnConnectBlockingCompleted,
                      weak_factory_.GetWeakPtr()));
 }
 
-void AgentClient::OnTransportConnected(ConnectResult result) {
+void AgentClient::OnConnectBlockingCompleted(ConnectResult result) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   CHECK(state_ == State::kConnecting);
 

--- a/components/brave_vpn/browser/v2/agent_client.h
+++ b/components/brave_vpn/browser/v2/agent_client.h
@@ -1,0 +1,189 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_AGENT_CLIENT_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_AGENT_CLIENT_H_
+
+#include <memory>
+#include <optional>
+#include <string_view>
+
+#include "base/functional/callback.h"
+#include "base/memory/weak_ptr.h"
+#include "base/observer_list.h"
+#include "base/observer_list_types.h"
+#include "base/sequence_checker.h"
+#include "base/time/tick_clock.h"
+#include "base/timer/timer.h"
+#include "base/types/expected.h"
+#include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "mojo/public/cpp/platform/named_platform_channel.h"
+#include "mojo/public/cpp/system/message_pipe.h"
+#include "net/base/backoff_entry.h"
+
+namespace brave_vpn::v2 {
+
+class BrowserEndpointImpl;
+
+// The browser end of the browser to agent contract: owns the single connection
+// a VPN keyed service has to the user's agent, drives the handshake, and hands
+// out the authenticated BrowserHost once the agent accepts.
+//
+// Owned per eligible profile, by a VPN keyed service, and constructed on that
+// service's sequence; every method must then be called on that sequence.
+// Several instances per browser process is the expected arrangement, not a
+// mistake to guard against: the agent keys sessions by connection, so each
+// profile gets its own connection/handshake/API surface, and the agent is what
+// reconciles them.
+//
+// There is one agent per user and many clients per agent - every eligible
+// profile of every browser instance the user has open - so from here the agent
+// looks like a shared service that may not be running yet and may go away at
+// any time. Connecting is therefore lazy and failure is routine: a failed
+// connect or a dropped pipe is retried with exponential backoff and jitter. The
+// jitter is load-bearing, because the events worth retrying after are exactly
+// the ones every client sees at the same instant: the agent restarting, or a
+// browser launching several profiles at once.
+class AgentClient {
+ public:
+  enum class State {
+    // Not connected means nothing bound and no attempt scheduled; this is the
+    // initial state, and also the state after a reset.
+    kDisconnected,
+    // Transport connect or handshake in flight.
+    kConnecting,
+    // The agent accepted the connection; browser host is valid.
+    kConnected,
+    // Transient failure; a retry is on the timer.
+    kWaitingToRetry,
+    // No attempt is scheduled, because the last one failed in a way that
+    // retrying cannot change: either the agent refused the browser, or there
+    // is no server name to connect to at all. In the first case the provider
+    // pipe is still held and this state is left on its own when that agent
+    // process exits; in the second nothing is held and only a reset leaves.
+    kUnavailable,
+  };
+
+  class Observer : public base::CheckedObserver {
+   public:
+    // The handshake succeeded; browser host is now usable.
+    virtual void OnAgentConnected() {}
+    // A previously connected session went away. Any browser host pointer handed
+    // out earlier is dangling from here on.
+    virtual void OnAgentDisconnected() {}
+    // Entered "unavailable" state. |result| is the agent's reply, or nullopt
+    // when the failure was not an auth result - today, no server name for this
+    // session. That distinction is also the recovery rule: with a reply there
+    // was a live agent; with nullopt nothing will change without a reset.
+    virtual void OnAgentUnavailable(
+        std::optional<mojom::BrowserAuthResult> result) {}
+    // The agent is not reachable at all, and the client will retry on its own,
+    // while the observing code can start (or restart) the agent.
+    virtual void OnAgentNotRunning() {}
+  };
+
+  // Resolves the agent's server name; runs on a blocking sequence.
+  using ServerNameProvider = base::RepeatingCallback<
+      std::optional<mojo::NamedPlatformChannel::ServerName>()>;
+
+  // Establishes the transport to the agent listening on |server_name| and
+  // returns the pipe its BrowserHostProvider is bound to, or an invalid handle
+  // on failure; runs on a blocking sequence.
+  using Connector = base::RepeatingCallback<mojo::ScopedMessagePipeHandle(
+      const mojo::NamedPlatformChannel::ServerName&)>;
+
+  AgentClient();
+  ~AgentClient();
+
+  AgentClient(const AgentClient&) = delete;
+  AgentClient& operator=(const AgentClient&) = delete;
+
+  // The test seam lets a fake agent be reached without a real socket or pipe.
+  // |tick_clock| overrides the backoff's clock; tests using MOCK_TIME must pass
+  // TaskEnvironment's mock tick clock, or the retry paths will not advance.
+  static std::unique_ptr<AgentClient> CreateForTesting(
+      ServerNameProvider server_name_provider,
+      Connector connector,
+      const base::TickClock* tick_clock);
+
+  // Starts connecting if nothing is in flight, connected, or already scheduled.
+  // Idempotent and safe to call from every entry point that needs the agent. In
+  // the "unavailable" state it does nothing: that state either recovers by
+  // itself or needs a reset, and calling again cannot help either way.
+  void EnsureConnected();
+
+  // Drops the connection, cancels any scheduled retry, clears the backoff and
+  // any terminal state, and returns to the "disconnected" state. Notifies
+  // observers if a session was live.
+  void Reset();
+
+  // The authenticated surface, or nullptr unless state() is "connected". Use it
+  // and drop it within the same task: it is invalidated by disconnection, which
+  // observers learn about through OnAgentDisconnected().
+  mojom::BrowserHost* browser_host();
+
+  State state() const;
+  bool is_connected() const;
+
+  void AddObserver(Observer* observer);
+  void RemoveObserver(Observer* observer);
+
+ private:
+  AgentClient(ServerNameProvider server_name_provider,
+              Connector connector,
+              const base::TickClock* tick_clock = nullptr);
+
+  enum class ConnectError {
+    // No valid server name could be obtained (no GUI session on Linux, or a
+    // path too long for sockaddr_un); cannot be fixed by the service, so this
+    // is a fatal non-retryable error.
+    kNoServerName,
+    // There is a valid server name, but nothing listening on it: the agent is
+    // likely not running, and the service should start it;  this is a transient
+    // error, so retrying is appropriate.
+    kNoAgentRunning,
+  };
+  using ConnectResult =
+      base::expected<mojo::ScopedMessagePipeHandle, ConnectError>;
+
+  // Resolves the server name and connects, both blocking. Static because it
+  // runs off-sequence, where |this| must not be touched.
+  static ConnectResult ConnectBlocking(ServerNameProvider server_name_provider,
+                                       Connector connector);
+
+  void StartConnect();
+  void OnTransportConnected(ConnectResult result);
+  void OnAuthResult(mojom::BrowserAuthResult result);
+  void OnHandshakeTimeout();
+  void OnSessionPipeDisconnected(std::string_view reason);
+  void OnProviderDisconnected();
+  void TeardownAndRetry(std::string_view reason);
+  void EnterUnavailable(std::string_view reason,
+                        std::optional<mojom::BrowserAuthResult> result);
+  void ReportNotRunningIfNeeded();
+  void ClearFailureRun();
+  void ResetSession();
+  void ResetConnection();
+
+  SEQUENCE_CHECKER(sequence_checker_);
+  const ServerNameProvider server_name_provider_;
+  const Connector connector_;
+  State state_ = State::kDisconnected;
+  net::BackoffEntry backoff_;
+  bool not_running_reported_ = false;
+  bool session_pipe_dropped_ = false;
+  mojo::Remote<mojom::BrowserHostProvider> provider_;
+  mojo::Remote<mojom::BrowserHost> host_;
+  std::unique_ptr<BrowserEndpointImpl> browser_endpoint_;
+  base::OneShotTimer handshake_timer_;
+  base::OneShotTimer retry_timer_;
+  base::ObserverList<Observer> observers_;
+  base::WeakPtrFactory<AgentClient> weak_factory_{this};
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_AGENT_CLIENT_H_

--- a/components/brave_vpn/browser/v2/agent_client.h
+++ b/components/brave_vpn/browser/v2/agent_client.h
@@ -18,11 +18,14 @@
 #include "base/time/tick_clock.h"
 #include "base/timer/timer.h"
 #include "base/types/expected.h"
+#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "mojo/public/cpp/platform/named_platform_channel.h"
 #include "mojo/public/cpp/system/message_pipe.h"
 #include "net/base/backoff_entry.h"
+
+static_assert(BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS));
 
 namespace brave_vpn::v2 {
 
@@ -155,7 +158,7 @@ class AgentClient {
                                        Connector connector);
 
   void StartConnect();
-  void OnTransportConnected(ConnectResult result);
+  void OnConnectBlockingCompleted(ConnectResult result);
   void OnAuthResult(mojom::BrowserAuthResult result);
   void OnHandshakeTimeout();
   void OnSessionPipeDisconnected(std::string_view reason);

--- a/components/brave_vpn/browser/v2/agent_client_unittest.cc
+++ b/components/brave_vpn/browser/v2/agent_client_unittest.cc
@@ -1,0 +1,440 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/agent_client.h"
+
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "base/functional/callback.h"
+#include "base/task/thread_pool/thread_pool_instance.h"
+#include "base/test/task_environment.h"
+#include "base/time/time.h"
+#include "brave/components/brave_vpn/browser/v2/test/fake_agent.h"
+#include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2 {
+namespace {
+// Time span long enough to run out any retry the client can schedule, since the
+// backoff is capped: used where a test asserts that nothing further happens.
+constexpr base::TimeDelta kTimePastEveryRetry = base::Minutes(60);
+
+// Time span enough for a queued task or two to run without reaching any timer.
+constexpr base::TimeDelta kTimeBriefly = base::Milliseconds(10);
+
+// Time span between the first and second retry windows, to assert that the
+// backoff is growing.
+constexpr base::TimeDelta kTimeBetweenRetryWindows = base::Seconds(10);
+
+class TestObserver : public AgentClient::Observer {
+ public:
+  void OnAgentConnected() override {
+    ++connected_count_;
+    Notify();
+  }
+
+  void OnAgentDisconnected() override {
+    ++disconnected_count_;
+    Notify();
+  }
+
+  void OnAgentUnavailable(
+      std::optional<mojom::BrowserAuthResult> result) override {
+    ++unavailable_count_;
+    last_unavailable_result_ = result;
+    Notify();
+  }
+
+  void OnAgentNotRunning() override {
+    ++not_running_count_;
+    Notify();
+  }
+
+  // Set to a RunLoop's quit closure for the duration of a wait, so that any
+  // notification ends it: a test that takes the wrong path then fails on an
+  // assertion instead of running out the harness timeout.
+  void set_on_notification(base::RepeatingClosure on_notification) {
+    on_notification_ = std::move(on_notification);
+  }
+
+  int connected_count() const { return connected_count_; }
+  int disconnected_count() const { return disconnected_count_; }
+  int unavailable_count() const { return unavailable_count_; }
+  int not_running_count() const { return not_running_count_; }
+  std::optional<mojom::BrowserAuthResult> last_unavailable_result() const {
+    return last_unavailable_result_;
+  }
+
+ private:
+  void Notify() {
+    if (on_notification_) {
+      on_notification_.Run();
+    }
+  }
+
+  int connected_count_ = 0;
+  int disconnected_count_ = 0;
+  int unavailable_count_ = 0;
+  int not_running_count_ = 0;
+  std::optional<mojom::BrowserAuthResult> last_unavailable_result_;
+  base::RepeatingClosure on_notification_;
+};
+}  // namespace
+
+class AgentClientTest : public testing::Test {
+ public:
+  void SetUp() override { client_ = CreateClient(&observer_); }
+
+  void TearDown() override {
+    if (client_) {
+      client_->RemoveObserver(&observer_);
+      client_.reset();
+    }
+    // The connector runs on the thread pool holding an unretained pointer to
+    // |agent_|, and posts back here to bind the provider. Both have to have run
+    // before either member is destroyed: flush the pool, then this sequence.
+    // Safe to drain fully, because the client is already gone and nothing is
+    // left to schedule more work.
+    base::ThreadPoolInstance::Get()->FlushForTesting();
+    task_environment_.FastForwardUntilNoTasksRemain();
+  }
+
+ protected:
+  std::unique_ptr<AgentClient> CreateClient(TestObserver* observer) {
+    auto client = AgentClient::CreateForTesting(
+        agent_.GetServerNameProvider(), agent_.GetConnector(),
+        task_environment_.GetMockTickClock());
+    client->AddObserver(observer);
+    return client;
+  }
+
+  // Runs until the next notification of any kind reaches |observer_|.
+  void WaitForNotification() {
+    observer_.set_on_notification(task_environment_.QuitClosure());
+    task_environment_.RunUntilQuit();
+    observer_.set_on_notification(base::RepeatingClosure());
+  }
+
+  void ConnectAndWait() {
+    client_->EnsureConnected();
+    WaitForNotification();
+  }
+
+  // Every refusal is terminal in the same way, whatever the agent's reason.
+  void ExpectRefusalIsTerminal(mojom::BrowserAuthResult result) {
+    agent_.set_auth_result(result);
+    ConnectAndWait();
+
+    EXPECT_EQ(observer_.unavailable_count(), 1);
+    EXPECT_EQ(observer_.last_unavailable_result(), result);
+    EXPECT_EQ(observer_.connected_count(), 0);
+    EXPECT_EQ(client_->state(), AgentClient::State::kUnavailable);
+    EXPECT_FALSE(client_->browser_host());
+
+    // No retry, however long we wait or however often we ask.
+    const int attempts = agent_.connect_attempts();
+    client_->EnsureConnected();
+    task_environment_.FastForwardBy(kTimePastEveryRetry);
+    EXPECT_EQ(agent_.connect_attempts(), attempts);
+    EXPECT_EQ(client_->state(), AgentClient::State::kUnavailable);
+  }
+
+  base::test::TaskEnvironment task_environment_{
+      base::test::TaskEnvironment::TimeSource::MOCK_TIME};
+  FakeAgent agent_;
+  TestObserver observer_;
+  std::unique_ptr<AgentClient> client_;
+};
+
+// Constructing a client must not reach for the agent, or every profile would
+// wake it at startup.
+TEST_F(AgentClientTest, InitiallyIdle) {
+  EXPECT_EQ(client_->state(), AgentClient::State::kDisconnected);
+  EXPECT_FALSE(client_->browser_host());
+  EXPECT_EQ(agent_.connect_attempts(), 0);
+}
+
+TEST_F(AgentClientTest, HandshakeSucceeds) {
+  ConnectAndWait();
+
+  EXPECT_EQ(observer_.connected_count(), 1);
+  EXPECT_EQ(observer_.not_running_count(), 0);
+  EXPECT_EQ(observer_.unavailable_count(), 0);
+
+  EXPECT_EQ(client_->state(), AgentClient::State::kConnected);
+  EXPECT_TRUE(client_->is_connected());
+  EXPECT_TRUE(client_->browser_host());
+
+  EXPECT_EQ(agent_.connect_attempts(), 1);
+  EXPECT_EQ(agent_.bind_browser_host_calls(), 1);
+  EXPECT_EQ(agent_.last_protocol_version(), mojom::kProtocolVersion);
+  EXPECT_TRUE(agent_.has_browser_endpoint());
+}
+
+TEST_F(AgentClientTest, EnsureConnectedIsIdempotent) {
+  client_->EnsureConnected();
+  client_->EnsureConnected();
+  client_->EnsureConnected();
+  WaitForNotification();
+
+  EXPECT_EQ(observer_.connected_count(), 1);
+  EXPECT_EQ(agent_.connect_attempts(), 1);
+  EXPECT_EQ(agent_.bind_browser_host_calls(), 1);
+}
+
+TEST_F(AgentClientTest, LosingSessionPipesWhileConnectedReconnects) {
+  ConnectAndWait();
+
+  agent_.DropSessionHandles();
+  WaitForNotification();
+
+  EXPECT_EQ(observer_.disconnected_count(), 1);
+  EXPECT_FALSE(client_->browser_host());
+  EXPECT_EQ(client_->state(), AgentClient::State::kWaitingToRetry);
+}
+
+// The host pipe is bound before the handshake completes, so the state is what
+// gates access to it, not the remote.
+TEST_F(AgentClientTest, HostIsNotPublishedBeforeAcceptance) {
+  agent_.set_auth_result(std::nullopt);
+  client_->EnsureConnected();
+  task_environment_.FastForwardBy(kTimeBriefly);
+
+  ASSERT_TRUE(agent_.has_held_request());
+  EXPECT_EQ(client_->state(), AgentClient::State::kConnecting);
+  EXPECT_FALSE(client_->browser_host());
+  EXPECT_EQ(observer_.connected_count(), 0);
+}
+
+TEST_F(AgentClientTest, UnreachableAgentIsRetriedUntilItAppears) {
+  agent_.set_transport_fails(true);
+  ConnectAndWait();
+
+  EXPECT_EQ(observer_.not_running_count(), 1);
+  EXPECT_EQ(client_->state(), AgentClient::State::kWaitingToRetry);
+  EXPECT_FALSE(client_->browser_host());
+  // Nothing was ever up, so there is no session loss to report.
+  EXPECT_EQ(observer_.disconnected_count(), 0);
+
+  agent_.set_transport_fails(false);
+  task_environment_.FastForwardBy(kTimePastEveryRetry);
+
+  EXPECT_GT(agent_.connect_attempts(), 1);
+  EXPECT_EQ(client_->state(), AgentClient::State::kConnected);
+  EXPECT_EQ(observer_.connected_count(), 1);
+}
+
+// The service reacts to this by trying to start the agent, so it has to be one
+// notification per run of failures rather than one per attempt.
+TEST_F(AgentClientTest, NotRunningIsNotifiedOncePerRunOfFailures) {
+  agent_.set_transport_fails(true);
+  ConnectAndWait();
+  ASSERT_EQ(observer_.not_running_count(), 1);
+
+  task_environment_.FastForwardBy(kTimePastEveryRetry);
+  ASSERT_GT(agent_.connect_attempts(), 2);
+  EXPECT_EQ(observer_.not_running_count(), 1);
+
+  // A success ends the run; the next failure after it is a new one.
+  agent_.set_transport_fails(false);
+  task_environment_.FastForwardBy(kTimePastEveryRetry);
+  ASSERT_EQ(client_->state(), AgentClient::State::kConnected);
+
+  agent_.set_transport_fails(true);
+  agent_.CloseAllConnections();
+  task_environment_.FastForwardBy(kTimePastEveryRetry);
+  EXPECT_EQ(observer_.not_running_count(), 2);
+}
+
+TEST_F(AgentClientTest, RetryDelayGrowsWhileFailing) {
+  agent_.set_transport_fails(true);
+  ConnectAndWait();
+
+  const int before_first_window = agent_.connect_attempts();
+  task_environment_.FastForwardBy(kTimeBetweenRetryWindows);
+  const int first_window = agent_.connect_attempts() - before_first_window;
+
+  task_environment_.FastForwardBy(kTimeBetweenRetryWindows);
+  const int second_window =
+      agent_.connect_attempts() - first_window - before_first_window;
+
+  EXPECT_GT(first_window, 0);
+  EXPECT_GT(first_window, second_window);
+}
+
+// A session that was up and then dropped is not evidence that reconnecting will
+// fail, so the ramp starts over rather than continuing from where it was.
+TEST_F(AgentClientTest, LosingSessionResetsTheBackoff) {
+  // Climb the ramp first, so that inheriting it would be visible.
+  agent_.set_transport_fails(true);
+  ConnectAndWait();
+  task_environment_.FastForwardBy(kTimePastEveryRetry);
+  ASSERT_GT(agent_.connect_attempts(), 2);
+
+  agent_.set_transport_fails(false);
+  task_environment_.FastForwardBy(kTimePastEveryRetry);
+  ASSERT_EQ(client_->state(), AgentClient::State::kConnected);
+
+  // Drop the session and make the next attempt fail, so the client stops in
+  // kWaitingToRetry with a delay we can time.
+  agent_.set_transport_fails(true);
+  agent_.CloseAllConnections();
+  WaitForNotification();
+  ASSERT_EQ(observer_.disconnected_count(), 1);
+  ASSERT_EQ(client_->state(), AgentClient::State::kWaitingToRetry);
+
+  // Well under the capped delay the old ramp had reached, but over the first
+  // delay of a fresh one.
+  const int attempts = agent_.connect_attempts();
+  task_environment_.FastForwardBy(base::Seconds(2));
+  EXPECT_GT(agent_.connect_attempts(), attempts);
+}
+
+TEST_F(AgentClientTest, RejectionIsTerminal) {
+  ExpectRefusalIsTerminal(mojom::BrowserAuthResult::kRejected);
+}
+
+TEST_F(AgentClientTest, VersionMismatchIsTerminal) {
+  ExpectRefusalIsTerminal(mojom::BrowserAuthResult::kVersionMismatch);
+}
+
+TEST_F(AgentClientTest, HostAlreadyRequestedIsTerminal) {
+  ExpectRefusalIsTerminal(mojom::BrowserAuthResult::kHostAlreadyRequested);
+}
+
+// The reason the provider pipe is held open in the terminal state: the verdict
+// belongs to that agent binary, so its replacement gets a fresh answer. This is
+// how a browser that updated ahead of a running agent recovers without being
+// restarted.
+TEST_F(AgentClientTest, RefusedClientReconnectsWhenAgentIsReplaced) {
+  agent_.set_auth_result(mojom::BrowserAuthResult::kVersionMismatch);
+  ConnectAndWait();
+  ASSERT_EQ(client_->state(), AgentClient::State::kUnavailable);
+
+  // The refusing agent exits and a newer one takes its place.
+  agent_.set_auth_result(mojom::BrowserAuthResult::kAccepted);
+  agent_.CloseAllConnections();
+  WaitForNotification();
+
+  EXPECT_EQ(observer_.connected_count(), 1);
+  EXPECT_EQ(client_->state(), AgentClient::State::kConnected);
+  EXPECT_TRUE(client_->browser_host());
+}
+
+TEST_F(AgentClientTest, NoServerNameIsTerminalUntilReset) {
+  agent_.set_server_name_available(false);
+  ConnectAndWait();
+
+  EXPECT_EQ(observer_.unavailable_count(), 1);
+  // Not an auth result: there was no agent to hear from.
+  EXPECT_EQ(observer_.last_unavailable_result(), std::nullopt);
+  EXPECT_EQ(client_->state(), AgentClient::State::kUnavailable);
+  EXPECT_EQ(agent_.connect_attempts(), 0);
+
+  task_environment_.FastForwardBy(kTimePastEveryRetry);
+  EXPECT_EQ(agent_.connect_attempts(), 0);
+
+  // Reset() is the only way out, and there is nothing holding the state open.
+  client_->Reset();
+  EXPECT_EQ(client_->state(), AgentClient::State::kDisconnected);
+
+  agent_.set_server_name_available(true);
+  ConnectAndWait();
+  EXPECT_EQ(client_->state(), AgentClient::State::kConnected);
+}
+
+// A peer that takes the connection and never answers, shouldn't hold the client
+// in kConnecting forever.
+TEST_F(AgentClientTest, SilentAgentTimesOutAndRetries) {
+  agent_.set_auth_result(std::nullopt);
+  client_->EnsureConnected();
+  task_environment_.FastForwardBy(kTimeBriefly);
+  ASSERT_EQ(client_->state(), AgentClient::State::kConnecting);
+
+  task_environment_.FastForwardBy(kTimePastEveryRetry);
+
+  EXPECT_EQ(observer_.connected_count(), 0);
+  EXPECT_FALSE(client_->browser_host());
+  EXPECT_GT(agent_.connect_attempts(), 1);
+}
+
+// The reply travels on the provider pipe and the refusal drops handles on two
+// others, with no ordering between them. An acceptance that lands after the
+// session pipes are gone must not publish a host that cannot deliver anything.
+TEST_F(AgentClientTest, AcceptanceOnDeadSessionIsNotPublished) {
+  agent_.set_auth_result(std::nullopt);
+  client_->EnsureConnected();
+  task_environment_.FastForwardBy(kTimeBriefly);
+  ASSERT_TRUE(agent_.has_held_request());
+
+  // The client sees the pipes close first.
+  agent_.DropSessionHandles();
+  task_environment_.FastForwardBy(kTimeBriefly);
+  agent_.AnswerHeldRequest(mojom::BrowserAuthResult::kAccepted);
+  task_environment_.FastForwardBy(kTimeBriefly);
+
+  EXPECT_EQ(observer_.connected_count(), 0);
+  EXPECT_FALSE(client_->browser_host());
+  EXPECT_EQ(client_->state(), AgentClient::State::kWaitingToRetry);
+}
+
+TEST_F(AgentClientTest, ResetWhileConnectingIsSafe) {
+  client_->EnsureConnected();
+  client_->Reset();
+
+  base::ThreadPoolInstance::Get()->FlushForTesting();
+  task_environment_.FastForwardBy(kTimeBriefly);
+
+  EXPECT_EQ(client_->state(), AgentClient::State::kDisconnected);
+  EXPECT_EQ(observer_.connected_count(), 0);
+  EXPECT_EQ(observer_.disconnected_count(), 0);
+
+  ConnectAndWait();
+  EXPECT_EQ(client_->state(), AgentClient::State::kConnected);
+}
+
+TEST_F(AgentClientTest, ResetWhileConnectedNotifiesAndSchedulesNothing) {
+  ConnectAndWait();
+  ASSERT_EQ(client_->state(), AgentClient::State::kConnected);
+
+  client_->Reset();
+
+  EXPECT_EQ(observer_.disconnected_count(), 1);
+  EXPECT_EQ(client_->state(), AgentClient::State::kDisconnected);
+  EXPECT_FALSE(client_->browser_host());
+
+  const int attempts = agent_.connect_attempts();
+  task_environment_.FastForwardBy(kTimePastEveryRetry);
+  EXPECT_EQ(agent_.connect_attempts(), attempts);
+}
+
+// Several clients per browser process is the expected arrangement, since the
+// agent keys sessions by connection.
+TEST_F(AgentClientTest, TwoClientsGetIndependentSessions) {
+  TestObserver second_observer;
+  std::unique_ptr<AgentClient> second_client = CreateClient(&second_observer);
+
+  ConnectAndWait();
+  second_client->EnsureConnected();
+  task_environment_.FastForwardBy(kTimeBriefly);
+
+  EXPECT_TRUE(client_->is_connected());
+  EXPECT_TRUE(second_client->is_connected());
+  EXPECT_EQ(agent_.connection_count(), 2u);
+  EXPECT_EQ(agent_.session_count(), 2u);
+  EXPECT_EQ(agent_.bind_browser_host_calls(), 2);
+
+  // One going away leaves the other alone.
+  second_client->Reset();
+  task_environment_.FastForwardBy(kTimeBriefly);
+  EXPECT_TRUE(client_->is_connected());
+  EXPECT_EQ(agent_.connection_count(), 1u);
+
+  second_client->RemoveObserver(&second_observer);
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
@@ -23,7 +23,6 @@
 #include "brave/components/brave_vpn/browser/v2/skus_service_client.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
-#include "build/build_config.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 
 namespace brave_vpn::v2 {
@@ -121,10 +120,7 @@ void BraveVpnServiceImpl::GetAllRegions(GetAllRegionsCallback callback) {
 
 void BraveVpnServiceImpl::Shutdown() {
 #if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
-  if (agent_client_) {
-    agent_client_->RemoveObserver(this);
-    agent_client_.reset();
-  }
+  agent_client_.reset();
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
   purchased_state_manager_.reset();
   api_client_.reset();

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
@@ -8,11 +8,13 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 
 #include "base/check.h"
 #include "base/check_deref.h"
 #include "base/functional/bind.h"
+#include "base/logging.h"
 #include "base/notimplemented.h"
 #include "base/sequence_checker.h"
 #include "base/types/to_address.h"
@@ -20,9 +22,33 @@
 #include "brave/components/brave_vpn/browser/v2/purchased_state_manager.h"
 #include "brave/components/brave_vpn/browser/v2/skus_service_client.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
+#include "build/build_config.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 
 namespace brave_vpn::v2 {
+namespace {
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+
+std::string_view BrowserAuthResultToString(
+    std::optional<mojom::BrowserAuthResult> result) {
+  if (!result.has_value()) {
+    return "unknown";
+  }
+  switch (result.value()) {
+    case mojom::BrowserAuthResult::kAccepted:
+      return "accepted";
+    case mojom::BrowserAuthResult::kRejected:
+      return "rejected";
+    case mojom::BrowserAuthResult::kVersionMismatch:
+      return "version mismatch";
+    case mojom::BrowserAuthResult::kHostAlreadyRequested:
+      return "host already requested";
+  }
+}
+
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+}  // namespace
 
 BraveVpnServiceImpl::BraveVpnServiceImpl(
     PrefService* local_prefs,
@@ -36,6 +62,10 @@ BraveVpnServiceImpl::BraveVpnServiceImpl(
           std::make_unique<SkusServiceClient>(std::move(skus_service_getter))),
       connection_state_(mojom::ConnectionState::DISCONNECTED) {
   DCHECK(IsBraveVPNFeatureEnabled());
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+  agent_client_ = std::make_unique<AgentClient>();
+  agent_client_->AddObserver(this);
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
   purchased_state_manager_ = std::make_unique<PurchasedStateManager>(
       local_prefs, api_client_.get(), skus_client_.get(),
       base::BindRepeating(&BraveVpnServiceImpl::OnPurchasedStateChanged,
@@ -90,6 +120,12 @@ void BraveVpnServiceImpl::GetAllRegions(GetAllRegionsCallback callback) {
 }
 
 void BraveVpnServiceImpl::Shutdown() {
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+  if (agent_client_) {
+    agent_client_->RemoveObserver(this);
+    agent_client_.reset();
+  }
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
   purchased_state_manager_.reset();
   api_client_.reset();
   skus_client_->Reset();
@@ -100,12 +136,81 @@ void BraveVpnServiceImpl::OnPurchasedStateChanged(
     mojom::PurchasedState state,
     std::optional<std::string> description) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+  UpdateAgentConnection(state);
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+
   NotifyPurchasedStateChanged(state, description);
 
   // TODO: If purchased state changed to PURCHASED on desktop, we can attempt to
-  // install VPN apps, connect to the agent, etc. We also need to make sure
-  // agent gets connected and fetches the region data - BEFORE we actually send
-  // a notification to the UI.
+  // install VPN helper, etc. We also need to make sure the agent, once
+  // connected, fetches the region data - BEFORE we actually send a notification
+  // to the UI.
 }
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+
+void BraveVpnServiceImpl::UpdateAgentConnection(mojom::PurchasedState state) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (!agent_client_) {
+    return;
+  }
+
+  switch (state) {
+    case mojom::PurchasedState::PURCHASED:
+      // The only state that justifies waking the agent. Policy still gets
+      // checked: a profile where the VPN is disabled must not open a connection
+      // at all.
+      if (IsBraveVPNEnabled()) {
+        agent_client_->EnsureConnected();
+      }
+      return;
+    case mojom::PurchasedState::NOT_PURCHASED:
+      // Nothing left to drive, so stop holding a session the agent would keep
+      // alive for this profile. Reset() also clears any refusal verdict, so a
+      // later purchase starts from a clean attempt.
+      agent_client_->Reset();
+      return;
+    case mojom::PurchasedState::LOADING:
+    case mojom::PurchasedState::SESSION_EXPIRED:
+    case mojom::PurchasedState::FAILED:
+    case mojom::PurchasedState::OUT_OF_CREDENTIALS:
+      // Deliberately no change. All four are recoverable and can coexist with a
+      // live tunnel, so an existing connection stays up - the person still has
+      // to be able to disconnect - while none of them is a reason to open one.
+      return;
+  }
+}
+
+void BraveVpnServiceImpl::OnAgentConnected() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  VLOG(1) << "Agent session established";
+}
+
+void BraveVpnServiceImpl::OnAgentDisconnected() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  VLOG(1) << "Agent session lost";
+}
+
+void BraveVpnServiceImpl::OnAgentUnavailable(
+    std::optional<mojom::BrowserAuthResult> result) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  LOG(ERROR) << "Agent refused this browser, reason: "
+             << BrowserAuthResultToString(result);
+}
+
+void BraveVpnServiceImpl::OnAgentNotRunning() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  LOG(ERROR) << "Agent is not running";
+
+  // TODO(https://github.com/brave/brave-browser/issues/58243)
+  // The agent process is apparently not running. While the agent client will
+  // retry on its own, check if the agent is running and start it if not. This
+  // is a workaround for the case where the agent is not started by the
+  // privileged helper.
+}
+
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
@@ -14,7 +14,12 @@
 #include "base/memory/raw_ref.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/browser/v2/skus_service_client.h"
+#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "build/build_config.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+#include "brave/components/brave_vpn/browser/v2/agent_client.h"
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
 
 namespace network {
 class SharedURLLoaderFactory;
@@ -27,7 +32,12 @@ namespace brave_vpn::v2 {
 class BraveVpnApiClient;
 class PurchasedStateManager;
 
-class BraveVpnServiceImpl : public BraveVpnService {
+class BraveVpnServiceImpl : public BraveVpnService
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+    ,
+                            public AgentClient::Observer
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+{
  public:
   BraveVpnServiceImpl(
       PrefService* local_prefs,
@@ -127,8 +137,22 @@ class BraveVpnServiceImpl : public BraveVpnService {
   // KeyedService overrides:
   void Shutdown() override;
 
-  // BraveVpnService overrides:
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+  // Brings the agent connection in line with |state|. The subscription is what
+  // decides whether this profile has any business holding a connection, so this
+  // is the one place that opens or drops one.
+  void UpdateAgentConnection(mojom::PurchasedState state);
+
+  // AgentClient::Observer overrides:
+  void OnAgentConnected() override;
+  void OnAgentDisconnected() override;
+  void OnAgentUnavailable(
+      std::optional<mojom::BrowserAuthResult> result) override;
+  void OnAgentNotRunning() override;
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+
 #if !BUILDFLAG(IS_ANDROID)
+  // BraveVpnService overrides:
   void SetConnectionStateForTesting(mojom::ConnectionState state) override;
   void SetPurchasedStateForTesting(const std::string& env,
                                    mojom::PurchasedState state) override;
@@ -140,7 +164,11 @@ class BraveVpnServiceImpl : public BraveVpnService {
   const raw_ref<PrefService> profile_prefs_;
   std::unique_ptr<BraveVpnApiClient> api_client_;
   std::unique_ptr<SkusServiceClient> skus_client_;
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+  std::unique_ptr<AgentClient> agent_client_;
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
   std::unique_ptr<PurchasedStateManager> purchased_state_manager_;
+
   [[maybe_unused]] mojom::ConnectionState connection_state_;
 };
 

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_unittest.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_unittest.cc
@@ -10,10 +10,13 @@
 #include <string>
 
 #include "base/functional/bind.h"
+#include "base/task/thread_pool/thread_pool_instance.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/task_environment.h"
 #include "base/test/test_future.h"
+#include "base/values.h"
 #include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/features.h"
 #include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"
 #include "brave/components/brave_vpn/common/pref_names.h"
@@ -29,6 +32,10 @@
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+#include "brave/components/brave_vpn/browser/v2/test/fake_agent.h"
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
 
 namespace brave_vpn::v2 {
 namespace {
@@ -51,6 +58,10 @@ class BraveVpnServiceImplTest : public testing::Test {
     brave_vpn::RegisterProfilePrefs(profile_pref_service_.registry());
   }
 
+  void TearDown() override {
+    base::ThreadPoolInstance::Get()->FlushForTesting();
+  }
+
   mojo::PendingRemote<skus::mojom::SkusService> GetSkusService() {
     ++skus_bind_count_;
     return fake_skus_service_.MakeRemote();
@@ -62,9 +73,41 @@ class BraveVpnServiceImplTest : public testing::Test {
         url_loader_factory_.GetSafeWeakWrapper(),
         base::BindRepeating(&BraveVpnServiceImplTest::GetSkusService,
                             base::Unretained(this)));
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+    // Replace the inert agent client the constructor made with one that never
+    // talks to the real agent, so tests are properly isolated.
+    ASSERT_TRUE(service_->agent_client_);
+    ASSERT_EQ(service_->agent_client_->state(),
+              AgentClient::State::kDisconnected);
+    ReplaceAgentClientWithFake();
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
   }
 
   void ShutdownService() { service_->Shutdown(); }
+
+  void BlockVPNByPolicy(bool value) {
+    profile_pref_service_.SetManagedPref(prefs::kManagedBraveVPNDisabled,
+                                         base::Value(value));
+    EXPECT_EQ(brave_vpn::IsBraveVPNDisabledByPolicy(&profile_pref_service_),
+              value);
+  }
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+  // Mirrors the wiring in BraveVpnServiceImpl's constructor. Keep in sync.
+  void ReplaceAgentClientWithFake() {
+    service_->agent_client_->RemoveObserver(service_.get());
+    service_->agent_client_ = AgentClient::CreateForTesting(
+        fake_agent_.GetServerNameProvider(), fake_agent_.GetConnector(),
+        /*tick_clock=*/nullptr);
+    service_->agent_client_->AddObserver(service_.get());
+  }
+
+  void UpdateAgentConnection(mojom::PurchasedState state) {
+    service_->UpdateAgentConnection(state);
+  }
+
+  AgentClient* agent_client() { return service_->agent_client_.get(); }
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
 
  protected:
   base::test::TaskEnvironment task_environment_;
@@ -74,8 +117,11 @@ class BraveVpnServiceImplTest : public testing::Test {
   network::TestURLLoaderFactory url_loader_factory_;
   skus::FakeSkusService fake_skus_service_;
   int skus_bind_count_ = 0;
-  // Declared last so it is destroyed before the prefs and the fake SKUS
-  // service it points at.
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+  FakeAgent fake_agent_;
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+  // Declared last so it is destroyed before the prefs, the fake SKUS
+  // service, and the fake agent it points at.
   std::unique_ptr<BraveVpnServiceImpl> service_;
 };
 
@@ -123,6 +169,13 @@ TEST_F(BraveVpnServiceImplTest, SafeDefaultsAfterShutdown) {
     EXPECT_EQ(info->state, mojom::PurchasedState::NOT_PURCHASED);
     EXPECT_EQ(info->description, std::nullopt);
   }
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+  // The agent client is gone; the mapping must not dereference it.
+  UpdateAgentConnection(mojom::PurchasedState::PURCHASED);
+  UpdateAgentConnection(mojom::PurchasedState::NOT_PURCHASED);
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+
 #if !BUILDFLAG(IS_ANDROID)
   {
     base::test::TestFuture<bool, std::string> future;
@@ -134,5 +187,39 @@ TEST_F(BraveVpnServiceImplTest, SafeDefaultsAfterShutdown) {
   }
 #endif  // !BUILDFLAG(IS_ANDROID)
 }
+
+#if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+
+TEST_F(BraveVpnServiceImplTest, PurchasedStateDrivesAgentConnection) {
+  CreateService();
+  ASSERT_TRUE(agent_client());
+  ASSERT_EQ(agent_client()->state(), AgentClient::State::kDisconnected);
+
+  UpdateAgentConnection(mojom::PurchasedState::PURCHASED);
+  EXPECT_EQ(agent_client()->state(), AgentClient::State::kConnecting);
+
+  // The recoverable states leave a live connection alone: each can coexist with
+  // a running tunnel, and the person still has to be able to disconnect it.
+  for (const auto state :
+       {mojom::PurchasedState::LOADING, mojom::PurchasedState::SESSION_EXPIRED,
+        mojom::PurchasedState::FAILED,
+        mojom::PurchasedState::OUT_OF_CREDENTIALS}) {
+    UpdateAgentConnection(state);
+    EXPECT_EQ(agent_client()->state(), AgentClient::State::kConnecting)
+        << "dropped the connection on " << static_cast<int>(state);
+  }
+
+  UpdateAgentConnection(mojom::PurchasedState::NOT_PURCHASED);
+  EXPECT_EQ(agent_client()->state(), AgentClient::State::kDisconnected);
+}
+
+TEST_F(BraveVpnServiceImplTest, PolicyDisabledKeepsAgentDisconnected) {
+  BlockVPNByPolicy(true);
+  CreateService();
+  UpdateAgentConnection(mojom::PurchasedState::PURCHASED);
+  EXPECT_EQ(agent_client()->state(), AgentClient::State::kDisconnected);
+}
+
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_unittest.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_unittest.cc
@@ -200,7 +200,7 @@ TEST_F(BraveVpnServiceImplTest, PurchasedStateDrivesAgentConnection) {
 
   // The recoverable states leave a live connection alone: each can coexist with
   // a running tunnel, and the person still has to be able to disconnect it.
-  for (const auto state :
+  for (const mojom::PurchasedState state :
        {mojom::PurchasedState::LOADING, mojom::PurchasedState::SESSION_EXPIRED,
         mojom::PurchasedState::FAILED,
         mojom::PurchasedState::OUT_OF_CREDENTIALS}) {

--- a/components/brave_vpn/browser/v2/browser_endpoint_impl.cc
+++ b/components/brave_vpn/browser/v2/browser_endpoint_impl.cc
@@ -1,0 +1,39 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/browser_endpoint_impl.h"
+
+#include <utility>
+
+#include "base/check.h"
+#include "base/functional/bind.h"
+
+namespace brave_vpn::v2 {
+
+BrowserEndpointImpl::BrowserEndpointImpl(base::OnceClosure disconnect_handler)
+    : disconnect_handler_(std::move(disconnect_handler)) {
+  CHECK(disconnect_handler_);
+}
+
+BrowserEndpointImpl::~BrowserEndpointImpl() = default;
+
+mojo::PendingRemote<mojom::BrowserEndpoint>
+BrowserEndpointImpl::BindNewPipeAndPassRemote() {
+  CHECK(!receiver_.is_bound());
+  auto remote = receiver_.BindNewPipeAndPassRemote();
+  receiver_.set_disconnect_handler(base::BindOnce(
+      &BrowserEndpointImpl::OnPipeDisconnected, base::Unretained(this)));
+  return remote;
+}
+
+void BrowserEndpointImpl::OnPipeDisconnected() {
+  // Stop listening before running the handler.
+  receiver_.reset();
+  if (disconnect_handler_) {
+    std::move(disconnect_handler_).Run();
+  }
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/browser_endpoint_impl.h
+++ b/components/brave_vpn/browser/v2/browser_endpoint_impl.h
@@ -1,0 +1,48 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_BROWSER_ENDPOINT_IMPL_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_BROWSER_ENDPOINT_IMPL_H_
+
+#include "base/functional/callback.h"
+#include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+
+namespace brave_vpn::v2 {
+
+// The browser's subordinate surface: everything the agent may call back into
+// this browser, one instance per connection attempt, created and owned by
+// AgentClient.
+class BrowserEndpointImpl : public brave_vpn::mojom::BrowserEndpoint {
+ public:
+  // |disconnect_handler| runs the first time the pipe drops, which happens
+  // either because the agent refused this connection, or because the agent went
+  // away. It is allowed to destroy this object.
+  explicit BrowserEndpointImpl(base::OnceClosure disconnect_handler);
+  ~BrowserEndpointImpl() override;
+
+  BrowserEndpointImpl(const BrowserEndpointImpl&) = delete;
+  BrowserEndpointImpl& operator=(const BrowserEndpointImpl&) = delete;
+
+  // Binds the receiver and returns the remote to send to the agent. Called
+  // exactly once, before the instance is handed to the agent API.
+  mojo::PendingRemote<mojom::BrowserEndpoint> BindNewPipeAndPassRemote();
+
+ private:
+  // brave_vpn::mojom::BrowserEndpoint:
+  // Nothing yet: the interface is a placeholder for the agent-initiated half of
+  // the contract. New methods forward to a delegate injected here rather than
+  // reaching into browser state directly.
+
+  void OnPipeDisconnected();
+
+  base::OnceClosure disconnect_handler_;
+  mojo::Receiver<mojom::BrowserEndpoint> receiver_{this};
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_BROWSER_ENDPOINT_IMPL_H_

--- a/components/brave_vpn/browser/v2/browser_endpoint_impl.h
+++ b/components/brave_vpn/browser/v2/browser_endpoint_impl.h
@@ -7,9 +7,12 @@
 #define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_BROWSER_ENDPOINT_IMPL_H_
 
 #include "base/functional/callback.h"
+#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver.h"
+
+static_assert(BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS));
 
 namespace brave_vpn::v2 {
 

--- a/components/brave_vpn/browser/v2/test/fake_agent.cc
+++ b/components/brave_vpn/browser/v2/test/fake_agent.cc
@@ -1,0 +1,168 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/test/fake_agent.h"
+
+#include <utility>
+
+#include "base/check.h"
+#include "base/functional/bind.h"
+#include "base/location.h"
+#include "base/task/sequenced_task_runner.h"
+#include "build/build_config.h"
+
+namespace brave_vpn::v2 {
+
+namespace {
+#if BUILDFLAG(IS_WIN)
+constexpr wchar_t kFakeServerName[] = L"fake-agent";
+#else
+constexpr char kFakeServerName[] = "fake-agent";
+#endif
+}  // namespace
+
+FakeAgent::FakeAgent() = default;
+
+FakeAgent::~FakeAgent() = default;
+
+AgentClient::ServerNameProvider FakeAgent::GetServerNameProvider() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  return base::BindRepeating(&FakeAgent::GetServerName, base::Unretained(this));
+}
+
+AgentClient::Connector FakeAgent::GetConnector() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  return base::BindRepeating(&FakeAgent::Connect, base::Unretained(this),
+                             base::SequencedTaskRunner::GetCurrentDefault());
+}
+
+void FakeAgent::set_auth_result(
+    std::optional<mojom::BrowserAuthResult> result) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  auth_result_ = result;
+}
+
+void FakeAgent::AnswerHeldRequest(mojom::BrowserAuthResult result) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  CHECK(held_reply_) << "No withheld request to answer";
+  std::move(held_reply_).Run(result);
+}
+
+void FakeAgent::DropSessionHandles() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  browser_endpoints_.clear();
+  parked_hosts_.clear();
+}
+
+void FakeAgent::CloseAllConnections() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  DropSessionHandles();
+  provider_receivers_.Clear();
+  held_reply_.Reset();
+}
+
+int FakeAgent::bind_browser_host_calls() const {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  return bind_browser_host_calls_;
+}
+
+std::optional<uint32_t> FakeAgent::last_protocol_version() const {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  return last_protocol_version_;
+}
+
+size_t FakeAgent::connection_count() const {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  return provider_receivers_.size();
+}
+
+size_t FakeAgent::session_count() const {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  return browser_endpoints_.size();
+}
+
+bool FakeAgent::has_held_request() const {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  return !held_reply_.is_null();
+}
+
+std::optional<mojo::NamedPlatformChannel::ServerName>
+FakeAgent::GetServerName() {
+  // Deliberately no sequence check: runs on the thread pool. The name is never
+  // looked up - Connect() ignores it - so its only job is to be present or
+  // absent.
+  if (!server_name_available_.load()) {
+    return std::nullopt;
+  }
+  return mojo::NamedPlatformChannel::ServerName(kFakeServerName);
+}
+
+mojo::ScopedMessagePipeHandle FakeAgent::Connect(
+    scoped_refptr<base::SequencedTaskRunner> agent_task_runner,
+    const mojo::NamedPlatformChannel::ServerName& server_name) {
+  // Deliberately no sequence check: this runs on the thread pool, like the
+  // production connector, and touches only the atomics.
+  connect_attempts_.fetch_add(1);
+  if (transport_fails_.load()) {
+    return mojo::ScopedMessagePipeHandle();
+  }
+
+  // Stands in for a connected channel plus an accepted invitation. Created here
+  // rather than on the agent's sequence so that the handle reaches the client
+  // the same way the real one does: as the return value of an off-sequence
+  // call.
+  mojo::MessagePipe pipe;
+  agent_task_runner->PostTask(
+      FROM_HERE,
+      base::BindOnce(&FakeAgent::BindProvider, base::Unretained(this),
+                     std::move(pipe.handle0)));
+  return std::move(pipe.handle1);
+}
+
+void FakeAgent::BindProvider(mojo::ScopedMessagePipeHandle pipe) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  provider_receivers_.Add(
+      this, mojo::PendingReceiver<mojom::BrowserHostProvider>(std::move(pipe)));
+}
+
+void FakeAgent::BindBrowserHost(
+    uint32_t protocol_version,
+    mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint,
+    mojo::PendingReceiver<mojom::BrowserHost> host,
+    BindBrowserHostCallback callback) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  ++bind_browser_host_calls_;
+  last_protocol_version_ = protocol_version;
+
+  if (!auth_result_) {
+    // An agent that has taken the connection and gone quiet. The handles are
+    // kept so that a test can decide when, and whether, they go away.
+    //
+    // A withheld reply may already be here: the client times the handshake out
+    // and retries, which arrives as a second request. The earlier one belongs
+    // to a connection the client has since dropped, so answering it could reach
+    // nobody; the newest request is the only one worth holding.
+    held_reply_ = std::move(callback);
+    KeepSession(std::move(browser_endpoint), std::move(host));
+    return;
+  }
+
+  if (*auth_result_ == mojom::BrowserAuthResult::kAccepted) {
+    KeepSession(std::move(browser_endpoint), std::move(host));
+  }
+  // On any other reply both handles go out of scope here, as they do in the
+  // real agent, which is what makes a refusal race its own reply.
+  std::move(callback).Run(*auth_result_);
+}
+
+void FakeAgent::KeepSession(
+    mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint,
+    mojo::PendingReceiver<mojom::BrowserHost> host) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  browser_endpoints_.emplace_back(std::move(browser_endpoint));
+  parked_hosts_.push_back(std::move(host));
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/test/fake_agent.h
+++ b/components/brave_vpn/browser/v2/test/fake_agent.h
@@ -1,0 +1,156 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_TEST_FAKE_AGENT_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_TEST_FAKE_AGENT_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <atomic>
+#include <optional>
+#include <vector>
+
+#include "base/memory/scoped_refptr.h"
+#include "base/sequence_checker.h"
+#include "base/thread_annotations.h"
+#include "brave/components/brave_vpn/browser/v2/agent_client.h"
+#include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+#include "mojo/public/cpp/bindings/receiver_set.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "mojo/public/cpp/platform/named_platform_channel.h"
+#include "mojo/public/cpp/system/message_pipe.h"
+
+namespace base {
+class SequencedTaskRunner;
+}  // namespace base
+
+namespace brave_vpn::v2 {
+// FakeAgent simulates agent's IPC server, in-process. It substitutes for the
+// whole transport: the connector hands the client one end of an ordinary
+// message pipe instead of connecting a channel and accepting an invitation.
+// Nothing here needs a rendezvous or a mojo IPC thread. Everything past the
+// pipe - the handshake, refusals, retries, teardown - runs the real code on
+// real mojo pipes; the transport itself is the part this does not cover. The
+// caller should construct this on the sequence the client will live on and call
+// everything from there, except the two knobs marked as read off-sequence.
+class FakeAgent : public brave_vpn::mojom::BrowserHostProvider {
+ public:
+  FakeAgent();
+  ~FakeAgent() override;
+
+  FakeAgent(const FakeAgent&) = delete;
+  FakeAgent& operator=(const FakeAgent&) = delete;
+
+  // Callbacks to pass to AgentClient::CreateForTesting().
+  AgentClient::ServerNameProvider GetServerNameProvider();
+  AgentClient::Connector GetConnector();
+
+  // Whether a server name can be resolved at all; "false" models a session the
+  // agent cannot be reached in on any attempt which the client treats as
+  // terminal rather than retryable. Read off-sequence.
+  void set_server_name_available(bool available) {
+    server_name_available_.store(available);
+  }
+
+  // Whether the transport can be established; "false" models an agent that is
+  // not running, which the client retries. Read off-sequence.
+  void set_transport_fails(bool fails) { transport_fails_.store(fails); }
+
+  // The reply to BindBrowserHost(), or nullopt to withhold it: an agent that
+  // accepts the connection and then goes quiet. Defaults to kAccepted.
+  void set_auth_result(std::optional<mojom::BrowserAuthResult> result);
+
+  // Sends a reply withheld by set_auth_result(std::nullopt). Lets a test order
+  // the reply against other events instead of racing two pipes: dropping the
+  // session handles first and answering kAccepted after is what reproduces an
+  // acceptance landing on a session that is already gone.
+  void AnswerHeldRequest(mojom::BrowserAuthResult result);
+
+  // Closes the BrowserEndpoint remotes and BrowserHost receivers handed over so
+  // far, leaving the connections themselves up. Models the agent dropping a
+  // session without exiting.
+  void DropSessionHandles();
+
+  // Closes everything: connections, sessions, and any withheld reply. Models
+  // the agent process exiting.
+  void CloseAllConnections();
+
+  // Attempts to establish the transport, including ones failed by the knobs
+  // above. Updated off-sequence.
+  int connect_attempts() const { return connect_attempts_.load(); }
+
+  // Calls to BindBrowserHost() across all connections.
+  int bind_browser_host_calls() const;
+
+  // The version the last BindBrowserHost() carried, or nullopt if it has not
+  // been called.
+  std::optional<uint32_t> last_protocol_version() const;
+
+  // Connections currently bound: a number of clients the agent could still
+  // answer.
+  size_t connection_count() const;
+
+  // Sessions currently held: a number of accepted handshakes whose handles are
+  // alive.
+  size_t session_count() const;
+
+  // Whether the agent has a way to call back into a browser, as opposed to only
+  // a host request.
+  bool has_browser_endpoint() const { return session_count() > 0u; }
+
+  bool has_held_request() const;
+
+ private:
+  // Both of these run on a blocking sequence, like their production
+  // counterparts, so they touch only the atomics and what they create.
+  std::optional<mojo::NamedPlatformChannel::ServerName> GetServerName();
+  mojo::ScopedMessagePipeHandle Connect(
+      scoped_refptr<base::SequencedTaskRunner> agent_task_runner,
+      const mojo::NamedPlatformChannel::ServerName& server_name);
+
+  // Binds the provider to the agent's end of the pipe, back on the agent's own
+  // sequence, since that is where mojo objects have to live.
+  void BindProvider(mojo::ScopedMessagePipeHandle pipe);
+
+  // brave_vpn::mojom::BrowserHostProvider:
+  void BindBrowserHost(
+      uint32_t protocol_version,
+      mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint,
+      mojo::PendingReceiver<mojom::BrowserHost> host,
+      BindBrowserHostCallback callback) override;
+
+  // Keeps the handles a BindBrowserHost() handed over. BrowserHost has no
+  // methods yet, so its receiver is parked rather than bound: holding the pipe
+  // open is all the client can observe.
+  void KeepSession(mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint,
+                   mojo::PendingReceiver<mojom::BrowserHost> host);
+
+  std::atomic<bool> server_name_available_{true};
+  std::atomic<bool> transport_fails_{false};
+  std::atomic<int> connect_attempts_{0};
+
+  std::optional<mojom::BrowserAuthResult> auth_result_ GUARDED_BY_CONTEXT(
+      sequence_checker_) = mojom::BrowserAuthResult::kAccepted;
+  std::optional<uint32_t> last_protocol_version_
+      GUARDED_BY_CONTEXT(sequence_checker_);
+  int bind_browser_host_calls_ GUARDED_BY_CONTEXT(sequence_checker_) = 0;
+  BindBrowserHostCallback held_reply_ GUARDED_BY_CONTEXT(sequence_checker_);
+
+  mojo::ReceiverSet<mojom::BrowserHostProvider> provider_receivers_
+      GUARDED_BY_CONTEXT(sequence_checker_);
+  std::vector<mojo::Remote<mojom::BrowserEndpoint>> browser_endpoints_
+      GUARDED_BY_CONTEXT(sequence_checker_);
+  std::vector<mojo::PendingReceiver<mojom::BrowserHost>> parked_hosts_
+      GUARDED_BY_CONTEXT(sequence_checker_);
+
+  SEQUENCE_CHECKER(sequence_checker_);
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_TEST_FAKE_AGENT_H_

--- a/components/brave_vpn/common/buildflags/BUILD.gn
+++ b/components/brave_vpn/common/buildflags/BUILD.gn
@@ -13,5 +13,6 @@ buildflag_header("buildflags") {
     "ENABLE_BRAVE_VPN_V1=$enable_brave_vpn_v1",
     "ENABLE_BRAVE_VPN_V2=$enable_brave_vpn_v2",
     "ENABLE_BRAVE_VPN_WIREGUARD=$enable_brave_vpn_wireguard",
+    "ENABLE_BRAVE_VPN_V2_APPS=$enable_brave_vpn_v2_apps",
   ]
 }


### PR DESCRIPTION
Adds `AgentClient`, which owns one connection from a profile to the user's agent and drives the BindBrowserHost() handshake, plus `BrowserEndpointImpl` for the agent-initiated direction. Connecting is lazy and retried with backoff, since one agent is shared by every profile and may not be running.

`BraveVpnServiceImpl` owns the client per profile and connects or drops it based on purchased state. Verification of the agent's identity by the browser is not implemented yet; until then the peer is treated as unauthenticated.

Implements part of https://github.com/brave/brave-browser/issues/54608

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
