### PR TITLE
[iOS] Add tooling to support Swift autocomplete in non-Xcode editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,10 @@ xcuserdata
 # A file that may be left behind in the CI after running presubmits
 .presubmit_results.json
 
+# Per-developer configuration for tools/swift/bsp/gn_bsp_server.py
+buildServer.json
+.gn_bsp_config.json
+
 # Claude LLM settings (user-specific, not tracked)
 .claude/settings.local.json
 .claude/CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -106,7 +106,6 @@ xcuserdata
 
 # Per-developer configuration for tools/swift/bsp/gn_bsp_server.py
 buildServer.json
-.gn_bsp_config.json
 
 # Claude LLM settings (user-specific, not tracked)
 .claude/settings.local.json

--- a/tools/swift/bsp/README.md
+++ b/tools/swift/bsp/README.md
@@ -1,0 +1,211 @@
+# Swift editor support for GN-built Swift code
+
+Gives editors that use
+[sourcekit-lsp](https://github.com/swiftlang/sourcekit-lsp) (VS Code's
+[Swift extension](https://github.com/swiftlang/vscode-swift), Neovim, Emacs,
+Zed, ...) working autocomplete, jump-to-definition and diagnostics for Swift
+files compiled by GN/ninja — including symbols coming from imported modules such
+as `BraveCore` and C++ modules exposed through `cxx_import_deps`.
+
+This does not cover `ios/brave-ios`, which is built by Xcode; use a tool like
+[xcode-build-server](https://github.com/SolaWing/xcode-build-server) for that.
+
+## Setup
+
+1.  Build the Swift targets you want editor support for at least once. The
+    compiler arguments come from the generated ninja files, and imported modules
+    have to exist on disk before they can be resolved.
+
+2.  Create `buildServer.json` in `src/brave` (the directory the editor is opened
+    at). It is ignored by git, so it can hold absolute local paths:
+
+    ```json
+    {
+      "name": "brave-gn-swift-build-server",
+      "version": "0.1.0",
+      "bspVersion": "2.2.0",
+      "languages": ["swift"],
+      "argv": [
+        "/usr/bin/python3",
+        "/abs/path/to/src/brave/tools/swift/bsp/gn_bsp_server.py",
+        "--source-root",
+        "/abs/path/to/src",
+        "--out-dir",
+        "out/ios_current_link"
+      ]
+    }
+    ```
+
+    `argv` is executed without a shell, so every path must be absolute.
+
+3.  Reopen the editor. It launches `gn_bsp_server.py` on its own and asks it for
+    compiler arguments whenever a `.swift` file is opened.
+
+To use a different output directory without editing `buildServer.json` (which
+may be shared through other means), create `src/brave/.gn_bsp_config.json`:
+
+```json
+{ "out_dir": "out/ios_sim" }
+```
+
+## Which targets are exposed
+
+Only targets sources under the workspace root are advertised to sourcekit-lsp,
+because it background indexes everything it is told about, which would mean
+typechecking upstream code nobody opened and filling its module cache.
+
+Upstream files are **not** cut off by this. When one is opened, sourcekit-lsp
+asks for its settings anyway, and the server resolves it against all targets in
+the build, so it still gets the real build arguments. The filter only controls
+what gets indexed up front.
+
+To index everything, point `--workspace-root` at the source root in
+`buildServer.json`:
+
+```json
+"--workspace-root", "/abs/path/to/src"
+```
+
+## How it works
+
+```
+editor -> sourcekit-lsp -> gn_bsp_server.py -> generated ninja files
+             LSP              BSP
+```
+
+`sourcekit-lsp` supports the [Build Server Protocol][bsp] to obtain build
+settings from an external build system. `gn_bsp_server.py` implements the subset
+of it that sourcekit-lsp needs, backed by `gn_swift_args.py`.
+
+Recovering the swiftc arguments is not completely obvious, because GN does not
+run swiftc directly: the `swift` ninja rule runs
+`//build/toolchain/apple/swiftc.py`, which assembles the real command line. So
+`gn_swift_args.py`:
+
+1. Scans `out/<dir>/obj/**/*.ninja` for `swift` build edges to discover Swift
+   targets, their sources and their ninja variables. (`gn desc` would be the
+   obvious source of this, but it needs a full graph load per invocation, which
+   is far too slow at Chromium scale.)
+2. Expands the `rule swift` command template from `toolchain.ninja` with those
+   variables to reconstruct the `swiftc.py` invocation.
+3. Runs `swiftc.py` as a subprocess with `--swift-toolchain-path` pointed at a
+   fake toolchain whose `swiftc` records the arguments it was given and exits
+   non-zero. `swiftc.py` builds the compiler path as
+   `<toolchain>/usr/bin/swiftc`, so this intercepts the invocation through its
+   documented command line interface only, and stops it before the post-compile
+   steps that read real build outputs. `--target-out-dir` and `--header-path`
+   are also overridden to point inside `swift_lsp_cache/`, so the bookkeeping
+   files swiftc.py writes before that point (its `OutputFileMap.json` and
+   `SwiftFileList`) land in the cache instead of the real build directory.
+4. Strips code generation flags (`-c`, `-emit-*`, `-output-file-map`, ...) and
+   expands the `@Module.SwiftFileList` response file, leaving arguments that
+   only describe how to parse and typecheck the module.
+
+Results are cached in memory and invalidated when `build.ninja`'s mtime changes,
+so re-running `gn gen` is picked up automatically.
+
+Intermediate state the compiler needs (module cache, precompiled headers, index
+store) is written to `out/<dir>/swift_lsp_cache/`, keeping it out of the way of
+the real build.
+
+The clang module cache is shared across targets, in
+`swift_lsp_cache/SharedModuleCache.noindex/`. swiftc.py gives each target its
+own (correct for a build, where rebuilding one target should not disturb
+another) but entries are keyed by a hash of the compilation settings, so targets
+built with the same flags produce byte-identical modules and can reuse each
+other's work, while targets with differing flags coexist under different hashes.
+Measured over 23 targets in an iOS build, typechecking all of them from cold
+went from 153s to 77s, and the cache from 1376 MB to 563 MB.
+
+Two things are deliberately **not** shared:
+
+- `-pch-output-dir`. Bridging header PCHs are named
+  `<header basename>-<hash>.pch`, and that hash does not distinguish two targets
+  with different `bridge_header.h` files, so sharing makes them collide and
+  emitting the PCH fails outright.
+- `-index-store-path`. Kept per-target so index units cannot be attributed to
+  the wrong target.
+
+swiftc creates neither of these directories itself and fails if they are
+missing, so they are recreated on every request rather than only at extraction
+time — otherwise deleting `swift_lsp_cache` to reclaim disk would break every
+open file until the editor was restarted.
+
+## Coupling to Chromium, and how it is contained
+
+Nothing here is a supported extension point, so the parts that depend on code we
+do not control are deliberately narrow and fail loudly:
+
+- **swiftc.py's interface.** Five things are assumed: the file exists, it
+  accepts `--swift-toolchain-path`, it runs `<toolchain>/usr/bin/swiftc`, and it
+  accepts `--target-out-dir`/`--header-path` (all documented flags). The first
+  three are checked before use, with an error naming this directory. No internal
+  function or variable is touched, so upstream refactors of how the command line
+  is assembled do not matter — that logic is executed rather than reimplemented,
+  so the arguments follow it automatically.
+- **Build isolation.** swiftc.py writes its own bookkeeping files under
+  `--target-out-dir`/`--header-path` before the fake `swiftc` stops it, so both
+  are redirected into `swift_lsp_cache/` (see step 3). Nothing swiftc.py writes
+  can reach the real build directory regardless of which flags it assembles, so
+  this holds even if upstream adds new output flags. `_DROPPED_FLAGS` and
+  friends still strip codegen flags, but only to keep the argument list to what
+  describes parsing and typechecking; they are no longer load-bearing for
+  isolation, so a missed one is harmless rather than a write into the build.
+- **The ninja file format.** The `swift` build edge shape and the `rule swift`
+  command template are parsed. `gn_swift_args_test.py` covers this.
+
+What none of the above can catch is arguments that are still well-formed but no
+longer describe how the module is built. `gn_swift_args_test.py` catches that by
+typechecking real targets with the extracted arguments:
+
+```sh
+python3 tools/swift/bsp/gn_swift_args_test.py --out-dir out/ios_current_link
+```
+
+Worth running after a Chromium roll that touches `build/toolchain/apple/` or
+`build/config/apple/swift_source_set.gni`.
+
+## Debugging
+
+`gn_swift_args.py` runs standalone, which is the fastest way to tell whether a
+problem is in the argument extraction or in the editor integration:
+
+```sh
+# List all Swift targets in an output directory.
+python3 tools/swift/bsp/gn_swift_args.py --out-dir out/ios_current_link
+
+# Print the arguments for one file.
+python3 tools/swift/bsp/gn_swift_args.py --out-dir out/ios_current_link \
+    ios/swift/foo.swift
+
+# Verify the arguments actually typecheck the file.
+python3 tools/swift/bsp/gn_swift_args.py --out-dir out/ios_current_link \
+    ios/swift/foo.swift --json > /tmp/args.json
+(cd ../out/ios_current_link && xcrun swiftc -typecheck $(python3 -c \
+    'import json, shlex; print(shlex.join(json.load(open("/tmp/args.json"))))'))
+```
+
+The server logs to stderr, which the VS Code Swift extension shows in its
+"SourceKit Language Server" output channel. Set `BRAVE_BSP_DEBUG=1` in the
+environment for per-request logging.
+
+Common failures:
+
+- **No completions at all, no server output.** The editor did not find
+  `buildServer.json`, or a path in `argv` is wrong. `argv` is not run through a
+  shell and `~` is not expanded.
+- **"no Swift target owns <file>".** The file is not in any target's `sources`
+  in the current output directory. Add it to `BUILD.gn` and re-run `gn gen`.
+- **Imports of other modules do not resolve.** That module has not been built in
+  this output directory yet.
+
+## Compatibility
+
+The sourceKit BSP extensions are experimental and change between toolchain
+versions. This was developed against the Swift 6.3 toolchain shipped with
+Xcode 26. If a toolchain upgrade breaks things, check the [BSP extensions
+documentation][bsp-extensions] for the corresponding sourcekit-lsp release.
+
+[bsp]: https://build-server-protocol.github.io/docs/specification
+[bsp-extensions]:
+  https://github.com/swiftlang/sourcekit-lsp/blob/main/Contributor%20Documentation/BSP%20Extensions.md

--- a/tools/swift/bsp/README.md
+++ b/tools/swift/bsp/README.md
@@ -26,7 +26,6 @@ This does not cover `ios/brave-ios`, which is built by Xcode; use a tool like
       "bspVersion": "2.2.0",
       "languages": ["swift"],
       "argv": [
-        "/usr/bin/python3",
         "/abs/path/to/src/brave/tools/swift/bsp/gn_bsp_server.py",
         "--source-root",
         "/abs/path/to/src",

--- a/tools/swift/bsp/README.md
+++ b/tools/swift/bsp/README.md
@@ -40,13 +40,6 @@ This does not cover `ios/brave-ios`, which is built by Xcode; use a tool like
 3.  Reopen the editor. It launches `gn_bsp_server.py` on its own and asks it for
     compiler arguments whenever a `.swift` file is opened.
 
-To use a different output directory without editing `buildServer.json` (which
-may be shared through other means), create `src/brave/.gn_bsp_config.json`:
-
-```json
-{ "out_dir": "out/ios_sim" }
-```
-
 ## Which targets are exposed
 
 Only targets sources under the workspace root are advertised to sourcekit-lsp,

--- a/tools/swift/bsp/gn_bsp_server.py
+++ b/tools/swift/bsp/gn_bsp_server.py
@@ -1,0 +1,430 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Build Server Protocol server exposing GN Swift targets to sourcekit-lsp.
+
+sourcekit-lsp launches this as a subprocess (configured via `buildServer.json`
+at the workspace root) and asks it for the compiler arguments of each Swift
+file it opens. The arguments come from the generated ninja files, see
+gn_swift_args.py for how they are recovered.
+
+Protocol reference (the sourceKit BSP extensions are experimental and tied to
+the toolchain version, developed against Swift 6.3):
+https://github.com/swiftlang/sourcekit-lsp/blob/main/Contributor%20Documentation/BSP%20Extensions.md
+
+Log output goes to stderr, which the VS Code Swift extension shows in its
+"SourceKit Language Server" output channel. Set BRAVE_BSP_DEBUG=1 for verbose
+request logging.
+"""
+
+import argparse
+import json
+import os
+import sys
+import threading
+import traceback
+import urllib.parse
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import gn_swift_args  # pylint: disable=wrong-import-position
+
+BSP_VERSION = '2.2.0'
+SERVER_NAME = 'brave-gn-swift-build-server'
+SERVER_VERSION = '0.1.0'
+
+_DEBUG = bool(os.environ.get('BRAVE_BSP_DEBUG'))
+
+
+def _log(message):
+    print(f'[{SERVER_NAME}] {message}', file=sys.stderr, flush=True)
+
+
+def _debug(message):
+    if _DEBUG:
+        _log(message)
+
+
+def _path_to_uri(path):
+    return 'file://' + urllib.parse.quote(os.path.abspath(path))
+
+
+def _uri_to_path(uri):
+    if uri.startswith('file://'):
+        uri = uri[len('file://'):]
+    return os.path.normpath(urllib.parse.unquote(uri))
+
+
+class TargetIndex:
+    """Swift target information, refreshed when build.ninja changes."""
+
+    def __init__(self, source_root, out_dir, workspace_root):
+        self.source_root = source_root
+        self.out_dir = out_dir
+        self.workspace_root = workspace_root
+        self._lock = threading.Lock()
+        self._build_ninja_mtime = None
+        self._targets_by_uri = {}
+        self._targets_by_source = {}
+        self._arguments_by_uri = {}
+
+    def _in_workspace(self, target):
+        """Whether any of `target`'s sources live under the workspace root."""
+        prefix = self.workspace_root + os.sep
+        return any(
+            os.path.realpath(os.path.join(self.out_dir, source)).startswith(
+                prefix) for source in target.sources)
+
+    def _build_ninja_path(self):
+        return os.path.join(self.out_dir, 'build.ninja')
+
+    def _current_mtime(self):
+        try:
+            return os.path.getmtime(self._build_ninja_path())
+        except OSError:
+            return None
+
+    def _refresh_locked(self):
+        """Rescans the ninja files if they changed since the last scan."""
+        mtime = self._current_mtime()
+        if mtime is not None and mtime == self._build_ninja_mtime:
+            return
+        if mtime is None:
+            _log(f'{self._build_ninja_path()} is missing, run `gn gen` first')
+            return
+
+        _debug(f'scanning {self.out_dir} for Swift targets')
+        targets = gn_swift_args.find_targets(self.out_dir)
+        self._targets_by_uri = {target.uri: target for target in targets}
+        self._targets_by_source = {}
+        for target in targets:
+            for source in target.sources:
+                path = os.path.realpath(os.path.join(self.out_dir, source))
+                self._targets_by_source.setdefault(path, []).append(target)
+        self._arguments_by_uri = {}
+        self._build_ninja_mtime = mtime
+        in_workspace = sum(1 for target in targets
+                           if self._in_workspace(target))
+        _log(f'found {len(targets)} Swift target(s) in {self.out_dir}, '
+             f'{in_workspace} under {self.workspace_root}')
+
+    def targets(self, workspace_only=False):
+        """Returns known targets, optionally only those in the workspace."""
+        with self._lock:
+            self._refresh_locked()
+            return [
+                target for target in self._targets_by_uri.values()
+                if not workspace_only or self._in_workspace(target)
+            ]
+
+    def targets_for_source(self, path):
+        with self._lock:
+            self._refresh_locked()
+            return list(self._targets_by_source.get(os.path.realpath(path),
+                                                    []))
+
+    def compiler_arguments(self, target_uri):
+        """Returns cached swiftc arguments for a target, or None."""
+        with self._lock:
+            self._refresh_locked()
+            if target_uri in self._arguments_by_uri:
+                arguments = self._arguments_by_uri[target_uri]
+                # Cheap, and the directories can be deleted underneath us at any
+                # point during a long-lived editor session.
+                gn_swift_args.ensure_cache_dirs(arguments)
+                return arguments
+            target = self._targets_by_uri.get(target_uri)
+            if target is None:
+                return None
+            arguments = gn_swift_args.compiler_arguments(
+                target, self.source_root)
+            self._arguments_by_uri[target_uri] = arguments
+            return arguments
+
+
+class BuildServer:
+    """JSON-RPC 2.0 server speaking BSP over stdio."""
+
+    def __init__(self, source_root, out_dir, workspace_root):
+        self.index = TargetIndex(source_root, out_dir, workspace_root)
+        self.source_root = source_root
+        self.out_dir = out_dir
+        self.workspace_root = workspace_root
+        self._shutdown = False
+
+    # -- Transport ----------------------------------------------------------
+
+    def _read_message(self):
+        """Reads one LSP-framed JSON-RPC message from stdin."""
+        headers = {}
+        stream = sys.stdin.buffer
+        while True:
+            line = stream.readline()
+            if not line:
+                return None
+            line = line.strip()
+            if not line:
+                break
+            name, _, value = line.decode('utf8').partition(':')
+            headers[name.strip().lower()] = value.strip()
+
+        length = int(headers.get('content-length', 0))
+        if not length:
+            return None
+        return json.loads(stream.read(length).decode('utf8'))
+
+    def _write_message(self, message):
+        payload = json.dumps(message).encode('utf8')
+        # Messages are only ever written from the single request-handling loop
+        # in run(); the one background thread (index warm-up) never writes.
+        sys.stdout.buffer.write(b'Content-Length: %d\r\n\r\n' % len(payload))
+        sys.stdout.buffer.write(payload)
+        sys.stdout.buffer.flush()
+
+    def _respond(self, request_id, result):
+        self._write_message({
+            'jsonrpc': '2.0',
+            'id': request_id,
+            'result': result
+        })
+
+    def _respond_error(self, request_id, code, message):
+        self._write_message({
+            'jsonrpc': '2.0',
+            'id': request_id,
+            'error': {
+                'code': code,
+                'message': message
+            }
+        })
+
+    def run(self):
+        _log(f'started, source root {self.source_root}, '
+             f'output directory {self.out_dir}')
+        while not self._shutdown:
+            try:
+                message = self._read_message()
+            except Exception:  # pylint: disable=broad-except
+                _log(f'failed to read message:\n{traceback.format_exc()}')
+                break
+            if message is None:
+                break
+
+            method = message.get('method')
+            request_id = message.get('id')
+            params = message.get('params') or {}
+            _debug(f'--> {method} {json.dumps(params)[:400]}')
+
+            handler = self._handlers().get(method)
+            if handler is None:
+                # Unknown notifications are ignored; unknown requests get a
+                # "method not found" so sourcekit-lsp can probe capabilities.
+                if request_id is not None:
+                    self._respond_error(request_id, -32601,
+                                        f'unhandled method: {method}')
+                else:
+                    _debug(f'ignoring notification {method}')
+                continue
+
+            try:
+                result = handler(params)
+            except Exception:  # pylint: disable=broad-except
+                _log(f'{method} failed:\n{traceback.format_exc()}')
+                if request_id is not None:
+                    self._respond_error(request_id, -32603,
+                                        f'{method} failed, see server log')
+                continue
+
+            if request_id is not None:
+                self._respond(request_id, result)
+                _debug(f'<-- {method} {json.dumps(result)[:400]}')
+
+    def _handlers(self):
+        return {
+            'build/initialize': self.on_build_initialize,
+            'build/initialized': self.on_build_initialized,
+            'build/shutdown': self.on_build_shutdown,
+            'build/exit': self.on_build_exit,
+            'workspace/buildTargets': self.on_workspace_build_targets,
+            'buildTarget/sources': self.on_build_target_sources,
+            'textDocument/sourceKitOptions': self.
+            on_text_document_sourcekit_options,
+            'workspace/waitForBuildSystemUpdates': self.
+            on_workspace_wait_for_build_system_updates,
+        }
+
+    # -- Lifecycle ----------------------------------------------------------
+
+    def on_build_initialize(self, params):
+        del params
+        index_root = gn_swift_args.cache_root(self.out_dir)
+        return {
+            'displayName': SERVER_NAME,
+            'version': SERVER_VERSION,
+            'bspVersion': BSP_VERSION,
+            'rootUri': _path_to_uri(self.source_root),
+            'capabilities': {
+                'languageIds': ['swift']
+            },
+            'dataKind': 'sourceKit',
+            'data': {
+                'sourceKitOptionsProvider': True,
+                'indexDatabasePath': os.path.join(index_root, 'IndexDatabase'),
+            },
+        }
+
+    def on_build_initialized(self, params):
+        del params
+        # Warm the target index so the first opened file responds quickly.
+        threading.Thread(target=self.index.targets, daemon=True).start()
+
+    def on_build_shutdown(self, params):
+        del params
+
+    def on_build_exit(self, params):
+        del params
+        self._shutdown = True
+
+    # -- Targets and sources ------------------------------------------------
+
+    def on_workspace_build_targets(self, params):
+        del params
+        targets = []
+        # Only workspace targets are advertised. sourcekit-lsp background
+        # indexes everything it is told about, and indexing the ~30 upstream
+        # Swift targets in an iOS build means typechecking code the user did not
+        # open and filling their module caches. Files in those targets still get
+        # full settings when opened, see on_text_document_sourcekit_options.
+        for target in self.index.targets(workspace_only=True):
+            targets.append({
+                'id': {
+                    'uri': target.uri
+                },
+                'displayName': target.label,
+                'baseDirectory': _path_to_uri(
+                    os.path.join(self.source_root,
+                                 target.label[2:].split(':')[0])),
+                'tags': ['library'],
+                'languageIds': ['swift'],
+                'dependencies': [],
+                'capabilities': {},
+            })
+        return {'targets': targets}
+
+    def on_build_target_sources(self, params):
+        items = []
+        targets_by_uri = {
+            target.uri: target
+            for target in self.index.targets()
+        }
+        for identifier in params.get('targets', []):
+            uri = identifier.get('uri')
+            target = targets_by_uri.get(uri)
+            if target is None:
+                continue
+            sources = []
+            for source in target.sources:
+                path = os.path.realpath(os.path.join(self.out_dir, source))
+                sources.append({
+                    'uri': _path_to_uri(path),
+                    'kind': 1,
+                    'generated': not path.startswith(self.source_root + os.sep)
+                    or '/gen/' in path,
+                    'dataKind': 'sourceKit',
+                    'data': {
+                        'language': 'swift'
+                    },
+                })
+            items.append({'target': {'uri': uri}, 'sources': sources})
+        return {'items': items}
+
+    def on_workspace_wait_for_build_system_updates(self, params):
+        del params
+        self.index.targets()
+
+    # -- Compiler arguments -------------------------------------------------
+
+    def on_text_document_sourcekit_options(self, params):
+        path = _uri_to_path(params['textDocument']['uri'])
+        target_uri = (params.get('target') or {}).get('uri')
+
+        if not target_uri:
+            targets = self.index.targets_for_source(path)
+            if not targets:
+                _log(f'no Swift target owns {path}')
+                return None
+            target_uri = targets[0].uri
+
+        arguments = self.index.compiler_arguments(target_uri)
+        if arguments is None:
+            _log(f'no compiler arguments for target {target_uri}')
+            return None
+
+        # sourcekit-lsp requires the requested file to be in the argument list.
+        # The argument list holds each source as swiftc.py named it, which may
+        # differ from the URI the editor opened (e.g. a symlinked checkout), so
+        # matching is done on the resolved path. A file added to BUILD.gn but
+        # not yet `gn gen`-ed is absent entirely and is appended as opened, so
+        # it still typechecks with its module's arguments.
+        resolved = os.path.realpath(path)
+        if not any(
+                argument.endswith('.swift')
+                and os.path.realpath(argument) == resolved
+                for argument in arguments):
+            arguments = arguments + [path]
+
+        return {
+            'compilerArguments': arguments,
+            'workingDirectory': self.out_dir,
+        }
+
+
+def _resolve_out_dir(source_root, out_dir):
+    """Resolves the output directory, honouring a local config override.
+
+    Developers use different GN output directories, so `--out-dir` can be
+    overridden per checkout by an untracked `.gn_bsp_config.json` next to
+    `buildServer.json`:
+
+        { "out_dir": "out/ios_sim" }
+    """
+    config_path = os.path.join(source_root, 'brave', '.gn_bsp_config.json')
+    if os.path.exists(config_path):
+        with open(config_path, encoding='utf8') as stream:
+            configured = json.load(stream).get('out_dir')
+        if configured:
+            _log(f'using out_dir {configured} from {config_path}')
+            out_dir = configured
+    return os.path.realpath(os.path.join(source_root, out_dir))
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--source-root',
+                        default=os.path.join(os.path.dirname(__file__), '..',
+                                             '..', '..', '..'),
+                        help='path to the Chromium src directory')
+    parser.add_argument('--out-dir',
+                        default='out/ios_current_link',
+                        help='GN output directory, relative to --source-root')
+    parser.add_argument(
+        '--workspace-root',
+        default=None,
+        help='only advertise targets with sources under this '
+        'directory (default: the `brave` directory inside '
+        '--source-root). Pass --source-root to advertise every '
+        'Swift target in the build.')
+    args = parser.parse_args(argv)
+
+    source_root = os.path.realpath(args.source_root)
+    out_dir = _resolve_out_dir(source_root, args.out_dir)
+    workspace_root = os.path.realpath(
+        args.workspace_root) if args.workspace_root else os.path.join(
+            source_root, 'brave')
+    BuildServer(source_root, out_dir, workspace_root).run()
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/tools/swift/bsp/gn_bsp_server.py
+++ b/tools/swift/bsp/gn_bsp_server.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright (c) 2026 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,

--- a/tools/swift/bsp/gn_bsp_server.py
+++ b/tools/swift/bsp/gn_bsp_server.py
@@ -381,25 +381,6 @@ class BuildServer:
         }
 
 
-def _resolve_out_dir(source_root, out_dir):
-    """Resolves the output directory, honouring a local config override.
-
-    Developers use different GN output directories, so `--out-dir` can be
-    overridden per checkout by an untracked `.gn_bsp_config.json` next to
-    `buildServer.json`:
-
-        { "out_dir": "out/ios_sim" }
-    """
-    config_path = os.path.join(source_root, 'brave', '.gn_bsp_config.json')
-    if os.path.exists(config_path):
-        with open(config_path, encoding='utf8') as stream:
-            configured = json.load(stream).get('out_dir')
-        if configured:
-            _log(f'using out_dir {configured} from {config_path}')
-            out_dir = configured
-    return os.path.realpath(os.path.join(source_root, out_dir))
-
-
 def main(argv):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('--source-root',
@@ -419,7 +400,7 @@ def main(argv):
     args = parser.parse_args(argv)
 
     source_root = os.path.realpath(args.source_root)
-    out_dir = _resolve_out_dir(source_root, args.out_dir)
+    out_dir = os.path.realpath(os.path.join(source_root, args.out_dir))
     workspace_root = os.path.realpath(
         args.workspace_root) if args.workspace_root else os.path.join(
             source_root, 'brave')

--- a/tools/swift/bsp/gn_swift_args.py
+++ b/tools/swift/bsp/gn_swift_args.py
@@ -1,0 +1,479 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Extracts swiftc arguments for GN Swift targets out of a ninja build dir.
+
+GN compiles Swift through the `swift` ninja rule, which runs
+//build/toolchain/apple/swiftc.py rather than swiftc directly. That wrapper is
+the only thing that knows the final swiftc command line, so the arguments are
+recovered by:
+
+  1. Scanning the generated `obj/**/*.ninja` files for `swift` build edges to
+     find Swift targets, their sources and their ninja variables.
+  2. Expanding the `rule swift` command template from `toolchain.ninja` with
+     those variables to rebuild the swiftc.py invocation.
+  3. Running swiftc.py as a subprocess with `--swift-toolchain-path` pointed at
+     a fake toolchain whose `swiftc` records its arguments and exits non-zero,
+     so it assembles the command line without compiling anything.
+  4. Rewriting the result into something an index/language server can consume
+     (dropping code generation flags, expanding the `@file.SwiftFileList`
+     response file).
+
+Can be run standalone for debugging:
+
+    python3 gn_swift_args.py --out-dir out/ios_sim path/to/File.swift
+"""
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+
+# Substituted for the temporary directory swiftc.py uses for the module cache,
+# precompiled headers and index store, so the paths outlive the extraction.
+LSP_CACHE_DIR_NAME = 'swift_lsp_cache'
+
+# Caches that are safe to share between targets, mapped to their shared
+# location inside the cache directory. swiftc.py points these at a per-target
+# derived data directory, which is right for a build (where an incremental
+# rebuild of one target should not disturb another) but wasteful here: entries
+# are keyed by a hash of the compilation settings, so targets built with the
+# same flags produce byte-identical entries and can reuse each other's work,
+# while targets with differing flags coexist under different hashes.
+#
+# `-pch-output-dir` is deliberately not shared. Bridging header PCHs are named
+# `<header basename>-<hash>.pch`, and that hash does not distinguish two targets
+# with different `bridge_header.h` files, so sharing makes them collide and
+# emitting the PCH fails.
+_SHARED_CACHE_FLAGS = {
+    '-module-cache-path': 'SharedModuleCache.noindex',
+}
+
+# swiftc arguments that produce build outputs. They are useless for indexing,
+# so they are stripped to keep the argument list to what describes how the
+# module is parsed and typechecked. This is a correctness/tidiness measure for
+# sourcekit-lsp, not the build-isolation guarantee: `--target-out-dir` and
+# `--header-path` are redirected into the cache directory (see
+# `_extract_swiftc_command`), so nothing swiftc.py writes can reach the real
+# build directory regardless of which of these survive.
+_DROPPED_FLAGS = frozenset([
+    '-c',
+    '-emit-const-values',
+    '-emit-dependencies',
+    '-emit-module',
+    '-emit-objc-header',
+    '-incremental',
+    '-save-temps',
+    '-serialize-diagnostics',
+    '-whole-module-optimization',
+    '-no-emit-module-separately-wmo',
+    '-experimental-emit-module-separately',
+    '-enable-batch-mode',
+])
+
+# Same, but the flag takes a value that must be dropped along with it.
+_DROPPED_FLAGS_WITH_VALUE = frozenset([
+    '-emit-module-path',
+    '-emit-objc-header-path',
+    '-output-file-map',
+    '-file-prefix-map',
+])
+
+_NINJA_VAR_RE = re.compile(r'\$\{(\w+)\}|\$(\w+)')
+_ENV_ASSIGNMENT_RE = re.compile(r'^\w+=')
+
+
+class Target:
+    """A Swift module built by GN."""
+
+    def __init__(self, label, module_name, sources, ninja_vars, out_dir):
+        self.label = label
+        self.module_name = module_name
+        self.sources = sources
+        self.ninja_vars = ninja_vars
+        self.out_dir = out_dir
+
+    @property
+    def uri(self):
+        # `//foo/bar:baz` -> `gn://foo/bar:baz`
+        return 'gn:' + self.label
+
+    def __repr__(self):
+        return f'<Target {self.label} module={self.module_name}>'
+
+
+def _unescape_ninja(value):
+    return value.replace('$:', ':').replace('$ ', ' ').replace('$$', '$')
+
+
+def _expand_ninja_vars(template, variables):
+
+    def replace(match):
+        name = match.group(1) or match.group(2)
+        return variables.get(name, '')
+
+    return _NINJA_VAR_RE.sub(replace, template)
+
+
+def _parse_rule_command(toolchain_ninja_path, rule_name):
+    """Returns the `command` line of `rule <rule_name>` in toolchain.ninja."""
+    wanted = f'rule {rule_name}'
+    with open(toolchain_ninja_path, encoding='utf8') as stream:
+        in_rule = False
+        for line in stream:
+            line = line.rstrip('\n')
+            if not line.startswith((' ', '\t')):
+                in_rule = line.strip() == wanted
+                continue
+            if in_rule:
+                stripped = line.strip()
+                if stripped.startswith('command = '):
+                    return stripped[len('command = '):]
+    raise LookupError(f'no `{wanted}` in {toolchain_ninja_path}')
+
+
+def _parse_target_ninja(path, out_dir):
+    """Parses a generated `obj/**/*.ninja` file into a Target, or None.
+
+    Only the variable block and the single `swift` build edge are of interest;
+    everything else in the file describes linking.
+    """
+    variables = {}
+    sources = None
+    with open(path, encoding='utf8') as stream:
+        for line in stream:
+            line = line.rstrip('\n')
+            if line.startswith('build '):
+                # `build <outputs>: swift <inputs> | <implicit> || <order-only>`
+                edge = line[len('build '):]
+                outputs, _, rest = edge.partition(': ')
+                if not rest.startswith('swift '):
+                    continue
+                del outputs
+                inputs = rest[len('swift '):]
+                for separator in (' | ', ' || '):
+                    inputs = inputs.split(separator)[0]
+                sources = [
+                    _unescape_ninja(source) for source in inputs.split(' ')
+                    if source.endswith('.swift')
+                ]
+                continue
+            name, separator, value = line.partition(' = ')
+            if separator and ' ' not in name:
+                variables[name] = value
+
+    if not sources or 'module_name' not in variables:
+        return None
+
+    label_name = variables.get('label_name')
+    target_out_dir = variables.get('target_out_dir', '')
+    # `obj/brave/ios/swift` -> `//brave/ios/swift`
+    label_dir = '//' + target_out_dir.removeprefix('obj/')
+    label = f'{label_dir}:{label_name}'
+    return Target(label, variables['module_name'], sources, variables, out_dir)
+
+
+def find_targets(out_dir):
+    """Finds every Swift target in `out_dir` by scanning generated ninja files.
+
+    `gn desc` would be the obvious source of this information but it needs a
+    full graph load per invocation, which is far too slow at Chromium scale.
+    """
+    targets = []
+    obj_dir = os.path.join(out_dir, 'obj')
+    for root, _, files in os.walk(obj_dir):
+        for name in files:
+            if not name.endswith('.ninja'):
+                continue
+            path = os.path.join(root, name)
+            # Cheap pre-filter: the swift edge is the only thing being looked
+            # for, and it names the sources inline.
+            with open(path, 'rb') as stream:
+                if b': swift ' not in stream.read():
+                    continue
+            target = _parse_target_ninja(path, out_dir)
+            if target:
+                targets.append(target)
+    return targets
+
+
+def _swiftc_py_argv(target):
+    """Rebuilds the swiftc.py command line for `target`."""
+    toolchain_ninja = os.path.join(target.out_dir, 'toolchain.ninja')
+    command = _parse_rule_command(toolchain_ninja, 'swift')
+    variables = dict(target.ninja_vars)
+    variables['in'] = ' '.join(target.sources)
+    expanded = _expand_ninja_vars(command, variables)
+
+    argv = shlex.split(expanded)
+    # Strip the leading `FOO=bar ... python3` prefix from the ninja command.
+    # The dropped environment assignments (TOOL_VERSION, XCODE_VERSION,
+    # DEVELOPER_DIR, ...) only feed swiftc.py's derived-data build signature
+    # hash and are never used to assemble the swiftc arguments, so extraction
+    # does not need them.
+    while argv and _ENV_ASSIGNMENT_RE.match(argv[0]):
+        argv.pop(0)
+    if argv and os.path.basename(argv[0]).startswith('python'):
+        argv.pop(0)
+    if argv and argv[0].endswith('swiftc.py'):
+        argv.pop(0)
+    return argv
+
+
+# Contents of the fake `swiftc` that swiftc.py is pointed at. It records the
+# command line it was invoked with and fails, so swiftc.py stops before its
+# post-compile steps (which read files only a real compile produces).
+_CAPTURE_SWIFTC = '''\
+#!/usr/bin/env python3
+# Generated by brave/tools/swift/gn_swift_args.py. Do not edit.
+import json, os, sys
+with open(os.environ['GN_SWIFT_ARGS_OUTPUT'], 'w', encoding='utf8') as stream:
+    json.dump(sys.argv, stream)
+sys.exit(1)
+'''
+
+
+def cache_root(out_dir):
+    """Returns the directory holding all editor-only build state."""
+    return os.path.join(os.path.abspath(out_dir), LSP_CACHE_DIR_NAME)
+
+
+def _write_capture_toolchain(out_dir):
+    """Creates a fake toolchain whose `swiftc` records its arguments.
+
+    swiftc.py builds the compiler path as `<toolchain>/usr/bin/swiftc` from its
+    `--swift-toolchain-path` argument, so pointing that at a directory we own is
+    enough to intercept the invocation without depending on anything internal to
+    swiftc.py.
+    """
+    toolchain_dir = os.path.join(cache_root(out_dir), 'capture_toolchain')
+    swiftc_path = os.path.join(toolchain_dir, 'usr', 'bin', 'swiftc')
+    os.makedirs(os.path.dirname(swiftc_path), exist_ok=True)
+
+    existing = None
+    if os.path.exists(swiftc_path):
+        with open(swiftc_path, encoding='utf8') as stream:
+            existing = stream.read()
+    if existing != _CAPTURE_SWIFTC:
+        with open(swiftc_path, 'w', encoding='utf8') as stream:
+            stream.write(_CAPTURE_SWIFTC)
+        os.chmod(swiftc_path, 0o700)
+    return toolchain_dir
+
+
+def _swiftc_py_path(source_root):
+    """Returns the path to swiftc.py, checking the interception still holds."""
+    path = os.path.join(source_root, 'build', 'toolchain', 'apple',
+                        'swiftc.py')
+    if not os.path.exists(path):
+        raise RuntimeError(
+            f'{path} does not exist. The Swift toolchain wrapper moved '
+            f'upstream; brave/tools/swift/gn_swift_args.py needs updating.')
+    with open(path, encoding='utf8') as stream:
+        contents = stream.read()
+    for expected in ('--swift-toolchain-path', 'usr/bin/swiftc'):
+        if expected not in contents:
+            raise RuntimeError(
+                f'{path} no longer references `{expected}`, so the swiftc '
+                f'invocation can no longer be intercepted. '
+                f'brave/tools/swift/gn_swift_args.py needs updating.')
+    return path
+
+
+def _extract_swiftc_command(target, source_root):
+    """Returns the swiftc command line swiftc.py would run for `target`."""
+    out_dir = target.out_dir
+    # Keep each module's derived data separate: swiftc.py prunes stale entries
+    # from this directory, so sharing it between modules would make them delete
+    # each other's module caches.
+    derived_data_dir = os.path.join(cache_root(out_dir), 'modules',
+                                    target.module_name)
+    # swiftc.py writes a handful of bookkeeping files (OutputFileMap.json, the
+    # SwiftFileList response file) and creates directories under
+    # `--target-out-dir`/`--header-path` before it ever runs the compiler, i.e.
+    # before the capture toolchain stops it. Left at their ninja values those
+    # would land in the real build directory. Both are documented, required
+    # swiftc.py flags and argparse takes the last occurrence, so redirecting
+    # them into the cache directory (appended after the ninja arguments) keeps
+    # every write swiftc.py makes inside `swift_lsp_cache/`. This is separate
+    # from `derived_data_dir`, which swiftc.py prunes.
+    scratch_dir = os.path.join(cache_root(out_dir), 'scratch',
+                               target.module_name)
+    os.makedirs(scratch_dir, exist_ok=True)
+    # Deliberately outside `derived_data_dir`: swiftc.py deletes everything in
+    # there that it does not recognise.
+    output_path = os.path.join(cache_root(out_dir),
+                               f'{target.module_name}.swiftc_argv.json')
+    os.makedirs(derived_data_dir, exist_ok=True)
+    if os.path.exists(output_path):
+        os.unlink(output_path)
+
+    command = [
+        sys.executable,
+        _swiftc_py_path(source_root),
+        '--swift-toolchain-path',
+        _write_capture_toolchain(out_dir),
+        '--derived-data-dir',
+        derived_data_dir,
+    ] + _swiftc_py_argv(target) + [
+        '--target-out-dir',
+        os.path.join(scratch_dir, 'target_out'),
+        '--header-path',
+        os.path.join(scratch_dir, f'{target.module_name}.h'),
+    ]
+
+    # Everything in the ninja files is relative to the build directory, and
+    # swiftc.py bakes its working directory into `-working-directory`. Running
+    # it as a subprocess keeps this out of our own process, whose working
+    # directory is global and shared across threads.
+    process = subprocess.run(
+        command,
+        cwd=out_dir,
+        env={
+            **os.environ, 'GN_SWIFT_ARGS_OUTPUT': output_path
+        },
+        capture_output=True,
+        text=True,
+        check=False)
+
+    if not os.path.exists(output_path):
+        raise RuntimeError(
+            f'could not extract swiftc arguments for {target.label}:\n'
+            f'{process.stdout}\n{process.stderr}')
+
+    with open(output_path, encoding='utf8') as stream:
+        return json.load(stream)
+
+
+def _read_swift_file_list(path, out_dir):
+    """Expands a `@Module.SwiftFileList` response file into source paths."""
+    with open(os.path.join(out_dir, path), encoding='utf8') as stream:
+        return [
+            os.path.normpath(os.path.join(out_dir, line))
+            for line in shlex.split(stream.read())
+        ]
+
+
+def _rewrite_for_indexing(command, out_dir):
+    """Turns a build swiftc command line into one usable for indexing."""
+    arguments = []
+    index = 1  # Skip argv[0], the swiftc path.
+    while index < len(command):
+        argument = command[index]
+        index += 1
+        if argument in _DROPPED_FLAGS:
+            continue
+        if argument in _DROPPED_FLAGS_WITH_VALUE:
+            index += 1
+            continue
+        if argument in _SHARED_CACHE_FLAGS:
+            arguments.append(argument)
+            arguments.append(
+                os.path.join(cache_root(out_dir),
+                             _SHARED_CACHE_FLAGS[argument]))
+            index += 1  # Discard the per-target path swiftc.py chose.
+            continue
+        if re.fullmatch(r'-j\d*', argument):
+            continue
+        if argument == '-num-threads':
+            index += 1
+            continue
+        if argument == '-Xfrontend' and index + 2 < len(
+                command) and command[index] == '-const-gather-protocols-file':
+            index += 3
+            continue
+        if argument.startswith('@') and argument.endswith('.SwiftFileList'):
+            arguments.extend(_read_swift_file_list(argument[1:], out_dir))
+            continue
+        arguments.append(argument)
+    return arguments
+
+
+# Cache directories swiftc needs to write into during indexing but does not
+# create itself, failing if they are missing. They all resolve inside the
+# editor-only cache directory: `-module-cache-path` is redirected to the shared
+# module cache by `_rewrite_for_indexing`, while `-index-store-path` and
+# `-pch-output-dir` keep the per-target locations swiftc.py chose under
+# `--derived-data-dir` (also inside the cache directory).
+_CACHE_DIR_FLAGS = frozenset([
+    '-index-store-path',
+    '-module-cache-path',
+    '-pch-output-dir',
+])
+
+
+def ensure_cache_dirs(arguments):
+    """Creates the cache directories `arguments` refers to.
+
+    swiftc creates neither its module cache nor its PCH output directory, it
+    fails if they are missing. They exist right after extraction, but the
+    arguments are cached in memory and outlive them: anything that reclaims disk
+    space by deleting the cache directory would otherwise break every open file
+    until the editor is restarted.
+    """
+    for index, argument in enumerate(arguments):
+        if argument in _CACHE_DIR_FLAGS and index + 1 < len(arguments):
+            os.makedirs(arguments[index + 1], exist_ok=True)
+
+
+def compiler_arguments(target, source_root):
+    """Returns swiftc arguments for indexing every source file in `target`."""
+    command = _extract_swiftc_command(target, source_root)
+    arguments = _rewrite_for_indexing(command, target.out_dir)
+    ensure_cache_dirs(arguments)
+    return arguments
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--source-root',
+                        default=os.path.abspath(
+                            os.path.join(os.path.dirname(__file__), '..', '..',
+                                         '..', '..')),
+                        help='path to the Chromium src directory')
+    parser.add_argument('--out-dir',
+                        required=True,
+                        help='GN output directory, e.g. out/ios_sim')
+    parser.add_argument('--json',
+                        action='store_true',
+                        help='print the arguments as a JSON array')
+    parser.add_argument('file',
+                        nargs='?',
+                        help='.swift file to print arguments for; if omitted, '
+                        'lists all Swift targets')
+    args = parser.parse_args(argv)
+
+    source_root = os.path.abspath(args.source_root)
+    out_dir = os.path.abspath(os.path.join(source_root, args.out_dir))
+    targets = find_targets(out_dir)
+
+    if not args.file:
+        for target in sorted(targets, key=lambda target: target.label):
+            print(f'{target.label}  module={target.module_name}  '
+                  f'{len(target.sources)} source(s)')
+        return 0
+
+    wanted = os.path.abspath(args.file)
+    for target in targets:
+        for source in target.sources:
+            if os.path.normpath(os.path.join(out_dir, source)) == wanted:
+                arguments = compiler_arguments(target, source_root)
+                if args.json:
+                    print(json.dumps(arguments, indent=2))
+                else:
+                    print(f'# target: {target.label}')
+                    print(f'# working directory: {out_dir}')
+                    print(shlex.join(arguments))
+                return 0
+
+    print(f'{wanted} does not belong to any Swift target in {out_dir}',
+          file=sys.stderr)
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/tools/swift/bsp/gn_swift_args_test.py
+++ b/tools/swift/bsp/gn_swift_args_test.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Checks that swiftc arguments can still be extracted from a GN build dir.
+
+gn_swift_args.py depends on things outside this repository: the shape of
+//build/toolchain/apple/swiftc.py, the `swift` ninja rule and the generated
+ninja files. Those can change under us during a Chromium roll. This verifies
+the extraction end to end, so the breakage is a test failure rather than an
+editor that quietly stops autocompleting.
+
+    python3 gn_swift_args_test.py --out-dir out/ios_current_link
+
+Requires the Swift targets in that output directory to have been built, since
+typechecking resolves the modules they import.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import gn_swift_args
+
+
+def _fail(message):
+    print(f'FAIL: {message}')
+    return False
+
+
+def check_targets_found(targets, out_dir):
+    """Every output directory with Swift code should yield some targets."""
+    if not targets:
+        return _fail(f'no Swift targets found in {out_dir}. Either the ninja '
+                     f'files are missing (run `gn gen`) or the `swift` build '
+                     f'edge format changed.')
+    print(f'ok: found {len(targets)} Swift target(s)')
+    return True
+
+
+def check_arguments_extractable(targets, source_root):
+    """Argument extraction must succeed and yield the source files."""
+    failures = []
+    for target in targets:
+        try:
+            arguments = gn_swift_args.compiler_arguments(target, source_root)
+        except Exception as error:  # pylint: disable=broad-except
+            failures.append(f'{target.label}: {error}')
+            continue
+        if not any(argument.endswith('.swift') for argument in arguments):
+            failures.append(f'{target.label}: no .swift files in arguments, '
+                            f'the SwiftFileList response file may have moved')
+    if failures:
+        for failure in failures:
+            print(f'FAIL: {failure}')
+        return False
+    print(f'ok: extracted arguments for all {len(targets)} target(s)')
+    return True
+
+
+def check_typechecks(target, source_root):
+    """The extracted arguments must actually typecheck the module.
+
+    This is the check that catches semantic drift: arguments that still look
+    plausible but no longer describe how the module is built (a missing search
+    path, a dropped interop flag) fail here.
+    """
+    arguments = gn_swift_args.compiler_arguments(target, source_root)
+    process = subprocess.run(['xcrun', 'swiftc', '-typecheck'] + arguments,
+                             cwd=target.out_dir,
+                             capture_output=True,
+                             text=True,
+                             check=False)
+    if process.returncode:
+        return _fail(f'{target.label} does not typecheck with the extracted '
+                     f'arguments:\n{process.stderr[-2000:]}')
+    print(f'ok: {target.label} typechecks')
+    return True
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--source-root',
+                        default=os.path.abspath(
+                            os.path.join(os.path.dirname(__file__), '..', '..',
+                                         '..', '..')),
+                        help='path to the Chromium src directory')
+    parser.add_argument('--out-dir',
+                        required=True,
+                        help='GN output directory, e.g. out/ios_sim')
+    parser.add_argument('--typecheck-all',
+                        action='store_true',
+                        help='typecheck every target instead of Brave ones '
+                        'only (slow)')
+    args = parser.parse_args(argv)
+
+    source_root = os.path.abspath(args.source_root)
+    out_dir = os.path.realpath(os.path.join(source_root, args.out_dir))
+    targets = gn_swift_args.find_targets(out_dir)
+
+    results = [
+        check_targets_found(targets, out_dir),
+        check_arguments_extractable(targets, source_root),
+    ]
+
+    # Typechecking is the slow part, so by default only Brave's own targets are
+    # checked; upstream ones may not have been built in this output directory.
+    to_typecheck = [
+        target for target in targets
+        if args.typecheck_all or target.label.startswith('//brave')
+    ]
+    if not to_typecheck:
+        print('warning: no targets to typecheck')
+    for target in to_typecheck:
+        results.append(check_typechecks(target, source_root))
+
+    if all(results):
+        print('\nall checks passed')
+        return 0
+    print('\nsome checks failed')
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
This adds an experimental BSP (Build Server Protocol) implementation that connects Apple's SourceKit-LSP with brave-core's GN build rules. This enables autocomplete, builtin errors, etc. when the editor supports BSP like via the official Swift VS Code extension. This is only activated when a developer has a `buildServer.json` in root workspace location as documented in the README and the BSP only indexes Swift files. This doesn't affect the actual build and is purely for an enhanced IDE experience writing Swift outside of Xcode
