### PR TITLE
Added EA hint toggle on settings page even if not logged-in.

### DIFF
--- a/browser/email_aliases/email_aliases_browsertest.cc
+++ b/browser/email_aliases/email_aliases_browsertest.cc
@@ -565,15 +565,26 @@ IN_PROC_BROWSER_TEST_F(EmailAliasesBrowserTest, ContextMenuAuthorizedCancel) {
   EXPECT_TRUE(AwaitText("#type-email", ""));  // text not changed
 }
 IN_PROC_BROWSER_TEST_F(EmailAliasesBrowserTest, LogInLogOut) {
+  browser()->GetProfile()->GetPrefs()->SetBoolean(prefs::kPromoShown, false);
+
   SetBraveAccountLoggedIn();
+
+  // Login stops promo showing.
+  EXPECT_TRUE(
+      browser()->GetProfile()->GetPrefs()->GetBoolean(prefs::kPromoShown));
 
   // Settings in logged-in state
   Navigate(GURL("chrome://settings/email-aliases"));
   InjectHelpers(ActiveWebContents());
   Wait("#create-new-item-button");
+  Wait("settings-toggle-button[icon='email-shield']");
 
   SetBraveAccountLoggedOut();
   WaitDisappear("#create-new-item-button");  // Settings in sing-in state.
+  // Still showing the toggle.
+  Wait("settings-toggle-button[icon='email-shield']");
+  EXPECT_TRUE(
+      browser()->GetProfile()->GetPrefs()->GetBoolean(prefs::kPromoShown));
 
   SetBraveAccountLoggedIn();
   Wait("#create-new-item-button");  // Logged-in state.

--- a/browser/resources/settings/email_aliases_page/email_aliases_page.html
+++ b/browser/resources/settings/email_aliases_page/email_aliases_page.html
@@ -4,7 +4,6 @@
     <settings-toggle-button
         class="cr-row"
         icon="email-shield"
-        hidden$="[[!showEmailAliasesSettings_]]"
         pref="{{prefs.brave.email_aliases.new_alias_autofill_suggestion_enabled}}"
         label="[[autofillSuggestionToggleLabel_]]">
     </settings-toggle-button>

--- a/browser/resources/settings/email_aliases_page/email_aliases_page.html
+++ b/browser/resources/settings/email_aliases_page/email_aliases_page.html
@@ -4,6 +4,7 @@
     <settings-toggle-button
         class="cr-row"
         icon="email-shield"
+        hidden$="[[!showEmailAliasesSettings_]]"
         pref="{{prefs.brave.email_aliases.new_alias_autofill_suggestion_enabled}}"
         label="[[autofillSuggestionToggleLabel_]]">
     </settings-toggle-button>

--- a/browser/resources/settings/email_aliases_page/email_aliases_page.ts
+++ b/browser/resources/settings/email_aliases_page/email_aliases_page.ts
@@ -47,16 +47,11 @@ class SettingsEmailAliasesPageElement extends PrefsMixin(PolymerElement) {
           EmailAliasesStrings.SETTINGS_EMAIL_ALIASES_AUTOFILL_SUGGESTION_LABEL
         ),
       },
-      showEmailAliasesSettings_: {
-        type: Boolean,
-        value: false,
-      },
     };
   }
 
   declare pageTitle_: string;
   declare autofillSuggestionToggleLabel_: string;
-  declare showEmailAliasesSettings_: boolean;
 
   override ready() {
     super.ready();
@@ -64,11 +59,7 @@ class SettingsEmailAliasesPageElement extends PrefsMixin(PolymerElement) {
     customElements.whenDefined('settings-brave-account-row').then(() => {
       const bundlePath = '/email_aliases.bundle.js'
       import(bundlePath).then(({mount}) => {
-        mount(this.$.signInRoot, this.$.manageSection, {
-          onLoggedInChange: (loggedIn: boolean) => {
-            this.showEmailAliasesSettings_ = loggedIn;
-          },
-        });
+        mount(this.$.signInRoot, this.$.manageSection, {});
       });
     });
 

--- a/browser/resources/settings/email_aliases_page/email_aliases_page.ts
+++ b/browser/resources/settings/email_aliases_page/email_aliases_page.ts
@@ -47,11 +47,16 @@ class SettingsEmailAliasesPageElement extends PrefsMixin(PolymerElement) {
           EmailAliasesStrings.SETTINGS_EMAIL_ALIASES_AUTOFILL_SUGGESTION_LABEL
         ),
       },
+      showEmailAliasesSettings_: {
+        type: Boolean,
+        value: false,
+      },
     };
   }
 
   declare pageTitle_: string;
   declare autofillSuggestionToggleLabel_: string;
