### PR TITLE
[VPN 2.0] Endpoint-based region-discovery APIs

### DIFF
--- a/components/brave_vpn/browser/v2/api/BUILD.gn
+++ b/components/brave_vpn/browser/v2/api/BUILD.gn
@@ -11,10 +11,12 @@ source_set("api") {
   sources = [
     "brave_vpn_api_client.cc",
     "brave_vpn_api_client.h",
+    "empty_request_body.h",
     "endpoint_constants.h",
     "error_body.h",
     "purchase_endpoints.h",
     "raw_json_response_body.h",
+    "region_endpoints.h",
     "support_endpoints.h",
   ]
 
@@ -37,6 +39,7 @@ source_set("unit_tests") {
   sources = [
     "brave_vpn_api_client_unittest.cc",
     "purchase_endpoints_unittest.cc",
+    "region_endpoints_unittest.cc",
     "support_endpoints_unittest.cc",
   ]
 

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client.cc
@@ -16,6 +16,9 @@
 #include "base/types/expected.h"
 #include "brave/components/brave_account/endpoint_client/client.h"
 #include "brave/components/brave_account/endpoint_client/with_headers.h"
+#include "brave/components/brave_vpn/browser/v2/api/purchase_endpoints.h"
+#include "brave/components/brave_vpn/browser/v2/api/region_endpoints.h"
+#include "brave/components/brave_vpn/browser/v2/api/support_endpoints.h"
 #include "net/base/net_errors.h"
 #include "net/http/http_status_code.h"
 #include "net/traffic_annotation/network_traffic_annotation.h"
@@ -29,8 +32,11 @@ using brave_account::endpoint_client::WithHeaders;
 namespace brave_vpn::v2 {
 
 using endpoints::CreateSupportTicket;
+using endpoints::GetHostnamesForRegion;
+using endpoints::GetServerRegions;
 using endpoints::GetSubscriberCredential;
 using endpoints::GetSubscriberCredentialV12;
+using endpoints::GetTimezonesForRegions;
 using endpoints::VerifyPurchaseToken;
 
 namespace {
@@ -97,6 +103,22 @@ BraveVpnApiClient::BraveVpnApiClient(
 }
 
 BraveVpnApiClient::~BraveVpnApiClient() = default;
+
+void BraveVpnApiClient::OnRawJsonResponse(RawJsonCallback callback,
+                                          RawJsonResponse response) {
+  if (auto unrecoverable = MaybeDescribeUnrecoverableResponse(response)) {
+    return std::move(callback).Run(base::unexpected(*std::move(unrecoverable)));
+  }
+
+  std::move(callback).Run(
+      std::move(CHECK_DEREF(response.body))
+          .transform([](endpoints::RawJsonResponseBody success) {
+            return std::move(success.json);
+          })
+          .transform_error([](endpoints::VpnErrorBody error) {
+            return std::move(error.error_title);
+          }));
+}
 
 void BraveVpnApiClient::GetSubscriberCredential(
     SubscriberCredentialCallback callback,
@@ -190,7 +212,7 @@ void BraveVpnApiClient::OnVerifyPurchaseTokenResponse(
 }
 
 void BraveVpnApiClient::CreateSupportTicket(
-    CreateSupportTicketCallback callback,
+    RawJsonCallback callback,
     const std::string& email,
     const std::string& subject,
     const std::string& body,
@@ -205,25 +227,42 @@ void BraveVpnApiClient::CreateSupportTicket(
 
   Client<endpoints::CreateSupportTicket>::Send(
       url_loader_factory_, std::move(request),
-      base::BindOnce(&BraveVpnApiClient::OnCreateSupportTicketResponse,
+      base::BindOnce(&BraveVpnApiClient::OnRawJsonResponse,
                      weak_factory_.GetWeakPtr(), std::move(callback)));
 }
 
-void BraveVpnApiClient::OnCreateSupportTicketResponse(
-    CreateSupportTicketCallback callback,
-    endpoints::CreateSupportTicket::Response response) {
-  if (auto unrecoverable = MaybeDescribeUnrecoverableResponse(response)) {
-    return std::move(callback).Run(base::unexpected(*std::move(unrecoverable)));
-  }
+void BraveVpnApiClient::GetServerRegions(RawJsonCallback callback,
+                                         const std::string& region_precision) {
+  auto request = MakeRequest<GetServerRegions::Request>();
+  request.url_replacements.SetPath(
+      base::StrCat({GetServerRegions::URL().path(), "/", region_precision}));
 
-  std::move(callback).Run(
-      std::move(CHECK_DEREF(response.body))
-          .transform([](endpoints::RawJsonResponseBody success) {
-            return std::move(success.json);
-          })
-          .transform_error([](endpoints::VpnErrorBody error) {
-            return std::move(error.error_title);
-          }));
+  Client<endpoints::GetServerRegions>::Send(
+      url_loader_factory_, std::move(request),
+      base::BindOnce(&BraveVpnApiClient::OnRawJsonResponse,
+                     weak_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void BraveVpnApiClient::GetTimezonesForRegions(RawJsonCallback callback) {
+  auto request = MakeRequest<GetTimezonesForRegions::Request>();
+  Client<endpoints::GetTimezonesForRegions>::Send(
+      url_loader_factory_, std::move(request),
+      base::BindOnce(&BraveVpnApiClient::OnRawJsonResponse,
+                     weak_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void BraveVpnApiClient::GetHostnamesForRegion(
+    RawJsonCallback callback,
+    const std::string& region,
+    const std::string& region_precision) {
+  auto request = MakeRequest<GetHostnamesForRegion::Request>();
+  request.body.region = region;
+  request.body.region_precision = region_precision;
+
+  Client<endpoints::GetHostnamesForRegion>::Send(
+      url_loader_factory_, std::move(request),
+      base::BindOnce(&BraveVpnApiClient::OnRawJsonResponse,
+                     weak_factory_.GetWeakPtr(), std::move(callback)));
 }
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h
@@ -12,8 +12,10 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/types/expected.h"
+#include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_vpn/browser/v2/api/error_body.h"
 #include "brave/components/brave_vpn/browser/v2/api/purchase_endpoints.h"
-#include "brave/components/brave_vpn/browser/v2/api/support_endpoints.h"
+#include "brave/components/brave_vpn/browser/v2/api/raw_json_response_body.h"
 
 namespace network {
 class SharedURLLoaderFactory;
@@ -34,6 +36,15 @@ class BraveVpnApiClient {
   BraveVpnApiClient(const BraveVpnApiClient&) = delete;
   BraveVpnApiClient& operator=(const BraveVpnApiClient&) = delete;
   virtual ~BraveVpnApiClient();
+
+  // The response shape common to every Guardian Connect-API endpoint whose
+  // success is forwarded as opaque JSON and whose error is a parsed
+  // VpnErrorBody title.
+  using RawJsonResponse =
+      brave_account::endpoint_client::Response<endpoints::RawJsonResponseBody,
+                                               endpoints::VpnErrorBody>;
+  using RawJsonCallback =
+      base::OnceCallback<void(base::expected<std::string, std::string>)>;
 
   // Connect API: GetSubscriberCredential (legacy, store purchase token).
   // Exchanges store purchase details for a subscriber credential.
@@ -73,25 +84,35 @@ class BraveVpnApiClient {
   // Submits a customer support inquiry. On success: the server's confirmation
   // JSON (an echo of the submitted data). On failure: a user-facing error
   // string.
-  using CreateSupportTicketCallback =
-      base::OnceCallback<void(base::expected<std::string, std::string>)>;
-  virtual void CreateSupportTicket(CreateSupportTicketCallback callback,
+  virtual void CreateSupportTicket(RawJsonCallback callback,
                                    const std::string& email,
                                    const std::string& subject,
                                    const std::string& body,
                                    const std::string& subscriber_credential,
                                    const std::string& timezone);
 
+  // Connect API: GetServerRegions.
+  // Returns all regions at the given precision, as the server's JSON response
+  // verbatim. Typed parsing is left to the caller (e.g. a region data manager).
+  virtual void GetServerRegions(RawJsonCallback callback,
+                                const std::string& region_precision);
+
+  // Connect API: GetTimezonesForRegions.
+  virtual void GetTimezonesForRegions(RawJsonCallback callback);
+
+  // Connect API: GetHostnamesForRegion.
+  virtual void GetHostnamesForRegion(RawJsonCallback callback,
+                                     const std::string& region,
+                                     const std::string& region_precision);
+
  private:
+  void OnRawJsonResponse(RawJsonCallback callback, RawJsonResponse response);
   void OnGetSubscriberCredentialResponse(
       SubscriberCredentialCallback callback,
       endpoints::GetSubscriberCredential::Response response);
   void OnVerifyPurchaseTokenResponse(
       VerifyPurchaseTokenCallback callback,
       endpoints::VerifyPurchaseToken::Response response);
-  void OnCreateSupportTicketResponse(
-      CreateSupportTicketCallback callback,
-      endpoints::CreateSupportTicket::Response response);
 
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   base::WeakPtrFactory<BraveVpnApiClient> weak_factory_{this};

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
@@ -15,9 +15,12 @@
 #include "base/test/test_future.h"
 #include "base/types/expected.h"
 #include "brave/components/brave_account/endpoint_client/test_support.h"
+#include "brave/components/brave_account/endpoint_client/url_replacements.h"
 #include "brave/components/brave_vpn/browser/v2/api/error_body.h"
 #include "brave/components/brave_vpn/browser/v2/api/purchase_endpoints.h"
 #include "brave/components/brave_vpn/browser/v2/api/raw_json_response_body.h"
+#include "brave/components/brave_vpn/browser/v2/api/region_endpoints.h"
+#include "brave/components/brave_vpn/browser/v2/api/support_endpoints.h"
 #include "net/base/net_errors.h"
 #include "net/http/http_status_code.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
@@ -41,6 +44,8 @@ constexpr char kTestEmail[] = "user@example.com";
 constexpr char kTestSubject[] = "Help";
 constexpr char kTestBody[] = "It doesn't connect.";
 constexpr char kTestTimezone[] = "America/Los_Angeles";
+constexpr char kTestRegion[] = "us-east";
+constexpr char kTestRegionPrecision[] = "city-by-country";
 
 // Canonical JSON (compact, keys sorted): MockResponseFor re-serializes the
 // body via ToValue() and the client re-parses it via FromValue(), so only
@@ -274,6 +279,131 @@ INSTANTIATE_TEST_SUITE_P(
                               .error_title = "Invalid credential.",
                               .error_message = "expired"})},
              .expected = base::unexpected("Invalid credential.")}})),
+    [](const auto& info) { return info.param.test_name; });
+
+struct GetServerRegionsTestCase {
+  std::string test_name;
+  endpoints::GetServerRegions::Response response;
+  base::expected<std::string, std::string> expected;
+};
+
+using BraveVpnApiClientGetServerRegionsTest =
+    BraveVpnApiClientTest<GetServerRegionsTestCase>;
+
+TEST_P(BraveVpnApiClientGetServerRegionsTest, MapsResponseToResult) {
+  const auto& test_case = GetParam();
+  brave_account::endpoint_client::UrlReplacements url_replacements;
+  url_replacements.SetPath(base::StrCat(
+      {endpoints::GetServerRegions::URL().path(), "/", kTestRegionPrecision}));
+  MockResponseFor<endpoints::GetServerRegions>(
+      url_loader_factory_, test_case.response, url_replacements);
+  EXPECT_EQ(
+      CallClientApi(&BraveVpnApiClient::GetServerRegions, kTestRegionPrecision),
+      test_case.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BraveVpnApiClientTests,
+    BraveVpnApiClientGetServerRegionsTest,
+    testing::ValuesIn(WithCommonUnrecoverableCases<GetServerRegionsTestCase>(
+        {GetServerRegionsTestCase{
+             .test_name = "Success",
+             .response = {.net_error = net::OK,
+                          .status_code = net::HTTP_OK,
+                          .body = base::ok(endpoints::RawJsonResponseBody{
+                              .json = kTestSuccessJson})},
+             .expected = base::ok(kTestSuccessJson)},
+         GetServerRegionsTestCase{
+             .test_name = "RequestError",
+             .response = {.net_error = net::OK,
+                          .status_code = net::HTTP_BAD_REQUEST,
+                          .body = base::unexpected(endpoints::VpnErrorBody{
+                              .error_title = "Invalid precision.",
+                              .error_message = "bad"})},
+             .expected = base::unexpected("Invalid precision.")}})),
+    [](const auto& info) { return info.param.test_name; });
+
+struct GetTimezonesForRegionsTestCase {
+  std::string test_name;
+  endpoints::GetTimezonesForRegions::Response response;
+  base::expected<std::string, std::string> expected;
+};
+
+using BraveVpnApiClientGetTimezonesForRegionsTest =
+    BraveVpnApiClientTest<GetTimezonesForRegionsTestCase>;
+
+TEST_P(BraveVpnApiClientGetTimezonesForRegionsTest, MapsResponseToResult) {
+  const auto& test_case = GetParam();
+  MockResponseFor<endpoints::GetTimezonesForRegions>(url_loader_factory_,
+                                                     test_case.response);
+  EXPECT_EQ(CallClientApi(&BraveVpnApiClient::GetTimezonesForRegions),
+            test_case.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BraveVpnApiClientTests,
+    BraveVpnApiClientGetTimezonesForRegionsTest,
+    testing::ValuesIn(WithCommonUnrecoverableCases<
+                      GetTimezonesForRegionsTestCase>(
+        {// 2xx body is forwarded verbatim.
+         GetTimezonesForRegionsTestCase{
+             .test_name = "Success",
+             .response = {.net_error = net::OK,
+                          .status_code = net::HTTP_OK,
+                          .body = base::ok(endpoints::RawJsonResponseBody{
+                              .json = kTestSuccessJson})},
+             .expected = base::ok(kTestSuccessJson)},
+         // A non-2xx response with a parseable error body surfaces its title.
+         GetTimezonesForRegionsTestCase{
+             .test_name = "RequestError",
+             .response = {.net_error = net::OK,
+                          .status_code = net::HTTP_BAD_REQUEST,
+                          .body = base::unexpected(endpoints::VpnErrorBody{
+                              .error_title = "Invalid request.",
+                              .error_message = "bad"})},
+             .expected = base::unexpected("Invalid request.")}})),
+    [](const auto& info) { return info.param.test_name; });
+
+struct GetHostnamesForRegionTestCase {
+  std::string test_name;
+  endpoints::GetHostnamesForRegion::Response response;
+  base::expected<std::string, std::string> expected;
+};
+
+using BraveVpnApiClientGetHostnamesForRegionTest =
+    BraveVpnApiClientTest<GetHostnamesForRegionTestCase>;
+
+TEST_P(BraveVpnApiClientGetHostnamesForRegionTest, MapsResponseToResult) {
+  const auto& test_case = GetParam();
+  MockResponseFor<endpoints::GetHostnamesForRegion>(url_loader_factory_,
+                                                    test_case.response);
+  EXPECT_EQ(CallClientApi(&BraveVpnApiClient::GetHostnamesForRegion,
+                          kTestRegion, kTestRegionPrecision),
+            test_case.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BraveVpnApiClientTests,
+    BraveVpnApiClientGetHostnamesForRegionTest,
+    testing::ValuesIn(WithCommonUnrecoverableCases<
+                      GetHostnamesForRegionTestCase>(
+        {// 2xx body is forwarded verbatim.
+         GetHostnamesForRegionTestCase{
+             .test_name = "Success",
+             .response = {.net_error = net::OK,
+                          .status_code = net::HTTP_OK,
+                          .body = base::ok(endpoints::RawJsonResponseBody{
+                              .json = kTestSuccessJson})},
+             .expected = base::ok(kTestSuccessJson)},
+         // A non-2xx response with a parseable error body surfaces its title.
+         GetHostnamesForRegionTestCase{
+             .test_name = "RequestError",
+             .response = {.net_error = net::OK,
+                          .status_code = net::HTTP_BAD_REQUEST,
+                          .body = base::unexpected(endpoints::VpnErrorBody{
+                              .error_title = "Invalid region.",
+                              .error_message = "bad"})},
+             .expected = base::unexpected("Invalid region.")}})),
     [](const auto& info) { return info.param.test_name; });
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/api/empty_request_body.h
+++ b/components/brave_vpn/browser/v2/api/empty_request_body.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_EMPTY_REQUEST_BODY_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_EMPTY_REQUEST_BODY_H_
+
+#include "base/values.h"
+
+namespace brave_vpn::v2::endpoints {
+
+// Request body with no fields, for bodyless Guardian VPN endpoints.
+struct EmptyRequestBody {
+  base::DictValue ToValue() const { return base::DictValue(); }
+};
+
+}  // namespace brave_vpn::v2::endpoints
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_EMPTY_REQUEST_BODY_H_

--- a/components/brave_vpn/browser/v2/api/endpoint_constants.h
+++ b/components/brave_vpn/browser/v2/api/endpoint_constants.h
@@ -18,6 +18,12 @@ inline constexpr char kVerifyPurchaseTokenApi[] =
     "api/v1.1/verify-purchase-token";
 inline constexpr char kCreateSupportTicketApi[] =
     "api/v1.2/partners/support-ticket";
+inline constexpr char kAllServerRegionsApi[] =
+    "api/v1.3/servers/all-server-regions";
+inline constexpr char kTimezonesForRegionsApi[] =
+    "api/v1.1/servers/timezones-for-regions";
+inline constexpr char kHostnamesForRegionApi[] =
+    "api/v1.3/servers/hostnames-for-region";
 
 // Endpoint request JSON keys that can be shared between multiple APIs.
 inline constexpr char kProductTypeKey[] = "product-type";
@@ -33,6 +39,8 @@ inline constexpr char kSupportTicketKey[] = "support-ticket";
 inline constexpr char kPartnerClientIdKey[] = "partner-client-id";
 inline constexpr char kPaymentValidationMethodKey[] =
     "payment-validation-method";
+inline constexpr char kRegionKey[] = "region";
+inline constexpr char kRegionPrecisionKey[] = "region-precision";
 
 // Default payment validation method used by Brave.
 inline constexpr char kValidationMethodDefaultValue[] = "brave-premium";

--- a/components/brave_vpn/browser/v2/api/region_endpoints.h
+++ b/components/brave_vpn/browser/v2/api/region_endpoints.h
@@ -1,0 +1,83 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_REGION_ENDPOINTS_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_REGION_ENDPOINTS_H_
+
+#include <string>
+
+#include "base/strings/strcat.h"
+#include "base/values.h"
+#include "brave/components/brave_account/endpoint_client/request_types.h"
+#include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_vpn/browser/v2/api/empty_request_body.h"
+#include "brave/components/brave_vpn/browser/v2/api/endpoint_constants.h"
+#include "brave/components/brave_vpn/browser/v2/api/error_body.h"
+#include "brave/components/brave_vpn/browser/v2/api/raw_json_response_body.h"
+#include "url/gurl.h"
+#include "url/url_constants.h"
+
+// Region-discovery endpoints all hit the fixed Guardian account host
+// (kVpnHost). Responses are forwarded verbatim (RawJsonResponseBody) rather
+// than parsed into fields - typed interpretation belongs to higher-level
+// components, not API layer.
+
+namespace brave_vpn::v2::endpoints {
+
+// GetServerRegions API returns all regions at a given precision which is a URL
+// path segment and is appended by callers.
+struct GetServerRegions {
+  using Request = brave_account::endpoint_client::GET<EmptyRequestBody>;
+  using Response = brave_account::endpoint_client::Response<RawJsonResponseBody,
+                                                            VpnErrorBody>;
+
+  static GURL URL() {
+    return GURL(base::StrCat({url::kHttpsScheme, url::kStandardSchemeSeparator,
+                              kVpnHost}))
+        .Resolve(kAllServerRegionsApi);
+  }
+};
+
+// GetTimezonesForRegions API returns timezone metadata for all regions.
+struct GetTimezonesForRegions {
+  using Request = brave_account::endpoint_client::GET<EmptyRequestBody>;
+  using Response = brave_account::endpoint_client::Response<RawJsonResponseBody,
+                                                            VpnErrorBody>;
+
+  static GURL URL() {
+    return GURL(base::StrCat({url::kHttpsScheme, url::kStandardSchemeSeparator,
+                              kVpnHost}))
+        .Resolve(kTimezonesForRegionsApi);
+  }
+};
+
+// GetHostnamesForRegion API returns the SGW servers available for a region.
+struct GetHostnamesForRegionRequestBody {
+  std::string region;
+  std::string region_precision;
+
+  base::DictValue ToValue() const {
+    return base::DictValue()
+        .Set(kRegionKey, region)
+        .Set(kRegionPrecisionKey, region_precision);
+  }
+};
+
+struct GetHostnamesForRegion {
+  using Request =
+      brave_account::endpoint_client::POST<GetHostnamesForRegionRequestBody>;
+  using Response = brave_account::endpoint_client::Response<RawJsonResponseBody,
+                                                            VpnErrorBody>;
+
+  static GURL URL() {
+    return GURL(base::StrCat({url::kHttpsScheme, url::kStandardSchemeSeparator,
+                              kVpnHost}))
+        .Resolve(kHostnamesForRegionApi);
+  }
+};
+
+}  // namespace brave_vpn::v2::endpoints
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_REGION_ENDPOINTS_H_

--- a/components/brave_vpn/browser/v2/api/region_endpoints_unittest.cc
+++ b/components/brave_vpn/browser/v2/api/region_endpoints_unittest.cc
@@ -1,0 +1,25 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/api/region_endpoints.h"
+
+#include "base/values.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2::endpoints {
+namespace {
+constexpr char kTestRegion[] = "us-east";
+constexpr char kTestRegionPrecision[] = "city-by-country";
+}  // namespace
+
+TEST(RegionEndpointsTest, GetHostnamesForRegionRequestBodyToValue) {
+  const GetHostnamesForRegionRequestBody body{
+      .region = kTestRegion, .region_precision = kTestRegionPrecision};
+  EXPECT_EQ(body.ToValue(), base::DictValue()
+                                .Set("region", kTestRegion)
+                                .Set("region-precision", kTestRegionPrecision));
+}
+
+}  // namespace brave_vpn::v2::endpoints

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_android.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_android.cc
@@ -33,14 +33,25 @@ void BraveVpnServiceImpl::GetPurchaseToken(GetPurchaseTokenCallback callback) {
 }
 
 void BraveVpnServiceImpl::GetTimezonesForRegions(ResponseCallback callback) {
-  NOTIMPLEMENTED();
+  if (!api_client_) {
+    std::move(callback).Run({}, false);
+    return;
+  }
+  api_client_->GetTimezonesForRegions(
+      base::BindOnce(&RunResponseCallback, std::move(callback)));
 }
 
 void BraveVpnServiceImpl::GetHostnamesForRegion(
     ResponseCallback callback,
     const std::string& region,
     const std::string& region_precision) {
-  NOTIMPLEMENTED();
+  if (!api_client_) {
+    std::move(callback).Run({}, false);
+    return;
+  }
+  api_client_->GetHostnamesForRegion(
+      base::BindOnce(&RunResponseCallback, std::move(callback)), region,
+      region_precision);
 }
 
 void BraveVpnServiceImpl::GetProfileCredentials(


### PR DESCRIPTION
Port the three region-discovery endpoints to the endpoint client. Responses are forwarded verbatim; typed interpretation is left to a higher-level region data manager.

- GetServerRegions takes region-precision as a URL path segment via UrlReplacements::SetPath();
- added EmptyRequestBody for the two bodyless GET endpoints;
- consolidated CreateSupportTicket and these three onto one shared response type and handler;
- wired GetTimezonesForRegions and GetHostnamesForRegion through on Android;
- new behaviour is covered by unit tests.

Implements part of https://github.com/brave/brave-browser/issues/54600

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
