### PR TITLE
Adblock extension webcompat reporting

### DIFF
--- a/browser/webcompat_reporter/webcompat_reporter_service_delegate.cc
+++ b/browser/webcompat_reporter/webcompat_reporter_service_delegate.cc
@@ -21,6 +21,8 @@
 #include "components/component_updater/component_updater_service.h"
 #include "components/prefs/pref_service.h"
 
+using extensions::ExtensionRegistry;
+
 namespace webcompat_reporter {
 
 WebcompatReporterServiceDelegateImpl::WebcompatReporterServiceDelegateImpl(
@@ -29,13 +31,15 @@ WebcompatReporterServiceDelegateImpl::WebcompatReporterServiceDelegateImpl(
     component_updater::ComponentUpdateService* component_update_service,
     brave_shields::AdBlockService* adblock_service,
     HostContentSettingsMap* host_content_settings_map,
-    scoped_refptr<content_settings::CookieSettings> content_settings)
+    scoped_refptr<content_settings::CookieSettings> content_settings,
+    content::BrowserContext* browser_context)
     : WebcompatReporterServiceDelegateBase(component_update_service),
       local_state_(local_state),
       application_locale_(application_locale),
       adblock_service_(adblock_service),
       host_content_settings_map_(host_content_settings_map),
-      cookie_settings_(content_settings) {}
+      cookie_settings_(content_settings),
+      context_(browser_context) {}
 
 WebcompatReporterServiceDelegateImpl::~WebcompatReporterServiceDelegateImpl() =
     default;
@@ -110,5 +114,26 @@ WebcompatReporterServiceDelegateImpl::GetAdblockOnlyModeEnabled() const {
   return BoolToString(
       local_state_->GetBoolean(brave_shields::prefs::kAdBlockOnlyModeEnabled));
 }
+
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+  std::optional<std::string>
+  WebcompatReporterServiceDelegateImpl::GetAdblockExtensionInstalled() const {
+    ExtensionRegistry* registry = ExtensionRegistry::Get(context_);
+    if (!registry) {
+      return std::nullopt;
+    }
+
+    const char adblock_plus_extension_id[] = "cfhdojbkjhnklbpkdaibdccddilifddb";
+    const char adguard_extension_id[] = "bgnkhhnnamicmpeenaelnjfhikgbkllg";
+    const char ublock_origin_extension_id[] = "jcokkipkhhgiakinbnnplhkdbjbgcgpe"; 
+    const char ublock_origin_lite_extension_id[] = "ddkjiahejlhfcafbddmgiahcphecmpfh";
+
+      return BoolToString(registry->GetInstalledExtension(adblock_plus_extension_id) != nullptr ||
+                          registry->GetInstalledExtension(adguard_extension_id) != nullptr ||
+                          registry->GetInstalledExtension(ublock_origin_extension_id) != nullptr ||
+                          registry->GetInstalledExtension(ublock_origin_lite_extension_id) != nullptr);
+    }
+  }
+#endif
 
 }  // namespace webcompat_reporter

--- a/browser/webcompat_reporter/webcompat_reporter_service_delegate.h
+++ b/browser/webcompat_reporter/webcompat_reporter_service_delegate.h
@@ -38,7 +38,7 @@ class WebcompatReporterServiceDelegateImpl
       brave_shields::AdBlockService* adblock_service,
       HostContentSettingsMap* host_content_settings_map,
       scoped_refptr<content_settings::CookieSettings> content_settings,
