### PR TITLE
Surface malware verdict on brave://extensions

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -655,6 +655,9 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
       <message name="IDS_EXTENSIONS_BRAVE_HOSTED" desc="Displayed in extensions management UI if an extension is hosted on the Brave server.">
         Brave-hosted
       </message>
+      <message name="IDS_BRAVE_EXTENSIONS_BLOCKLISTED_MALWARE" desc="Shown on the extensions page when an extension has been disabled because it appears on Brave's malicious-extension list, which is sourced from Socket.">
+        This extension contains malware. Flagged by Socket.
+      </message>
 
       <!-- App shortcuts -->
       <if expr="not is_win">

--- a/chromium_src/chrome/browser/extensions/DEPS
+++ b/chromium_src/chrome/browser/extensions/DEPS
@@ -1,3 +1,4 @@
 include_rules = [
   "+brave/components/brave_extension",
+  "+brave/components/extension_malware_blocklist/browser",
 ]

--- a/chromium_src/chrome/browser/extensions/DEPS
+++ b/chromium_src/chrome/browser/extensions/DEPS
@@ -1,4 +1,3 @@
 include_rules = [
   "+brave/components/brave_extension",
-  "+brave/components/extension_malware_blocklist/browser",
 ]

--- a/chromium_src/chrome/browser/extensions/api/developer_private/extension_info_generator.cc
+++ b/chromium_src/chrome/browser/extensions/api/developer_private/extension_info_generator.cc
@@ -3,10 +3,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/components/extension_malware_blocklist/browser/extension_malware_blocklist.h"
+#include "brave/grit/brave_generated_resources.h"
 #include "chrome/common/extensions/api/developer_private.h"
 #include "extensions/common/constants.h"
 #include "extensions/common/extension_features.h"
 #include "extensions/common/manifest_handlers/incognito_info.h"
+#include "ui/base/l10n/l10n_util.h"
 
 namespace {
 
@@ -25,7 +28,14 @@ void ProcessKnownMV2Extensions(
 
 }  // namespace
 
-#define BRAVE_CREATE_EXTENSION_INFO_HELPER \
-  info.is_split_mode = IncognitoInfo::IsSplitMode(&extension);
+#define BRAVE_CREATE_EXTENSION_INFO_HELPER                                  \
+  info.is_split_mode = IncognitoInfo::IsSplitMode(&extension);              \
+  if (auto* brave_malware_blocklist = extension_malware_blocklist::         \
+          ExtensionMalwareBlocklist::GetInstance();                         \
+      info.blocklist_text.has_value() && brave_malware_blocklist &&         \
+      brave_malware_blocklist->IsMalware(extension.id())) {                 \
+    info.blocklist_text =                                                   \
+        l10n_util::GetStringUTF8(IDS_BRAVE_EXTENSIONS_BLOCKLISTED_MALWARE); \
+  }
 #include <chrome/browser/extensions/api/developer_private/extension_info_generator.cc>
 #undef BRAVE_CREATE_EXTENSION_INFO_HELPER

--- a/chromium_src/chrome/browser/extensions/api/developer_private/extension_info_generator.cc
+++ b/chromium_src/chrome/browser/extensions/api/developer_private/extension_info_generator.cc
@@ -3,9 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "brave/components/extension_malware_blocklist/browser/extension_malware_blocklist.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/common/extensions/api/developer_private.h"
+#include "extensions/browser/extensions_browser_client.h"
 #include "extensions/common/constants.h"
 #include "extensions/common/extension_features.h"
 #include "extensions/common/manifest_handlers/incognito_info.h"
@@ -30,10 +30,9 @@ void ProcessKnownMV2Extensions(
 
 #define BRAVE_CREATE_EXTENSION_INFO_HELPER                                  \
   info.is_split_mode = IncognitoInfo::IsSplitMode(&extension);              \
-  if (auto* brave_malware_blocklist = extension_malware_blocklist::         \
-          ExtensionMalwareBlocklist::GetInstance();                         \
-      info.blocklist_text.has_value() && brave_malware_blocklist &&         \
-      brave_malware_blocklist->IsMalware(extension.id())) {                 \
+  if (info.blocklist_text.has_value() &&                                    \
+      ExtensionsBrowserClient::Get()->IsOnBraveMalwareExtensionList(        \
+          extension.id())) {                                                \
     info.blocklist_text =                                                   \
         l10n_util::GetStringUTF8(IDS_BRAVE_EXTENSIONS_BLOCKLISTED_MALWARE); \
   }


### PR DESCRIPTION
Stacks on top of https://github.com/brave/brave-core/pull/39257

Replaces the generic blocklist message for flagged extensions with a Brave-specific string on `brave://extensions`.

Draft: still missing the `brave://settings/security` toggle.

- Resolves https://github.com/brave/brave-browser/issues/57971