### PR TITLE
[iOS] Always update toolbar item alphas when toolbar state updates

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -2212,9 +2212,8 @@ public class BrowserViewController: UIViewController {
       toolbarTopConstraint?.update(offset: 0)
       toolbarBottomConstraint?.update(offset: 0)
 
-      // Check if UI side is collapsed already, and that bar visibility isn't being managed
-      // externally (e.g. by the keyboard handler which sets isEnabled = false)
-      if topToolbar.locationContainer.alpha < 1, toolbarVisibilityViewModel.isEnabled {
+      // Check if UI side is collapsed already
+      if topToolbar.locationContainer.alpha < 1 {
         let animator = toolbarVisibilityViewModel.toolbarChangePropertyAnimator
         animator.addAnimations { [self] in
           view.layoutIfNeeded()
@@ -2267,16 +2266,10 @@ public class BrowserViewController: UIViewController {
       topToolbar.locationContainer.alpha = 0
       toolbarBottomConstraint?.update(offset: footerHeight)
     }
-    // Only update bar visibility alphas when the toolbar visibility isn't being managed
-    // externally (e.g. by the keyboard handler which sets isEnabled = false). Skipping
-    // this when isEnabled = false prevents zeroing out collapsedBarContainerView while
-    // expandedBarStackView is already hidden, which would leave both bars invisible.
-    if toolbarVisibilityViewModel.isEnabled {
-      tabsBar.view.alpha = topToolbar.locationContainer.alpha
-      topToolbar.actionButtons.forEach { $0.alpha = topToolbar.locationContainer.alpha }
-      header.collapsedBarContainerView.alpha = 1 - topToolbar.locationContainer.alpha
-      toolbar?.actionButtons.forEach { $0.alpha = topToolbar.locationContainer.alpha }
-    }
+    tabsBar.view.alpha = topToolbar.locationContainer.alpha
+    topToolbar.actionButtons.forEach { $0.alpha = topToolbar.locationContainer.alpha }
+    header.collapsedBarContainerView.alpha = 1 - topToolbar.locationContainer.alpha
+    toolbar?.actionButtons.forEach { $0.alpha = topToolbar.locationContainer.alpha }
     let animator = toolbarVisibilityViewModel.toolbarChangePropertyAnimator
     animator.addAnimations {
       self.view.layoutIfNeeded()


### PR DESCRIPTION
This partially reverts a speculative fix we landed (#34237) that added keyboard checks in the `handleToolbarVisibilityStateChange` method which could cause a race a user tapped on an input field that brings up a keyboard while the url bar was collapsed.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58292