-      content::BrowserContext* browser_context));
+      content::BrowserContext* browser_context);
   WebcompatReporterServiceDelegateImpl(
       const WebcompatReporterServiceDelegateImpl&) = delete;
   WebcompatReporterServiceDelegateImpl& operator=(

--- a/browser/webcompat_reporter/webcompat_reporter_service_delegate.h
+++ b/browser/webcompat_reporter/webcompat_reporter_service_delegate.h
@@ -18,6 +18,10 @@
 
 class PrefService;
 
+namespace content {
+class BrowserContext;
+}  // namespace content
+
 namespace brave_shields {
 class AdBlockService;
 }  // namespace brave_shields
@@ -33,7 +37,8 @@ class WebcompatReporterServiceDelegateImpl
       component_updater::ComponentUpdateService* component_update_service,
       brave_shields::AdBlockService* adblock_service,
       HostContentSettingsMap* host_content_settings_map,
-      scoped_refptr<content_settings::CookieSettings> content_settings);
+      scoped_refptr<content_settings::CookieSettings> content_settings,
+      content::BrowserContext* browser_context));
   WebcompatReporterServiceDelegateImpl(
       const WebcompatReporterServiceDelegateImpl&) = delete;
   WebcompatReporterServiceDelegateImpl& operator=(
@@ -48,6 +53,9 @@ class WebcompatReporterServiceDelegateImpl
   std::optional<std::string> GetScriptBlockingFlag(
       const std::optional<std::string>& current_url) const override;
   std::optional<std::string> GetAdblockOnlyModeEnabled() const override;
+  #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+    std::optional<std::string> GetAdblockExtensionInstalled() const override;
+  #endif  
 
  private:
   const raw_ref<PrefService> local_state_;
@@ -55,6 +63,7 @@ class WebcompatReporterServiceDelegateImpl
   const raw_ptr<brave_shields::AdBlockService> adblock_service_;
   const raw_ptr<HostContentSettingsMap> host_content_settings_map_;
   scoped_refptr<content_settings::CookieSettings> cookie_settings_;
+  const raw_ptr<content::BrowserContext> context_;
 };
 
 }  // namespace webcompat_reporter

--- a/browser/webcompat_reporter/webcompat_reporter_service_factory.cc
+++ b/browser/webcompat_reporter/webcompat_reporter_service_factory.cc
@@ -81,7 +81,8 @@ WebcompatReporterServiceFactory::BuildServiceInstanceForBrowserContext(
           g_brave_browser_process->ad_block_service(),
           HostContentSettingsMapFactory::GetForProfile(context),
           CookieSettingsFactory::GetForProfile(
-              Profile::FromBrowserContext(context))),
+              Profile::FromBrowserContext(context)),
+          context),
       std::move(report_uploader));
 }
 

--- a/components/webcompat_reporter/browser/fields.h
+++ b/components/webcompat_reporter/browser/fields.h
@@ -17,6 +17,7 @@ inline constexpr char kAdBlockComponentsVersionField[] =
     "adBlockComponentsInfo";
 inline constexpr char kShieldsEnabledField[] = "shieldsEnabled";
 inline constexpr char kAdblockOnlyModeEnabledField[] = "adblockOnlyModeEnabled";
+inline constexpr char kAdblockExtensionInstalledField[] ="adblockExtensionInstalled";
 inline constexpr char kLanguagesField[] = "languages";
 inline constexpr char kLanguageFarblingField[] = "languageFarblingEnabled";
 inline constexpr char kBraveVPNEnabledField[] = "braveVPNEnabled";

--- a/components/webcompat_reporter/browser/webcompat_report_uploader.cc
+++ b/components/webcompat_reporter/browser/webcompat_report_uploader.cc
@@ -127,6 +127,12 @@ void WebcompatReportUploader::SubmitReport(mojom::ReportInfoPtr report_info) {
         report_info->adblock_only_mode_enabled.value() == kStringTrue);
   }
 
+  if (report_info->adblock_extension_installed) {
+    report_details_dict.Set(
+        kAdblockExtensionInstalledField,
+        report_info->adblock_extension_installed.value() == kStringTrue);
+  }
+
   if (report_info->ad_block_setting) {
     report_details_dict.Set(kAdBlockSettingField,
                             report_info->ad_block_setting.value());

--- a/components/webcompat_reporter/browser/webcompat_reporter_service.cc
+++ b/components/webcompat_reporter/browser/webcompat_reporter_service.cc
@@ -129,6 +129,16 @@ struct ReportFiller {
     return *this;
   }
 
+  #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+    ReportFiller& FillAdblockExtensionInstalled() {
+      if (!(*report_info)->adblock_extension_installed) {
+        (*report_info)->adblock_extension_installed =
+            service_delegate->GetAdblockExtensionInstalled();
+      }
+      return *this;
+    }
+  #endif
+
   raw_ref<webcompat_reporter::mojom::ReportInfoPtr> report_info;
   const raw_ptr<webcompat_reporter::WebcompatReporterService::Delegate>
       service_delegate;
