### PR TITLE
[AI Chat]: Add expandable section for viewing tool arguments

### DIFF
--- a/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/tool_event.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/tool_event.test.tsx
@@ -270,4 +270,102 @@ describe('ToolEvent', () => {
     fireEvent.click(denyButton)
     expect(mockProcessPermissionChallenge).not.toHaveBeenCalled()
   })
+
+  describe('permission challenge tool arguments', () => {
+    function renderPermissionChallenge(argumentsJson: string) {
+      return render(
+        <MockContext>
+          <ToolEvent
+            toolUseEvent={{
+              toolName: Mojom.NAVIGATE_TOOL_NAME,
+              id: '123',
+              argumentsJson,
+              output: undefined,
+              permissionChallenge: {
+                assessment: undefined,
+                plan: undefined,
+                description: undefined,
+              },
+            }}
+            isEntryActive={true}
+          />
+        </MockContext>,
+      )
+    }
+
+    it('should hide the tool arguments until requested', () => {
+      renderPermissionChallenge('{"website_url": "https://www.example.com"}')
+
+      expect(
+        screen.getByText(S.CHAT_UI_PERMISSION_CHALLENGE_SHOW_ARGUMENTS_BUTTON),
+      ).toBeInTheDocument()
+      expect(screen.queryByTestId('tool-arguments')).not.toBeInTheDocument()
+    })
+
+    it('should show the tool arguments on click', () => {
+      renderPermissionChallenge('{"website_url": "https://www.example.com"}')
+
+      fireEvent.click(screen.getByTestId('tool-arguments-toggle'))
+
+      // The code block splits the text across syntax-highlighted elements, so
+      // assert on the rendered text content rather than a single text node.
+      const args = screen.getByTestId('tool-arguments')
+      expect(args).toHaveTextContent('website_url')
+      expect(args).toHaveTextContent('https://www.example.com')
+      expect(
+        screen.getByText(S.CHAT_UI_PERMISSION_CHALLENGE_HIDE_ARGUMENTS_BUTTON),
+      ).toBeInTheDocument()
+    })
+
+    it('should hide the tool arguments again on click', () => {
+      renderPermissionChallenge('{"website_url": "https://www.example.com"}')
+
+      const toggle = screen.getByTestId('tool-arguments-toggle')
+      fireEvent.click(toggle)
+      expect(screen.getByTestId('tool-arguments')).toBeInTheDocument()
+
+      fireEvent.click(toggle)
+      expect(screen.queryByTestId('tool-arguments')).not.toBeInTheDocument()
+    })
+
+    it('should show all arguments, including nested ones', () => {
+      renderPermissionChallenge(
+        '{"action": "group", "options": {"collapse": true}}',
+      )
+
+      fireEvent.click(screen.getByTestId('tool-arguments-toggle'))
+
+      const args = screen.getByTestId('tool-arguments')
+      expect(args).toHaveTextContent('action')
+      expect(args).toHaveTextContent('group')
+      expect(args).toHaveTextContent('options')
+      expect(args).toHaveTextContent('collapse')
+    })
+
+    it('should show unparseable arguments verbatim', () => {
+      renderPermissionChallenge('2 invalid 2 json')
+
+      fireEvent.click(screen.getByTestId('tool-arguments-toggle'))
+
+      expect(screen.getByTestId('tool-arguments')).toHaveTextContent(
+        '2 invalid 2 json',
+      )
+    })
+
+    it('should not offer to show arguments when there are none', () => {
+      renderPermissionChallenge('')
+
+      expect(
+        screen.queryByTestId('tool-arguments-toggle'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('should not offer to show arguments for an empty argument object', () => {
+      renderPermissionChallenge('{}')
+
+      expect(
+        screen.queryByTestId('tool-arguments-toggle'),
+      ).not.toBeInTheDocument()
+    })
+  })
 })

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/tool_event.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/tool_event.tsx
@@ -116,6 +116,7 @@ function ToolEventContent(
         isInteractive={props.isEntryActive}
         toolUseEvent={toolUseEvent}
         toolLabel={content.toolLabel!}
+        toolInput={input}
       />
     )
     content.toolLabel = null

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/tool_permission_challenge/tool_permission_challenge.module.scss
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/tool_permission_challenge/tool_permission_challenge.module.scss
@@ -45,6 +45,40 @@
   font-style: italic;
 }
 
+.argumentsToggle {
+  all: unset;
+  display: flex;
+  align-items: center;
+  gap: var(--leo-spacing-xs);
+  width: fit-content;
+  cursor: pointer;
+  font: var(--leo-font-small-semibold);
+  // A subordinate disclosure control, so it sits back from the card's primary
+  // body text rather than competing with the warning accent in the header.
+  color: var(--leo-color-text-secondary);
+  --leo-icon-size: 16px;
+
+  &:hover {
+    color: var(--leo-color-text-primary);
+  }
+
+  &:focus-visible {
+    outline: 1px solid var(--leo-color-schemes-outline);
+    outline-offset: 2px;
+  }
+}
+
+.arguments {
+  margin-top: var(--leo-spacing-m);
+  // The card's body text is sized for prose - step it down so the code block
+  // reads as data rather than copy.
+  font: var(--leo-font-x-small-regular);
+  // Tool arguments are model output and can be arbitrarily long, so cap the
+  // height rather than letting them push the Allow/Deny buttons off screen.
+  max-height: 240px;
+  overflow: auto;
+}
+
 .permissionButton {
   --leo-button-color: var(--leo-color-divider-subtle);
 }

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/tool_permission_challenge/tool_permission_challenge.stories.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/tool_permission_challenge/tool_permission_challenge.stories.tsx
@@ -16,6 +16,7 @@ type CustomArgs = {
   hasPlan: boolean
   hasImplications: boolean
   isWebTool: boolean
+  argumentsJson: string
 }
 
 const args: CustomArgs = {
@@ -24,10 +25,25 @@ const args: CustomArgs = {
   hasPlan: false,
   hasImplications: true,
   isWebTool: false,
+  argumentsJson: JSON.stringify({
+    action: 'group',
+    group_title: 'Recipes',
+    tab_ids: [12, 13, 14],
+    options: { collapse: true, color: 'blue' },
+  }),
 }
 
 export const _ToolPermissionChallenge = {
   render: (args: CustomArgs) => {
+    // Mirrors what tool_event.tsx does before rendering this component: the
+    // arguments are parsed from LLM output, so parsing can fail.
+    let toolInput: any = null
+    try {
+      toolInput = JSON.parse(args.argumentsJson)
+    } catch (e) {
+      toolInput = null
+    }
+
     const toolUseEvent: Mojom.ToolUseEvent = {
       toolName: args.isWebTool
         ? 'web_example_com_get_stock_price'
@@ -35,7 +51,7 @@ export const _ToolPermissionChallenge = {
           ? Mojom.TAB_MANAGEMENT_TOOL_NAME
           : Mojom.CODE_EXECUTION_TOOL_NAME,
       id: 'toolId',
-      argumentsJson: 'toolArguments',
+      argumentsJson: args.argumentsJson,
       output: undefined,
       isServerResult: false,
       artifacts: undefined,
@@ -56,6 +72,7 @@ export const _ToolPermissionChallenge = {
         <ToolPermissionChallenge
           isInteractive={args.isInteractive}
           toolUseEvent={toolUseEvent}
+          toolInput={toolInput}
           toolLabel={
             args.hasPlan
               ? 'Managing your tabs'

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/tool_permission_challenge/tool_permission_challenge.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/tool_permission_challenge/tool_permission_challenge.tsx
@@ -10,6 +10,7 @@ import ConversationAreaButton from '../../../common/components/conversation_area
 import * as Mojom from '../../../common/mojom'
 import { useUntrustedConversationContext } from '../../untrusted_conversation_context'
 import { getToolPermissionImplications } from '../assistant_response/get_tool_permission_implications'
+import CodeBlock from '../code_block'
 import MarkdownRenderer from '../markdown_renderer'
 import styles from './tool_permission_challenge.module.scss'
 
@@ -28,6 +29,76 @@ interface Props {
    * Display label for the tool that needs permission
    */
   toolLabel: string
+
+  /**
+   * The tool's arguments, already parsed from `toolUseEvent.argumentsJson` by
+   * the parent. It is created by parsing LLM output, so it could be anything -
+   * including `null` when the JSON was absent or malformed. In that case we
+   * fall back to displaying the raw `argumentsJson`, since the user should
+   * still be able to see what the tool was asked to do before allowing it.
+   */
+  toolInput?: any
+}
+
+/**
+ * The exact arguments the tool would be called with, for the user to inspect
+ * before granting permission. Renders nothing when there is nothing useful to
+ * show, so that tools taking no arguments don't get an empty disclosure.
+ */
+function ToolArguments({
+  toolInput,
+  argumentsJson,
+}: {
+  toolInput: any
+  argumentsJson: string
+}) {
+  const [isExpanded, setIsExpanded] = React.useState(false)
+
+  const argumentsText = React.useMemo(() => {
+    // Pretty-print whatever the parent managed to parse. Anything that came
+    // out of JSON.parse is safe to re-stringify.
+    if (typeof toolInput === 'object' && toolInput !== null) {
+      // Don't show a disclosure for `{}` - there are no arguments to inspect.
+      if (!Array.isArray(toolInput) && Object.keys(toolInput).length === 0) {
+        return null
+      }
+      return JSON.stringify(toolInput, null, 2)
+    }
+    // Malformed, partial or non-object JSON - show it verbatim rather than
+    // hiding the arguments the user is being asked to approve.
+    return argumentsJson || null
+  }, [toolInput, argumentsJson])
+
+  if (!argumentsText) {
+    return null
+  }
+
+  return (
+    <div>
+      <button
+        className={styles.argumentsToggle}
+        aria-expanded={isExpanded}
+        data-testid='tool-arguments-toggle'
+        onClick={() => setIsExpanded((expanded) => !expanded)}
+      >
+        {isExpanded
+          ? getLocale(S.CHAT_UI_PERMISSION_CHALLENGE_HIDE_ARGUMENTS_BUTTON)
+          : getLocale(S.CHAT_UI_PERMISSION_CHALLENGE_SHOW_ARGUMENTS_BUTTON)}
+        <Icon name={isExpanded ? 'carat-down' : 'carat-right'} />
+      </button>
+      {isExpanded && (
+        <div
+          className={styles.arguments}
+          data-testid='tool-arguments'
+        >
+          <CodeBlock.Block
+            code={argumentsText}
+            lang='json'
+          />
+        </div>
+      )}
+    </div>
+  )
 }
 
 export default function ToolPermissionChallenge(props: Props) {
@@ -86,6 +157,11 @@ export default function ToolPermissionChallenge(props: Props) {
         {permissionChallenge.plan && (
           <p className={styles.assessment}>{permissionChallenge.plan}</p>
         )}
+
+        <ToolArguments
+          toolInput={props.toolInput}
+          argumentsJson={props.toolUseEvent.argumentsJson}
+        />
 
         <ConversationAreaButton
           className={styles.permissionButton}

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -927,6 +927,12 @@
   <message name="IDS_CHAT_UI_PERMISSION_CHALLENGE_DENY_BUTTON" desc="Button text to deny the permission challenge" formatter_data="webui=AiChat">
     Deny
   </message>
+  <message name="IDS_CHAT_UI_PERMISSION_CHALLENGE_SHOW_ARGUMENTS_BUTTON" desc="Button label on the tool permission prompt that expands a section showing the full arguments the AI wants to pass to the tool" formatter_data="webui=AiChat">
+    Show tool arguments
+  </message>
+  <message name="IDS_CHAT_UI_PERMISSION_CHALLENGE_HIDE_ARGUMENTS_BUTTON" desc="Button label on the tool permission prompt that collapses the section showing the full arguments the AI wants to pass to the tool" formatter_data="webui=AiChat">
+    Hide tool arguments
+  </message>
   <message name="IDS_AI_CHAT_VERIFIED_LABEL" desc="Label for the verified NEAR AI model" formatter_data="webui=AiChat">
     Verified
   </message>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58071

**Note:** This doesn't add support for viewing arguments to past tool calls.

By default, arguments are collapsed:
<img width="497" height="1332" alt="image" src="https://github.com/user-attachments/assets/7193130b-1c3b-459a-af30-08c3c4533dca" />

Clicking the `Show tool arguments` text shows the arguments:
<img width="471" height="1249" alt="image" src="https://github.com/user-attachments/assets/9371d0df-d4da-4ed7-8e34-34a873295c35" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
