### PR TITLE
[recipes] Normalising path separators

### DIFF
--- a/tools/recipes/config_types.py
+++ b/tools/recipes/config_types.py
@@ -48,6 +48,24 @@ class ResolvedBasePath:
     """
     resolved: str
 
+    @classmethod
+    def for_recipe_module(cls, test_enabled: bool, module_name: str,
+                          module_dir: str) -> ResolvedBasePath:
+        """The base for a recipe module's `resources/` directory.
+        """
+        if not test_enabled:
+            return cls(module_dir)
+        return cls(f'RECIPE_MODULE[{module_name}]')
+
+    @classmethod
+    def for_recipe_script_resources(cls, test_enabled: bool, recipe_name: str,
+                                    resources_dir: str) -> ResolvedBasePath:
+        """The base for a recipe script's `<recipe>.resources/` directory.
+        """
+        if not test_enabled:
+            return cls(resources_dir)
+        return cls(f'RECIPE[{recipe_name}].resources')
+
     def __repr__(self) -> str:
         return self.resolved
 

--- a/tools/recipes/engine.py
+++ b/tools/recipes/engine.py
@@ -31,6 +31,7 @@ import types
 
 from google.protobuf import json_format as jsonpb
 
+import config_types
 import proto_support
 from recipe_api import RecipeApi
 from recipe_test_api import RecipeTestApi
@@ -49,6 +50,28 @@ class RecipeScriptApi:
     Carries the recipe's top-level `DEPS`: each one is attached as an attribute
     named after the module (e.g. `api.chromium_checkout`).
     """
+
+    def __init__(self) -> None:
+        # Simulation context, seeded by `run_loaded_recipe` (see
+        # `RecipeApi._test`; the same `None`-means-production convention).
+        self._test = None
+
+        # This recipe's `/`-separated id (e.g. `gerrit/refresh_mirrors`),
+        # seeded by `run_loaded_recipe`. Used to namespace `resource()`'s
+        # test-mode token.
+        self._recipe_name: str = ''
+
+        # This recipe's own `<name>.resources` directory, seeded by
+        # `run_loaded_recipe`. `resource()` derives real paths from it.
+        self._resources_dir: Path = Path()
+
+    def resource(self, *pieces: str) -> config_types.Path:
+        """Path to a file under this recipe's `<name>.resources/` directory.
+        """
+        base = config_types.ResolvedBasePath.for_recipe_script_resources(
+            self._test is not None, self._recipe_name,
+            str(self._resources_dir))
+        return config_types.Path(base, *pieces)
 
     def __getattr__(self, name: str):
         # DEPS are injected by the engine; a missing one means it was not
@@ -170,7 +193,7 @@ def _load_config_ctx(module_name: str):
     if not config_path.exists():
         return None
     _ensure_protos()
