### PR TITLE
Hide bottom navigation in omnibox search

### DIFF
--- a/android/java/org/chromium/chrome/browser/toolbar/BraveToolbarManager.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/BraveToolbarManager.java
@@ -565,6 +565,14 @@ public class BraveToolbarManager extends ToolbarManager
         HomepageManager.getInstance().removeListener(mBraveHomepageStateListener);
     }
 
+    @Override
+    public void onUrlFocusChange(boolean hasFocus) {
+        super.onUrlFocusChange(hasFocus);
+        if (isToolbarPhone()) {
+            updateBraveBottomControlsVisibility(hasFocus);
+        }
+    }
+
     private void recordNewTabClick() {
         if (!mIncognitoStateProvider.isIncognitoSelected()) {
             if (mActivity instanceof BraveActivity) {
@@ -583,9 +591,7 @@ public class BraveToolbarManager extends ToolbarManager
         if (mTabGroupUiBottomControlsCoordinatorSupplier != null
                 && mTabGroupUiBottomControlsCoordinatorSupplier.get() != null
                 && BottomToolbarConfiguration.isBraveBottomControlsEnabled()) {
-            boolean isBraveBottomControlsVisible =
-                    mCurrentOrientation != Configuration.ORIENTATION_LANDSCAPE;
-            setBraveBottomControlsVisible(isBraveBottomControlsVisible);
+            updateBraveBottomControlsVisibility();
         }
 
         if (mActivity instanceof FullScreenCustomTabActivity) {
@@ -674,11 +680,24 @@ public class BraveToolbarManager extends ToolbarManager
     }
 
     private void updateBraveBottomControlsVisibility() {
+        updateBraveBottomControlsVisibility(mOmniboxFocusStateSupplier.get());
+    }
+
+    private void updateBraveBottomControlsVisibility(boolean isOmniboxFocused) {
         boolean isBraveBottomControlsVisible =
-                BottomToolbarConfiguration.isBraveBottomControlsEnabled()
-                        && mActivity.getResources().getConfiguration().orientation
-                                != Configuration.ORIENTATION_LANDSCAPE;
+                shouldShowBraveBottomControls(
+                        BottomToolbarConfiguration.isBraveBottomControlsEnabled(),
+                        mActivity.getResources().getConfiguration().orientation,
+                        isOmniboxFocused);
         setBraveBottomControlsVisible(isBraveBottomControlsVisible);
+    }
+
+    @VisibleForTesting
+    static boolean shouldShowBraveBottomControls(
+            boolean isBottomControlsEnabled, int orientation, boolean isOmniboxFocused) {
+        return isBottomControlsEnabled
+                && orientation != Configuration.ORIENTATION_LANDSCAPE
+                && !isOmniboxFocused;
     }
 
     private boolean isToolbarPhone() {

--- a/android/junit/src/org/chromium/chrome/browser/toolbar/BraveToolbarManagerUnitTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/toolbar/BraveToolbarManagerUnitTest.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.lenient;
 
+import android.content.res.Configuration;
+
 import androidx.test.filters.SmallTest;
 
 import org.junit.Rule;
@@ -109,5 +111,30 @@ public final class BraveToolbarManagerUnitTest {
         assertTrue(
                 BraveToolbarManager.shouldSuppressToolbarLongPressForTab(
                         /* suppressedByUpstream= */ true, mTab, /* isOmniboxFocused= */ false));
+    }
+
+    @Test
+    @SmallTest
+    public void testBottomControlsVisibleOnlyForUnfocusedPortraitOmnibox() {
+        assertTrue(
+                BraveToolbarManager.shouldShowBraveBottomControls(
+                        /* isBottomControlsEnabled= */ true,
+                        Configuration.ORIENTATION_PORTRAIT,
+                        /* isOmniboxFocused= */ false));
+        assertFalse(
+                BraveToolbarManager.shouldShowBraveBottomControls(
+                        /* isBottomControlsEnabled= */ true,
+                        Configuration.ORIENTATION_PORTRAIT,
+                        /* isOmniboxFocused= */ true));
+        assertFalse(
+                BraveToolbarManager.shouldShowBraveBottomControls(
+                        /* isBottomControlsEnabled= */ true,
+                        Configuration.ORIENTATION_LANDSCAPE,
+                        /* isOmniboxFocused= */ false));
+        assertFalse(
+                BraveToolbarManager.shouldShowBraveBottomControls(
+                        /* isBottomControlsEnabled= */ false,
+                        Configuration.ORIENTATION_PORTRAIT,
+                        /* isOmniboxFocused= */ false));
     }
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58317.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

## Screenshots

&nbsp;|`Bottom navigation toolbar` on|`Bottom navigation toolbar` off
--|--|--
Brave|<img width="1344" height="2992" alt="Screenshot_1787292659" src="https://github.com/user-attachments/assets/c7095bd7-ced0-48a9-8720-199d22b22a06" />|<img width="1344" height="2992" alt="Screenshot_1787293323" src="https://github.com/user-attachments/assets/b5f17039-71af-42c5-98e4-4a709e066e46" />
Google|<img width="1344" height="2992" alt="Screenshot_1787292679" src="https://github.com/user-attachments/assets/0035d7cb-e4a1-40ab-91f1-bfd814286ddb" />|<img width="1344" height="2992" alt="Screenshot_1787292793" src="https://github.com/user-attachments/assets/7bf607ce-2e88-4c02-b75b-0cc901dec065" />