@@ -245,7 +255,8 @@ void WebcompatReporterService::SubmitWebcompatReport(
       .FillReportWithAdblockListNames()
       .FillCookiePolicy()
       .FillScriptBlockingFlag()
-      .FillAdblockOnlyModeEnabled();
+      .FillAdblockOnlyModeEnabled()
+      .FillAdblockExtensionInstalled();
 
   ProcessContactInfo(profile_prefs_, report_info);
 

--- a/components/webcompat_reporter/browser/webcompat_reporter_service.h
+++ b/components/webcompat_reporter/browser/webcompat_reporter_service.h
@@ -46,6 +46,9 @@ class WebcompatReporterService : public KeyedService,
     virtual std::optional<std::string> GetScriptBlockingFlag(
         const std::optional<std::string>& current_url) const = 0;
     virtual std::optional<std::string> GetAdblockOnlyModeEnabled() const = 0;
+    #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+        virtual std::optional<std::string> GetAdblockExtensionInstalled() const = 0;
+    #endif
   };
 
   WebcompatReporterService(

--- a/components/webcompat_reporter/browser/webcompat_reporter_service_unittest.cc
+++ b/components/webcompat_reporter/browser/webcompat_reporter_service_unittest.cc
@@ -32,6 +32,10 @@ constexpr char kGetScriptBlockingFlagMockedValue[] =
     "MockedScriptBlockingFlagValue";
 constexpr char kAdblockOnlyModeEnabledMockedValue[] =
     "MockedAdblockOnlyModeEnabledValue";
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+  constexpr char kAdblockExtensionInstalledMockedValue[] =
+      "MockedAdblockExtensionInstalledValue";
+#endif
 
 class MockWebcompatReportUploader
     : public webcompat_reporter::WebcompatReportUploader {
@@ -70,6 +74,12 @@ class MockWebCompatServiceDelegate : public WebCompatServiceDelegate {
               GetAdblockOnlyModeEnabled,
               (),
               (const));
+  #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+    MOCK_METHOD(std::optional<std::string>,
+                GetAdblockExtensionInstalled,
+                (),
+                (const));
+  #endif
 };
 }  // namespace
 
@@ -155,7 +165,9 @@ class WebcompatReporterServiceUnitTest : public testing::Test {
     EXPECT_CALL(*delegate_, GetCookiePolicy).Times(0);
     EXPECT_CALL(*delegate_, GetScriptBlockingFlag).Times(0);
     EXPECT_CALL(*delegate_, GetAdblockOnlyModeEnabled).Times(0);
-
+    #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+      EXPECT_CALL(*delegate_, GetAdblockExtensionInstalled).Times(0);
+    #endif
     webcompat_reporter_service_->SubmitWebcompatReport(std::move(report_info));
   }
 
@@ -251,6 +263,10 @@ TEST_F(WebcompatReporterServiceUnitTest, SubmitReportWithNoPropsOverride) {
                   kGetScriptBlockingFlagMockedValue);
         EXPECT_EQ(report->adblock_only_mode_enabled.value(),
                   kAdblockOnlyModeEnabledMockedValue);
+        #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+          EXPECT_EQ(report->adblock_extension_installed.value(),
+                    kAdblockExtensionInstalledMockedValue);
+        #endif
         EXPECT_FALSE(report->fp_block_setting);
         EXPECT_FALSE(report->ad_block_setting);
         EXPECT_FALSE(report->language_farbling);
@@ -275,6 +291,11 @@ TEST_F(WebcompatReporterServiceUnitTest, SubmitReportWithNoPropsOverride) {
   EXPECT_CALL(*delegate_, GetAdblockOnlyModeEnabled)
       .Times(1)
       .WillOnce(testing::Return(kAdblockOnlyModeEnabledMockedValue));
+  #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+    EXPECT_CALL(*delegate_, GetAdblockExtensionInstalled)
+        .Times(1)
+        .WillOnce(testing::Return(kAdblockExtensionInstalledMockedValue));
+  #endif
 
   webcompat_reporter_service_->SubmitWebcompatReport(std::move(report_info));
 }

--- a/components/webcompat_reporter/common/webcompat_reporter.mojom
+++ b/components/webcompat_reporter/common/webcompat_reporter.mojom
@@ -17,6 +17,7 @@ struct ReportInfo {
   string? report_url;
   string? shields_enabled;
   string? adblock_only_mode_enabled;
+  string? adblock_extension_installed;
   string? ad_block_setting;
   string? fp_block_setting;
   string? ad_block_list_names;


### PR DESCRIPTION
We have seen an increasing number of webcompat reports for issues caused by users using adblocker extensions on Brave. These extensions create unexpected results when run alongside Brave Shields. In order to diagnose webcompat issues faster, it would be helpful to see whether or not the users have an adblocking extension installed on their browser. Please see this privacy review for more details https://github.com/brave/reviews/issues/2002#issuecomment-4803079029

To do this, we need to expose the presence of adblock extensions as a boolean from Brave core so that it can be used in our webcompat reporting tools.