### PR TITLE
[Wallet]: Add compact formatting for tiny and large balances

### DIFF
--- a/components/brave_wallet_ui/components/desktop/account-list-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/account-list-item/index.tsx
@@ -494,7 +494,7 @@ export const AccountListItem = ({
                       textColor='primary'
                       variant='default.semibold'
                     >
-                      {accountsFiatValue.formatAsFiat(defaultFiatCurrency)}
+                      {accountsFiatValue.compactAsFiat(defaultFiatCurrency)}
                     </AccountBalanceText>
                   </>
                 )}

--- a/components/brave_wallet_ui/components/desktop/card-headers/account-details-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/account-details-header.tsx
@@ -335,7 +335,7 @@ export const AccountDetailsHeader = (props: Props) => {
                 />
               ) : (
                 <AccountBalanceText>
-                  {accountsFiatValue.formatAsFiat(defaultFiatCurrency)}
+                  {accountsFiatValue.compactAsFiat(defaultFiatCurrency)}
                 </AccountBalanceText>
               )}
             </Column>

--- a/components/brave_wallet_ui/components/desktop/card-headers/asset-details-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/asset-details-header.tsx
@@ -250,7 +250,7 @@ export const AssetDetailsHeader = (props: Props) => {
             textAlign='right'
           >
             {selectedAssetFiatPrice
-              ? new Amount(selectedAssetFiatPrice.price).formatAsFiat(
+              ? new Amount(selectedAssetFiatPrice.price).compactAsSpotPrice(
                   defaultFiatCurrency,
                 )
               : '0.00'}

--- a/components/brave_wallet_ui/components/desktop/portfolio-account-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-account-item/index.tsx
@@ -103,8 +103,8 @@ export const PortfolioAccountItem = (props: Props) => {
   const formattedAssetBalance: string = React.useMemo(() => {
     return new Amount(assetBalance)
       .divideByDecimals(asset.decimals)
-      .format(6, true)
-  }, [assetBalance, asset.decimals])
+      .compactAsAsset(6, asset.symbol)
+  }, [assetBalance, asset.decimals, asset.symbol])
 
   const tokenPriceRequests = React.useMemo(
     () => getPriceRequestsForTokens([asset]),
@@ -217,7 +217,7 @@ export const PortfolioAccountItem = (props: Props) => {
                 textColor='primary'
                 textAlign='right'
               >
-                {`${formattedAssetBalance} ${asset.symbol}`}
+                {formattedAssetBalance}
               </Text>
               <Text
                 textSize='12px'
@@ -225,7 +225,7 @@ export const PortfolioAccountItem = (props: Props) => {
                 textColor='secondary'
                 textAlign='right'
               >
-                {fiatBalance.formatAsFiat(defaultFiatCurrency)}
+                {fiatBalance.compactAsFiat(defaultFiatCurrency)}
               </Text>
             </WithHideBalancePlaceholder>
           </Column>

--- a/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
@@ -135,7 +135,7 @@ export const PortfolioAssetItem = ({
     ? new Amount(assetBalance).divideByDecimals(token.decimals).format()
     : new Amount(assetBalance)
         .divideByDecimals(token.decimals)
-        .formatAsAsset(6, token.symbol)
+        .compactAsAsset(6, token.symbol)
 
   const fiatBalance = React.useMemo(() => {
     if (!spotPrice) {
@@ -147,7 +147,7 @@ export const PortfolioAssetItem = ({
       .times(spotPrice)
   }, [spotPrice, assetBalance, token.decimals])
 
-  const formattedFiatBalance = fiatBalance.formatAsFiat(defaultFiatCurrency)
+  const formattedFiatBalance = fiatBalance.compactAsFiat(defaultFiatCurrency)
 
   const isLoading = formattedAssetBalance === '' && !isNonFungibleToken
 

--- a/components/brave_wallet_ui/components/extension/connect-with-site-panel/select-account-item/select-account-item.tsx
+++ b/components/brave_wallet_ui/components/extension/connect-with-site-panel/select-account-item/select-account-item.tsx
@@ -148,7 +148,7 @@ export const SelectAccountItem = (props: Props) => {
     const reducedAmounts = amounts.reduce(function (a, b) {
       return a !== '' && b !== '' ? new Amount(a).plus(b).format() : ''
     })
-    return new Amount(reducedAmounts).formatAsFiat(defaultFiatCurrency)
+    return new Amount(reducedAmounts).compactAsFiat(defaultFiatCurrency)
   }, [
     tokenListByAccount,
     defaultFiatCurrency,

--- a/components/brave_wallet_ui/page/screens/composer_ui/select_token_modal/select_account/select_account.tsx
+++ b/components/brave_wallet_ui/page/screens/composer_ui/select_token_modal/select_account/select_account.tsx
@@ -25,10 +25,7 @@ import {
 // Utils
 import Amount from '../../../../../utils/amount'
 import { reduceAddress } from '../../../../../utils/reduce-address'
-import {
-  formatTokenBalanceWithSymbol,
-  getBalance,
-} from '../../../../../utils/balance-utils'
+import { getBalance } from '../../../../../utils/balance-utils'
 import { getLocale } from '../../../../../../common/locale'
 
 // Components
@@ -68,8 +65,8 @@ const getFiatBalance = (
     ? new Amount(getBalance(accountId, token, tokenBalancesRegistry))
         .divideByDecimals(token.decimals)
         .times(spotPrice.price)
-        .formatAsFiat(defaultFiatCurrency)
-    : Amount.empty().formatAsFiat(defaultFiatCurrency)
+        .compactAsFiat(defaultFiatCurrency)
+    : Amount.empty().compactAsFiat(defaultFiatCurrency)
 }
 
 interface Props {
@@ -241,11 +238,11 @@ export const SelectAccount = (props: Props) => {
                 isBold={true}
                 textAlign='right'
               >
-                {formatTokenBalanceWithSymbol(
+                {new Amount(
                   getBalance(account.accountId, token, tokenBalancesRegistry),
-                  token.decimals,
-                  token.symbol,
-                )}
+                )
+                  .divideByDecimals(token.decimals)
+                  .compactAsAsset(6, token.symbol)}
               </Text>
               <Text
                 textSize='12px'

--- a/components/brave_wallet_ui/page/screens/composer_ui/select_token_modal/token_details/token_details.tsx
+++ b/components/brave_wallet_ui/page/screens/composer_ui/select_token_modal/token_details/token_details.tsx
@@ -169,7 +169,7 @@ export const TokenDetails = (props: Props) => {
                   textColor='primary'
                   isBold={true}
                 >
-                  {new Amount(spotPrice?.price ?? '').formatAsFiat(
+                  {new Amount(spotPrice?.price ?? '').compactAsSpotPrice(
                     defaultFiatCurrency,
                   )}
                 </Text>

--- a/components/brave_wallet_ui/page/screens/composer_ui/token_list_item/token_list_item.tsx
+++ b/components/brave_wallet_ui/page/screens/composer_ui/token_list_item/token_list_item.tsx
@@ -12,7 +12,6 @@ import { BraveWallet } from '../../../../constants/types'
 // Utils
 import { getLocale } from '../../../../../common/locale'
 import Amount from '../../../../utils/amount'
-import { formatTokenBalanceWithSymbol } from '../../../../utils/balance-utils'
 import { isShieldedToken } from '../../../../utils/asset-utils'
 import {
   useGetDefaultFiatCurrencyQuery,
@@ -125,7 +124,17 @@ export const TokenListItem = React.forwardRef<HTMLDivElement, Props>(
     }, [token])
 
     // Computed
-    const formattedFiatBalance = fiatBalance.formatAsFiat(defaultFiatCurrency)
+    const formattedFiatBalance = fiatBalance.compactAsFiat(defaultFiatCurrency)
+
+    const formattedTokenBalance = React.useMemo(() => {
+      if (!balance) {
+        return ''
+      }
+
+      return new Amount(balance)
+        .divideByDecimals(token.decimals)
+        .compactAsAsset(6, token.symbol)
+    }, [balance, token.decimals, token.symbol])
 
     const tokenHasBalance = balance && new Amount(balance).gt(0)
 
@@ -225,11 +234,7 @@ export const TokenListItem = React.forwardRef<HTMLDivElement, Props>(
                   textAlign='left'
                   textColor='secondary'
                 >
-                  {formatTokenBalanceWithSymbol(
-                    balance ?? '',
-                    token.decimals,
-                    token.symbol,
-                  )}
+                  {formattedTokenBalance}
                 </TokenBalanceText>
               </NameAndBalanceColumn>
             </LeftSide>

--- a/components/brave_wallet_ui/page/screens/fungible_asset_details/components/accounts_and_transactions_list/accounts_and_transactions_list.tsx
+++ b/components/brave_wallet_ui/page/screens/fungible_asset_details/components/accounts_and_transactions_list/accounts_and_transactions_list.tsx
@@ -359,7 +359,7 @@ export const AccountsAndTransactionsList = ({
                               textSize='14px'
                             >
                               {'('
-                                + fullAssetFiatBalance.formatAsFiat(
+                                + fullAssetFiatBalance.compactAsFiat(
                                   defaultFiatCurrency,
                                 )
                                 + ')'}

--- a/components/brave_wallet_ui/page/screens/fungible_asset_details/fungible_asset_details.tsx
+++ b/components/brave_wallet_ui/page/screens/fungible_asset_details/fungible_asset_details.tsx
@@ -352,7 +352,7 @@ export const FungibleAssetDetails = () => {
       selectedAssetFromParams && fullAssetBalance
         ? new Amount(fullAssetBalance)
             .divideByDecimals(selectedAssetFromParams.decimals)
-            .formatAsAsset(6, selectedAssetFromParams.symbol)
+            .compactAsAsset(6, selectedAssetFromParams.symbol)
         : '',
     [selectedAssetFromParams, fullAssetBalance],
   )
@@ -362,7 +362,7 @@ export const FungibleAssetDetails = () => {
       selectedAssetFromParams && fullAssetBalance
         ? new Amount(fullAssetBalance)
             .divideByDecimals(selectedAssetFromParams.decimals)
-            .formatAsAsset(8)
+            .compactAsAsset(8)
         : '',
     [selectedAssetFromParams, fullAssetBalance],
   )
@@ -542,7 +542,7 @@ export const FungibleAssetDetails = () => {
               selectedAsset={selectedAssetFromParams}
               selectedAssetNetwork={selectedAssetsNetwork}
               assetBalance={formattedAssetBalance}
-              formattedFiatBalance={fullAssetFiatBalance.formatAsFiat(
+              formattedFiatBalance={fullAssetFiatBalance.compactAsFiat(
                 defaultFiat,
               )}
               onShowHideTokenModal={() => setShowHideTokenModal(true)}

--- a/components/brave_wallet_ui/page/screens/market/market_asset_details.tsx
+++ b/components/brave_wallet_ui/page/screens/market/market_asset_details.tsx
@@ -420,7 +420,7 @@ export const MarketAssetDetails = () => {
               selectedAsset={selectedAssetFromParams}
               selectedAssetNetwork={selectedAssetsNetwork}
               assetBalance={undefined}
-              formattedFiatBalance={fullAssetFiatBalance.formatAsFiat(
+              formattedFiatBalance={fullAssetFiatBalance.compactAsFiat(
                 defaultFiat,
               )}
               onShowHideTokenModal={() => setShowHideTokenModal(true)}

--- a/components/brave_wallet_ui/page/screens/portfolio_overview/components/token_lists/token_list.tsx
+++ b/components/brave_wallet_ui/page/screens/portfolio_overview/components/token_lists/token_list.tsx
@@ -491,7 +491,7 @@ export const TokenLists = ({
           balance={
             networksFiatValue.isUndefined()
               ? ''
-              : networksFiatValue.formatAsFiat(defaultFiatCurrency)
+              : networksFiatValue.compactAsFiat(defaultFiatCurrency)
           }
           network={network}
           isDisabled={networksAssets.length === 0}
@@ -573,7 +573,7 @@ export const TokenLists = ({
           balance={
             accountsFiatValue.isUndefined()
               ? ''
-              : accountsFiatValue.formatAsFiat(defaultFiatCurrency)
+              : accountsFiatValue.compactAsFiat(defaultFiatCurrency)
           }
           account={account}
           isDisabled={accountsAssets.length === 0}

--- a/components/brave_wallet_ui/page/screens/portfolio_overview/portfolio_overview.tsx
+++ b/components/brave_wallet_ui/page/screens/portfolio_overview/portfolio_overview.tsx
@@ -428,7 +428,7 @@ export const PortfolioOverview = () => {
 
   const formattedFullPortfolioFiatBalance = React.useMemo(() => {
     return !fullPortfolioFiatBalance.isUndefined() && defaultFiat
-      ? fullPortfolioFiatBalance.formatAsFiat(defaultFiat)
+      ? fullPortfolioFiatBalance.compactAsFiat(defaultFiat)
       : ''
   }, [fullPortfolioFiatBalance, defaultFiat])
 
@@ -477,7 +477,7 @@ export const PortfolioOverview = () => {
       return ''
     }
 
-    return difference.formatAsFiat(defaultFiat, 2)
+    return difference.compactAsFiat(defaultFiat, 2)
   }, [defaultFiat, change])
 
   const isPortfolioDown = new Amount(percentageChange).lt(0)
@@ -531,7 +531,7 @@ export const PortfolioOverview = () => {
           value: parseFloat(
             item.fiatAmount.div(fullPortfolioFiatBalance).times(100).format(2),
           ),
-          fiatValue: item.fiatAmount.formatAsFiat(defaultFiat),
+          fiatValue: item.fiatAmount.compactAsFiat(defaultFiat),
         }))
 
       // Add "Other" if there are more than DISTRIBUTION_LIMIT
@@ -541,7 +541,7 @@ export const PortfolioOverview = () => {
           value: parseFloat(
             otherTotal.div(fullPortfolioFiatBalance).times(100).format(2),
           ),
-          fiatValue: otherTotal.formatAsFiat(defaultFiat),
+          fiatValue: otherTotal.compactAsFiat(defaultFiat),
         })
       }
 

--- a/components/brave_wallet_ui/utils/amount.test.ts
+++ b/components/brave_wallet_ui/utils/amount.test.ts
@@ -379,5 +379,78 @@ describe('Amount class', () => {
         expect(new Amount(value).abbreviate(decimals, currency)).toBe(expected)
       },
     )
+
+    it.each([
+      ['0.000000000323', '0.00'],
+      ['0.0000026', '0.00'],
+      ['0.000009', '0.00'],
+      ['0.00026', '0.00026'],
+      ['0.0001', '0.0001'],
+      ['0.00001', '0.00001'],
+      ['0.0000000000000000000003', '0.00'],
+      ['1000', '1,000.00'],
+      ['12345.67890', '12,345.68'],
+      ['99999', '99,999.00'],
+      ['100000', '100.00k'],
+      ['123456789.0', '123.46M'],
+      ['-0.000000000323', '0.00'],
+      ['-1234', '-1,234.00'],
+    ])(
+      'should compact-format fiat amount %s as %s',
+      (value: string, expected: string) => {
+        expect(new Amount(value).compactAsFiat()).toBe(expected)
+      },
+    )
+
+    it.each([
+      ['0.000000000323', 'USD', '$0.00'],
+      ['0.0000026', 'USD', '$0.00'],
+      ['-0.000000000323', 'USD', '$0.00'],
+      ['100', 'USD', '$100.00'],
+      ['1000', 'USD', '$1,000.00'],
+      ['99999', 'USD', '$99,999.00'],
+      ['100000', 'USD', '$100.00k'],
+      ['-1234', 'USD', '-$1,234.00'],
+      ['0.0000000000000000000002564', 'USD', '$0.00'],
+    ])(
+      'should compact-format fiat amount %s with currency %s as %s',
+      (value: string, currency: string, expected: string) => {
+        expect(new Amount(value).compactAsFiat(currency)).toBe(expected)
+      },
+    )
+
+    it.each([
+      ['0.00000000002572', 'USD', '$0.0₁₀2572'],
+      ['0.000000000323', 'USD', '$0.0₉323'],
+      ['0.0000026', 'USD', '$0.0₅26'],
+      ['0.000009', 'USD', '$0.0₅9'],
+      ['100', 'USD', '$100.00'],
+      ['100000', 'USD', '$100.00k'],
+    ])(
+      'should compact-format spot price %s with currency %s as %s',
+      (value: string, currency: string, expected: string) => {
+        expect(new Amount(value).compactAsSpotPrice(currency)).toBe(expected)
+      },
+    )
+
+    it('should truncate dust balances but not spot prices', () => {
+      const amount = new Amount('0.00000000002572')
+      expect(amount.compactAsFiat('USD')).toBe('$0.00')
+      expect(amount.compactAsSpotPrice('USD')).toBe('$0.0₁₀2572')
+    })
+
+    it.each([
+      ['0.000000001', 'TangYuan', '0.0₈1 TangYuan'],
+      ['17120000000', 'BabyDoge', '17.12B BabyDoge'],
+      ['1500', 'USDC', '1,500 USDC'],
+      ['100000', 'USDC', '100,000 USDC'],
+      ['-0.000000000323', 'ETH', '-0.0₉323 ETH'],
+      ['123.456', 'ETH', '123.456 ETH'],
+    ])(
+      'should compact-format asset amount %s %s as %s',
+      (value: string, symbol: string, expected: string) => {
+        expect(new Amount(value).compactAsAsset(6, symbol)).toBe(expected)
+      },
+    )
   })
 })

--- a/components/brave_wallet_ui/utils/amount.ts
+++ b/components/brave_wallet_ui/utils/amount.ts
@@ -28,6 +28,14 @@ const abbreviations = {
   trillion: 'T',
 } as const
 
+const SUBSCRIPT_DIGITS = '₀₁₂₃₄₅₆₇₈₉'
+const TINY_COMPACT_LEADING_ZEROS = 4
+const TINY_COMPACT_SIGNIFICANT_DIGITS = 4
+const COMPACT_ABBREVIATION_DECIMALS = 2
+const COMPACT_ABBREVIATION_THRESHOLD = 100_000
+const COMPACT_ASSET_ABBREVIATION_THRESHOLD = 1_000_000_000
+const DUST_FIAT_THRESHOLD = 0.00001
+
 export default class Amount {
   public readonly value?: BigNumber
 
@@ -242,6 +250,126 @@ export default class Amount {
     )
   }
 
+  private static toSubscript(n: number): string {
+    return String(n).replace(/\d/g, (digit) => SUBSCRIPT_DIGITS[Number(digit)])
+  }
+
+  private static resolveCurrency(currency?: string): string | undefined {
+    if (!currency) {
+      return undefined
+    }
+
+    const currencyCode = currency.toUpperCase() as keyof typeof CurrencySymbols
+    return CurrencySymbols[currencyCode] ? currency : undefined
+  }
+
+  private static wrapWithCurrency(
+    formattedNumber: string,
+    currency?: string,
+  ): string {
+    if (!currency) {
+      return formattedNumber
+    }
+
+    const parts = Intl.NumberFormat(navigator.language, {
+      style: 'currency',
+      currency,
+      currencyDisplay: 'narrowSymbol',
+    }).formatToParts(0)
+
+    let result = ''
+    let insertedNumber = false
+    for (const part of parts) {
+      if (
+        part.type === 'integer'
+        || part.type === 'decimal'
+        || part.type === 'fraction'
+        || part.type === 'group'
+        || part.type === 'minusSign'
+        || part.type === 'plusSign'
+      ) {
+        if (!insertedNumber) {
+          result += formattedNumber
+          insertedNumber = true
+        }
+        continue
+      }
+      result += part.value
+    }
+
+    if (!insertedNumber) {
+      result += formattedNumber
+    }
+    return result
+  }
+
+  private formatTinyFiatCompact(currency?: string): string {
+    const compact = this.formatTinyCompact()
+    const wrapped = Amount.wrapWithCurrency(compact, currency)
+    return this.isNegative() ? `-${wrapped}` : wrapped
+  }
+
+  private countLeadingZerosAfterDecimal(): number {
+    if (this.value === undefined || this.value.isNaN() || this.value.isZero()) {
+      return 0
+    }
+
+    const exponent = this.value.absoluteValue().e
+    if (exponent === null || exponent >= 0) {
+      return 0
+    }
+
+    return -exponent - 1
+  }
+
+  private shouldFormatTinyCompact(): boolean {
+    return this.countLeadingZerosAfterDecimal() >= TINY_COMPACT_LEADING_ZEROS
+  }
+
+  private shouldAbbreviate(
+    threshold: number = COMPACT_ABBREVIATION_THRESHOLD,
+  ): boolean {
+    return this.value !== undefined && this.value.absoluteValue().gte(threshold)
+  }
+
+  private isDustFiatAmount(): boolean {
+    if (this.value === undefined || this.value.isNaN() || this.value.isZero()) {
+      return false
+    }
+
+    return this.value.absoluteValue().lt(DUST_FIAT_THRESHOLD)
+  }
+
+  /**
+   * Compact form for tiny asset amounts with a subscript leading-zero count,
+   * e.g. 0.000000000323 becomes 0.0₉323. Also used for tiny spot prices via
+   * formatTinyFiatCompact().
+   */
+  private formatTinyCompact(): string {
+    if (this.value === undefined || this.value.isNaN() || this.value.isZero()) {
+      return ''
+    }
+
+    const abs = this.value.absoluteValue()
+    let leadingZeros = this.countLeadingZerosAfterDecimal()
+    let rounded = abs
+      .times(new BigNumber(10).pow(leadingZeros + 1))
+      .precision(TINY_COMPACT_SIGNIFICANT_DIGITS)
+
+    if (rounded.gte(10)) {
+      leadingZeros -= 1
+      rounded = rounded.div(10)
+    }
+
+    const significand = rounded.toFixed().replace('.', '')
+    let end = significand.length
+    while (end > 0 && significand[end - 1] === '0') {
+      end -= 1
+    }
+    const digits = significand.slice(0, end) || '0'
+    return `0.0${Amount.toSubscript(leadingZeros)}${digits}`
+  }
+
   formatAsAsset(significantDigits?: number, symbol?: string): string {
     const result = this.format(significantDigits, true)
     if (!symbol) {
@@ -272,6 +400,81 @@ export default class Amount {
     return Intl.NumberFormat(navigator.language, options).format(
       new BigNumber(this.format(4)).toNumber(),
     )
+  }
+
+  /**
+   * Compact display formatting for asset amounts. Abbreviates large values
+   * (>= 1,000,000,000), uses subscript notation for tiny values (4+ leading
+   * zeros), and falls back to formatAsAsset for everything else.
+   */
+  compactAsAsset(significantDigits?: number, symbol?: string): string {
+    if (this.value === undefined || this.value.isNaN()) {
+      return ''
+    }
+
+    let result: string
+    if (this.shouldAbbreviate(COMPACT_ASSET_ABBREVIATION_THRESHOLD)) {
+      result = this.abbreviate(COMPACT_ABBREVIATION_DECIMALS)
+    } else if (this.shouldFormatTinyCompact()) {
+      const compact = this.formatTinyCompact()
+      result = this.isNegative() ? `-${compact}` : compact
+    } else {
+      result = this.format(significantDigits, true)
+    }
+
+    if (!symbol) {
+      return result
+    }
+
+    return result === '' ? '' : `${result} ${symbol}`
+  }
+
+  /**
+   * Compact display formatting for fiat amounts. Abbreviates large values
+   * (>= 100,000), shows $0.00 for dust values (< $0.00001), and falls back
+   * to formatAsFiat for everything else.
+   */
+  compactAsFiat(currency?: string, maxDecimals: number = 20): string {
+    if (this.value === undefined || this.value.isNaN()) {
+      return ''
+    }
+
+    const resolvedCurrency = Amount.resolveCurrency(currency)
+
+    if (this.shouldAbbreviate()) {
+      return this.abbreviate(COMPACT_ABBREVIATION_DECIMALS, resolvedCurrency)
+    }
+
+    if (this.isDustFiatAmount()) {
+      return Amount.zero().formatAsFiat(currency, maxDecimals)
+    }
+
+    return this.formatAsFiat(currency, maxDecimals)
+  }
+
+  /**
+   * Compact formatting for token spot prices. Like compactAsFiat but uses
+   * subscript notation for tiny prices instead of rounding dust to $0.00.
+   */
+  compactAsSpotPrice(currency?: string): string {
+    if (this.value === undefined || this.value.isNaN()) {
+      return ''
+    }
+
+    const resolvedCurrency = Amount.resolveCurrency(currency)
+
+    if (this.shouldAbbreviate()) {
+      return this.abbreviate(COMPACT_ABBREVIATION_DECIMALS, resolvedCurrency)
+    }
+
+    if (
+      !this.isZero()
+      && (this.isDustFiatAmount() || this.shouldFormatTinyCompact())
+    ) {
+      return this.formatTinyFiatCompact(resolvedCurrency)
+    }
+
+    return this.formatAsFiat(currency)
   }
 
   toHex(): string {


### PR DESCRIPTION
## Description 

Fixes wallet UI breakage caused by extremely long balance strings (e.g. `$0.000000000000000000003` overlapping portfolio action buttons).

Adds **opt-in** compact formatting methods on `Amount`. Existing `formatAsFiat()` / `formatAsAsset()` behavior is unchanged — transaction flows, gas fees, confirmations, etc. continue using full-precision formatting.

### New `Amount` methods

| Method | Purpose | Behavior |
|--------|---------|----------|
| **`compactAsFiat`** | Portfolio totals, account balances, asset row fiat values | ≥ $100k → abbreviated (`$100.00k`); < $0.00001 → `$0.00`; otherwise → `formatAsFiat` |
| **`compactAsAsset`** | Token quantity display in lists | ≥ 1B → abbreviated (`17.12B`); 4+ leading zeros → subscript (`0.0₈1`); otherwise → `formatAsAsset` |
| **`compactAsSpotPrice`** | Token detail headers / price displays | Same as fiat for large values; tiny/dust prices use **subscript** (e.g. `$0.0₁₀2572`) instead of `$0.00` |

Dust truncation (< $0.00001 → `$0.00`) applies only to **balances**, not spot prices — so a memecoin detail page still shows a meaningful price even when the user's holding is economically negligible.

### UI surfaces updated

- Portfolio overview (header balance, 24h change, distribution labels, asset/account group headers)
- Portfolio asset & account list items
- Accounts list & account details header
- Asset details header & fungible/market asset detail pages
- Select asset modal (token list, token details, account picker)
- Connect wallet (dApp) account picker

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/58226>

### Before vs After

<img width="789" height="480" alt="Screenshot" src="https://github.com/user-attachments/assets/5a42ab68-e7a7-44cd-af20-78f6f1ee2898" /> | <img width="778" height="471" alt="Screenshot 7" src="https://github.com/user-attachments/assets/26cdceb5-48ba-44b7-9baa-a58364198009" />
--|--

<img width="779" height="643" alt="Screenshot 1" src="https://github.com/user-attachments/assets/a94142f5-ed0c-40b5-b0e2-1d3aaacb1220" /> | <img width="776" height="641" alt="Screenshot 8" src="https://github.com/user-attachments/assets/d643b39d-cff5-437c-9d65-951768df1ed0" />
--|--

<img width="779" height="686" alt="Screenshot 2" src="https://github.com/user-attachments/assets/f98db59a-deee-44d1-a19a-20fb6f54b2a0" /> | <img width="775" height="683" alt="Screenshot 9" src="https://github.com/user-attachments/assets/3f69e2ff-55d9-4409-bda3-805b36ac529c" />
--|--

<img width="779" height="584" alt="Screenshot 3" src="https://github.com/user-attachments/assets/e63aa860-511a-4d72-b35c-bdf3602a693c" /> | <img width="775" height="582" alt="Screenshot 10" src="https://github.com/user-attachments/assets/99afc70c-c772-4437-a423-86b5da56c075" />
--|--

<img width="570" height="339" alt="Screenshot 4" src="https://github.com/user-attachments/assets/5213324e-f64e-42c6-b0e4-a189cb23e612" /> | <img width="572" height="328" alt="Screenshot 11" src="https://github.com/user-attachments/assets/dac61ad2-e060-43bc-9e80-f9b0c2d32cee" />
--|--

<img width="572" height="379" alt="Screenshot 5" src="https://github.com/user-attachments/assets/da3fbebb-1d68-4fd2-be85-d9bf55a1572b" /> | <img width="574" height="379" alt="Screenshot 12" src="https://github.com/user-attachments/assets/f3d59b46-7c85-4d87-991b-b02a89cbe1aa" />
--|--

<img width="402" height="663" alt="Screenshot 6" src="https://github.com/user-attachments/assets/d42993ab-24d9-46a2-aa7a-c481c48c03ce" /> | <img width="397" height="659" alt="Screenshot 13" src="https://github.com/user-attachments/assets/3dec36ad-3452-40aa-b43c-0c0836f85cba" />
--|--

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
