### PR TITLE
[WebPanel] Fixed crash when web panel activated by tab clicking

### DIFF
--- a/browser/ui/sidebar/BUILD.gn
+++ b/browser/ui/sidebar/BUILD.gn
@@ -106,6 +106,7 @@ source_set("test_support") {
     ":sidebar_impl",
     "//base",
     "//brave/browser/ui/views/frame",
+    "//brave/browser/ui/views/frame/split_view",
     "//brave/browser/ui/views/sidebar",
     "//brave/components/sidebar/browser",
     "//chrome/browser/ui",

--- a/browser/ui/sidebar/BUILD.gn
+++ b/browser/ui/sidebar/BUILD.gn
@@ -128,7 +128,10 @@ source_set("browser_tests") {
   testonly = true
   defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
 
-  sources = [ "//brave/browser/ui/sidebar/sidebar_browsertest.cc" ]
+  sources = [
+    "//brave/browser/ui/sidebar/sidebar_browsertest.cc",
+    "//brave/browser/ui/sidebar/web_panel_browsertest.cc",
+  ]
 
   deps = [
     ":sidebar",

--- a/browser/ui/sidebar/sidebar_browsertest_base.cc
+++ b/browser/ui/sidebar/sidebar_browsertest_base.cc
@@ -20,6 +20,7 @@
 #include "brave/browser/ui/sidebar/sidebar_model.h"
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/frame/split_view/brave_multi_contents_view.h"
 #include "brave/browser/ui/views/sidebar/sidebar_container_view.h"
 #include "brave/browser/ui/views/sidebar/sidebar_control_view.h"
 #include "brave/browser/ui/views/sidebar/sidebar_items_contents_view.h"
@@ -233,6 +234,10 @@ int SidebarBrowserTest::GetFirstWebItemIndex() {
   auto const iter =
       std::ranges::find(items, false, &SidebarItem::open_in_panel);
   return std::distance(items.cbegin(), iter);
+}
+
+BraveMultiContentsView* SidebarBrowserTest::GetBraveMultiContentsView() {
+  return browser_view()->GetBraveMultiContentsView();
 }
 
 BraveBrowserView* SidebarBrowserTest::browser_view() {

--- a/browser/ui/sidebar/sidebar_browsertest_base.h
+++ b/browser/ui/sidebar/sidebar_browsertest_base.h
@@ -19,6 +19,7 @@
 #include "ui/gfx/animation/animation_test_api.h"
 
 class BraveBrowserView;
+class BraveMultiContentsView;
 class SidebarContainerView;
 class SidebarControlView;
 class SidebarItemsContentsView;
@@ -114,6 +115,7 @@ class SidebarBrowserTest : public InProcessBrowserTest {
 
   int GetFirstPanelItemIndex();
   int GetFirstWebItemIndex();
+  BraveMultiContentsView* GetBraveMultiContentsView();
 
   BraveBrowserView* browser_view();
 

--- a/browser/ui/sidebar/web_panel_browsertest.cc
+++ b/browser/ui/sidebar/web_panel_browsertest.cc
@@ -32,10 +32,6 @@ class WebPanelBrowserTest : public SidebarBrowserTest {
   }
   ~WebPanelBrowserTest() override = default;
 
-  BraveMultiContentsView* GetBraveMultiContentsView() {
-    return browser_view()->GetBraveMultiContentsView();
-  }
-
   SidebarWebPanelController* web_panel_controller() {
     return controller()->GetWebPanelController();
   }
@@ -44,9 +40,10 @@ class WebPanelBrowserTest : public SidebarBrowserTest {
   base::test::ScopedFeatureList scoped_features_;
 };
 
-// Regression test for the crash by BraveMultiContentsView's web-panel
-// container wasn't registered in MultiContentsView::container_focusable_map_.
-// BrowserView::MaybeUpdateStoredFocusForWebContents() dereferenced a null
+// Regression test for a crash caused by BraveMultiContentsView's web-panel
+// container never being registered in
+// MultiContentsView::container_focusable_map_, which left
+// BrowserView::MaybeUpdateStoredFocusForWebContents() dereferencing a null
 // FocusableViewMap*.
 IN_PROC_BROWSER_TEST_F(WebPanelBrowserTest,
                        ReactivatingWebPanelTabAfterFocusLossDoesNotCrash) {
@@ -55,16 +52,15 @@ IN_PROC_BROWSER_TEST_F(WebPanelBrowserTest,
       kSidebarItemAddedFeedbackBubbleShowCount, 3);
 
   // Add the current tab as a web panel sidebar item.
-  ASSERT_TRUE(
-      ui_test_utils::NavigateToURL(browser(), GURL("https://brave.com/")));
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), GURL("about:blank")));
   ASSERT_TRUE(CanAddCurrentActiveTabToSidebar(browser()));
   controller()->AddItemWithCurrentTab();
-  const int web_panel_item_index = model()->GetAllSidebarItems().size() - 1;
+  const size_t web_panel_item_index = model()->GetAllSidebarItems().size() - 1;
   ASSERT_TRUE(
       model()->GetAllSidebarItems()[web_panel_item_index].is_web_panel_type());
 
   // Give ourselves another regular tab to switch to later.
-  chrome::AddTabAt(browser(), GURL("https://basicattentiontoken.com/"), -1,
+  chrome::AddTabAt(browser(), GURL("about:blank"), -1,
                    /*foreground*/ true);
 
   auto* tab_strip_model = browser()->tab_strip_model();
@@ -85,6 +81,7 @@ IN_PROC_BROWSER_TEST_F(WebPanelBrowserTest,
 
   // Force real UI focus onto the panel's contents view.
   GetBraveMultiContentsView()->GetActiveContentsView()->RequestFocus();
+  ASSERT_TRUE(GetBraveMultiContentsView()->GetActiveContentsView()->HasFocus());
 
   // Switch to another tab. This stores the focused view against the panel's
   // WebContents via ChromeWebContentsViewFocusHelper::StoreFocus().

--- a/browser/ui/sidebar/web_panel_browsertest.cc
+++ b/browser/ui/sidebar/web_panel_browsertest.cc
@@ -1,0 +1,106 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/test/scoped_feature_list.h"
+#include "brave/browser/ui/sidebar/sidebar_browsertest_base.h"
+#include "brave/browser/ui/sidebar/sidebar_controller.h"
+#include "brave/browser/ui/sidebar/sidebar_model.h"
+#include "brave/browser/ui/sidebar/sidebar_utils.h"
+#include "brave/browser/ui/sidebar/sidebar_web_panel_controller.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/frame/split_view/brave_multi_contents_view.h"
+#include "brave/components/sidebar/browser/pref_names.h"
+#include "brave/components/sidebar/common/features.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_tabstrip.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/browser/ui/views/frame/contents_web_view.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "components/prefs/pref_service.h"
+#include "content/public/test/browser_test.h"
+#include "url/gurl.h"
+
+namespace sidebar {
+
+class WebPanelBrowserTest : public SidebarBrowserTest {
+ public:
+  WebPanelBrowserTest() {
+    scoped_features_.InitAndEnableFeature(features::kSidebarWebPanel);
+  }
+  ~WebPanelBrowserTest() override = default;
+
+  BraveMultiContentsView* GetBraveMultiContentsView() {
+    return browser_view()->GetBraveMultiContentsView();
+  }
+
+  SidebarWebPanelController* web_panel_controller() {
+    return controller()->GetWebPanelController();
+  }
+
+ private:
+  base::test::ScopedFeatureList scoped_features_;
+};
+
+// Regression test for the crash by BraveMultiContentsView's web-panel
+// container wasn't registered in MultiContentsView::container_focusable_map_.
+// BrowserView::MaybeUpdateStoredFocusForWebContents() dereferenced a null
+// FocusableViewMap*.
+IN_PROC_BROWSER_TEST_F(WebPanelBrowserTest,
+                       ReactivatingWebPanelTabAfterFocusLossDoesNotCrash) {
+  // Avoid the "item added" feedback bubble interfering with the test.
+  browser()->GetProfile()->GetPrefs()->SetInteger(
+      kSidebarItemAddedFeedbackBubbleShowCount, 3);
+
+  // Add the current tab as a web panel sidebar item.
+  ASSERT_TRUE(
+      ui_test_utils::NavigateToURL(browser(), GURL("https://brave.com/")));
+  ASSERT_TRUE(CanAddCurrentActiveTabToSidebar(browser()));
+  controller()->AddItemWithCurrentTab();
+  const int web_panel_item_index = model()->GetAllSidebarItems().size() - 1;
+  ASSERT_TRUE(
+      model()->GetAllSidebarItems()[web_panel_item_index].is_web_panel_type());
+
+  // Give ourselves another regular tab to switch to later.
+  chrome::AddTabAt(browser(), GURL("https://basicattentiontoken.com/"), -1,
+                   /*foreground*/ true);
+
+  auto* tab_strip_model = browser()->tab_strip_model();
+
+  // Open the web panel. This creates a pinned tab for it at index 0, without
+  // making it the active/foreground tab.
+  controller()->ActivateItemAt(web_panel_item_index);
+  ASSERT_TRUE(GetBraveMultiContentsView()->IsWebPanelVisible());
+  ASSERT_EQ(3, tab_strip_model->count());
+  ASSERT_EQ(tab_strip_model->GetTabAtIndex(0)->GetContents(),
+            web_panel_controller()->panel_contents());
+
+  // First activation of the web panel's pinned tab: this alone doesn't
+  // trigger the crash because the panel's WebContents has never held focus
+  // yet (matches the existing WebPanelTest coverage).
+  tab_strip_model->ActivateTabAt(0);
+  ASSERT_TRUE(GetBraveMultiContentsView()->IsWebPanelVisible());
+
+  // Force real UI focus onto the panel's contents view.
+  GetBraveMultiContentsView()->GetActiveContentsView()->RequestFocus();
+
+  // Switch to another tab. This stores the focused view against the panel's
+  // WebContents via ChromeWebContentsViewFocusHelper::StoreFocus().
+  tab_strip_model->ActivateTabAt(1);
+
+  // Re-activate the web panel's pinned tab a second time. Pre-fix, this
+  // dereferenced a null FocusableViewMap* and crashed the browser process.
+  tab_strip_model->ActivateTabAt(0);
+
+  // If we get here, the crash didn't happen. Sanity-check the panel still
+  // works correctly afterwards.
+  EXPECT_EQ(0, tab_strip_model->active_index());
+  EXPECT_TRUE(GetBraveMultiContentsView()->IsWebPanelVisible());
+  EXPECT_EQ(
+      web_panel_controller()->panel_contents(),
+      GetBraveMultiContentsView()->GetActiveContentsView()->GetWebContents());
+}
+
+}  // namespace sidebar

--- a/browser/ui/sidebar/web_panel_interactive_ui_tests.cc
+++ b/browser/ui/sidebar/web_panel_interactive_ui_tests.cc
@@ -42,10 +42,6 @@ class SidebarWebPanelInteractiveUITest
   }
   ~SidebarWebPanelInteractiveUITest() override = default;
 
-  BraveMultiContentsView* GetBraveMultiContentsView() {
-    return browser_view()->GetBraveMultiContentsView();
-  }
-
   auto WaitForActiveTabChange(int index) {
     DEFINE_LOCAL_STATE_IDENTIFIER_VALUE(ui::test::PollingStateObserver<int>,
                                         kActiveTabIndexObserver);

--- a/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
+++ b/browser/ui/views/frame/split_view/brave_multi_contents_view.cc
@@ -84,6 +84,13 @@ void BraveMultiContentsView::UseContentsContainerViewForWebPanel() {
         AddChildView(std::make_unique<BraveContentsContainerView>(
             browser_view_, /*for_web_panel*/ true));
     contents_container_view_for_web_panel_->SetVisible(false);
+
+    auto& view_map =
+        container_focusable_map_[contents_container_view_for_web_panel_];
+    auto* contents_view =
+        contents_container_view_for_web_panel_->contents_view();
+    view_map[contents_view->GetClassName()] = contents_view;
+
     contents_focused_subscriptions_.push_back(
         contents_container_view_for_web_panel_->contents_view()
             ->AddWebContentsFocusedCallback(base::BindRepeating(


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Issue: Issue - https://github.com/brave/brave-browser/issues/33533

Need to add web panel container to `container_focusable_map_`.
Otherwise, BrowserView::MaybeUpdateStoredFocusForWebContents() will dereference a null.

TEST=WebPanelBrowserTest.ReactivatingWebPanelTabAfterFocusLossDoesNotCrash


https://github.com/user-attachments/assets/8901cbaf-da78-4626-b924-3053eb970d52



Crash callstack.
```
  0   libbase.dylib                       0x00000001013b1ad0 base::debug::CollectStackTrace(base::span<void const*, 18446744073709551615ul, void const**>) + 24
  1   libbase.dylib                       0x0000000101398c20 base::debug::StackTrace::StackTrace(unsigned long) + 224
  2   libbase.dylib                       0x00000001013b19bc base::debug::(anonymous namespace)::StackDumpSignalHandler(int, __siginfo*, void*) + 924
  3   libsystem_platform.dylib            0x00000001826fd744 _sigtramp + 56
  4   libchrome_dll.dylib                 0x000000011180dc84 BrowserView::MaybeUpdateStoredFocusForWebContents(content::WebContents*) + 172
  5   libchrome_dll.dylib                 0x000000011180dc84 BrowserView::MaybeUpdateStoredFocusForWebContents(content::WebContents*) + 172
  6   libchrome_dll.dylib                 0x000000011180d5b0 BrowserView::OnActiveTabChanged(content::WebContents*, content::WebContents*, int, int) + 1684
  7   libchrome_dll.dylib                 0x000000010ecf9584 BraveBrowserView::OnActiveTabChanged(content::WebContents*, content::WebContents*, int, int) + 76
  8   libchrome_dll.dylib                 0x00000001116e8bec Browser::OnActiveTabChanged(TabStripModelChange const&, TabStripSelectionChange const&) + 280
  9   libchrome_dll.dylib                 0x00000001116e853c Browser::OnTabStripModelChanged(TabStripModel*, TabStripModelChange const&, TabStripSelectionChange const&) + 460
  10  libchrome_dll.dylib                 0x000000010eca1314 BraveBrowser::OnTabStripModelChanged(TabStripModel*, TabStripModelChange const&, TabStripSelectionChange const&) + 52
  11  libchrome_dll.dylib                 0x000000010f77cad4 TabStripModel::OnChange(TabStripModelChange const&, TabStripSelectionChange const&) + 560
  12  libchrome_dll.dylib                 0x000000010f77b384 TabStripModel::SetSelection(tabs::TabStripModelSelectionState const&, TabStripModelObserver::ChangeReason, bool, bool) + 876
  13  libchrome_dll.dylib                 0x000000010f781bc0 TabStripModel::ActivateTab(tabs::TabInterface*, TabStripUserGestureDetails) + 384
  14  libchrome_dll.dylib                 0x00000001118b7ab8 BrowserTabStripController::SelectTab(int, ui::Event const&) + 112
  15  libchrome_dll.dylib                 0x0000000111904328 non-virtual thunk to TabStrip::SelectTab(Tab*, ui::Event const&) + 180
  16  libchrome_dll.dylib                 0x00000001118e9adc Tab::OnMousePressed(ui::MouseEvent const&) + 484
```

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
