### PR TITLE
[AI Chat] Add link to manage shares from sharing dialog

### DIFF
--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -218,6 +218,10 @@ function Main() {
         <ShareConversationModal
           isOpen={isShareDialogOpen}
           onClose={() => setIsShareDialogOpen(false)}
+          onManageShares={() => {
+            setIsShareDialogOpen(false)
+            setIsSharedConversationsDialogOpen(true)
+          }}
         />
       )}
       {/* Mounted only while open so the list of shares is fetched fresh each

--- a/components/ai_chat/resources/page/components/share_conversation_modal/index.tsx
+++ b/components/ai_chat/resources/page/components/share_conversation_modal/index.tsx
@@ -7,7 +7,7 @@ import * as React from 'react'
 import Button from '@brave/leo/react/button'
 import Dialog from '@brave/leo/react/dialog'
 import Icon from '@brave/leo/react/icon'
-import { getLocale } from '$web-common/locale'
+import { formatLocale, getLocale } from '$web-common/locale'
 import { serializeConversationForSharing } from '../../../common/conversation_serialization'
 import { encryptForSharing } from '../../../common/conversation_share_encryption'
 import { useAIChat } from '../../state/ai_chat_context'
@@ -18,6 +18,8 @@ import styles from './style.module.scss'
 interface Props {
   isOpen: boolean
   onClose: () => void
+  // Closes this dialog and opens the dialog listing every share the user has.
+  onManageShares: () => void
 }
 
 export default function ShareConversationModal(props: Props) {
@@ -112,6 +114,22 @@ export default function ShareConversationModal(props: Props) {
         )}
         <div className={styles.description}>
           {getLocale(S.CHAT_UI_SHARE_CONVERSATION_DIALOG_DESCRIPTION)}
+        </div>
+        <div className={styles.manageShares}>
+          {formatLocale(
+            S.CHAT_UI_SHARE_CONVERSATION_DIALOG_MANAGE_SHARES_LINK,
+            {
+              $1: (content) => (
+                <button
+                  key={content}
+                  className={styles.manageSharesLink}
+                  onClick={props.onManageShares}
+                >
+                  {content}
+                </button>
+              ),
+            },
+          )}
         </div>
       </div>
       <div slot='actions'>

--- a/components/ai_chat/resources/page/components/share_conversation_modal/style.module.scss
+++ b/components/ai_chat/resources/page/components/share_conversation_modal/style.module.scss
@@ -48,3 +48,18 @@
   --leo-color-button-background: var(--leo-color-button-success-background);
   --leo-color-schemes-on-primary: var(--leo-color-button-success-text);
 }
+
+.manageShares {
+  font: var(--leo-font-default-regular);
+  color: var(--leo-color-text-primary);
+}
+
+.manageSharesLink {
+  // Looks like a link but performs an in-page action, so it must be a button
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 0;
+  text-decoration: underline;
+  color: var(--leo-color-text-interactive);
+}

--- a/components/ai_chat/resources/page/components/shared_conversations_modal/style.module.scss
+++ b/components/ai_chat/resources/page/components/shared_conversations_modal/style.module.scss
@@ -40,6 +40,13 @@
   // Long lists shouldn't push the dialog past the viewport.
   max-height: 320px;
   overflow-y: auto;
+  // The dialog is a grid whose column can't be narrower than its content's
+  // min-content width, and a nowrap share title's min-content width is the
+  // whole title. Without this the title widens the dialog (which scrolls
+  // horizontally) instead of ellipsizing. `min-width: 0` below can't do this:
+  // it removes the floor on a flex item's size, it doesn't cap what the item
+  // contributes to an ancestor's intrinsic width.
+  contain: inline-size;
   margin: 0;
   padding: 0;
   list-style: none;
@@ -90,5 +97,5 @@
 .shareActions {
   display: flex;
   align-items: center;
-  gap: var(--leo-spacing-xs);
+  gap: var(--leo-spacing-m);
 }

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -423,6 +423,9 @@
   <message name="IDS_CHAT_UI_SHARE_CONVERSATION_DIALOG_DESCRIPTION" desc="Explanatory text in the share conversation dialog describing how the conversation is encrypted before being uploaded and when the shared link expires" formatter_data="webui=AiChat">
     Your conversation will be uploaded encrypted and can only be decrypted with the generated link. Brave will not be able to view your conversation. Only you and the people you share this link with can decrypt your shared conversation. All shared conversations will expire after 7 days.
   </message>
+  <message name="IDS_CHAT_UI_SHARE_CONVERSATION_DIALOG_MANAGE_SHARES_LINK" desc="Text with an inline link at the bottom of the share conversation dialog. The link opens the dialog which lists every conversation the user has shared, where they can be copied or deleted." formatter_data="webui=AiChat">
+    You can <ph name="LINK_BEFORE">$1</ph>manage your shares<ph name="LINK_AFTER">/$1</ph> to find or delete them at any time.
+  </message>
   <message name="IDS_CHAT_UI_SHARE_CONVERSATION_DIALOG_GENERATE_LINK_BUTTON_LABEL" desc="A label for the button which generates and copies a shareable link for the current conversation" formatter_data="webui=AiChat">
     Generate link
   </message>


### PR DESCRIPTION
Adds a link to manage conversations to the conversation sharing dialog

- Resolves https://github.com/brave/brave-browser/issues/58269

<img width="800" height="1006" alt="image" src="https://github.com/user-attachments/assets/b4505f31-ef8b-4f78-a9b1-03bb2c54d734" />
