### PR TITLE
[plaster] Pinning git algorithm for output

### DIFF
--- a/build/commands/lib/updatePatches.js
+++ b/build/commands/lib/updatePatches.js
@@ -5,17 +5,29 @@
 
 import path from 'node:path'
 import fs from 'fs-extra'
+import rootDir from './rootDir.cjs'
 import util from './util.js'
 
 const desiredReplacementSeparator = '-'
 const patchExtension = '.patch'
+
+// A shared git attributes file used by plaster to make the patch output
+// reproducible across machines.
+const PLASTER_GITATTRIBUTES_PATH = path.join(
+  rootDir,
+  'src',
+  'brave',
+  'tools',
+  'cr',
+  'plaster_gitattributes',
+)
 
 /**
  * Gets a list of modified files in a git repo
  * @param {string} gitRepoPath The repository to get modified files from
  * @param {(file: string) => boolean} [filter] Filter function for file paths to include or exclude (all included by default)
  * @param {string[]} [onlyFiles] If not empty, only modified paths for these files will be considered.
- * @returns {Promise<string[]>} List of modified file paths
+ * @returns {Promise<{paths: string[], binaryPaths: Set<string>}>}
  */
 async function getModifiedPaths(gitRepoPath, filter, onlyFiles) {
   const onlyFilesSet = new Set(onlyFiles)
@@ -23,18 +35,30 @@ async function getModifiedPaths(gitRepoPath, filter, onlyFiles) {
     'diff',
     '--ignore-submodules',
     '--diff-filter=M',
-    '--name-only',
+    '--numstat',
     '--ignore-space-at-eol',
   ]
   const cmdOutput = await util.runAsync('git', modifiedDiffArgs, {
     cwd: gitRepoPath,
     verbose: false,
   })
-  return cmdOutput
+  // `--numstat` has two formats: "-\t-\t<path>" for a binary file, and
+  // "<added>\t<removed>\t<path>" otherwise. We store the binary paths in its
+  // own set, so we skip them for output reproducibility.
+  const binaryPaths = new Set()
+  const paths = cmdOutput
     .split('\n')
     .filter((s) => s)
+    .map((line) => {
+      const [added, removed, filePath] = line.split('\t')
+      if (added === '-' && removed === '-') {
+        binaryPaths.add(filePath)
+      }
+      return filePath
+    })
     .filter((s) => (onlyFilesSet.size ? onlyFilesSet.has(s) : true))
     .filter(filter ?? (() => true))
+  return { paths, binaryPaths }
 }
 
 /**
@@ -49,6 +73,9 @@ async function getModifiedPaths(gitRepoPath, filter, onlyFiles) {
  * @param {string} patchDirPath Directory to write .patch files to
  * @param {(file: string) => boolean} [plasterPathFilter] Returns true if a repo
  *   path's patch is owned by a plaster file
+ * @param {Set<string>} [binaryPaths] Repo-relative paths, that are binary
+ * files, which we do not want to use the plaster attributes for
+ * reproducibility.
  * @returns {Promise<{patchFilenames: string[], outdatedPlasterPaths: string[]}>}
  *   `outdatedPlasterPaths` lists the repo-relative paths of plaster-managed
  *   sources whose patch is different.
@@ -58,6 +85,7 @@ async function writePatchFiles(
   gitRepoPath,
   patchDirPath,
   plasterPathFilter,
+  binaryPaths = new Set(),
 ) {
   // replacing forward slashes and adding the patch extension to get nice filenames
   // since git on Windows doesn't use backslashes, this is sufficient
@@ -92,7 +120,16 @@ async function writePatchFiles(
     const patchFilePath = path.join(patchDirPath, patchFilename)
     const isPlasterManaged = plasterPathFilter?.(old) ?? false
 
+    // Pinning the diff algorithm so we get the same output across machines.
+    const gitConfigArgs = ['-c', 'diff.algorithm=histogram']
+    if (!binaryPaths.has(old)) {
+      gitConfigArgs.push(
+        '-c',
+        `core.attributesFile=${PLASTER_GITATTRIBUTES_PATH}`,
+      )
+    }
     const singleDiffArgs = [
+      ...gitConfigArgs,
       'diff',
       '--src-prefix=a/',
       '--dst-prefix=b/',
@@ -104,6 +141,7 @@ async function writePatchFiles(
     const patchContents = await util.runAsync('git', singleDiffArgs, {
       cwd: gitRepoPath,
       verbose: false,
+      env: { ...process.env, GIT_ATTR_NOSYSTEM: '1' },
     })
 
     if (isPlasterManaged) {
@@ -207,7 +245,7 @@ async function updatePatches(
   keepPatchFilenames = [],
   plasterPathFilter,
 ) {
-  const modifiedPaths = await getModifiedPaths(
+  const { paths: modifiedPaths, binaryPaths } = await getModifiedPaths(
     gitRepoPath,
     repoPathFilter,
     onlyFiles,
@@ -217,6 +255,7 @@ async function updatePatches(
     gitRepoPath,
     patchDirPath,
     plasterPathFilter,
+    binaryPaths,
   )
   // We only remove stale patch files if we're updating everything.
   if (onlyFiles && onlyFiles.length === 0) {

--- a/build/commands/lib/updatePatches.test.js
+++ b/build/commands/lib/updatePatches.test.js
@@ -134,3 +134,75 @@ describe('updatePatches plaster detection', function () {
     ).toBe(false)
   })
 })
+
+describe('updatePatches diff pins', function () {
+  let repoPath, patchPath
+
+  beforeEach(async function () {
+    patchPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), dirPrefixTmp + 'pins-patches-'),
+    )
+    repoPath = await fs.mkdtemp(
+      path.join(os.tmpdir(), dirPrefixTmp + 'pins-repo-'),
+    )
+
+    await runGit(repoPath, ['init'])
+    await runGit(repoPath, ['config', 'user.email', 'unittests@local'])
+    await runGit(repoPath, ['config', 'user.name', 'Unit Tests'])
+    await runGit(repoPath, ['config', 'commit.gpgsign', 'false'])
+  })
+
+  afterEach(async function () {
+    jest.restoreAllMocks()
+    await fs.remove(repoPath).catch(() => {})
+    await fs.remove(patchPath).catch(() => {})
+  })
+
+  // The args a single-file `git diff` call passes to `util.runAsync`, i.e. a
+  // call whose args start with the pinning `-c` options and end in 'diff'.
+  function findSingleDiffCallArgs(spy) {
+    return spy.mock.calls
+      .map(([, args]) => args)
+      .find((args) => args.includes('diff') && args.includes('--full-index'))
+  }
+
+  test('pins diff.algorithm and core.attributesFile for a text file', async () => {
+    const textPath = path.join(repoPath, 'source.cc')
+    await fs.writeFile(textPath, 'line one\nline two\n')
+    await runGit(repoPath, ['add', '.'])
+    await runGit(repoPath, ['commit', '-m', 'initial'])
+    await fs.writeFile(textPath, 'line one\nline two modified\n')
+
+    const spy = jest.spyOn(util, 'runAsync')
+    await updatePatches(repoPath, patchPath, [])
+
+    const diffArgs = findSingleDiffCallArgs(spy)
+    expect(diffArgs).toContain('diff.algorithm=histogram')
+    expect(diffArgs.some((arg) => arg.startsWith('core.attributesFile='))).toBe(
+      true,
+    )
+  })
+
+  test('skips the attributesFile pin for a binary file, keeping it a binary diff', async () => {
+    const binaryPath = path.join(repoPath, 'image.bin')
+    await fs.writeFile(binaryPath, Buffer.from([0, 1, 2, 0, 3, 4]))
+    await runGit(repoPath, ['add', '.'])
+    await runGit(repoPath, ['commit', '-m', 'initial'])
+    await fs.writeFile(binaryPath, Buffer.from([0, 1, 2, 0, 3, 4, 5, 6]))
+
+    const spy = jest.spyOn(util, 'runAsync')
+    await updatePatches(repoPath, patchPath, [])
+
+    const diffArgs = findSingleDiffCallArgs(spy)
+    expect(diffArgs).toContain('diff.algorithm=histogram')
+    expect(diffArgs.some((arg) => arg.startsWith('core.attributesFile='))).toBe(
+      false,
+    )
+
+    const patchContents = await fs.readFile(
+      path.join(patchPath, 'image.bin.patch'),
+      'utf-8',
+    )
+    expect(patchContents).toContain('Binary files')
+  })
+})

--- a/patches/components-permissions-features.cc.patch
+++ b/patches/components-permissions-features.cc.patch
@@ -17,9 +17,9 @@ index f4a1fa6a33d44e215332c39073940efc367036fa..eb857746488ae669720713f193d577b2
  // user has not yet taken an action. Therefore, that parameter is ignored in
  // that case.
 +#if !BUILDFLAG(IS_ANDROID)
-+BASE_FEATURE(kPermissionsPromptSurvey, base::FEATURE_DISABLED_BY_DEFAULT);
-+#else
  BASE_FEATURE(kPermissionsPromptSurvey, base::FEATURE_DISABLED_BY_DEFAULT);
++#else
++BASE_FEATURE(kPermissionsPromptSurvey, base::FEATURE_DISABLED_BY_DEFAULT);
 +#endif
  
  // When enabled, use the value of the `allowlist_urls` FeatureParam as the

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -352,9 +352,16 @@ class PatchinfoBuilder:
         # We pin the attibutes when creating a diff (`plaster_gitattributes`),
         # and ignore the system gitattributes (`GIT_ATTR_NOSYSTEM`), so the
         # output is deterministic across platforms and git versions.
+        #
+        # We also pin the diff algorithm, since a user's `.gitconfig` may
+        # select a different one (e.g. `histogram`) than git's own default,
+        # which would produce different hunks for the same change and fail
+        # presubmit in CI.
         content = repository.chromium.run_git(
             '-c',
             f'core.attributesFile={PLASTER_GITATTRIBUTES_PATH}',
+            '-c',
+            'diff.algorithm=histogram',
             'diff',
             '--src-prefix=a/',
             '--dst-prefix=b/',

--- a/tools/cr/plaster_gitattributes
+++ b/tools/cr/plaster_gitattributes
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# Attributes used exclusively by plaster.py when generating patch files.
+# Attributes used to guarantee byte-indetical output across machines for diffs.
 #
 # `* diff` forces git's built-in default funcname driver for every path,
 # overriding any language-specific driver git might otherwise select (notably

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -6,6 +6,7 @@
 
 import unittest
 from pathlib import Path
+from unittest import mock
 import argparse
 import contextlib
 import copy
@@ -17,6 +18,7 @@ import os
 import time
 
 import plaster
+import repository
 
 from test.fake_chromium_repo import FakeChromiumRepo
 
@@ -152,6 +154,55 @@ class PlasterTest(unittest.TestCase):
         self.assertNotEqual(mtime_after, mtime_changed)
         self.assertEqual(temp_file.read_text(), 'bar')
         temp_file.unlink()
+
+    def test_save_patch_pins_diff_algorithm_and_attributes(self):
+        """save_patch_if_changed must pin the diff algorithm and attributes.
+
+        Regression test: a user's own `.gitconfig` (`diff.algorithm`) or
+        gitattributes could otherwise make the same substitution produce
+        different patch bytes than what CI generates, failing presubmit.
+        """
+        test_file_chromium = Path('chrome/common/pin_test.cc')
+        self.fake_chromium_src.write_and_stage_file(
+            test_file_chromium, 'Initial content for Chromium file.\n',
+            self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit('Add pin_test.cc',
+                                      self.fake_chromium_src.chromium)
+
+        plaster_path = plaster.PLASTER_FILES_PATH / (str(test_file_chromium) +
+                                                     '.yaml')
+        plaster_path.parent.mkdir(parents=True, exist_ok=True)
+        plaster_path.write_text('''
+          substitutions:
+            - description: Simple test substitution
+              regex:
+                re_pattern: 'Chromium'
+                replace: 'Plaster'
+        ''')
+
+        plaster_file = plaster.PlasterFile(plaster_path)
+        with mock.patch.object(
+                repository.Repository,
+                'run_git',
+                autospec=True,
+                side_effect=repository.Repository.run_git) as run_git_mock:
+            plaster_file.apply()
+
+        # `autospec` includes the bound `self` as the first positional arg.
+        diff_calls = [
+            call for call in run_git_mock.call_args_list
+            if 'diff' in call.args[1:]
+        ]
+        self.assertEqual(len(diff_calls), 1)
+        diff_args = diff_calls[0].args[1:]
+        pinned_options = set(zip(diff_args, diff_args[1:]))
+        self.assertIn(('-c', 'diff.algorithm=histogram'), pinned_options)
+        self.assertIn(
+            ('-c',
+             f'core.attributesFile={plaster.PLASTER_GITATTRIBUTES_PATH}'),
+            pinned_options)
+        self.assertEqual(
+            diff_calls[0].kwargs.get('env', {}).get('GIT_ATTR_NOSYSTEM'), '1')
 
     def test_checksum_hashes_raw_bytes_without_newline_normalization(self):
         # The checksum must be over the file's raw bytes so it matches


### PR DESCRIPTION
This change pins the git algorithm both in plaster and in
`update_patches`  to make sure we get a byte-identical output when
gerating patches across the board.

Fixed: https://github.com/brave/brave-browser/issues/58307