-    from config import ConfigContext  # pylint: disable=import-outside-toplevel
+    from config import ConfigContext
     config_module = importlib.import_module(f'{MODULES_PKG}.{module_name}'
                                             '.config')
     contexts = [
@@ -302,6 +325,8 @@ class _Engine:
         setattr(inst, '_brave_core_ref', self._brave_core_ref)
         setattr(inst, '_step_stack', self._step_stack)
         setattr(inst, '_module_name', name)
+        setattr(inst, '_module_dir',
+                Path(api_module.__file__).resolve().parent)
         setattr(inst, '_config_ctx', _load_config_ctx(name))
         inst.test_api = instantiate_test_module(name, [], self._test_api_cache)
         for dep_name in deps:
@@ -343,13 +368,18 @@ class _Engine:
         self._properties = properties or {}
         self._environ = self._test.env if self._test is not None else os.environ
 
-        api = RecipeScriptApi()
-        for dep_name in getattr(recipe, 'DEPS', []):
-            setattr(api, dep_name, self._instantiate_module(dep_name, []))
-
         run_steps = getattr(recipe, 'RunSteps', None)
         if run_steps is None:
             raise RuntimeError(f"recipe '{recipe_name}' is missing RunSteps")
+
+        api = RecipeScriptApi()
+        setattr(api, '_test', self._test)
+        setattr(api, '_recipe_name', recipe_name)
+        recipe_file = Path(recipe.__file__).resolve()
+        setattr(api, '_resources_dir',
+                recipe_file.parent / f'{recipe_file.stem}.resources')
+        for dep_name in getattr(recipe, 'DEPS', []):
+            setattr(api, dep_name, self._instantiate_module(dep_name, []))
 
         try:
             return _run_steps(run_steps, api, self._properties, self._environ,

--- a/tools/recipes/recipe_api.py
+++ b/tools/recipes/recipe_api.py
@@ -24,6 +24,7 @@ import functools
 from pathlib import Path
 from typing import Any
 
+import config_types
 from step_stack import StepStack
 
 
@@ -145,10 +146,8 @@ def _returns_placeholder(func: Callable[..., Placeholder],
         assert isinstance(placeholder, Placeholder), (
             f'{func.__name__} is decorated with returns_placeholder but '
             f'returned {placeholder!r}')
-        placeholder.namespaces = (
-            self._module_name,
-            alternate_name  # pylint: disable=protected-access
-            or func.__name__)
+        placeholder.namespaces = (self._module_name, alternate_name
+                                  or func.__name__)
         return placeholder
 
     return inner
@@ -178,36 +177,48 @@ class RecipeApi:
     def __init__(self) -> None:
         # Populated by the engine after construction with this module's DEPS.
         self.m: ModuleInjectionSite = ModuleInjectionSite()
+
         # The job's workspace root, seeded by the engine after construction.
         # The `path` module derives the named job paths from it; most modules
         # ignore it. Defaults to `.` until the engine overrides it.
         self._workspace: Path = Path()
+
         # brave-core ref the checkout modules clone, seeded by the engine.
         # `brave_core_checkout` uses it; defaults to `master` until overridden.
         self._brave_core_ref: str = 'master'
+
         # The run's stack of open steps, seeded by the engine. `step` pushes
         # each step onto it and `futures` registers spawned greenlets against
         # it; every other module ignores it. Defaults to a private stack so a
         # module instantiated outside the engine still works.
         self._step_stack = StepStack()
+
         # Simulation context, seeded by the engine only in test mode. `None`
         # means production: the seam modules (`path`, `env`, `platform`, `step`)
         # touch the real machine. When set, they read/mutate this instead. Its
         # presence (`self._test is not None`) is the sole test-mode flag.
         self._test = None
+
         # The module's name, seeded by the engine (used in config error text
         # and to namespace the placeholders this module hands out).
         self._module_name: str = type(self).__name__
+
+        # This module's own directory (`recipe_modules/<name>`), seeded by the
+        # engine. `resource()` derives `<module>/resources/...` from it.
+        self._module_dir: Path = Path()
+
         # This module's own `TEST_API` instance (from its `test_api.py`), seeded
         # by the engine, or None if the module has no test api. Modules use it
         # to build the default simulated data for the steps they run, e.g.
         # `step_test_data=self.test_api.errno`.
         self.test_api = None
+
         # The module's configuration context (the `ConfigContext` from its
         # `config.py`), seeded by the engine, or None if the module has no
         # config. See `set_config`/`make_config`/`apply_config` below and the
         # "Configs" section of README.md.
         self._config_ctx = None
+
         # The module's current config blob (a `config.ConfigGroup`), or None
         # until a config is applied. A module reads it as `self.c`, and its
         # users reach it directly as `api.<module>.c`.
@@ -215,6 +226,13 @@ class RecipeApi:
 
     def initialise(self) -> None:
         """Hook run once after DEPS are injected. Override for setup."""
+
+    def resource(self, *pieces: str) -> config_types.Path:
+        """Path to a file under this module's `resources/` directory.
+        """
+        base = config_types.ResolvedBasePath.for_recipe_module(
+            self._test is not None, self._module_name, str(self._module_dir))
+        return config_types.Path(base, 'resources', *pieces)
 
     # -- Configs (see the "Configs" section of README.md) ---------------------
 

--- a/tools/recipes/recipe_modules/chromium_checkout/api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/api.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import contextlib
 import functools
 import logging
-from pathlib import Path
 import re
 import subprocess
 
@@ -26,11 +25,6 @@ WIN_HERMETIC_TOOLCHAIN_BASE_URL = (
 
 # The URL for Chromium's googlesource.
 CHROMIUM_URL = 'https://chromium.googlesource.com/chromium/src.git'
-
-# Resolves the `GYP_MSVS_HASH_<hash>` override for the hermetic Windows
-# toolchain. See `_pin_win_toolchain_hash`.
-_WIN_TOOLCHAIN_HASH_SCRIPT = (Path(__file__).resolve().parent / 'resources' /
-                              'win_toolchain_hash.py')
 
 
 def _is_tag_ref(ref: str) -> bool:
@@ -344,7 +338,8 @@ class ChromiumCheckoutApi(RecipeApi):
         """
         vpython3 = self.m.depot_tools.vpython3()
         result = self.m.step('resolve win toolchain hash', [
-            vpython3, '-u', _WIN_TOOLCHAIN_HASH_SCRIPT,
+            vpython3, '-u',
+            self.resource('win_toolchain_hash.py'),
             chromium_src / 'build' / 'vs_toolchain.py',
             WIN_HERMETIC_TOOLCHAIN_BASE_URL, '--json-output',
             self.m.json.output()

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_hermetic_toolchain.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_hermetic_toolchain.json
@@ -128,7 +128,7 @@
     "cmd": [
       "[WORKSPACE]\\b\\src\\third_party\\depot_tools\\vpython3.bat",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/chromium_checkout/resources/win_toolchain_hash.py",
+      "RECIPE_MODULE[chromium_checkout]\\resources\\win_toolchain_hash.py",
       "[WORKSPACE]\\b\\src\\build\\vs_toolchain.py",
       "https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-2.on.aws/windows-hermetic-toolchain/",
       "--json-output",

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_toolchain_hash_pinned.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_toolchain_hash_pinned.json
@@ -128,7 +128,7 @@
     "cmd": [
       "[WORKSPACE]\\b\\src\\third_party\\depot_tools\\vpython3.bat",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/chromium_checkout/resources/win_toolchain_hash.py",
+      "RECIPE_MODULE[chromium_checkout]\\resources\\win_toolchain_hash.py",
       "[WORKSPACE]\\b\\src\\build\\vs_toolchain.py",
       "https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-2.on.aws/windows-hermetic-toolchain/",
       "--json-output",

--- a/tools/recipes/recipe_modules/file/api.py
+++ b/tools/recipes/recipe_modules/file/api.py
@@ -38,11 +38,6 @@ from recipe_api import OutputPlaceholder, Placeholder, RecipeApi
 from recipe_test_api import StepTestData
 from step_data import StepData
 
-# The resource script `_run` invokes for every operation. Lives alongside this
-# module (not under brave-core), so it's always present -- no sparse checkout
-# needed, unlike e.g. `tools/cr/toolchains/ephemeral_xcode.py`.
-_FILEUTIL = Path(__file__).resolve().parent / 'resources' / 'fileutil.py'
-
 ProtoMessage = TypeVar('ProtoMessage', bound=Message)
 
 
@@ -92,7 +87,8 @@ class FileApi(RecipeApi):
         """
         vpython3 = self.m.depot_tools.vpython3()
         cmd = [
-            vpython3, '-u', _FILEUTIL, '--json-output',
+            vpython3, '-u',
+            self.resource('fileutil.py'), '--json-output',
             self.m.json.output(), *args
         ]
         result = self.m.step(name,

--- a/tools/recipes/recipe_modules/file/examples/full.expected/basic.json
+++ b/tools/recipes/recipe_modules/file/examples/full.expected/basic.json
@@ -20,7 +20,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "copy",
@@ -40,7 +40,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "copy",
@@ -60,7 +60,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "copy",
@@ -80,7 +80,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "copy",
@@ -100,7 +100,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "copy",
@@ -120,7 +120,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "copy",
@@ -133,7 +133,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "copy",
@@ -146,7 +146,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "copy",
@@ -159,7 +159,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "copy",

--- a/tools/recipes/recipe_modules/file/examples/operations.expected/basic.json
+++ b/tools/recipes/recipe_modules/file/examples/operations.expected/basic.json
@@ -20,7 +20,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "copy",
@@ -33,7 +33,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "copytree",
@@ -49,7 +49,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "move",
@@ -62,7 +62,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "chmod",
@@ -77,7 +77,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "remove",
@@ -89,7 +89,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "rmtree",
@@ -101,7 +101,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "rmcontents",
@@ -113,7 +113,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "rmglob",
@@ -127,7 +127,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "glob",
@@ -148,7 +148,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "listdir",
@@ -168,7 +168,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "ensure_directory",
@@ -182,7 +182,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "filesizes",
@@ -202,7 +202,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "symlink",
@@ -215,7 +215,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "truncate",
@@ -228,7 +228,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "flatten_single_directories",
@@ -240,7 +240,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "compute_hash",
@@ -261,7 +261,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "file_hash",
@@ -280,7 +280,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/file/resources/fileutil.py",
+      "RECIPE_MODULE[file]/resources/fileutil.py",
       "--json-output",
       "/path/to/tmp/json",
       "is_executable",

--- a/tools/recipes/recipe_modules/osx_sdk/api.py
+++ b/tools/recipes/recipe_modules/osx_sdk/api.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import Iterator
-from pathlib import Path
 from typing import Any
 
 from recipe_api import RecipeApi
@@ -18,13 +17,6 @@ EPHEMERAL_XCODE_SCRIPT = 'tools/cr/toolchains/ephemeral_xcode.py'
 
 # Path for Chromium's macOS SDK pin.
 MAC_SDK_GNI_PATH = 'build/config/mac/mac_sdk.gni'
-
-# The resource script `ensure()` runs to read `MAC_SDK_GNI_PATH`. Lives
-# alongside this module (not under brave-core), so it's always present -- no
-# sparse checkout needed for this half of the work, unlike
-# `EPHEMERAL_XCODE_SCRIPT`.
-_READ_MAC_SDK_GNI_SCRIPT = (Path(__file__).resolve().parent / 'resources' /
-                            'read_mac_sdk_gni.py')
 
 
 class OSXSDKApi(RecipeApi):
@@ -57,8 +49,8 @@ class OSXSDKApi(RecipeApi):
 
         vpython3 = self.m.depot_tools.vpython3()
         gni_result = self.m.step('read mac_sdk.gni', [
-            vpython3, '-u', _READ_MAC_SDK_GNI_SCRIPT, mac_sdk_gni,
-            '--json-output',
+            vpython3, '-u',
+            self.resource('read_mac_sdk_gni.py'), mac_sdk_gni, '--json-output',
             self.m.json.output()
         ])
         sdk_version = gni_result.json.output['sdk_version']

--- a/tools/recipes/recipe_modules/osx_sdk/examples/full.expected/mac.json
+++ b/tools/recipes/recipe_modules/osx_sdk/examples/full.expected/mac.json
@@ -20,7 +20,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/osx_sdk/resources/read_mac_sdk_gni.py",
+      "RECIPE_MODULE[osx_sdk]/resources/read_mac_sdk_gni.py",
       "/b/checkout/src/build/config/mac/mac_sdk.gni",
       "--json-output",
       "/path/to/tmp/json"

--- a/tools/recipes/recipe_modules/path/api.py
+++ b/tools/recipes/recipe_modules/path/api.py
@@ -220,7 +220,7 @@ class _SimFs:
     def sep(self) -> str:
         # The single source of truth for the simulated separator, so this
         # always agrees with how a `config_types.Path` renders.
-        return config_types.Path._OS_SEP  # pylint: disable=protected-access
+        return config_types.Path._OS_SEP
 
     @property
     def pathsep(self) -> str:
@@ -294,13 +294,18 @@ class PathApi(RecipeApi):
             # Local import: `simulation` (and the `gevent` it pulls in) is
             # test-only, so keep it off the production import path (matches
             # `step/api.py`'s `_prod_runner_lazy` convention).
-            import simulation  # pylint: disable=import-outside-toplevel
+            import simulation
             self._workspace_token = simulation.WORKSPACE_TOKEN
             self._fs = _SimFs(self._test)
             # Simulated separator, driven by the platform under test -- never
             # the real host's `sys.platform`/`os.sep`.
-            config_types.Path._OS_SEP = (  # pylint: disable=protected-access
-                '\\' if self._test.platform == 'win' else '/')
+            config_types.Path._OS_SEP = ('\\' if self._test.platform == 'win'
+                                         else '/')
+        else:
+            # Every other named path here bypasses `config_types.Path`
+            # entirely in production (see `workspace` below), but
+            # `RecipeApi.resource()` doesn't, so this still needs to be set.
+            config_types.Path._OS_SEP = os.sep  # pragma: no cover - production only
 
     def exists(self, path: str | Path | config_types.Path) -> bool:
         """Whether *path* exists (a file or a directory)."""

--- a/tools/recipes/recipe_modules/step/api.py
+++ b/tools/recipes/recipe_modules/step/api.py
@@ -12,6 +12,7 @@ import logging
 from pathlib import Path
 import subprocess
 
+import config_types
 from engine_types import ResourceCost as _ResourceCost
 from recipe_api import (InputPlaceholder, OutputPlaceholder, Placeholder,
                         RecipeApi)
@@ -194,7 +195,7 @@ class StepApi(RecipeApi):
     def __call__(
         self,
         name: str,
-        cmd: Sequence[str | Path | Placeholder] | None,
+        cmd: Sequence[str | Path | config_types.Path | Placeholder] | None,
         *,
         cwd: str | Path | None = None,
         env: Mapping[str, str] | None = None,

--- a/tools/recipes/recipes/gerrit/refresh_mirrors.expected/fresh_checkout.json
+++ b/tools/recipes/recipes/gerrit/refresh_mirrors.expected/fresh_checkout.json
@@ -186,7 +186,7 @@
   {
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
-      "[RECIPES_ROOT]/recipes/gerrit/refresh_mirrors.resources/refresh_mirrors.py",
+      "RECIPE[gerrit/refresh_mirrors].resources/refresh_mirrors.py",
       "--user",
       "chromium-mirror-bot",
       "--git-cache-path",

--- a/tools/recipes/recipes/gerrit/refresh_mirrors.expected/reused_checkout_at_explicit_ref.json
+++ b/tools/recipes/recipes/gerrit/refresh_mirrors.expected/reused_checkout_at_explicit_ref.json
@@ -158,7 +158,7 @@
   {
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
-      "[RECIPES_ROOT]/recipes/gerrit/refresh_mirrors.resources/refresh_mirrors.py",
+      "RECIPE[gerrit/refresh_mirrors].resources/refresh_mirrors.py",
       "--user",
       "chromium-mirror-bot",
       "--git-cache-path",

--- a/tools/recipes/recipes/gerrit/refresh_mirrors.py
+++ b/tools/recipes/recipes/gerrit/refresh_mirrors.py
@@ -7,7 +7,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import post_process
@@ -17,11 +16,6 @@ if TYPE_CHECKING:
     from engine import RecipeScriptApi
 
 DEPS = ['path', 'step', 'chromium_checkout', 'depot_tools', 'git_cache']
-
-# Publishes the git cache into Gerrit; lives alongside this recipe (rather than
-# in brave-core proper) since this recipe is its only caller.
-_REFRESH_MIRRORS_SCRIPT = (Path(__file__).resolve().parent /
-                           'refresh_mirrors.resources' / 'refresh_mirrors.py')
 
 PROPERTIES = InputProperties
 
@@ -43,7 +37,7 @@ def RunSteps(api: RecipeScriptApi, properties: InputProperties) -> None:
     vpython3 = api.depot_tools.vpython3()
     api.step('refresh gerrit mirrors', [
         vpython3,
-        _REFRESH_MIRRORS_SCRIPT,
+        api.resource('refresh_mirrors.py'),
         '--user',
         properties.gerrit_user,
         '--git-cache-path',

--- a/tools/recipes/recipes/toolchains/rust/package_rust.expected/mac.json
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.expected/mac.json
@@ -208,7 +208,7 @@
     "cmd": [
       "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
       "-u",
-      "[RECIPES_ROOT]/recipe_modules/osx_sdk/resources/read_mac_sdk_gni.py",
+      "RECIPE_MODULE[osx_sdk]/resources/read_mac_sdk_gni.py",
       "[WORKSPACE]/b/src/build/config/mac/mac_sdk.gni",
       "--json-output",
       "/path/to/tmp/json"


### PR DESCRIPTION
This change is a follow-up on the introduction of a `Path` type for the
recipes engine that can be integrated with the simulated layer. This PR
goes further in providing normalisation for separators, and additional
helpers to move away from python's `Path` type.
