### PR TITLE
[VPN 2.0] Endpoint-based API: SGW device APIs

### DIFF
--- a/components/brave_vpn/browser/v2/api/BUILD.gn
+++ b/components/brave_vpn/browser/v2/api/BUILD.gn
@@ -11,6 +11,7 @@ source_set("api") {
   sources = [
     "brave_vpn_api_client.cc",
     "brave_vpn_api_client.h",
+    "device_endpoints.h",
     "empty_request_body.h",
     "endpoint_constants.h",
     "error_body.h",
@@ -18,6 +19,7 @@ source_set("api") {
     "raw_json_response_body.h",
     "region_endpoints.h",
     "support_endpoints.h",
+    "transport_protocol.h",
   ]
 
   public_deps = [
@@ -38,6 +40,7 @@ source_set("unit_tests") {
 
   sources = [
     "brave_vpn_api_client_unittest.cc",
+    "device_endpoints_unittest.cc",
     "purchase_endpoints_unittest.cc",
     "region_endpoints_unittest.cc",
     "support_endpoints_unittest.cc",

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client.cc
@@ -271,15 +271,20 @@ void BraveVpnApiClient::GetHostnamesForRegion(
 
 void BraveVpnApiClient::GetProfileCredentials(
     RawJsonCallback callback,
+    const std::string& hostname,
     const std::string& subscriber_credential,
     endpoints::TransportProtocol transport_protocol,
-    const std::string& public_key,
-    const std::string& multihop_exit_region,
-    const std::string& hostname) {
+    const std::optional<std::string>& public_key,
+    const std::optional<std::string>& multihop_exit_region) {
+  CHECK_EQ(public_key.has_value(),
+           transport_protocol == endpoints::TransportProtocol::kWireguard)
+      << "public key must be set if and only if transport protocol is "
+         "WireGuard";
+
   auto request = MakeRequest<GetProfileCredentials::Request>();
   request.body.subscriber_credential = subscriber_credential;
   request.body.transport_protocol = transport_protocol;
-  request.body.public_key = public_key;
+  request.body.public_key = public_key.value_or("");
   request.body.multihop_exit_region = multihop_exit_region;
   request.url_replacements.SetHost(hostname);
 
@@ -298,7 +303,7 @@ void BraveVpnApiClient::VerifyCredentials(RawJsonCallback callback,
   request.url_replacements.SetHost(hostname);
   request.url_replacements.SetPath(
       base::StrCat({VerifyCredentials::URL().path(), "/", client_id, "/",
-                    endpoints::kVerifyCredentialsSuffix}));
+                    endpoints::kDeviceApiVerifyCredentialsSuffix}));
 
   Client<endpoints::VerifyCredentials>::Send(
       url_loader_factory_, std::move(request),
@@ -318,7 +323,7 @@ void BraveVpnApiClient::InvalidateCredentials(
   request.url_replacements.SetHost(hostname);
   request.url_replacements.SetPath(
       base::StrCat({InvalidateCredentials::URL().path(), "/", client_id, "/",
-                    endpoints::kInvalidateCredentialsSuffix}));
+                    endpoints::kDeviceApiInvalidateCredentialsSuffix}));
 
   Client<endpoints::InvalidateCredentials>::Send(
       url_loader_factory_, std::move(request),

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client.cc
@@ -16,6 +16,7 @@
 #include "base/types/expected.h"
 #include "brave/components/brave_account/endpoint_client/client.h"
 #include "brave/components/brave_account/endpoint_client/with_headers.h"
+#include "brave/components/brave_vpn/browser/v2/api/device_endpoints.h"
 #include "brave/components/brave_vpn/browser/v2/api/purchase_endpoints.h"
 #include "brave/components/brave_vpn/browser/v2/api/region_endpoints.h"
 #include "brave/components/brave_vpn/browser/v2/api/support_endpoints.h"
@@ -33,10 +34,13 @@ namespace brave_vpn::v2 {
 
 using endpoints::CreateSupportTicket;
 using endpoints::GetHostnamesForRegion;
+using endpoints::GetProfileCredentials;
 using endpoints::GetServerRegions;
 using endpoints::GetSubscriberCredential;
 using endpoints::GetSubscriberCredentialV12;
 using endpoints::GetTimezonesForRegions;
+using endpoints::InvalidateCredentials;
+using endpoints::VerifyCredentials;
 using endpoints::VerifyPurchaseToken;
 
 namespace {
@@ -260,6 +264,63 @@ void BraveVpnApiClient::GetHostnamesForRegion(
   request.body.region_precision = region_precision;
 
   Client<endpoints::GetHostnamesForRegion>::Send(
+      url_loader_factory_, std::move(request),
+      base::BindOnce(&BraveVpnApiClient::OnRawJsonResponse,
+                     weak_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void BraveVpnApiClient::GetProfileCredentials(
+    RawJsonCallback callback,
+    const std::string& subscriber_credential,
+    endpoints::TransportProtocol transport_protocol,
+    const std::string& public_key,
+    const std::string& multihop_exit_region,
+    const std::string& hostname) {
+  auto request = MakeRequest<GetProfileCredentials::Request>();
+  request.body.subscriber_credential = subscriber_credential;
+  request.body.transport_protocol = transport_protocol;
+  request.body.public_key = public_key;
+  request.body.multihop_exit_region = multihop_exit_region;
+  request.url_replacements.SetHost(hostname);
+
+  Client<endpoints::GetProfileCredentials>::Send(
+      url_loader_factory_, std::move(request),
+      base::BindOnce(&BraveVpnApiClient::OnRawJsonResponse,
+                     weak_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void BraveVpnApiClient::VerifyCredentials(RawJsonCallback callback,
+                                          const std::string& hostname,
+                                          const std::string& client_id,
+                                          const std::string& api_auth_token) {
+  auto request = MakeRequest<WithHeaders<VerifyCredentials::Request>>();
+  request.headers.SetHeader(endpoints::kHeaderGrdApiAuthToken, api_auth_token);
+  request.url_replacements.SetHost(hostname);
+  request.url_replacements.SetPath(
+      base::StrCat({VerifyCredentials::URL().path(), "/", client_id, "/",
+                    endpoints::kVerifyCredentialsSuffix}));
+
+  Client<endpoints::VerifyCredentials>::Send(
+      url_loader_factory_, std::move(request),
+      base::BindOnce(&BraveVpnApiClient::OnRawJsonResponse,
+                     weak_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void BraveVpnApiClient::InvalidateCredentials(
+    RawJsonCallback callback,
+    const std::string& hostname,
+    const std::string& client_id,
+    const std::string& api_auth_token,
+    const std::string& subscriber_credential) {
+  auto request = MakeRequest<InvalidateCredentials::Request>();
+  request.body.api_auth_token = api_auth_token;
+  request.body.subscriber_credential = subscriber_credential;
+  request.url_replacements.SetHost(hostname);
+  request.url_replacements.SetPath(
+      base::StrCat({InvalidateCredentials::URL().path(), "/", client_id, "/",
+                    endpoints::kInvalidateCredentialsSuffix}));
+
+  Client<endpoints::InvalidateCredentials>::Send(
       url_loader_factory_, std::move(request),
       base::BindOnce(&BraveVpnApiClient::OnRawJsonResponse,
                      weak_factory_.GetWeakPtr(), std::move(callback)));

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_BRAVE_VPN_API_CLIENT_H_
 #define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_BRAVE_VPN_API_CLIENT_H_
 
+#include <optional>
 #include <string>
 
 #include "base/functional/callback_forward.h"
@@ -111,11 +112,11 @@ class BraveVpnApiClient {
   // protocol. Returns the server's JSON response verbatim.
   virtual void GetProfileCredentials(
       RawJsonCallback callback,
+      const std::string& hostname,
       const std::string& subscriber_credential,
       endpoints::TransportProtocol transport_protocol,
-      const std::string& public_key,
-      const std::string& multihop_exit_region,
-      const std::string& hostname);
+      const std::optional<std::string>& public_key,
+      const std::optional<std::string>& multihop_exit_region);
 
   // SGW API: VerifyCredentials.
   // Confirms the credential has not been invalidated. Per Guardian, any non-2xx

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h
@@ -16,6 +16,7 @@
 #include "brave/components/brave_vpn/browser/v2/api/error_body.h"
 #include "brave/components/brave_vpn/browser/v2/api/purchase_endpoints.h"
 #include "brave/components/brave_vpn/browser/v2/api/raw_json_response_body.h"
+#include "brave/components/brave_vpn/browser/v2/api/transport_protocol.h"
 
 namespace network {
 class SharedURLLoaderFactory;
@@ -104,6 +105,36 @@ class BraveVpnApiClient {
   virtual void GetHostnamesForRegion(RawJsonCallback callback,
                                      const std::string& region,
                                      const std::string& region_precision);
+
+  // SGW API: GetProfileCredentials.
+  // Registers VPN credentials with the given node for the given transport
+  // protocol. Returns the server's JSON response verbatim.
+  virtual void GetProfileCredentials(
+      RawJsonCallback callback,
+      const std::string& subscriber_credential,
+      endpoints::TransportProtocol transport_protocol,
+      const std::string& public_key,
+      const std::string& multihop_exit_region,
+      const std::string& hostname);
+
+  // SGW API: VerifyCredentials.
+  // Confirms the credential has not been invalidated. Per Guardian, any non-2xx
+  // response should be treated as a hard failure: the credential must not be
+  // reused.
+  virtual void VerifyCredentials(RawJsonCallback callback,
+                                 const std::string& hostname,
+                                 const std::string& client_id,
+                                 const std::string& api_auth_token);
+
+  // SGW API: InvalidateCredentials.
+  // Allows for explicit disabling of VPN credentials to ensure that they cannot
+  // be used ever again. VPN credentials that are no longer going to be used
+  // should always be invalidated.
+  virtual void InvalidateCredentials(RawJsonCallback callback,
+                                     const std::string& hostname,
+                                     const std::string& client_id,
+                                     const std::string& api_auth_token,
+                                     const std::string& subscriber_credential);
 
  private:
   void OnRawJsonResponse(RawJsonCallback callback, RawJsonResponse response);

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
@@ -395,9 +395,9 @@ TEST_P(BraveVpnApiClientGetProfileCredentialsTest, MapsResponseToResult) {
   MockResponseFor<endpoints::GetProfileCredentials>(
       url_loader_factory_, test_case.response, url_replacements);
   EXPECT_EQ(CallClientApi(&BraveVpnApiClient::GetProfileCredentials,
-                          kTestSubscriberCredential,
-                          endpoints::TransportProtocol::kIKEv2, kTestPublicKey,
-                          kTestMultihopExitRegion, kTestHostname),
+                          kTestHostname, kTestSubscriberCredential,
+                          endpoints::TransportProtocol::kWireguard,
+                          kTestPublicKey, kTestMultihopExitRegion),
             test_case.expected);
 }
 

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
@@ -16,11 +16,13 @@
 #include "base/types/expected.h"
 #include "brave/components/brave_account/endpoint_client/test_support.h"
 #include "brave/components/brave_account/endpoint_client/url_replacements.h"
+#include "brave/components/brave_vpn/browser/v2/api/device_endpoints.h"
 #include "brave/components/brave_vpn/browser/v2/api/error_body.h"
 #include "brave/components/brave_vpn/browser/v2/api/purchase_endpoints.h"
 #include "brave/components/brave_vpn/browser/v2/api/raw_json_response_body.h"
 #include "brave/components/brave_vpn/browser/v2/api/region_endpoints.h"
 #include "brave/components/brave_vpn/browser/v2/api/support_endpoints.h"
+#include "brave/components/brave_vpn/browser/v2/api/transport_protocol.h"
 #include "net/base/net_errors.h"
 #include "net/http/http_status_code.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
@@ -32,6 +34,8 @@ namespace brave_vpn::v2 {
 namespace {
 using brave_account::endpoint_client::MockResponseFor;
 
+constexpr char kTestErrorTitle[] = "Test error title.";
+constexpr char kTestErrorMessage[] = "test error message";
 constexpr char kTestProductType[] = "test-product-type";
 constexpr char kTestProductId[] = "test-product-id";
 constexpr char kTestValidationMethod[] = "test-validation-method";
@@ -46,6 +50,11 @@ constexpr char kTestBody[] = "It doesn't connect.";
 constexpr char kTestTimezone[] = "America/Los_Angeles";
 constexpr char kTestRegion[] = "us-east";
 constexpr char kTestRegionPrecision[] = "city-by-country";
+constexpr char kTestHostname[] = "sgw-node.guardianapp.com";
+constexpr char kTestClientId[] = "test-client-id";
+constexpr char kTestApiAuthToken[] = "test-api-auth-token";
+constexpr char kTestPublicKey[] = "test-public-key";
+constexpr char kTestMultihopExitRegion[] = "us-west";
 
 // Canonical JSON (compact, keys sorted): MockResponseFor re-serializes the
 // body via ToValue() and the client re-parses it via FromValue(), so only
@@ -99,6 +108,32 @@ std::vector<TestCase> WithCommonUnrecoverableCases(
                    "HTTP %d %s: body missing or failed to parse",
                    net::HTTP_INTERNAL_SERVER_ERROR,
                    net::GetHttpReasonPhrase(net::HTTP_INTERNAL_SERVER_ERROR)))},
+  };
+  base::Extend(cases, std::move(endpoint_specific_cases));
+  return cases;
+}
+
+// Two "Success" and "RequestError" cases are identical for every endpoint whose
+// response is Response<RawJsonResponseBody, VpnErrorBody>.
+template <typename TestCase>
+std::vector<TestCase> WithCommonRawJsonCases(
+    std::vector<TestCase> endpoint_specific_cases) {
+  std::vector<TestCase> cases = {
+      // 2xx body is forwarded verbatim.
+      TestCase{.test_name = "Success",
+               .response = {.net_error = net::OK,
+                            .status_code = net::HTTP_OK,
+                            .body = base::ok(endpoints::RawJsonResponseBody{
+                                .json = kTestSuccessJson})},
+               .expected = base::ok(kTestSuccessJson)},
+      // A non-2xx response with a parseable error body surfaces its title.
+      TestCase{.test_name = "RequestError",
+               .response = {.net_error = net::OK,
+                            .status_code = net::HTTP_BAD_REQUEST,
+                            .body = base::unexpected(endpoints::VpnErrorBody{
+                                .error_title = kTestErrorTitle,
+                                .error_message = kTestErrorMessage})},
+               .expected = base::unexpected(kTestErrorTitle)},
   };
   base::Extend(cases, std::move(endpoint_specific_cases));
   return cases;
@@ -262,23 +297,7 @@ INSTANTIATE_TEST_SUITE_P(
     BraveVpnApiClientTests,
     BraveVpnApiClientCreateSupportTicketTest,
     testing::ValuesIn(WithCommonUnrecoverableCases<CreateSupportTicketTestCase>(
-        {// 2xx echoes the confirmation JSON verbatim.
-         CreateSupportTicketTestCase{
-             .test_name = "Success",
-             .response = {.net_error = net::OK,
-                          .status_code = net::HTTP_OK,
-                          .body = base::ok(endpoints::RawJsonResponseBody{
-                              .json = kTestSuccessJson})},
-             .expected = base::ok(kTestSuccessJson)},
-         // A non-2xx response with a parseable error body surfaces its title.
-         CreateSupportTicketTestCase{
-             .test_name = "RequestError",
-             .response = {.net_error = net::OK,
-                          .status_code = net::HTTP_BAD_REQUEST,
-                          .body = base::unexpected(endpoints::VpnErrorBody{
-                              .error_title = "Invalid credential.",
-                              .error_message = "expired"})},
-             .expected = base::unexpected("Invalid credential.")}})),
+        WithCommonRawJsonCases<CreateSupportTicketTestCase>({}))),
     [](const auto& info) { return info.param.test_name; });
 
 struct GetServerRegionsTestCase {
@@ -306,21 +325,7 @@ INSTANTIATE_TEST_SUITE_P(
     BraveVpnApiClientTests,
     BraveVpnApiClientGetServerRegionsTest,
     testing::ValuesIn(WithCommonUnrecoverableCases<GetServerRegionsTestCase>(
-        {GetServerRegionsTestCase{
-             .test_name = "Success",
-             .response = {.net_error = net::OK,
-                          .status_code = net::HTTP_OK,
-                          .body = base::ok(endpoints::RawJsonResponseBody{
-                              .json = kTestSuccessJson})},
-             .expected = base::ok(kTestSuccessJson)},
-         GetServerRegionsTestCase{
-             .test_name = "RequestError",
-             .response = {.net_error = net::OK,
-                          .status_code = net::HTTP_BAD_REQUEST,
-                          .body = base::unexpected(endpoints::VpnErrorBody{
-                              .error_title = "Invalid precision.",
-                              .error_message = "bad"})},
-             .expected = base::unexpected("Invalid precision.")}})),
+        WithCommonRawJsonCases<GetServerRegionsTestCase>({}))),
     [](const auto& info) { return info.param.test_name; });
 
 struct GetTimezonesForRegionsTestCase {
@@ -343,25 +348,9 @@ TEST_P(BraveVpnApiClientGetTimezonesForRegionsTest, MapsResponseToResult) {
 INSTANTIATE_TEST_SUITE_P(
     BraveVpnApiClientTests,
     BraveVpnApiClientGetTimezonesForRegionsTest,
-    testing::ValuesIn(WithCommonUnrecoverableCases<
-                      GetTimezonesForRegionsTestCase>(
-        {// 2xx body is forwarded verbatim.
-         GetTimezonesForRegionsTestCase{
-             .test_name = "Success",
-             .response = {.net_error = net::OK,
-                          .status_code = net::HTTP_OK,
-                          .body = base::ok(endpoints::RawJsonResponseBody{
-                              .json = kTestSuccessJson})},
-             .expected = base::ok(kTestSuccessJson)},
-         // A non-2xx response with a parseable error body surfaces its title.
-         GetTimezonesForRegionsTestCase{
-             .test_name = "RequestError",
-             .response = {.net_error = net::OK,
-                          .status_code = net::HTTP_BAD_REQUEST,
-                          .body = base::unexpected(endpoints::VpnErrorBody{
-                              .error_title = "Invalid request.",
-                              .error_message = "bad"})},
-             .expected = base::unexpected("Invalid request.")}})),
+    testing::ValuesIn(
+        WithCommonUnrecoverableCases<GetTimezonesForRegionsTestCase>(
+            WithCommonRawJsonCases<GetTimezonesForRegionsTestCase>({}))),
     [](const auto& info) { return info.param.test_name; });
 
 struct GetHostnamesForRegionTestCase {
@@ -385,25 +374,101 @@ TEST_P(BraveVpnApiClientGetHostnamesForRegionTest, MapsResponseToResult) {
 INSTANTIATE_TEST_SUITE_P(
     BraveVpnApiClientTests,
     BraveVpnApiClientGetHostnamesForRegionTest,
-    testing::ValuesIn(WithCommonUnrecoverableCases<
-                      GetHostnamesForRegionTestCase>(
-        {// 2xx body is forwarded verbatim.
-         GetHostnamesForRegionTestCase{
-             .test_name = "Success",
-             .response = {.net_error = net::OK,
-                          .status_code = net::HTTP_OK,
-                          .body = base::ok(endpoints::RawJsonResponseBody{
-                              .json = kTestSuccessJson})},
-             .expected = base::ok(kTestSuccessJson)},
-         // A non-2xx response with a parseable error body surfaces its title.
-         GetHostnamesForRegionTestCase{
-             .test_name = "RequestError",
-             .response = {.net_error = net::OK,
-                          .status_code = net::HTTP_BAD_REQUEST,
-                          .body = base::unexpected(endpoints::VpnErrorBody{
-                              .error_title = "Invalid region.",
-                              .error_message = "bad"})},
-             .expected = base::unexpected("Invalid region.")}})),
+    testing::ValuesIn(
+        WithCommonUnrecoverableCases<GetHostnamesForRegionTestCase>(
+            WithCommonRawJsonCases<GetHostnamesForRegionTestCase>({}))),
+    [](const auto& info) { return info.param.test_name; });
+
+struct GetProfileCredentialsTestCase {
+  std::string test_name;
+  endpoints::GetProfileCredentials::Response response;
+  base::expected<std::string, std::string> expected;
+};
+
+using BraveVpnApiClientGetProfileCredentialsTest =
+    BraveVpnApiClientTest<GetProfileCredentialsTestCase>;
+
+TEST_P(BraveVpnApiClientGetProfileCredentialsTest, MapsResponseToResult) {
+  const auto& test_case = GetParam();
+  brave_account::endpoint_client::UrlReplacements url_replacements;
+  url_replacements.SetHost(kTestHostname);
+  MockResponseFor<endpoints::GetProfileCredentials>(
+      url_loader_factory_, test_case.response, url_replacements);
+  EXPECT_EQ(CallClientApi(&BraveVpnApiClient::GetProfileCredentials,
+                          kTestSubscriberCredential,
+                          endpoints::TransportProtocol::kIKEv2, kTestPublicKey,
+                          kTestMultihopExitRegion, kTestHostname),
+            test_case.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BraveVpnApiClientTests,
+    BraveVpnApiClientGetProfileCredentialsTest,
+    testing::ValuesIn(
+        WithCommonUnrecoverableCases<GetProfileCredentialsTestCase>(
+            WithCommonRawJsonCases<GetProfileCredentialsTestCase>({}))),
+    [](const auto& info) { return info.param.test_name; });
+
+struct VerifyCredentialsTestCase {
+  std::string test_name;
+  endpoints::VerifyCredentials::Response response;
+  base::expected<std::string, std::string> expected;
+};
+
+using BraveVpnApiClientVerifyCredentialsTest =
+    BraveVpnApiClientTest<VerifyCredentialsTestCase>;
+
+TEST_P(BraveVpnApiClientVerifyCredentialsTest, MapsResponseToResult) {
+  const auto& test_case = GetParam();
+  brave_account::endpoint_client::UrlReplacements url_replacements;
+  url_replacements.SetHost(kTestHostname);
+  url_replacements.SetPath(
+      base::StrCat({endpoints::VerifyCredentials::URL().path(), "/",
+                    kTestClientId, "/verify-credentials"}));
+  MockResponseFor<endpoints::VerifyCredentials>(
+      url_loader_factory_, test_case.response, url_replacements);
+  EXPECT_EQ(CallClientApi(&BraveVpnApiClient::VerifyCredentials, kTestHostname,
+                          kTestClientId, kTestApiAuthToken),
+            test_case.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BraveVpnApiClientTests,
+    BraveVpnApiClientVerifyCredentialsTest,
+    testing::ValuesIn(WithCommonUnrecoverableCases<VerifyCredentialsTestCase>(
+        WithCommonRawJsonCases<VerifyCredentialsTestCase>({}))),
+    [](const auto& info) { return info.param.test_name; });
+
+struct InvalidateCredentialsTestCase {
+  std::string test_name;
+  endpoints::InvalidateCredentials::Response response;
+  base::expected<std::string, std::string> expected;
+};
+
+using BraveVpnApiClientInvalidateCredentialsTest =
+    BraveVpnApiClientTest<InvalidateCredentialsTestCase>;
+
+TEST_P(BraveVpnApiClientInvalidateCredentialsTest, MapsResponseToResult) {
+  const auto& test_case = GetParam();
+  brave_account::endpoint_client::UrlReplacements url_replacements;
+  url_replacements.SetHost(kTestHostname);
+  url_replacements.SetPath(
+      base::StrCat({endpoints::InvalidateCredentials::URL().path(), "/",
+                    kTestClientId, "/invalidate-credentials"}));
+  MockResponseFor<endpoints::InvalidateCredentials>(
+      url_loader_factory_, test_case.response, url_replacements);
+  EXPECT_EQ(CallClientApi(&BraveVpnApiClient::InvalidateCredentials,
+                          kTestHostname, kTestClientId, kTestApiAuthToken,
+                          kTestSubscriberCredential),
+            test_case.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BraveVpnApiClientTests,
+    BraveVpnApiClientInvalidateCredentialsTest,
+    testing::ValuesIn(
+        WithCommonUnrecoverableCases<InvalidateCredentialsTestCase>(
+            WithCommonRawJsonCases<InvalidateCredentialsTestCase>({}))),
     [](const auto& info) { return info.param.test_name; });
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/api/device_endpoints.h
+++ b/components/brave_vpn/browser/v2/api/device_endpoints.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_DEVICE_ENDPOINTS_H_
 #define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_DEVICE_ENDPOINTS_H_
 
+#include <optional>
 #include <string>
 
 #include "base/strings/strcat.h"
@@ -35,12 +36,12 @@ inline constexpr char kHeaderGrdApiAuthToken[] = "grd-api-auth-token";
 
 // GetProfileCredentials API registers VPN credentials with an SGW node.
 // |public_key| is only required and sent for WireGuard protocol.
-// |multihop_exit_region| is optional and omitted when empty.
+// |multihop_exit_region| is optional and omitted when not set.
 struct GetProfileCredentialsRequestBody {
   std::string subscriber_credential;
   TransportProtocol transport_protocol = TransportProtocol::kIKEv2;
   std::string public_key;
-  std::string multihop_exit_region;
+  std::optional<std::string> multihop_exit_region;
 
   base::DictValue ToValue() const {
     base::DictValue dict;
@@ -50,8 +51,8 @@ struct GetProfileCredentialsRequestBody {
     if (transport_protocol == TransportProtocol::kWireguard) {
       dict.Set(kPublicKeyKey, public_key);
     }
-    if (!multihop_exit_region.empty()) {
-      dict.Set(kMultihopExitRegionKey, multihop_exit_region);
+    if (multihop_exit_region.has_value()) {
+      dict.Set(kMultihopExitRegionKey, multihop_exit_region.value());
     }
     return dict;
   }

--- a/components/brave_vpn/browser/v2/api/device_endpoints.h
+++ b/components/brave_vpn/browser/v2/api/device_endpoints.h
@@ -1,0 +1,116 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_DEVICE_ENDPOINTS_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_DEVICE_ENDPOINTS_H_
+
+#include <string>
+
+#include "base/strings/strcat.h"
+#include "base/values.h"
+#include "brave/components/brave_account/endpoint_client/request_types.h"
+#include "brave/components/brave_account/endpoint_client/response.h"
+#include "brave/components/brave_vpn/browser/v2/api/empty_request_body.h"
+#include "brave/components/brave_vpn/browser/v2/api/endpoint_constants.h"
+#include "brave/components/brave_vpn/browser/v2/api/error_body.h"
+#include "brave/components/brave_vpn/browser/v2/api/raw_json_response_body.h"
+#include "brave/components/brave_vpn/browser/v2/api/transport_protocol.h"
+#include "url/gurl.h"
+#include "url/url_constants.h"
+
+// SGW endpoints, unlike the Connect API endpoints, target a caller-supplied VPN
+// node, not a fixed host, so URL() resolves against a placeholder that every
+// client method must override via UrlReplacements::SetHost() before sending.
+
+namespace brave_vpn::v2::endpoints {
+
+// Reserved per RFC 2606; never resolved. Every endpoint below must have its
+// host overridden via UrlReplacements::SetHost().
+inline constexpr char kDeviceHostPlaceholder[] = "device.invalid";
+
+// Guardian authenticates bodyless GET calls via this request header instead.
+inline constexpr char kHeaderGrdApiAuthToken[] = "grd-api-auth-token";
+
+// GetProfileCredentials API registers VPN credentials with an SGW node.
+// |public_key| is only required and sent for WireGuard protocol.
+// |multihop_exit_region| is optional and omitted when empty.
+struct GetProfileCredentialsRequestBody {
+  std::string subscriber_credential;
+  TransportProtocol transport_protocol = TransportProtocol::kIKEv2;
+  std::string public_key;
+  std::string multihop_exit_region;
+
+  base::DictValue ToValue() const {
+    base::DictValue dict;
+    dict.Set(kSubscriberCredentialKey, subscriber_credential);
+    dict.Set(kTransportProtocolKey,
+             ToTransportProtocolString(transport_protocol));
+    if (transport_protocol == TransportProtocol::kWireguard) {
+      dict.Set(kPublicKeyKey, public_key);
+    }
+    if (!multihop_exit_region.empty()) {
+      dict.Set(kMultihopExitRegionKey, multihop_exit_region);
+    }
+    return dict;
+  }
+};
+
+struct GetProfileCredentials {
+  using Request =
+      brave_account::endpoint_client::POST<GetProfileCredentialsRequestBody>;
+  using Response = brave_account::endpoint_client::Response<RawJsonResponseBody,
+                                                            VpnErrorBody>;
+
+  static GURL URL() {
+    return GURL(base::StrCat({url::kHttpsScheme, url::kStandardSchemeSeparator,
+                              kDeviceHostPlaceholder}))
+        .Resolve(kDeviceCredentialsApi);
+  }
+};
+
+// VerifyCredentials API confirms a VPN credential (identified by a client-id
+// path segment and an api auth token) has not been invalidated.
+struct VerifyCredentials {
+  using Request = brave_account::endpoint_client::GET<EmptyRequestBody>;
+  using Response = brave_account::endpoint_client::Response<RawJsonResponseBody,
+                                                            VpnErrorBody>;
+
+  static GURL URL() {
+    return GURL(base::StrCat({url::kHttpsScheme, url::kStandardSchemeSeparator,
+                              kDeviceHostPlaceholder}))
+        .Resolve(kDeviceApi);
+  }
+};
+
+// InvalidateCredentials API explicitly disables a VPN credential (identified
+// by a client-id path segment and an api auth token). This is a destructive
+// action and should be confirmed by sending a subscriber credential too.
+struct InvalidateCredentialsRequestBody {
+  std::string api_auth_token;
+  std::string subscriber_credential;
+
+  base::DictValue ToValue() const {
+    return base::DictValue()
+        .Set(kApiAuthTokenKey, api_auth_token)
+        .Set(kSubscriberCredentialKey, subscriber_credential);
+  }
+};
+
+struct InvalidateCredentials {
+  using Request =
+      brave_account::endpoint_client::POST<InvalidateCredentialsRequestBody>;
+  using Response = brave_account::endpoint_client::Response<RawJsonResponseBody,
+                                                            VpnErrorBody>;
+
+  static GURL URL() {
+    return GURL(base::StrCat({url::kHttpsScheme, url::kStandardSchemeSeparator,
+                              kDeviceHostPlaceholder}))
+        .Resolve(kDeviceApi);
+  }
+};
+
+}  // namespace brave_vpn::v2::endpoints
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_DEVICE_ENDPOINTS_H_

--- a/components/brave_vpn/browser/v2/api/device_endpoints_unittest.cc
+++ b/components/brave_vpn/browser/v2/api/device_endpoints_unittest.cc
@@ -1,0 +1,73 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/api/device_endpoints.h"
+
+#include "base/values.h"
+#include "brave/components/brave_vpn/browser/v2/api/transport_protocol.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2::endpoints {
+namespace {
+constexpr char kTestSubscriberCredential[] = "test-subscriber-credential";
+constexpr char kTestPublicKey[] = "test-public-key";
+constexpr char kTestMultihopExitRegion[] = "us-west";
+constexpr char kTestApiAuthToken[] = "test-api-auth-token";
+}  // namespace
+
+TEST(DeviceEndpointsTest, TransportProtocolToStringConversion) {
+  EXPECT_EQ(ToTransportProtocolString(TransportProtocol::kIKEv2), "ikev2");
+  EXPECT_EQ(ToTransportProtocolString(TransportProtocol::kWireguard),
+            "wireguard");
+}
+
+TEST(DeviceEndpointsTest, GetProfileCredentialsRequestBodyToValueIkev2) {
+  // IKEv2 never sends "public-key", even if explicitly set.
+  const GetProfileCredentialsRequestBody body{
+      .subscriber_credential = kTestSubscriberCredential,
+      .transport_protocol = TransportProtocol::kIKEv2,
+      .public_key = kTestPublicKey};
+  EXPECT_EQ(body.ToValue(),
+            base::DictValue()
+                .Set("subscriber-credential", kTestSubscriberCredential)
+                .Set("transport-protocol", "ikev2"));
+}
+
+TEST(DeviceEndpointsTest, GetProfileCredentialsRequestBodyToValueWireguard) {
+  const GetProfileCredentialsRequestBody body{
+      .subscriber_credential = kTestSubscriberCredential,
+      .transport_protocol = TransportProtocol::kWireguard,
+      .public_key = kTestPublicKey};
+  EXPECT_EQ(body.ToValue(),
+            base::DictValue()
+                .Set("subscriber-credential", kTestSubscriberCredential)
+                .Set("transport-protocol", "wireguard")
+                .Set("public-key", kTestPublicKey));
+}
+
+TEST(DeviceEndpointsTest,
+     GetProfileCredentialsRequestBodyToValueIncludesMultihopExitRegionWhenSet) {
+  const GetProfileCredentialsRequestBody body{
+      .subscriber_credential = kTestSubscriberCredential,
+      .transport_protocol = TransportProtocol::kIKEv2,
+      .multihop_exit_region = kTestMultihopExitRegion};
+  EXPECT_EQ(body.ToValue(),
+            base::DictValue()
+                .Set("subscriber-credential", kTestSubscriberCredential)
+                .Set("transport-protocol", "ikev2")
+                .Set("multihop-exit-region", kTestMultihopExitRegion));
+}
+
+TEST(DeviceEndpointsTest, InvalidateCredentialsRequestBodyToValue) {
+  const InvalidateCredentialsRequestBody body{
+      .api_auth_token = kTestApiAuthToken,
+      .subscriber_credential = kTestSubscriberCredential};
+  EXPECT_EQ(body.ToValue(),
+            base::DictValue()
+                .Set("api-auth-token", kTestApiAuthToken)
+                .Set("subscriber-credential", kTestSubscriberCredential));
+}
+
+}  // namespace brave_vpn::v2::endpoints

--- a/components/brave_vpn/browser/v2/api/endpoint_constants.h
+++ b/components/brave_vpn/browser/v2/api/endpoint_constants.h
@@ -24,12 +24,17 @@ inline constexpr char kTimezonesForRegionsApi[] =
     "api/v1.1/servers/timezones-for-regions";
 inline constexpr char kHostnamesForRegionApi[] =
     "api/v1.3/servers/hostnames-for-region";
+
+// "Device" is Guardian's term for a VPN credential/connection instance, not a
+// physical device - interchangeable with "client" in Guardian's own docs. These
+// two constants along with suffixes cover registering, verifying, and
+// invalidating those credentials.
 inline constexpr char kDeviceCredentialsApi[] = "api/v1.4/device-credentials";
 inline constexpr char kDeviceApi[] = "api/v1.4/device";
-
-// Device API suffixes.
-inline constexpr char kVerifyCredentialsSuffix[] = "verify-credentials";
-inline constexpr char kInvalidateCredentialsSuffix[] = "invalidate-credentials";
+inline constexpr char kDeviceApiVerifyCredentialsSuffix[] =
+    "verify-credentials";
+inline constexpr char kDeviceApiInvalidateCredentialsSuffix[] =
+    "invalidate-credentials";
 
 // Endpoint request JSON keys that can be shared between multiple APIs.
 inline constexpr char kProductTypeKey[] = "product-type";

--- a/components/brave_vpn/browser/v2/api/endpoint_constants.h
+++ b/components/brave_vpn/browser/v2/api/endpoint_constants.h
@@ -24,6 +24,12 @@ inline constexpr char kTimezonesForRegionsApi[] =
     "api/v1.1/servers/timezones-for-regions";
 inline constexpr char kHostnamesForRegionApi[] =
     "api/v1.3/servers/hostnames-for-region";
+inline constexpr char kDeviceCredentialsApi[] = "api/v1.4/device-credentials";
+inline constexpr char kDeviceApi[] = "api/v1.4/device";
+
+// Device API suffixes.
+inline constexpr char kVerifyCredentialsSuffix[] = "verify-credentials";
+inline constexpr char kInvalidateCredentialsSuffix[] = "invalidate-credentials";
 
 // Endpoint request JSON keys that can be shared between multiple APIs.
 inline constexpr char kProductTypeKey[] = "product-type";
@@ -41,6 +47,10 @@ inline constexpr char kPaymentValidationMethodKey[] =
     "payment-validation-method";
 inline constexpr char kRegionKey[] = "region";
 inline constexpr char kRegionPrecisionKey[] = "region-precision";
+inline constexpr char kTransportProtocolKey[] = "transport-protocol";
+inline constexpr char kPublicKeyKey[] = "public-key";
+inline constexpr char kMultihopExitRegionKey[] = "multihop-exit-region";
+inline constexpr char kApiAuthTokenKey[] = "api-auth-token";
 
 // Default payment validation method used by Brave.
 inline constexpr char kValidationMethodDefaultValue[] = "brave-premium";

--- a/components/brave_vpn/browser/v2/api/transport_protocol.h
+++ b/components/brave_vpn/browser/v2/api/transport_protocol.h
@@ -1,0 +1,39 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_TRANSPORT_PROTOCOL_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_TRANSPORT_PROTOCOL_H_
+
+#include <string_view>
+
+#include "base/notreached.h"
+
+namespace brave_vpn::v2::endpoints {
+
+// The VPN tunnel protocols Guardian's device-credentials API supports.
+enum class TransportProtocol {
+  kIKEv2,
+  kWireguard,
+};
+
+inline constexpr std::string_view kTransportProtocolIKEv2Value = "ikev2";
+inline constexpr std::string_view kTransportProtocolWireguardValue =
+    "wireguard";
+
+// Returns the wire-format string Guardian expects for transport-protocol.
+inline std::string_view ToTransportProtocolString(
+    TransportProtocol transport_protocol) {
+  switch (transport_protocol) {
+    case TransportProtocol::kIKEv2:
+      return kTransportProtocolIKEv2Value;
+    case TransportProtocol::kWireguard:
+      return kTransportProtocolWireguardValue;
+  }
+  NOTREACHED();
+}
+
+}  // namespace brave_vpn::v2::endpoints
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_TRANSPORT_PROTOCOL_H_

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_android.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_android.cc
@@ -64,9 +64,9 @@ void BraveVpnServiceImpl::GetIKEv2ProfileCredentials(
     return;
   }
   api_client_->GetProfileCredentials(
-      base::BindOnce(&RunResponseCallback, std::move(callback)),
-      subscriber_credential, endpoints::TransportProtocol::kIKEv2, {}, {},
-      hostname);
+      base::BindOnce(&RunResponseCallback, std::move(callback)), hostname,
+      subscriber_credential, endpoints::TransportProtocol::kIKEv2, std::nullopt,
+      std::nullopt);
 }
 
 void BraveVpnServiceImpl::GetWireguardProfileCredentials(
@@ -79,9 +79,9 @@ void BraveVpnServiceImpl::GetWireguardProfileCredentials(
     return;
   }
   api_client_->GetProfileCredentials(
-      base::BindOnce(&RunResponseCallback, std::move(callback)),
+      base::BindOnce(&RunResponseCallback, std::move(callback)), hostname,
       subscriber_credential, endpoints::TransportProtocol::kWireguard,
-      public_key, {}, hostname);
+      public_key, std::nullopt);
 }
 
 void BraveVpnServiceImpl::VerifyCredentials(

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_android.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_android.cc
@@ -13,6 +13,7 @@
 #include "base/notimplemented.h"
 #include "base/types/expected.h"
 #include "brave/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h"
+#include "brave/components/brave_vpn/browser/v2/api/transport_protocol.h"
 #include "brave/components/brave_vpn/browser/v2/purchased_state_manager.h"
 
 namespace brave_vpn::v2 {
@@ -58,7 +59,14 @@ void BraveVpnServiceImpl::GetIKEv2ProfileCredentials(
     ResponseCallback callback,
     const std::string& subscriber_credential,
     const std::string& hostname) {
-  NOTIMPLEMENTED();
+  if (!api_client_) {
+    std::move(callback).Run({}, false);
+    return;
+  }
+  api_client_->GetProfileCredentials(
+      base::BindOnce(&RunResponseCallback, std::move(callback)),
+      subscriber_credential, endpoints::TransportProtocol::kIKEv2, {}, {},
+      hostname);
 }
 
 void BraveVpnServiceImpl::GetWireguardProfileCredentials(
@@ -66,16 +74,30 @@ void BraveVpnServiceImpl::GetWireguardProfileCredentials(
     const std::string& subscriber_credential,
     const std::string& public_key,
     const std::string& hostname) {
-  NOTIMPLEMENTED();
+  if (!api_client_) {
+    std::move(callback).Run({}, false);
+    return;
+  }
+  api_client_->GetProfileCredentials(
+      base::BindOnce(&RunResponseCallback, std::move(callback)),
+      subscriber_credential, endpoints::TransportProtocol::kWireguard,
+      public_key, {}, hostname);
 }
 
 void BraveVpnServiceImpl::VerifyCredentials(
     ResponseCallback callback,
     const std::string& hostname,
     const std::string& client_id,
-    const std::string& subscriber_credential,
+    const std::string& /*subscriber_credential*/,
     const std::string& api_auth_token) {
-  NOTIMPLEMENTED();
+  if (!api_client_) {
+    std::move(callback).Run({}, false);
+    return;
+  }
+  // Note: in v1.4 API, the subscriber credential is not used for verification.
+  api_client_->VerifyCredentials(
+      base::BindOnce(&RunResponseCallback, std::move(callback)), hostname,
+      client_id, api_auth_token);
 }
 
 void BraveVpnServiceImpl::InvalidateCredentials(
@@ -84,7 +106,13 @@ void BraveVpnServiceImpl::InvalidateCredentials(
     const std::string& client_id,
     const std::string& subscriber_credential,
     const std::string& api_auth_token) {
-  NOTIMPLEMENTED();
+  if (!api_client_) {
+    std::move(callback).Run({}, false);
+    return;
+  }
+  api_client_->InvalidateCredentials(
+      base::BindOnce(&RunResponseCallback, std::move(callback)), hostname,
+      client_id, api_auth_token, subscriber_credential);
 }
 
 void BraveVpnServiceImpl::VerifyPurchaseToken(ResponseCallback callback,


### PR DESCRIPTION
Port the four remaining SGW (per-node) endpoints to the endpoint client, using Guardian's new v1.4 device-credentials API. Collapse `GetProfileCredentials` and `GetWireguardProfileCredentials` into one api-client call taking a `TransportProtocol` (IKEv2 or WireGuard); the service layer keeps both methods, each picking a protocol.

`VerifyCredentials` moves to a headerless GET with "grd-api-auth-token" auth. `InvalidateCredentials` keeps "api-auth-token" and "subscriber-credential" in the body.

Android calls are wired up, and the new behaviour is covered by unit tests.

Implements part of https://github.com/brave/brave-browser/issues/54600

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
