### PR TITLE
[VPN 2.0] Use literal wire strings in purchase/support endpoint tests

### DIFF
--- a/components/brave_vpn/browser/v2/api/purchase_endpoints_unittest.cc
+++ b/components/brave_vpn/browser/v2/api/purchase_endpoints_unittest.cc
@@ -25,13 +25,12 @@ TEST(PurchaseEndpointsTest, GetSubscriberCredentialRequestBodyToValue) {
       .validation_method = kTestValidationMethod,
       .purchase_token = kTestPurchaseToken,
       .bundle_id = kTestBundleId};
-  EXPECT_EQ(body.ToValue(),
-            base::DictValue()
-                .Set(kProductTypeKey, kTestProductType)
-                .Set(kProductIdKey, kTestProductId)
-                .Set(kValidationMethodKey, kTestValidationMethod)
-                .Set(kPurchaseTokenKey, kTestPurchaseToken)
-                .Set(kBundleIdKey, kTestBundleId));
+  EXPECT_EQ(body.ToValue(), base::DictValue()
+                                .Set("product-type", kTestProductType)
+                                .Set("product-id", kTestProductId)
+                                .Set("validation-method", kTestValidationMethod)
+                                .Set("purchase-token", kTestPurchaseToken)
+                                .Set("bundle-id", kTestBundleId));
 }
 
 TEST(PurchaseEndpointsTest, GetSubscriberCredentialV12RequestBodyToValue) {
@@ -39,8 +38,8 @@ TEST(PurchaseEndpointsTest, GetSubscriberCredentialV12RequestBodyToValue) {
                                                        kTestSkusCredential};
   EXPECT_EQ(body.ToValue(),
             base::DictValue()
-                .Set(kValidationMethodKey, kValidationMethodDefaultValue)
-                .Set(kSkusCredentialKey, kTestSkusCredential));
+                .Set("validation-method", "brave-premium")
+                .Set("brave-vpn-premium-monthly-pass", kTestSkusCredential));
 }
 
 TEST(PurchaseEndpointsTest, VerifyPurchaseTokenRequestBodyToValue) {
@@ -50,10 +49,10 @@ TEST(PurchaseEndpointsTest, VerifyPurchaseTokenRequestBodyToValue) {
       .product_type = kTestProductType,
       .bundle_id = kTestBundleId};
   EXPECT_EQ(body.ToValue(), base::DictValue()
-                                .Set(kPurchaseTokenKey, kTestPurchaseToken)
-                                .Set(kProductIdKey, kTestProductId)
-                                .Set(kProductTypeKey, kTestProductType)
-                                .Set(kBundleIdKey, kTestBundleId));
+                                .Set("purchase-token", kTestPurchaseToken)
+                                .Set("product-id", kTestProductId)
+                                .Set("product-type", kTestProductType)
+                                .Set("bundle-id", kTestBundleId));
 }
 
 }  // namespace brave_vpn::v2::endpoints

--- a/components/brave_vpn/browser/v2/api/support_endpoints_unittest.cc
+++ b/components/brave_vpn/browser/v2/api/support_endpoints_unittest.cc
@@ -30,19 +30,18 @@ TEST(SupportEndpointsTest, CreateSupportTicketRequestBodyToValue) {
   // The encoded ticket body embeds credential, validation method, and
   // timezone as text lines, in addition to the separate JSON fields above.
   const std::string expected_encoded_body = base::Base64Encode(base::StrCat(
-      {kTestBody, "\n\n", kSubscriberCredentialKey, ": ",
-       kTestSubscriberCredential, "\n", kPaymentValidationMethodKey, ": ",
-       kValidationMethodDefaultValue, "\n", kTimezoneMetadataKey, ": ",
+      {kTestBody, "\n\nsubscriber-credential: ", kTestSubscriberCredential,
+       "\npayment-validation-method: brave-premium\ntimezone: ",
        kTestTimezone}));
 
   EXPECT_EQ(body.ToValue(),
             base::DictValue()
-                .Set(kEmailKey, kTestEmail)
-                .Set(kSubjectKey, kTestSubject)
-                .Set(kSupportTicketKey, expected_encoded_body)
-                .Set(kPartnerClientIdKey, kPartnerClientIdValue)
-                .Set(kPaymentValidationMethodKey, kValidationMethodDefaultValue)
-                .Set(kSubscriberCredentialKey, kTestSubscriberCredential));
+                .Set("email", kTestEmail)
+                .Set("subject", kTestSubject)
+                .Set("support-ticket", expected_encoded_body)
+                .Set("partner-client-id", "com.brave.browser")
+                .Set("payment-validation-method", "brave-premium")
+                .Set("subscriber-credential", kTestSubscriberCredential));
 }
 
 }  // namespace brave_vpn::v2::endpoints


### PR DESCRIPTION
Assert JSON keys and values as literals instead of the production constants `ToValue()` itself uses, so a renamed key or changed default value actually fails the test. Matches region/device endpoint tests, which already followed this pattern.

Implements part of https://github.com/brave/brave-browser/issues/54600

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
