### PR TITLE
Rename GetProfileCredentials into GetIKEv2ProfileCredentials

### DIFF
--- a/components/brave_vpn/browser/api/brave_vpn_api_request.cc
+++ b/components/brave_vpn/browser/api/brave_vpn_api_request.cc
@@ -104,7 +104,7 @@ void BraveVpnAPIRequest::GetHostnamesForRegion(
   OAuthRequest(base_url, "POST", request_body, std::move(internal_callback));
 }
 
-void BraveVpnAPIRequest::GetProfileCredentials(
+void BraveVpnAPIRequest::GetIKEv2ProfileCredentials(
     ResponseCallback callback,
     const std::string& subscriber_credential,
     const std::string& hostname) {

--- a/components/brave_vpn/browser/api/brave_vpn_api_request.h
+++ b/components/brave_vpn/browser/api/brave_vpn_api_request.h
@@ -39,9 +39,9 @@ class BraveVpnAPIRequest {
   void GetHostnamesForRegion(ResponseCallback callback,
                              const std::string& region,
                              const std::string& region_precision);
-  void GetProfileCredentials(ResponseCallback callback,
-                             const std::string& subscriber_credential,
-                             const std::string& hostname);
+  void GetIKEv2ProfileCredentials(ResponseCallback callback,
+                                  const std::string& subscriber_credential,
+                                  const std::string& hostname);
   void GetWireguardProfileCredentials(ResponseCallback callback,
                                       const std::string& subscriber_credential,
                                       const std::string& public_key,

--- a/components/brave_vpn/browser/brave_vpn_service.h
+++ b/components/brave_vpn/browser/brave_vpn_service.h
@@ -71,9 +71,10 @@ class BraveVpnService : public mojom::ServiceHandler, public KeyedService {
   virtual void GetHostnamesForRegion(ResponseCallback callback,
                                      const std::string& region,
                                      const std::string& region_precision) = 0;
-  virtual void GetProfileCredentials(ResponseCallback callback,
-                                     const std::string& subscriber_credential,
-                                     const std::string& hostname) = 0;
+  virtual void GetIKEv2ProfileCredentials(
+      ResponseCallback callback,
+      const std::string& subscriber_credential,
+      const std::string& hostname) = 0;
   virtual void GetWireguardProfileCredentials(
       ResponseCallback callback,
       const std::string& subscriber_credential,

--- a/components/brave_vpn/browser/brave_vpn_service_impl.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_impl.cc
@@ -948,12 +948,12 @@ void BraveVpnServiceImpl::GetHostnamesForRegion(
                                       region_precision);
 }
 
-void BraveVpnServiceImpl::GetProfileCredentials(
+void BraveVpnServiceImpl::GetIKEv2ProfileCredentials(
     ResponseCallback callback,
     const std::string& subscriber_credential,
     const std::string& hostname) {
-  api_request_->GetProfileCredentials(std::move(callback),
-                                      subscriber_credential, hostname);
+  api_request_->GetIKEv2ProfileCredentials(std::move(callback),
+                                           subscriber_credential, hostname);
 }
 
 void BraveVpnServiceImpl::GetWireguardProfileCredentials(

--- a/components/brave_vpn/browser/brave_vpn_service_impl.h
+++ b/components/brave_vpn/browser/brave_vpn_service_impl.h
@@ -120,9 +120,9 @@ class BraveVpnServiceImpl : public BraveVpnService,
   void GetHostnamesForRegion(ResponseCallback callback,
                              const std::string& region,
                              const std::string& region_precision) override;
-  void GetProfileCredentials(ResponseCallback callback,
-                             const std::string& subscriber_credential,
-                             const std::string& hostname) override;
+  void GetIKEv2ProfileCredentials(ResponseCallback callback,
+                                  const std::string& subscriber_credential,
+                                  const std::string& hostname) override;
   void GetWireguardProfileCredentials(ResponseCallback callback,
                                       const std::string& subscriber_credential,
                                       const std::string& public_key,

--- a/components/brave_vpn/browser/connection/ikev2/system_vpn_connection_api_impl_base.cc
+++ b/components/brave_vpn/browser/connection/ikev2/system_vpn_connection_api_impl_base.cc
@@ -296,7 +296,7 @@ void SystemVPNConnectionAPIImplBase::UpdateAndNotifyConnectionStateChange(
 }
 
 void SystemVPNConnectionAPIImplBase::FetchProfileCredentials() {
-  GetAPIRequest()->GetProfileCredentials(
+  GetAPIRequest()->GetIKEv2ProfileCredentials(
       base::BindOnce(&SystemVPNConnectionAPIImplBase::OnGetProfileCredentials,
                      base::Unretained(this)),
       GetSubscriberCredential(manager_->local_prefs()), GetHostname());

--- a/components/brave_vpn/browser/test/fake_brave_vpn_service.h
+++ b/components/brave_vpn/browser/test/fake_brave_vpn_service.h
@@ -76,9 +76,9 @@ class FakeBraveVpnService : public BraveVpnService {
   void GetHostnamesForRegion(ResponseCallback callback,
                              const std::string& region,
                              const std::string& region_precision) override {}
-  void GetProfileCredentials(ResponseCallback callback,
-                             const std::string& subscriber_credential,
-                             const std::string& hostname) override {}
+  void GetIKEv2ProfileCredentials(ResponseCallback callback,
+                                  const std::string& subscriber_credential,
+                                  const std::string& hostname) override {}
   void GetWireguardProfileCredentials(ResponseCallback callback,
                                       const std::string& subscriber_credential,
                                       const std::string& public_key,

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
@@ -87,9 +87,9 @@ class BraveVpnServiceImpl : public BraveVpnService {
   void GetHostnamesForRegion(ResponseCallback callback,
                              const std::string& region,
                              const std::string& region_precision) override;
-  void GetProfileCredentials(ResponseCallback callback,
-                             const std::string& subscriber_credential,
-                             const std::string& hostname) override;
+  void GetIKEv2ProfileCredentials(ResponseCallback callback,
+                                  const std::string& subscriber_credential,
+                                  const std::string& hostname) override;
   void GetWireguardProfileCredentials(ResponseCallback callback,
                                       const std::string& subscriber_credential,
                                       const std::string& public_key,

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_android.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_android.cc
@@ -54,7 +54,7 @@ void BraveVpnServiceImpl::GetHostnamesForRegion(
       region_precision);
 }
 
-void BraveVpnServiceImpl::GetProfileCredentials(
+void BraveVpnServiceImpl::GetIKEv2ProfileCredentials(
     ResponseCallback callback,
     const std::string& subscriber_credential,
     const std::string& hostname) {


### PR DESCRIPTION
In BraveVpnService, we currently have `GetProfileCredentials` which fetches IKEv2 profile credentials, and `GetWireguardProfileCredentials` which fetches WG profile credentials. This task is to rename the former into `GetIKEv2ProfileCredentials`, to avoid naming confusion.

Resolves https://github.com/brave/brave-browser/issues/58305

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
