### PR TITLE
[ai_chat] Serve the Leo workspace tools bundle from the WebUI

### DIFF
--- a/browser/ui/webui/ai_chat/leo_workspace_ui.h
+++ b/browser/ui/webui/ai_chat/leo_workspace_ui.h
@@ -25,13 +25,13 @@ class LeoWorkspaceUIConfig : public content::WebUIConfig {
       const GURL& url) override;
 };
 
-// Hidden, headless Untrusted WebUI that will host the Leo "workspace" tools.
-// One instance is created per conversation and served at
-// chrome-untrusted://leo-workspace/<guid>, with a locked-down CSP that only
-// permits its own first-party bundle. This page has no visible UI.
-//
-// At this stage the page only serves a placeholder document. The file tools
-// bundle and the FileSystemDirectoryHandle plumbing are added separately.
+// Hidden, headless Untrusted WebUI that hosts the Leo "workspace" tools. The
+// page receives a FileSystemDirectoryHandle (delivered by the browser via
+// launchQueue) for a user-picked folder, implements the file tools in
+// JavaScript against it, and registers them with Leo via WebMCP
+// (navigator.modelContext). One instance is created per conversation and served
+// at chrome-untrusted://leo-workspace/<guid>; it runs with a locked-down CSP
+// that only permits its own first-party bundle. This page has no visible UI.
 class LeoWorkspaceUI : public ui::UntrustedWebUIController {
  public:
   explicit LeoWorkspaceUI(content::WebUI* web_ui);

--- a/components/ai_chat/resources/leo_workspace/leo_workspace.html
+++ b/components/ai_chat/resources/leo_workspace/leo_workspace.html
@@ -5,6 +5,7 @@
     <title>Leo Workspace</title>
   </head>
   <body>
-    <div id="root">test workspace</div>
+    <div id="root"></div>
+    <script src="/leo_workspace.bundle.js" type="module"></script>
   </body>
 </html>


### PR DESCRIPTION
- Series https://github.com/brave/brave-browser/issues/57388

Loads the `leo_workspace` bundle from the `chrome-untrusted://leo-workspace`
page, so the file tools are registered with Leo via WebMCP once the page
receives its `FileSystemDirectoryHandle`.