+  declare showEmailAliasesSettings_: boolean;
 
   override ready() {
     super.ready();
@@ -59,7 +64,12 @@ class SettingsEmailAliasesPageElement extends PrefsMixin(PolymerElement) {
     customElements.whenDefined('settings-brave-account-row').then(() => {
       const bundlePath = '/email_aliases.bundle.js'
       import(bundlePath).then(({mount}) => {
-        mount(this.$.signInRoot, this.$.manageSection, {});
+        mount(this.$.signInRoot, this.$.manageSection, {
+          onLoggedInChange: (_: boolean) => {
+            // Show even if not logged-in.
+            this.showEmailAliasesSettings_ = true;
+          },
+        });
       });
     });
 

--- a/browser/ui/brave_browser_command_controller_browsertest.cc
+++ b/browser/ui/brave_browser_command_controller_browsertest.cc
@@ -924,7 +924,7 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerWithEmailAliasesTest,
   auto* controller = browser()->GetFeatures().email_aliases_controller();
   ASSERT_NE(nullptr, controller->GetBubbleForTesting());
 
-  // Closing the promo should record it as shown and navigate to settings.
+  // Closing navigates to settings.
   controller->CloseBubble();
 
   ASSERT_TRUE(base::test::RunUntil([&]() {
@@ -933,5 +933,9 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerWithEmailAliasesTest,
                ->GetActiveWebContents()
                ->GetVisibleURL() == chrome::GetSettingsUrl("email-aliases");
   }));
+
+  // Continue to show the promo until the first login
+  EXPECT_FALSE(browser()->GetProfile()->GetPrefs()->GetBoolean(
+      email_aliases::prefs::kPromoShown));
 }
 #endif  // BUILDFLAG(ENABLE_EMAIL_ALIASES)

--- a/browser/ui/email_aliases/email_aliases_controller.cc
+++ b/browser/ui/email_aliases/email_aliases_controller.cc
@@ -285,7 +285,6 @@ void EmailAliasesController::ShowPromoBubble(content::WebContents* initiator) {
 
 void EmailAliasesController::OnPromoBubbleClosed(const std::string&) {
   OnBubbleClosed({});
-  email_aliases_service_->MarkPromoShown();
   ShowSingletonTabOverwritingNTP(browser_view_->browser(),
                                  GURL(kEmailAliasesSettingsURL));
 }

--- a/components/email_aliases/email_aliases_service.cc
+++ b/components/email_aliases/email_aliases_service.cc
@@ -157,6 +157,9 @@ std::string EmailAliasesService::GetAuthEmail() const {
 }
 
 void EmailAliasesService::OnAuthChanged() {
+  if (IsAuthenticated()) {
+    MarkPromoShown();
+  }
   RefreshAliases();
 }
 

--- a/components/email_aliases/email_aliases_service.cc
+++ b/components/email_aliases/email_aliases_service.cc
@@ -157,7 +157,7 @@ std::string EmailAliasesService::GetAuthEmail() const {
 }
 
 void EmailAliasesService::OnAuthChanged() {
-  if (IsAuthenticated()) {
+  if (IsAuthenticated() && ShouldShowPromo()) {
     MarkPromoShown();
   }
   RefreshAliases();


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58291

Brave account logged out & toggle is shown:
<img width="1095" height="553" alt="image" src="https://github.com/user-attachments/assets/db3b2071-ac3d-47d2-9a9d-ba8fe36cea15" />

Additionally, in this PR, the logic of showing onboarding view has been changed: we want to show it until the user is logged at least once.
