### PR TITLE
[iOS] Shields Panel redesign

### DIFF
--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -301,7 +301,16 @@ var package = Package(
     .target(
       name: "BraveShields",
       dependencies: [
-        "Strings", "Preferences", "BraveCore", "BraveUI", "Web", "Data", "Shared", "BraveShared",
+        "BraveCore",
+        "BraveShared",
+        "BraveUI",
+        "Data",
+        "DesignSystem",
+        "Favicon",
+        "Preferences",
+        "Shared",
+        "Strings",
+        "Web",
       ],
       plugins: ["LoggerPlugin"]
     ),

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -7,6 +7,7 @@ import AVFoundation
 import BraveCore
 import BraveNews
 import BraveShared
+import BraveShields
 import BraveStrings
 import BraveUI
 import BraveWallet
@@ -463,7 +464,7 @@ extension BrowserViewController: TopToolbarDelegate, SearchContainerViewControll
     weak var weakPopover: PopoverController?
     let popover = PopoverController(
       contentController: PopoverNavigationController(
-        rootViewController: ShieldsPanelViewController(
+        rootViewController: LegacyShieldsPanelViewController(
           url: url,
           tab: selectedTab,
           domain: Domain.getOrCreate(forUrl: url, persistent: !selectedTab.isPrivate)
@@ -495,7 +496,7 @@ extension BrowserViewController: TopToolbarDelegate, SearchContainerViewControll
   }
 
   private func navigate(
-    to target: ShieldsPanelView.Action.NavigationTarget,
+    to target: ShieldsPanelAction.NavigationTarget,
     tab: some TabState,
     url: URL,
     on viewController: UIViewController?

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -14,6 +14,7 @@ import BraveWallet
 import BraveWidgetsModels
 import BrowserMenu
 import CertificateUtilities
+import Combine
 import Data
 import Lottie
 import Onboarding
@@ -461,38 +462,70 @@ extension BrowserViewController: TopToolbarDelegate, SearchContainerViewControll
       return
     }
 
-    weak var weakPopover: PopoverController?
-    let popover = PopoverController(
-      contentController: PopoverNavigationController(
-        rootViewController: LegacyShieldsPanelViewController(
-          url: url,
-          tab: selectedTab,
-          domain: Domain.getOrCreate(forUrl: url, persistent: !selectedTab.isPrivate)
-        ) { [weak self, weak selectedTab] action in
-          switch action {
-          case .navigate(let target, let dismiss):
-            guard let self, let selectedTab else { return }
-            if dismiss {
-              weakPopover?.dismiss(animated: true) {
-                self.navigate(to: target, tab: selectedTab, url: url, on: nil)
-              }
-            } else {
-              navigate(to: target, tab: selectedTab, url: url, on: weakPopover)
-            }
-          case .changedShieldSettings:
-            self?.changedShieldSettings()
-          case .shredSiteData:
-            weakPopover?.dismiss(animated: true) {
-              guard let selectedTab = selectedTab else { return }
-              self?.shredData(for: url, in: selectedTab)
-            }
+    weak var weakShieldsPanelVC: UIViewController?
+    let shieldsPanelActionHandler: (ShieldsPanelAction) -> Void = {
+      [weak self, weak selectedTab] action in
+      guard let self, let selectedTab else { return }
+      switch action {
+      case .navigate(let target, let dismiss):
+        if dismiss {
+          weakShieldsPanelVC?.dismiss(animated: true) {
+            self.navigate(to: target, tab: selectedTab, url: url, on: nil)
           }
+        } else {
+          self.navigate(to: target, tab: selectedTab, url: url, on: weakShieldsPanelVC)
         }
-      ),
-      contentSizeBehavior: .preferredContentSize
-    )
-    weakPopover = popover
-    popover.present(from: topToolbar.shieldsButton, on: self)
+      case .changedShieldSettings:
+        self.changedShieldSettings()
+      case .shredSiteData:
+        weakShieldsPanelVC?.dismiss(animated: true) {
+          self.shredData(for: url, in: selectedTab)
+        }
+      }
+    }
+    if FeatureList.kShowUpdatedShieldsPanel.enabled {
+      let shieldsPanelViewController = ShieldsPanelViewController(
+        url: url,
+        viewModel: ShieldsPanelViewModel(
+          tab: selectedTab,
+          stats: selectedTab.contentBlocker?.$stats.eraseToAnyPublisher()
+            ?? Just(.init()).eraseToAnyPublisher(),
+          blockedRequests: selectedTab.contentBlocker?.$blockedRequests.map(Array.init)
+            .eraseToAnyPublisher() ?? Just([]).eraseToAnyPublisher(),
+          isShredEnabled: FeatureList.kBraveShredFeature.enabled
+        ),
+        action: shieldsPanelActionHandler
+      )
+      weakShieldsPanelVC = shieldsPanelViewController
+      if UIDevice.current.userInterfaceIdiom == .pad {
+        shieldsPanelViewController.modalPresentationStyle = .popover
+      }
+      shieldsPanelViewController.popoverPresentationController?.sourceView =
+        topToolbar.shieldsButton
+      shieldsPanelViewController.popoverPresentationController?.sourceRect =
+        topToolbar.shieldsButton.bounds
+      shieldsPanelViewController.popoverPresentationController?.popoverLayoutMargins = .init(
+        equalInset: 4
+      )
+      shieldsPanelViewController.popoverPresentationController?.permittedArrowDirections = [
+        .up, .down,
+      ]
+      self.present(shieldsPanelViewController, animated: true)
+    } else {
+      let popover = PopoverController(
+        contentController: PopoverNavigationController(
+          rootViewController: LegacyShieldsPanelViewController(
+            url: url,
+            tab: selectedTab,
+            domain: Domain.getOrCreate(forUrl: url, persistent: !selectedTab.isPrivate),
+            callback: shieldsPanelActionHandler
+          )
+        ),
+        contentSizeBehavior: .preferredContentSize
+      )
+      weakShieldsPanelVC = popover
+      popover.present(from: topToolbar.shieldsButton, on: self)
+    }
   }
 
   private func navigate(

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -481,6 +481,14 @@ extension BrowserViewController: TopToolbarDelegate, SearchContainerViewControll
         weakShieldsPanelVC?.dismiss(animated: true) {
           self.shredData(for: url, in: selectedTab)
         }
+      case .openURLInNewTab(let url):
+        weakShieldsPanelVC?.dismiss(animated: true) {
+          self.tabManager.addTabAndSelect(
+            URLRequest(url: url),
+            afterTab: selectedTab,
+            isPrivate: selectedTab.isPrivate
+          )
+        }
       }
     }
     if FeatureList.kShowUpdatedShieldsPanel.enabled {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
@@ -358,6 +358,10 @@ class QuickViewController: UIViewController {
       weakShieldsPanelVC = shieldsPanelViewController
       if UIDevice.current.userInterfaceIdiom == .pad {
         shieldsPanelViewController.modalPresentationStyle = .popover
+      } else {
+        // A sheet stacked on top of this one only nests behind it at the `.large` detent, otherwise
+        // UIKit slides this one out of view for the duration of the presentation.
+        expandToLargeDetentForStackedSheet()
       }
       shieldsPanelViewController.popoverPresentationController?.sourceView =
         toolbarHostingController.rootView.shieldBackgroundView.uiView
@@ -384,6 +388,16 @@ class QuickViewController: UIViewController {
       )
       weakShieldsPanelVC = popover
       popover.present(from: toolbarHostingController.rootView.shieldBackgroundView.uiView, on: self)
+    }
+  }
+
+  /// Moves this sheet to the `.large` detent so a sheet presented on top of it nests behind it
+  /// rather than pushing it out of view.
+  private func expandToLargeDetentForStackedSheet() {
+    guard let sheet = sheetPresentationController, sheet.selectedDetentIdentifier != .large
+    else { return }
+    sheet.animateChanges {
+      sheet.selectedDetentIdentifier = .large
     }
   }
 
@@ -474,6 +488,9 @@ class QuickViewController: UIViewController {
       sheet.widthFollowsPreferredContentSizeWhenEdgeAttached = true
       sheet.detents = [.medium(), .large()]
       sheet.prefersGrabberVisible = true
+    }
+    if UIDevice.current.userInterfaceIdiom != .pad {
+      expandToLargeDetentForStackedSheet()
     }
     present(viewController, animated: true)
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
@@ -314,48 +314,77 @@ class QuickViewController: UIViewController {
       return
     }
 
-    weak var weakPopover: PopoverController?
-    let popover = PopoverController(
-      contentController: PopoverNavigationController(
-        rootViewController: LegacyShieldsPanelViewController(
-          url: url,
-          tab: tab,
-          domain: Domain.getOrCreate(forUrl: url, persistent: !tab.isPrivate),
-          isAdvancedControlsEnabled: false
-        ) { [weak self] action in
-          guard let self else { return }
-          switch action {
-          case .navigate(let target, _):
-            switch target {
-            case .reportBrokenSite:
-              weakPopover?.dismiss(animated: true) {
-                self.showSubmitReportView(for: url)
-              }
-            case .shareStats:
-              weakPopover?.dismiss(animated: true) {
-                let activityController =
-                  ShieldsActivityItemSourceProvider.shared.setupGlobalShieldsActivityController(
-                    isPrivateBrowsing: tab.isPrivate
-                  )
-                self.present(activityController, animated: true, completion: nil)
-              }
-            case .globalShields:  // not available in quickview mode
-              break
-            }
-          case .changedShieldSettings:
-            self.changedShieldSettings()
-          case .shredSiteData:  // not available in quickview mode
-            break
+    weak var weakShieldsPanelVC: UIViewController?
+    let shieldsPanelActionHandler: (ShieldsPanelAction) -> Void = { [weak self] action in
+      guard let self else { return }
+      switch action {
+      case .navigate(let target, _):
+        switch target {
+        case .reportBrokenSite:
+          weakShieldsPanelVC?.dismiss(animated: true) {
+            self.showSubmitReportView(for: url)
           }
+        case .shareStats:
+          weakShieldsPanelVC?.dismiss(animated: true) {
+            let activityController =
+              ShieldsActivityItemSourceProvider.shared.setupGlobalShieldsActivityController(
+                isPrivateBrowsing: tab.isPrivate
+              )
+            self.present(activityController, animated: true, completion: nil)
+          }
+        case .globalShields:  // not available in quickview mode
+          break
         }
-      ),
-      contentSizeBehavior: .preferredContentSize
-    )
-    weakPopover = popover
-    popover.present(
-      from: toolbarHostingController.rootView.shieldBackgroundView.uiView,
-      on: self
-    )
+      case .changedShieldSettings:
+        self.changedShieldSettings()
+      case .shredSiteData:  // not available in quickview mode
+        break
+      }
+    }
+    if FeatureList.kShowUpdatedShieldsPanel.enabled {
+      let shieldsPanelViewController = ShieldsPanelViewController(
+        url: url,
+        viewModel: ShieldsPanelViewModel(
+          tab: tab,
+          stats: tab.contentBlocker?.$stats.eraseToAnyPublisher()
+            ?? Just(.init()).eraseToAnyPublisher(),
+          blockedRequests: tab.contentBlocker?.$blockedRequests.map(Array.init)
+            .eraseToAnyPublisher() ?? Just([]).eraseToAnyPublisher(),
+          isAdvancedControlsEnabled: false,
+          isShredEnabled: false
+        ),
+        action: shieldsPanelActionHandler
+      )
+      weakShieldsPanelVC = shieldsPanelViewController
+      if UIDevice.current.userInterfaceIdiom == .pad {
+        shieldsPanelViewController.modalPresentationStyle = .popover
+      }
+      shieldsPanelViewController.popoverPresentationController?.sourceView =
+        toolbarHostingController.rootView.shieldBackgroundView.uiView
+      shieldsPanelViewController.popoverPresentationController?.sourceRect =
+        toolbarHostingController.rootView.shieldBackgroundView.uiView.bounds
+      shieldsPanelViewController.popoverPresentationController?.popoverLayoutMargins = .init(
+        equalInset: 4
+      )
+      shieldsPanelViewController.popoverPresentationController?.permittedArrowDirections = [
+        .up, .down,
+      ]
+      self.present(shieldsPanelViewController, animated: true)
+    } else {
+      let popover = PopoverController(
+        contentController: PopoverNavigationController(
+          rootViewController: LegacyShieldsPanelViewController(
+            url: url,
+            tab: tab,
+            domain: Domain.getOrCreate(forUrl: url, persistent: !tab.isPrivate),
+            callback: shieldsPanelActionHandler
+          )
+        ),
+        contentSizeBehavior: .preferredContentSize
+      )
+      weakShieldsPanelVC = popover
+      popover.present(from: toolbarHostingController.rootView.shieldBackgroundView.uiView, on: self)
+    }
   }
 
   private func presentSSLStatusView() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
@@ -339,6 +339,8 @@ class QuickViewController: UIViewController {
         self.changedShieldSettings()
       case .shredSiteData:  // not available in quickview mode
         break
+      case .openURLInNewTab(let url):
+        self.openNewTab(with: URLRequest(url: url), inPrivateMode: currentTab?.isPrivate ?? false)
       }
     }
     if FeatureList.kShowUpdatedShieldsPanel.enabled {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
@@ -317,7 +317,7 @@ class QuickViewController: UIViewController {
     weak var weakPopover: PopoverController?
     let popover = PopoverController(
       contentController: PopoverNavigationController(
-        rootViewController: ShieldsPanelViewController(
+        rootViewController: LegacyShieldsPanelViewController(
           url: url,
           tab: tab,
           domain: Domain.getOrCreate(forUrl: url, persistent: !tab.isPrivate),

--- a/ios/brave-ios/Sources/Brave/Frontend/Shields/LegacyShieldsPanelView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Shields/LegacyShieldsPanelView.swift
@@ -40,7 +40,8 @@ struct LegacyShieldsPanelView: View {
         ?? Just(.init()).eraseToAnyPublisher(),
       blockedRequests: tab.contentBlocker?.$blockedRequests.map(Array.init)
         .eraseToAnyPublisher() ?? Just([]).eraseToAnyPublisher(),
-      isAdvancedControlsEnabled: isAdvancedControlsEnabled
+      isAdvancedControlsEnabled: isAdvancedControlsEnabled,
+      isShredEnabled: FeatureList.kBraveShredFeature.enabled
     )
     self.actionCallback = callback
     self.displayHost =
@@ -64,8 +65,8 @@ struct LegacyShieldsPanelView: View {
             .foregroundStyle(Color(braveSystemName: .textSecondary))
             .multilineTextAlignment(.leading)
             .padding(.horizontal)
-            .padding(.bottom, viewModel.advancedControlsEnabled ? nil : 16)
-          if viewModel.advancedControlsEnabled {
+            .padding(.bottom, viewModel.isAdvancedControlsEnabled ? nil : 16)
+          if viewModel.isAdvancedControlsEnabled {
             DisclosureGroup(isExpanded: $advancedShieldsExpanded) {
               advancedShieldsSection
             } label: {
@@ -240,7 +241,7 @@ struct LegacyShieldsPanelView: View {
         actionCallback(.changedShieldSettings)
       }
     }
-    if FeatureList.kBraveShredFeature.enabled {
+    if viewModel.isShredEnabled {
       ShieldSettingRow {
         NavigationLink {
           ShredSiteSettingsView(

--- a/ios/brave-ios/Sources/Brave/Frontend/Shields/LegacyShieldsPanelView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Shields/LegacyShieldsPanelView.swift
@@ -16,31 +16,21 @@ import Strings
 import SwiftUI
 import Web
 
-struct ShieldsPanelView: View {
-  enum Action {
-    enum NavigationTarget {
-      case shareStats
-      case reportBrokenSite
-      case globalShields
-    }
-    case navigate(NavigationTarget, dismiss: Bool)
-    case changedShieldSettings
-    case shredSiteData
-  }
+struct LegacyShieldsPanelView: View {
 
   private let url: URL
   private var tab: any TabState
   private let displayHost: String
   @AppStorage("advancedShieldsExpanded") private var advancedShieldsExpanded = false
   @ObservedObject private var viewModel: ShieldsPanelViewModel
-  private var actionCallback: (Action) -> Void
+  private var actionCallback: (ShieldsPanelAction) -> Void
 
   @MainActor init(
     url: URL,
     tab: some TabState,
     domain: Domain,
     isAdvancedControlsEnabled: Bool,
-    callback: @escaping (Action) -> Void
+    callback: @escaping (ShieldsPanelAction) -> Void
   ) {
     self.url = url
     self.tab = tab
@@ -367,17 +357,19 @@ private struct ShieldSettingSectionHeader: View {
   }
 }
 
-class ShieldsPanelViewController: UIHostingController<ShieldsPanelView>, PopoverContentComponent {
-  private let shieldsPanelView: ShieldsPanelView
+class LegacyShieldsPanelViewController: UIHostingController<LegacyShieldsPanelView>,
+  PopoverContentComponent
+{
+  private let shieldsPanelView: LegacyShieldsPanelView
 
   init(
     url: URL,
     tab: some TabState,
     domain: Domain,
     isAdvancedControlsEnabled: Bool = true,
-    callback: @escaping (ShieldsPanelView.Action) -> Void
+    callback: @escaping (ShieldsPanelAction) -> Void
   ) {
-    let shieldsPanelView = ShieldsPanelView(
+    let shieldsPanelView = LegacyShieldsPanelView(
       url: url,
       tab: tab,
       domain: domain,

--- a/ios/brave-ios/Sources/BraveShields/ShieldLevel.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldLevel.swift
@@ -5,9 +5,10 @@
 
 import BraveCore
 import Foundation
+import Strings
 
 /// A 3 part option for shield levels varying in strength of blocking content
-public enum ShieldLevel: String, CaseIterable, Hashable {
+public enum ShieldLevel: String, CaseIterable, Hashable, Identifiable {
   /// Mode blocks all content
   case aggressive
   /// Mode indicating that 1st party content is not blocked for default and regional lists
@@ -44,6 +45,16 @@ public enum ShieldLevel: String, CaseIterable, Hashable {
     case .aggressive: return .aggressive
     case .standard: return .standard
     case .disabled: return .allow
+    }
+  }
+
+  public var id: Self { self }
+
+  public var localizedTitle: String {
+    switch self {
+    case .aggressive: return Strings.Shields.trackersAndAdsBlockingAggressive
+    case .disabled: return Strings.Shields.trackersAndAdsBlockingDisabled
+    case .standard: return Strings.Shields.trackersAndAdsBlockingStandard
     }
   }
 }

--- a/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
@@ -920,6 +920,54 @@ extension Strings.Shields {
   )
 }
 
+// MARK: Shields Panel
+extension Strings.Shields {
+  public static let shieldsUpForSite = NSLocalizedString(
+    "shields.shieldsUpForSite",
+    bundle: .module,
+    value: "Shields is **up** for this site",
+    comment: "A label displayed on Shields panel beside the toggle disabling shields."
+  )
+  public static let shieldsDownForSite = NSLocalizedString(
+    "shields.shieldsDownForSite",
+    bundle: .module,
+    value: "Shields is **down** for this site",
+    comment: "A label displayed on Shields panel beside the toggle enabling shields."
+  )
+  public static let trackersAdsAndMoreBlocked = NSLocalizedString(
+    "shields.trackersAdsAndMoreBlocked",
+    bundle: .module,
+    value: "trackers, ads, and more blocked",
+    comment: "A label displayed on Shields panel beside the number of blocked items."
+  )
+  public static let siteSeemsBroken = NSLocalizedString(
+    "shields.siteSeemsBroken",
+    bundle: .module,
+    value:
+      "If this site seems broken, try toggling Shields off. This may reduce Brave's privacy protections. [Learn more](%@)",
+    comment:
+      "A label displayed on Shields panel at the bottom. Learn more link is clickable, where `%@` will be replaced with the URL."
+  )
+  public static let shieldsGlobalSettingsButtonTitle = NSLocalizedString(
+    "shields.shieldsGlobalSettings",
+    bundle: .module,
+    value: "Shields Global Settings",
+    comment: "A button title displayed on Shields panel linking to Shields global settings."
+  )
+  public static let siteNotWorkingCorrectly = NSLocalizedString(
+    "shields.siteNotWorkingCorrectly",
+    bundle: .module,
+    value: "Is this site not working correctly with Shields up?",
+    comment: "A footer displayed on Shields panel when shields are down."
+  )
+  public static let reportBrokenSiteButtonTitle = NSLocalizedString(
+    "shields.reportBrokenSiteButtonTitle",
+    bundle: .module,
+    value: "Report",
+    comment: "A button title displayed on Shields panel linking to Webcompat Reporter."
+  )
+}
+
 extension Strings.Shields {
   public static let toggleHint = NSLocalizedString(
     "BraveShieldsToggleHint",

--- a/ios/brave-ios/Sources/BraveShields/ShieldsPanelAction.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldsPanelAction.swift
@@ -1,0 +1,17 @@
+// Copyright 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+public enum ShieldsPanelAction {
+  public enum NavigationTarget {
+    case shareStats
+    case reportBrokenSite
+    case globalShields
+  }
+  case navigate(NavigationTarget, dismiss: Bool)
+  case changedShieldSettings
+  case shredSiteData
+}

--- a/ios/brave-ios/Sources/BraveShields/ShieldsPanelAction.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldsPanelAction.swift
@@ -14,4 +14,5 @@ public enum ShieldsPanelAction {
   case navigate(NavigationTarget, dismiss: Bool)
   case changedShieldSettings
   case shredSiteData
+  case openURLInNewTab(URL)
 }

--- a/ios/brave-ios/Sources/BraveShields/ShieldsPanelView.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldsPanelView.swift
@@ -5,6 +5,7 @@
 
 import BraveCore
 import BraveShared
+import BraveUI
 import DesignSystem
 import Favicon
 import Strings
@@ -20,6 +21,7 @@ public struct ShieldsPanelView: View {
   private var action: (ShieldsPanelAction) -> Void
 
   @ScaledMetric private var faviconCircleSize = 32
+  @Environment(\.openURL) private var openURL
 
   public init(
     url: URL,
@@ -39,6 +41,15 @@ public struct ShieldsPanelView: View {
     NavigationStack {
       Form {
         shieldsToggle
+          .osAvailabilityModifiers {
+            // we only want to tweak horizontal when possible
+            // 4pts horizontal padding so the toggle isn't cut off
+            if #available(iOS 26, *) {
+              $0.listRowInsets([.horizontal], 4)
+            } else {
+              $0.listRowInsets(EdgeInsets(top: 8, leading: 4, bottom: 8, trailing: 4))
+            }
+          }
           .listRowBackground(Color.clear)
           .onChange(of: viewModel.shieldsEnabled) { _, _ in
             action(.changedShieldSettings)
@@ -69,11 +80,11 @@ public struct ShieldsPanelView: View {
   @ViewBuilder private var shieldsUpView: some View {
     Section {
       HStack {
-        Text("\(viewModel.stats.total)")
+        Text(viewModel.stats.total, format: .number)
           .font(.title2.weight(.semibold))
         Text(Strings.Shields.trackersAdsAndMoreBlocked)
-          .font(.footnote)
       }
+      .accessibilityElement(children: .combine)
     } footer: {
       if !viewModel.isAdvancedControlsEnabled {
         // display footer still when advanced controls disabled
@@ -99,7 +110,7 @@ public struct ShieldsPanelView: View {
 
   @ViewBuilder private var shieldsToggle: some View {
     Toggle(isOn: $viewModel.shieldsEnabled) {
-      HStack {
+      AccessibilityHStack {
         FaviconImage(
           url: url,
           isPrivateBrowsing: viewModel.isPrivateBrowsing
@@ -116,6 +127,9 @@ public struct ShieldsPanelView: View {
           URLElidedText(text: displayHost)
             .font(.title2.weight(.semibold))
             .foregroundStyle(viewModel.shieldsEnabled ? .primary : .secondary)
+            // keep text centred for AccessibilityHStack when isAccessibilitySize
+            .frame(maxWidth: .infinity)
+            .multilineTextAlignment(.center)
           Text(
             LocalizedStringKey(
               viewModel.shieldsEnabled
@@ -124,6 +138,9 @@ public struct ShieldsPanelView: View {
           )
           .font(.footnote)
           .foregroundStyle(.secondary)
+          // keep text centred for AccessibilityHStack when isAccessibilitySize
+          .frame(maxWidth: .infinity)
+          .multilineTextAlignment(.center)
         }
       }
     }
@@ -212,6 +229,7 @@ public struct ShieldsPanelView: View {
     Section {
       HStack {
         Text(Strings.Shields.siteNotWorkingCorrectly)
+        Spacer()
         Button {
           action(.navigate(.reportBrokenSite, dismiss: true))
         } label: {
@@ -264,7 +282,6 @@ public class ShieldsPanelViewController: UIHostingController<ShieldsPanelView> {
   public init(
     url: URL,
     viewModel: ShieldsPanelViewModel,
-    isShredEnabled: Bool = true,
     action: @escaping (ShieldsPanelAction) -> Void
   ) {
     super.init(
@@ -330,4 +347,27 @@ public class ShieldsPanelViewController: UIHostingController<ShieldsPanelView> {
 
 extension UISheetPresentationController.Detent.Identifier {
   fileprivate static let fitsContent: Self = .init("fitsContent")
+}
+
+/// HStack unless using an accessibility text size, then uses a VStack
+private struct AccessibilityHStack<Content: View>: View {
+
+  let content: Content
+  @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+  init(@ViewBuilder content: () -> Content) {
+    self.content = content()
+  }
+
+  var body: some View {
+    if dynamicTypeSize.isAccessibilitySize {
+      VStack {
+        content
+      }
+    } else {
+      HStack {
+        content
+      }
+    }
+  }
 }

--- a/ios/brave-ios/Sources/BraveShields/ShieldsPanelView.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldsPanelView.swift
@@ -21,7 +21,6 @@ public struct ShieldsPanelView: View {
   private var action: (ShieldsPanelAction) -> Void
 
   @ScaledMetric private var faviconCircleSize = 32
-  @Environment(\.openURL) private var openURL
 
   public init(
     url: URL,
@@ -75,6 +74,13 @@ public struct ShieldsPanelView: View {
         onContentHeightChanged?(height)
       }
     }
+    .environment(
+      \.openURL,
+      .init(handler: { [action] url in
+        action(.openURLInNewTab(url))
+        return .handled
+      })
+    )
   }
 
   @ViewBuilder private var shieldsUpView: some View {

--- a/ios/brave-ios/Sources/BraveShields/ShieldsPanelView.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldsPanelView.swift
@@ -1,0 +1,333 @@
+// Copyright 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveCore
+import BraveShared
+import DesignSystem
+import Favicon
+import Strings
+import SwiftUI
+
+public struct ShieldsPanelView: View {
+  /// Called with the height required to display the panel's contents without scrolling
+  public var onContentHeightChanged: ((CGFloat) -> Void)?
+
+  private let url: URL
+  private let displayHost: String
+  @ObservedObject private var viewModel: ShieldsPanelViewModel
+  private var action: (ShieldsPanelAction) -> Void
+
+  @ScaledMetric private var faviconCircleSize = 32
+
+  public init(
+    url: URL,
+    viewModel: ShieldsPanelViewModel,
+    action: @escaping (ShieldsPanelAction) -> Void
+  ) {
+    self.url = url
+    self.viewModel = viewModel
+    self.action = action
+    self.displayHost =
+      "\u{200E}\(URLFormatter.formatURLOrigin(forDisplayOmitSchemePathAndTrivialSubdomains: url.strippingBlobURLAuth.absoluteString))"
+  }
+
+  @AppStorage("advancedShieldsExpanded") private var isAdvancedControlsExpanded: Bool = false
+
+  public var body: some View {
+    NavigationStack {
+      Form {
+        shieldsToggle
+          .listRowBackground(Color.clear)
+          .onChange(of: viewModel.shieldsEnabled) { _, _ in
+            action(.changedShieldSettings)
+          }
+
+        if viewModel.shieldsEnabled {
+          shieldsUpView
+        } else {
+          shieldsDownView
+        }
+      }
+      .listSectionSpacing(.compact)
+      .contentMargins(.top, 16, for: .scrollContent)
+      // `isAdvancedControlsExpanded` is backed by UserDefaults, so it's change
+      // lands outside of a `withAnimation` transaction. Need to animate off
+      // value instead.
+      .animation(.default, value: isAdvancedControlsExpanded)
+      // A `Form` has no usable ideal size (it always fills its container),
+      // so pull height from underlying ScrollView instead.
+      .onScrollGeometryChange(for: CGFloat.self) { geometry in
+        geometry.contentSize.height
+      } action: { _, height in
+        onContentHeightChanged?(height)
+      }
+    }
+  }
+
+  @ViewBuilder private var shieldsUpView: some View {
+    Section {
+      HStack {
+        Text("\(viewModel.stats.total)")
+          .font(.title2)
+          .fontWeight(.semibold)
+        Text(Strings.Shields.trackersAdsAndMoreBlocked)
+          .font(.footnote)
+      }
+    } footer: {
+      if !viewModel.isAdvancedControlsEnabled {
+        // display footer still when advanced controls disabled
+        footerView
+      }
+    }
+
+    if viewModel.isAdvancedControlsEnabled {
+      Section {
+        DisclosureGroup(isExpanded: $isAdvancedControlsExpanded) {
+          advancedShieldsSection
+        } label: {
+          Text(Strings.Shields.advancedControls)
+            .foregroundStyle(Color(braveSystemName: .textPrimary))
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .disclosureGroupStyle(ShieldsPanelDisclosureStyle())
+      } footer: {
+        footerView
+      }
+    }
+  }
+
+  @ViewBuilder private var shieldsToggle: some View {
+    Toggle(isOn: $viewModel.shieldsEnabled) {
+      HStack {
+        FaviconImage(
+          url: url,
+          isPrivateBrowsing: viewModel.isPrivateBrowsing
+        )
+        .padding(8)
+        .frame(width: faviconCircleSize, height: faviconCircleSize, alignment: .center)
+        .background(Color(braveSystemName: .pageBackground), in: .circle)
+        .shadow(radius: 1.5, x: 0, y: 1)
+        VStack(alignment: .leading) {
+          URLElidedText(text: displayHost)
+            .font(.title2)
+            .fontWeight(.semibold)
+            .foregroundStyle(viewModel.shieldsEnabled ? .primary : .secondary)
+          Group {
+            Text(
+              LocalizedStringKey(
+                viewModel.shieldsEnabled
+                  ? Strings.Shields.shieldsUpForSite : Strings.Shields.shieldsDownForSite
+              )
+            )
+          }
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+        }
+      }
+    }
+    .tint(Color(braveSystemName: .primary40))
+  }
+
+  @ViewBuilder private var footerView: some View {
+    Text(
+      LocalizedStringKey(
+        String.localizedStringWithFormat(
+          Strings.Shields.siteSeemsBroken,
+          URL.Brave.privacyFeatures.absoluteString
+        )
+      )
+    )
+    .foregroundStyle(Color.secondary)
+    .font(.caption)
+  }
+
+  @ViewBuilder private var advancedShieldsSection: some View {
+    Picker(selection: $viewModel.blockAdsAndTrackingLevel) {
+      ForEach(ShieldLevel.allCases) { level in
+        Text(level.localizedTitle)
+          .tag(level)
+      }
+    } label: {
+      Text(Strings.Shields.trackersAndAdsBlocking)
+    }
+    .onChange(of: viewModel.blockAdsAndTrackingLevel) { _, _ in
+      action(.changedShieldSettings)
+    }
+
+    Toggle(Strings.Shields.blockScripts, isOn: $viewModel.blockScripts)
+      .tint(Color(braveSystemName: .primary40))
+      .onChange(of: viewModel.blockScripts) { _, _ in
+        action(.changedShieldSettings)
+      }
+
+    Toggle(Strings.Shields.fingerprintingProtection, isOn: $viewModel.fingerprintProtection)
+      .tint(Color(braveSystemName: .primary40))
+      .onChange(of: viewModel.fingerprintProtection) { _, _ in
+        action(.changedShieldSettings)
+      }
+
+    if viewModel.isShredEnabled {
+      NavigationLink {
+        ShredSiteSettingsView(viewModel: viewModel) {
+          action(.shredSiteData)
+        }
+      } label: {
+        HStack {
+          Text(Strings.Shields.shredSiteData)
+            .multilineTextAlignment(.leading)
+          Spacer()
+          Text(viewModel.autoShredLevel.localizedTitle)
+            .multilineTextAlignment(.trailing)
+            .foregroundStyle(.secondary)
+        }
+      }
+    }
+
+    if FeatureList.kBraveIOSDebugAdblock.enabled {
+      NavigationLink {
+        AdblockBlockedRequestsView(
+          url: url.baseDomain ?? url.absoluteDisplayString,
+          blockedRequests: viewModel.blockedRequests
+        )
+      } label: {
+        Text(Strings.Shields.blockedRequestsTitle)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .multilineTextAlignment(.leading)
+      }
+    }
+
+    Button {
+      action(.navigate(.globalShields, dismiss: true))
+    } label: {
+      Label(Strings.Shields.shieldsGlobalSettingsButtonTitle, braveSystemImage: "leo.launch")
+        .labelStyle(RightIconLabelStyle())
+        .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+  }
+
+  @ViewBuilder private var shieldsDownView: some View {
+    Section {
+      HStack {
+        Text(Strings.Shields.siteNotWorkingCorrectly)
+        Button {
+          action(.navigate(.reportBrokenSite, dismiss: true))
+        } label: {
+          Text(Strings.Shields.reportBrokenSiteButtonTitle)
+        }
+        .buttonStyle(.filled)
+      }
+    }
+  }
+}
+
+struct ShieldsPanelDisclosureStyle: DisclosureGroupStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    Button {
+      configuration.isExpanded.toggle()
+    } label: {
+      HStack {
+        configuration.label
+        Image(braveSystemName: "leo.carat.down")
+          .font(.body)
+          .rotationEffect(.degrees(configuration.isExpanded ? -180 : 0))
+      }
+      .contentShape(Rectangle())
+    }
+    .buttonStyle(.plain)
+
+    if configuration.isExpanded {
+      configuration.content
+        .transition(
+          .asymmetric(
+            insertion: .move(edge: .top).combined(with: .opacity),
+            removal: .identity
+          )
+        )
+    }
+  }
+}
+
+private struct RightIconLabelStyle: LabelStyle {
+  func makeBody(configuration: Configuration) -> some View {
+    HStack {
+      configuration.title
+      Spacer()
+      configuration.icon
+    }
+  }
+}
+
+public class ShieldsPanelViewController: UIHostingController<ShieldsPanelView> {
+  public init(
+    url: URL,
+    viewModel: ShieldsPanelViewModel,
+    isShredEnabled: Bool = true,
+    action: @escaping (ShieldsPanelAction) -> Void
+  ) {
+    super.init(
+      rootView: ShieldsPanelView(
+        url: url,
+        viewModel: viewModel,
+        action: action
+      )
+    )
+    rootView.onContentHeightChanged = { [weak self] height in
+      self?.updateContentHeight(height)
+    }
+  }
+
+  @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  /// The height the panel's contents need, as measured by SwiftUI. Zero until the first measurement
+  /// lands.
+  private var contentHeight: CGFloat = 0
+
+  private var sheetController: UISheetPresentationController? {
+    sheetPresentationController
+      ?? popoverPresentationController?.adaptiveSheetPresentationController
+  }
+
+  private func updateContentHeight(_ height: CGFloat) {
+    // Ignore rounding differences during a resize to avoid needlessly
+    // invalidating detents
+    guard height > 0, abs(height - contentHeight) > 1 else { return }
+    let isFirstMeasurement = contentHeight == 0
+    contentHeight = height
+    preferredContentSize = CGSize(width: 375, height: height)
+    guard let sheetController else { return }
+    if isFirstMeasurement {
+      sheetController.invalidateDetents()
+    } else {
+      sheetController.animateChanges {
+        sheetController.invalidateDetents()
+      }
+    }
+  }
+
+  public override func viewIsAppearing(_ animated: Bool) {
+    super.viewIsAppearing(animated)
+
+    if let sheetController {
+      sheetController.detents = [
+        .custom(identifier: .fitsContent) { [weak self] context in
+          guard let height = self?.contentHeight, height > 0 else {
+            return context.maximumDetentValue
+          }
+          return min(context.maximumDetentValue, height)
+        },
+        .large(),
+      ]
+      sheetController.prefersGrabberVisible = true
+      sheetController.prefersEdgeAttachedInCompactHeight = true
+    }
+  }
+}
+
+extension UISheetPresentationController.Detent.Identifier {
+  fileprivate static let fitsContent: Self = .init("fitsContent")
+}

--- a/ios/brave-ios/Sources/BraveShields/ShieldsPanelView.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldsPanelView.swift
@@ -70,8 +70,7 @@ public struct ShieldsPanelView: View {
     Section {
       HStack {
         Text("\(viewModel.stats.total)")
-          .font(.title2)
-          .fontWeight(.semibold)
+          .font(.title2.weight(.semibold))
         Text(Strings.Shields.trackersAdsAndMoreBlocked)
           .font(.footnote)
       }
@@ -106,22 +105,23 @@ public struct ShieldsPanelView: View {
           isPrivateBrowsing: viewModel.isPrivateBrowsing
         )
         .padding(8)
-        .frame(width: faviconCircleSize, height: faviconCircleSize, alignment: .center)
-        .background(Color(braveSystemName: .pageBackground), in: .circle)
-        .shadow(radius: 1.5, x: 0, y: 1)
+        .frame(width: faviconCircleSize, height: faviconCircleSize)
+        .background(
+          Color(braveSystemName: .pageBackground)
+            .shadow(.drop(color: Color(braveSystemName: .elevationSecondary), radius: 2, y: 1))
+            .shadow(.drop(color: Color(braveSystemName: .elevationSecondary), radius: 3, y: 1)),
+          in: .circle
+        )
         VStack(alignment: .leading) {
           URLElidedText(text: displayHost)
-            .font(.title2)
-            .fontWeight(.semibold)
+            .font(.title2.weight(.semibold))
             .foregroundStyle(viewModel.shieldsEnabled ? .primary : .secondary)
-          Group {
-            Text(
-              LocalizedStringKey(
-                viewModel.shieldsEnabled
-                  ? Strings.Shields.shieldsUpForSite : Strings.Shields.shieldsDownForSite
-              )
+          Text(
+            LocalizedStringKey(
+              viewModel.shieldsEnabled
+                ? Strings.Shields.shieldsUpForSite : Strings.Shields.shieldsDownForSite
             )
-          }
+          )
           .font(.footnote)
           .foregroundStyle(.secondary)
         }

--- a/ios/brave-ios/Sources/BraveShields/ShieldsPanelViewModel.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldsPanelViewModel.swift
@@ -52,9 +52,10 @@ public class ShieldsPanelViewModel: ObservableObject {
       tab.braveShieldsHelper?.setShredLevel(autoShredLevel, for: tab.visibleURL)
     }
   }
-  /// A boolean value indicates to wether to show `Advanced controls`or not inside the shield panel
-  /// with a default value true
-  @Published public var advancedControlsEnabled: Bool = true
+  /// Indicates if Advanced Controls are visible
+  public let isAdvancedControlsEnabled: Bool
+  /// Indicates if Shred is enabled
+  public let isShredEnabled: Bool
 
   public var isPrivateBrowsing: Bool {
     tab.isPrivate
@@ -71,7 +72,8 @@ public class ShieldsPanelViewModel: ObservableObject {
     tab: some TabState,
     stats: some Publisher<TrackingProtectionPageStats, Never>,
     blockedRequests: AnyPublisher<[BlockedRequestInfo], Never>,
-    isAdvancedControlsEnabled: Bool
+    isAdvancedControlsEnabled: Bool = true,
+    isShredEnabled: Bool
   ) {
     self.tab = tab
     self.blockedRequests = blockedRequests
@@ -104,7 +106,8 @@ public class ShieldsPanelViewModel: ObservableObject {
         considerAllShieldsOption: true
       ) ?? .never
     self.stats = .init()
-    self.advancedControlsEnabled = isAdvancedControlsEnabled
+    self.isAdvancedControlsEnabled = isAdvancedControlsEnabled
+    self.isShredEnabled = isShredEnabled
 
     stats.receive(on: DispatchQueue.main).assign(to: &$stats)
   }

--- a/ios/brave-ios/Sources/BraveShields/ShredSiteSettingsView.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShredSiteSettingsView.swift
@@ -81,31 +81,3 @@ public struct ShredSiteSettingsView: View {
     )
   }
 }
-
-extension SiteShredLevel: Identifiable {
-  public var id: String {
-    return rawValue
-  }
-
-  public var localizedTitle: String {
-    switch self {
-    case .never:
-      return Strings.Shields.shredNever
-    case .whenSiteClosed:
-      return Strings.Shields.shredOnSiteTabsClosed
-    case .appExit:
-      return Strings.Shields.shredOnAppClose
-    }
-  }
-
-  public var localizedDescription: String {
-    switch self {
-    case .never:
-      return Strings.Shields.shredNeverDescription
-    case .whenSiteClosed:
-      return Strings.Shields.shredOnSiteTabsClosedDescription
-    case .appExit:
-      return Strings.Shields.shredOnAppCloseDescription
-    }
-  }
-}

--- a/ios/brave-ios/Sources/BraveShields/SiteShredLevel.swift
+++ b/ios/brave-ios/Sources/BraveShields/SiteShredLevel.swift
@@ -5,9 +5,10 @@
 
 import BraveCore
 import Foundation
+import Strings
 
 /// A setting that will shred site data at various times
-public enum SiteShredLevel: String, CaseIterable, Hashable {
+public enum SiteShredLevel: String, CaseIterable, Hashable, Identifiable {
   /// An explicit value to never shred site data
   case never
   /// Shred the site data when the site is closed
@@ -33,6 +34,30 @@ public enum SiteShredLevel: String, CaseIterable, Hashable {
       return .lastTabClosed
     case .appExit:
       return .appExit
+    }
+  }
+
+  public var id: Self { self }
+
+  public var localizedTitle: String {
+    switch self {
+    case .never:
+      return Strings.Shields.shredNever
+    case .whenSiteClosed:
+      return Strings.Shields.shredOnSiteTabsClosed
+    case .appExit:
+      return Strings.Shields.shredOnAppClose
+    }
+  }
+
+  public var localizedDescription: String {
+    switch self {
+    case .never:
+      return Strings.Shields.shredNeverDescription
+    case .whenSiteClosed:
+      return Strings.Shields.shredOnSiteTabsClosedDescription
+    case .appExit:
+      return Strings.Shields.shredOnAppCloseDescription
     }
   }
 }


### PR DESCRIPTION
- Design link: https://www.figma.com/design/yv8ZAUPl43TI3PlzSElm2m/%F0%9F%9B%A1%EF%B8%8F-Shields-redesign?node-id=6399-150494
- Blocked resource icons not included (loading favicons of blocked resources..). They were removed from desktop as part of https://github.com/brave/brave-browser/issues/54013.



- Resolves https://github.com/brave/brave-browser/issues/56479

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

Light | Expanded | Dark | Shields Down
--|--|--|--
<img width="300" alt="iOS 26 - dark" src="https://github.com/user-attachments/assets/57f22855-0971-4bba-b009-885062d855bd" /> | <img width="300" alt="iOS 26 - expanded" src="https://github.com/user-attachments/assets/ce207acd-14be-4230-8dd6-82a1a8065157" /> | <img width="300" alt="iOS 26 - shields down" src="https://github.com/user-attachments/assets/51160fd4-6a80-48f2-935f-f80d57a657fd" /> | <img width="300" alt="iOS 26 - light" src="https://github.com/user-attachments/assets/8732bb8c-63b8-4e29-9807-8cacccd6e24f" />
<img width="300" alt="iPadOS 26 - shields down" src="https://github.com/user-attachments/assets/81615bb0-a5b5-4768-bb3b-539598370972" /> | <img width="300" alt="iPadOS 26 - dark" src="https://github.com/user-attachments/assets/bd0fefd9-e1be-41b8-9b62-ab1ed8db00f4" /> | <img width="300" alt="iPadOS 26 - expanded" src="https://github.com/user-attachments/assets/093f4f9d-da5b-4df6-96b1-52fad02f3ea1" /> | <img width="300" alt="iPadOS 26 - light" src="https://github.com/user-attachments/assets/98c8a8d7-ac0e-4bfa-8eaf-1015015d228c" />

### Testplan

Make sure Shields panel is still working as before. 
- Blocked item count updates
- Shields enabled/disabled state works
- Advanced controls work
- Learn more link is tappable
- Disabled state allows opening webcompat reporter
- Advanced controls persists expanded/collapsed state