### PR TITLE
[Android] Fix toolbar dynamic color tint after switching tab types

### DIFF
--- a/patches/chrome-browser-ui-android-toolbar-java-src-org-chromium-chrome-browser-toolbar-top-ToolbarPhone.java.patch
+++ b/patches/chrome-browser-ui-android-toolbar-java-src-org-chromium-chrome-browser-toolbar-top-ToolbarPhone.java.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/top/ToolbarPhone.java b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/top/ToolbarPhone.java
-index 32041e70256cdcc770b1f9af7ab9cb7d2a0daeac..061400f3b5d4743d278f431f396eadf37dd9ce80 100644
+index 32041e70256cdcc770b1f9af7ab9cb7d2a0daeac..23a599724082bf0cd94f3b2147b1fb4abf915d68 100644
 --- a/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/top/ToolbarPhone.java
 +++ b/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/top/ToolbarPhone.java
 @@ -284,8 +284,8 @@ public class ToolbarPhone extends ToolbarLayout
@@ -13,14 +13,14 @@ index 32041e70256cdcc770b1f9af7ab9cb7d2a0daeac..061400f3b5d4743d278f431f396eadf3
      private boolean mUseAdjustedTintColorForNtp;
      private boolean mIsToolbarExpandedOnNtp;
  
-@@ -595,6 +595,7 @@ public class ToolbarPhone extends ToolbarLayout
-         if (mOptionalButtonCoordinator != null) {
-             mOptionalButtonCoordinator.setBackgroundColorFilter(color);
-         }
-+        BraveToolbarLayout.class.cast(this).updateModernLocationBarColorImpl(color);
-     }
+@@ -589,6 +589,7 @@ public class ToolbarPhone extends ToolbarLayout
  
-     private void updateModernLocationBarCorners() {
+     /** Set the background color of the location bar to appropriately match the theme color. */
+     private void updateModernLocationBarColor(@ColorInt int color) {
++        BraveToolbarLayout.class.cast(this).updateModernLocationBarColorImpl(color);
+         if (mCurrentLocationBarColor == color) return;
+         mCurrentLocationBarColor = color;
+         mLocationBarBackground.setBackgroundColor(color);
 @@ -1285,6 +1286,7 @@ public class ToolbarPhone extends ToolbarLayout
       * Tab Page.
       */

--- a/rewrite/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/top/ToolbarPhone.java.yaml
+++ b/rewrite/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/top/ToolbarPhone.java.yaml
@@ -5,18 +5,16 @@
 
 substitutions:
   - description: |
-      Update Brave's modern location bar color after Chromium updates it.
+      Refresh the Brave toolbar button tint before Chromium's cached-color early return.
 
-      Run Brave's color update after the Chromium location bar and optional
-      button backgrounds use the new color.
+      A private-to-standard tab switch can replace Brave button backgrounds. Refreshing the color
+      at the start of the method ensures the toolbar displays correctly, and this refresh call
+      is not ignored by upstream's early-exit due to the cached color being unchanged.
     regex:
-      re_pattern:
-        '(private\s+void\s+updateModernLocationBarColor\([^)]*\)\s*\{.*?mOptionalButtonCoordinator\.setBackgroundColorFilter\(color\);\s*\}\n)([
-        \t]*)(\})'
-      re_flags: [DOTALL]
+      re_pattern: '(private\s+void\s+updateModernLocationBarColor\([^)]*\)\s*\{)'
       replace: |-
-        \1        BraveToolbarLayout.class.cast(this).updateModernLocationBarColorImpl(color);
-        \2\3
+        \1
+                BraveToolbarLayout.class.cast(this).updateModernLocationBarColorImpl(color);
   - description: |
       Skip location bar layout when the Brave location bar is unavailable.
 

--- a/rewrite/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/top/ToolbarPhone.java.yaml
+++ b/rewrite/chrome/browser/ui/android/toolbar/java/src/org/chromium/chrome/browser/toolbar/top/ToolbarPhone.java.yaml
@@ -11,7 +11,7 @@ substitutions:
       at the start of the method ensures the toolbar displays correctly, and this refresh call
       is not ignored by upstream's early-exit due to the cached color being unchanged.
     regex:
-      re_pattern: '(private\s+void\s+updateModernLocationBarColor\([^)]*\)\s*\{)'
+      re_pattern: '(private void updateModernLocationBarColor\([^)]*\)\s*\{)'
       replace: |-
         \1
                 BraveToolbarLayout.class.cast(this).updateModernLocationBarColorImpl(color);


### PR DESCRIPTION


<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58216.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->


### Changes

**Fix Android toolbar button tint**

Run the Brave toolbar button color update before Chromium's cached color guard so private-to-standard tab switches refresh button backgrounds.

### Demos

https://github.com/user-attachments/assets/3de6d20b-102f-4f0e-86d5-9c19ce666c84

Before|After
--|--
Note color tint beneath Brave/BAT icons:
<img width="1344" height="2992" alt="Screenshot_1787209330" src="https://github.com/user-attachments/assets/a14b540d-9f6f-4ad2-b4ac-f9116e41d677" />|<img width="1344" height="2992" alt="Screenshot_1787209398" src="https://github.com/user-attachments/assets/06fab296-c0fa-4f9d-bae8-717963f6cf1a" />


