### PR TITLE
Crash Report: PSST- #39183

### DIFF
--- a/browser/psst/psst_settings_service_factory.cc
+++ b/browser/psst/psst_settings_service_factory.cc
@@ -9,6 +9,7 @@
 
 #include "base/check_deref.h"
 #include "base/no_destructor.h"
+#include "brave/components/psst/core/browser/pref_names.h"
 #include "brave/components/psst/core/browser/psst_settings_service.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/profiles/profile.h"
@@ -45,6 +46,13 @@ std::unique_ptr<KeyedService>
 PsstSettingsServiceFactory::BuildServiceInstanceForBrowserContext(
     content::BrowserContext* context) const {
   auto* profile = Profile::FromBrowserContext(context);
+
+  if (!profile ||
+      (!psst::IsPsstEnabledForProfile(*profile->GetPrefs()) &&
+       profile->GetPrefs()->IsManagedPreference(psst::prefs::kPsstEnabled))) {
+    return nullptr;
+  }
+
   auto* map = HostContentSettingsMapFactory::GetForProfile(profile);
   return std::make_unique<psst::PsstSettingsService>(CHECK_DEREF(map),
                                                      profile->GetPrefs());

--- a/browser/psst/psst_settings_service_factory.cc
+++ b/browser/psst/psst_settings_service_factory.cc
@@ -48,11 +48,12 @@ PsstSettingsServiceFactory::BuildServiceInstanceForBrowserContext(
     content::BrowserContext* context) const {
   auto* profile = Profile::FromBrowserContext(context);
 
-  // When PSST is managed (Brave Origin/enterprise
-  // policy), a policy change to enable/disable it only takes effect after
-  // the browser restarts and this factory runs again.
-  if ((!psst::features::IsPsstFeatureFlagEnabled() ||
-       !psst::IsPsstSettingPrefEnabled(*profile->GetPrefs())) &&
+  if (!psst::features::IsPsstFeatureFlagEnabled()) {
+    return nullptr;
+  }
+
+  // Setting explicitly disabled via policy.
+  if (!psst::IsPsstSettingPrefEnabled(*profile->GetPrefs()) &&
       psst::IsPsstManaged(*profile->GetPrefs())) {
     return nullptr;
   }

--- a/browser/psst/psst_settings_service_factory.cc
+++ b/browser/psst/psst_settings_service_factory.cc
@@ -11,6 +11,7 @@
 #include "base/no_destructor.h"
 #include "brave/components/psst/core/browser/pref_names.h"
 #include "brave/components/psst/core/browser/psst_settings_service.h"
+#include "brave/components/psst/core/common/features.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/profiles/profile_selections.h"
@@ -47,9 +48,9 @@ PsstSettingsServiceFactory::BuildServiceInstanceForBrowserContext(
     content::BrowserContext* context) const {
   auto* profile = Profile::FromBrowserContext(context);
 
-  if (!profile ||
-      (!psst::IsPsstEnabledForProfile(*profile->GetPrefs()) &&
-       profile->GetPrefs()->IsManagedPreference(psst::prefs::kPsstEnabled))) {
+  if (!profile || ((!psst::features::IsPsstFeatureFlagEnabled() ||
+                    !psst::IsPsstSettingPrefEnabled(*profile->GetPrefs())) &&
+                   psst::IsPsstManaged(*profile->GetPrefs()))) {
     return nullptr;
   }
 

--- a/browser/psst/psst_settings_service_factory.cc
+++ b/browser/psst/psst_settings_service_factory.cc
@@ -48,9 +48,12 @@ PsstSettingsServiceFactory::BuildServiceInstanceForBrowserContext(
     content::BrowserContext* context) const {
   auto* profile = Profile::FromBrowserContext(context);
 
-  if (!profile || ((!psst::features::IsPsstFeatureFlagEnabled() ||
-                    !psst::IsPsstSettingPrefEnabled(*profile->GetPrefs())) &&
-                   psst::IsPsstManaged(*profile->GetPrefs()))) {
+  // When PSST is managed (Brave Origin/enterprise
+  // policy), a policy change to enable/disable it only takes effect after
+  // the browser restarts and this factory runs again.
+  if ((!psst::features::IsPsstFeatureFlagEnabled() ||
+       !psst::IsPsstSettingPrefEnabled(*profile->GetPrefs())) &&
+      psst::IsPsstManaged(*profile->GetPrefs())) {
     return nullptr;
   }
 

--- a/browser/psst/psst_settings_service_factory.h
+++ b/browser/psst/psst_settings_service_factory.h
@@ -17,9 +17,14 @@ namespace psst {
 class PsstSettingsService;
 }  // namespace psst
 
+// Profile keyed service factory for the `PsstSettingsService`.
 class PsstSettingsServiceFactory : public ProfileKeyedServiceFactory {
  public:
+  // Returns the singleton instance of `PsstSettingsServiceFactory`.
   static PsstSettingsServiceFactory* GetInstance();
+
+  // Returns the instance of `PsstSettingsServiceFactory` for the passed
+  // `profile`.
   static psst::PsstSettingsService* GetForProfile(Profile* profile);
 
  private:
@@ -29,6 +34,9 @@ class PsstSettingsServiceFactory : public ProfileKeyedServiceFactory {
   ~PsstSettingsServiceFactory() override;
 
   // ProfileKeyedServiceFactory overrides:
+  //
+  // Returns nullptr when PSST is disabled via feature flag, or explicitly
+  // disabled via policy.
   std::unique_ptr<KeyedService> BuildServiceInstanceForBrowserContext(
       content::BrowserContext* context) const override;
 };

--- a/browser/psst/psst_tab_web_contents_observer.cc
+++ b/browser/psst/psst_tab_web_contents_observer.cc
@@ -218,7 +218,7 @@ void PsstTabWebContentsObserver::DidFinishNavigation(
       handle->GetURL().SchemeIsHTTPOrHTTPS() &&
       handle->GetRestoreType() != content::RestoreType::kRestored &&
       (psst_settings_service_->IsPsstEnabled() ||
-       psst_settings_service_->WasPsstEnabledAtStartup());
+       psst_settings_service_->was_enabled_at_startup());
 }
 
 void PsstTabWebContentsObserver::DocumentOnLoadCompletedInPrimaryMainFrame() {

--- a/browser/psst/psst_tab_web_contents_observer.cc
+++ b/browser/psst/psst_tab_web_contents_observer.cc
@@ -217,7 +217,8 @@ void PsstTabWebContentsObserver::DidFinishNavigation(
   should_process_current_page_ =
       handle->GetURL().SchemeIsHTTPOrHTTPS() &&
       handle->GetRestoreType() != content::RestoreType::kRestored &&
-      psst_settings_service_->IsPsstEnabled();
+      (psst_settings_service_->IsPsstEnabled() ||
+       psst_settings_service_->IsManagedPreference());
 }
 
 void PsstTabWebContentsObserver::DocumentOnLoadCompletedInPrimaryMainFrame() {
@@ -400,6 +401,13 @@ void PsstTabWebContentsObserver::OnPsstEnableChange(bool new_value) {
   if (new_value) {
     return;
   }
+
+  // Do not interrupt the flow when it is in managed preferences mode (e.g.,
+  // admin or Brave Origin policies)
+  if (psst_settings_service_->IsManagedPreference()) {
+    return;
+  }
+
   CancelInFlightFlow();
 }
 

--- a/browser/psst/psst_tab_web_contents_observer.cc
+++ b/browser/psst/psst_tab_web_contents_observer.cc
@@ -218,7 +218,7 @@ void PsstTabWebContentsObserver::DidFinishNavigation(
       handle->GetURL().SchemeIsHTTPOrHTTPS() &&
       handle->GetRestoreType() != content::RestoreType::kRestored &&
       (psst_settings_service_->IsPsstEnabled() ||
-       psst_settings_service_->IsManagedPreference());
+       psst_settings_service_->WasPsstEnabledAtStartup());
 }
 
 void PsstTabWebContentsObserver::DocumentOnLoadCompletedInPrimaryMainFrame() {

--- a/browser/psst/psst_tab_web_contents_observer_browsertest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_browsertest.cc
@@ -40,6 +40,11 @@
 #include "components/infobars/content/content_infobar_manager.h"
 #include "components/infobars/core/confirm_infobar_delegate.h"
 #include "components/infobars/core/infobar.h"
+#include "components/policy/core/browser/browser_policy_connector.h"
+#include "components/policy/core/common/mock_configuration_policy_provider.h"
+#include "components/policy/core/common/policy_map.h"
+#include "components/policy/core/common/policy_types.h"
+#include "components/policy/policy_constants.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
@@ -481,6 +486,14 @@ void AcceptContextMenuItem(views::MenuItemView* item) {
   controller->OnWillDispatchKeyEvent(&return_event);
 }
 
+// Closes the active context menu without selecting any item.
+void CloseActiveContextMenu() {
+  views::MenuController* const controller =
+      views::MenuController::GetActiveInstance();
+  ASSERT_TRUE(controller);
+  controller->Cancel(views::MenuController::ExitType::kAll);
+}
+
 }  // namespace
 
 class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
@@ -641,13 +654,12 @@ class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
     }));
   }
 
-  // Navigates to `url`, waits for the PSST icon to appear in the location bar,
-  // then clicks it with the specified `event_flags` to open its context menu
-  // and waits for the menu to appear, or opens the consent dialog and waits
-  // for it to appear. For a left-click, the opened consent dialog's WebContents
-  // is returned via `dialog_wc_out` when provided.
-  void NavigateAndClickOnPsstLocationBarIcon(
-      const GURL& url,
+  // Clicks the (already visible) PSST location bar icon with the specified
+  // `event_flags` to open its context menu and waits for the menu to appear,
+  // or opens the consent dialog and waits for it to appear. For a left-click,
+  // the opened consent dialog's WebContents is returned via `dialog_wc_out`
+  // when provided.
+  void ClickOnPsstLocationBarIcon(
       ui::EventFlags event_flags,
       content::WebContents** dialog_wc_out = nullptr) {
     ASSERT_TRUE(event_flags == ui::EF_RIGHT_MOUSE_BUTTON ||
@@ -656,8 +668,6 @@ class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
     actions::ActionItem* const action =
         actions::ActionManager::Get().FindAction(kActionShowPsstIcon);
     ASSERT_TRUE(action);
-
-    ASSERT_NO_FATAL_FAILURE(NavigateAndWaitForPsstIconVisible(url));
 
     IconLabelBubbleView* const psst_view = GetPsstPageActionView();
     ASSERT_TRUE(psst_view);
@@ -689,6 +699,17 @@ class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
         *dialog_wc_out = dialog_wc;
       }
     }
+  }
+
+  // Navigates to `url`, waits for the PSST icon to appear in the location bar,
+  // then clicks it. See `ClickOnPsstLocationBarIcon()` for the click behavior.
+  void NavigateAndClickOnPsstLocationBarIcon(
+      const GURL& url,
+      ui::EventFlags event_flags,
+      content::WebContents** dialog_wc_out = nullptr) {
+    ASSERT_NO_FATAL_FAILURE(NavigateAndWaitForPsstIconVisible(url));
+    ASSERT_NO_FATAL_FAILURE(
+        ClickOnPsstLocationBarIcon(event_flags, dialog_wc_out));
   }
 
   // Waits for the PSST context menu to close.
@@ -982,14 +1003,31 @@ IN_PROC_BROWSER_TEST_F(PsstTabWebContentsObserverBrowserTest,
   ASSERT_NO_FATAL_FAILURE(WaitForPsstIconHidden());
 }
 
+// After navigating to a matching site, the PSST icon and infobar both appear.
+// Left-clicking the icon opens the consent dialog and hides the infobar.
 IN_PROC_BROWSER_TEST_F(PsstTabWebContentsObserverBrowserTest,
                        LocationBarIconLeftClickShowsConsentDialog) {
   GetPrefs()->SetBoolean(prefs::kPsstEnabled, true);
   ASSERT_TRUE(GetPrefs()->GetBoolean(prefs::kPsstEnabled));
 
   const GURL url = GetEmbeddedTestServer().GetURL("a.test", "/a_test_0.html");
+
+  infobars::ContentInfoBarManager* const manager =
+      infobars::ContentInfoBarManager::FromWebContents(web_contents());
+  InfobarObserver infobar_observer(
+      manager, infobars::InfoBarDelegate::BRAVE_PSST_INFOBAR_DELEGATE);
+
+  ASSERT_NO_FATAL_FAILURE(NavigateAndWaitForPsstIconVisible(url));
+  ASSERT_TRUE(infobar_observer.WaitForInfobarAdded());
+  ASSERT_TRUE(GetPsstInfobar(manager));
+
+  content::WebContents* dialog_wc = nullptr;
   ASSERT_NO_FATAL_FAILURE(
-      NavigateAndClickOnPsstLocationBarIcon(url, ui::EF_LEFT_MOUSE_BUTTON));
+      ClickOnPsstLocationBarIcon(ui::EF_LEFT_MOUSE_BUTTON, &dialog_wc));
+  ASSERT_TRUE(dialog_wc);
+
+  ASSERT_TRUE(infobar_observer.WaitForInfobarRemoved());
+  EXPECT_FALSE(GetPsstInfobar(manager));
 }
 
 // After navigating to the initial page and left-clicking the PSST location bar
@@ -1046,6 +1084,85 @@ IN_PROC_BROWSER_TEST_F(
   EXPECT_EQ(psst_website_settings->uids_to_perform, perform_uids);
 
   ASSERT_TRUE(CloseModalDialog(dialog_wc));
+}
+
+// Fixture that enables PSST via a mandatory administrator policy, which makes
+// `prefs::kPsstEnabled` a managed preference before the profile is created.
+class PsstEnabledByPolicyBrowserTest
+    : public PsstTabWebContentsObserverBrowserTest {
+ public:
+  PsstEnabledByPolicyBrowserTest() = default;
+  ~PsstEnabledByPolicyBrowserTest() override = default;
+
+  void SetUpInProcessBrowserTestFixture() override {
+    PsstTabWebContentsObserverBrowserTest::SetUpInProcessBrowserTestFixture();
+
+    EXPECT_CALL(policy_provider_, IsInitializationComplete(testing::_))
+        .WillRepeatedly(testing::Return(true));
+    policy::BrowserPolicyConnector::SetPolicyProviderForTesting(
+        &policy_provider_);
+
+    policy::PolicyMap policies;
+    policies.Set(policy::key::kPsstEnabled, policy::POLICY_LEVEL_MANDATORY,
+                 policy::POLICY_SCOPE_MACHINE, policy::POLICY_SOURCE_PLATFORM,
+                 base::Value(true), nullptr);
+    policy_provider_.UpdateChromePolicy(policies);
+  }
+
+ private:
+  policy::MockConfigurationPolicyProvider policy_provider_;
+};
+
+// When PSST is enabled by administrator policy, `prefs::kPsstEnabled` is
+// managed, so: the context menu only offers "Don't show for this site" (the
+// item that would disable PSST globally is hidden because that's not
+// something the user can override), and closing the infobar via its close
+// button doesn't disable the managed preference.
+IN_PROC_BROWSER_TEST_F(PsstEnabledByPolicyBrowserTest,
+                       ManagedPolicyRestrictsMenuAndSurvivesInfobarClose) {
+  ASSERT_TRUE(GetPrefs()->IsManagedPreference(prefs::kPsstEnabled));
+  ASSERT_TRUE(GetPrefs()->GetBoolean(prefs::kPsstEnabled));
+
+  const GURL url = GetEmbeddedTestServer().GetURL("a.test", "/a_test_0.html");
+
+  infobars::ContentInfoBarManager* const manager =
+      infobars::ContentInfoBarManager::FromWebContents(web_contents());
+  InfobarObserver infobar_observer(
+      manager, infobars::InfoBarDelegate::BRAVE_PSST_INFOBAR_DELEGATE);
+
+  ASSERT_NO_FATAL_FAILURE(NavigateAndWaitForPsstIconVisible(url));
+  ASSERT_TRUE(infobar_observer.WaitForInfobarAdded());
+
+  ASSERT_NO_FATAL_FAILURE(
+      ClickOnPsstLocationBarIcon(ui::EF_RIGHT_MOUSE_BUTTON));
+
+  views::MenuItemView* const root = GetActiveContextMenuRoot();
+  ASSERT_TRUE(root);
+  // Only "Don't show for this site" is present; the item that disables PSST
+  // globally is hidden because the preference is managed by policy.
+  EXPECT_TRUE(root->GetMenuItemByID(IDC_PSST_DONT_SHOW_FOR_THIS_SITE));
+  EXPECT_FALSE(root->GetMenuItemByID(IDC_PSST_DISABLE_PRIVACY_SETTINGS_TUNING));
+
+  ASSERT_NO_FATAL_FAILURE(CloseActiveContextMenu());
+  ASSERT_NO_FATAL_FAILURE(WaitForPsstContextMenuClosed());
+
+  auto* const psst_infobar = GetPsstInfobar(manager);
+  ASSERT_TRUE(psst_infobar);
+  auto* const confirm_delegate =
+      psst_infobar->delegate()->AsConfirmInfoBarDelegate();
+  ASSERT_TRUE(confirm_delegate);
+
+  // Close the infobar via its close ("x") button. Mirrors
+  // InfoBarView::CloseButtonPressed(), which reports the infobar as dismissed
+  // (rather than accepted or explicitly declined) and then removes it.
+  confirm_delegate->InfoBarDismissed();
+  psst_infobar->RemoveSelf();
+  ASSERT_TRUE(infobar_observer.WaitForInfobarRemoved());
+  EXPECT_FALSE(GetPsstInfobar(manager));
+
+  // The managed preference is untouched by the infobar dismissal.
+  EXPECT_TRUE(GetPrefs()->IsManagedPreference(prefs::kPsstEnabled));
+  EXPECT_TRUE(GetPrefs()->GetBoolean(prefs::kPsstEnabled));
 }
 
 }  // namespace psst

--- a/browser/psst/psst_tab_web_contents_observer_browsertest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_browsertest.cc
@@ -48,6 +48,7 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
+#include "content/public/test/test_utils.h"
 #include "net/dns/mock_host_resolver.h"
 #include "net/test/embedded_test_server/embedded_test_server.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -1163,6 +1164,61 @@ IN_PROC_BROWSER_TEST_F(PsstEnabledByPolicyBrowserTest,
   // The managed preference is untouched by the infobar dismissal.
   EXPECT_TRUE(GetPrefs()->IsManagedPreference(prefs::kPsstEnabled));
   EXPECT_TRUE(GetPrefs()->GetBoolean(prefs::kPsstEnabled));
+}
+
+// Fixture that disables PSST via a mandatory administrator policy, which
+// makes `prefs::kPsstEnabled` a managed, disabled preference before the
+// profile is created. This causes `PsstSettingsServiceFactory::GetForProfile`
+// to return null for the profile (see
+// `PsstSettingsServiceFactory::BuildServiceInstanceForBrowserContext`), which
+// previously crashed `BraveTabFeatures::Init()` when it unconditionally
+// dereferenced the null service.
+class PsstDisabledByPolicyBrowserTest
+    : public PsstTabWebContentsObserverBrowserTest {
+ public:
+  PsstDisabledByPolicyBrowserTest() = default;
+  ~PsstDisabledByPolicyBrowserTest() override = default;
+
+  void SetUpInProcessBrowserTestFixture() override {
+    PsstTabWebContentsObserverBrowserTest::SetUpInProcessBrowserTestFixture();
+
+    EXPECT_CALL(policy_provider_, IsInitializationComplete(testing::_))
+        .WillRepeatedly(testing::Return(true));
+    policy::BrowserPolicyConnector::SetPolicyProviderForTesting(
+        &policy_provider_);
+
+    policy::PolicyMap policies;
+    policies.Set(policy::key::kPsstEnabled, policy::POLICY_LEVEL_MANDATORY,
+                 policy::POLICY_SCOPE_MACHINE, policy::POLICY_SOURCE_PLATFORM,
+                 base::Value(false), nullptr);
+    policy_provider_.UpdateChromePolicy(policies);
+  }
+
+ private:
+  policy::MockConfigurationPolicyProvider policy_provider_;
+};
+
+// When PSST is disabled by administrator policy, no `PsstSettingsService`
+// exists for the profile. The browser must not crash creating or navigating
+// tabs, and since there's no service to drive the PSST flow, the location bar
+// icon never appears for a matching site.
+IN_PROC_BROWSER_TEST_F(PsstDisabledByPolicyBrowserTest,
+                       ManagedPolicyDisablesServiceWithoutCrash) {
+  ASSERT_TRUE(GetPrefs()->IsManagedPreference(prefs::kPsstEnabled));
+  ASSERT_FALSE(GetPrefs()->GetBoolean(prefs::kPsstEnabled));
+  // No service is created for the profile, exercising the null branch in
+  // `BraveTabFeatures::Init()`.
+  EXPECT_FALSE(GetPsstSettingsService());
+
+  const GURL url = GetEmbeddedTestServer().GetURL("a.test", "/a_test_0.html");
+  ASSERT_TRUE(content::NavigateToURL(web_contents(), url));
+  content::RunAllTasksUntilIdle();
+
+  IconLabelBubbleView* const psst_view = GetPsstPageActionView();
+  if (psst_view) {
+    views::test::RunScheduledLayout(psst_view);
+    EXPECT_FALSE(psst_view->GetVisible());
+  }
 }
 
 }  // namespace psst

--- a/browser/psst/psst_tab_web_contents_observer_unittest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_unittest.cc
@@ -232,6 +232,12 @@ class PsstTabWebContentsObserverUnitTestBase
   void SetUp() override {
     ChromeRenderViewHostTestHarness::SetUp();
 
+    // PsstSettingsService captures the initial pref value at construction
+    // time (see `was_enabled_at_startup_`), so tests that need it disabled
+    // from the start must set the pref before the service below is created,
+    // not from the test body.
+    ConfigurePrefsBeforeServiceCreation();
+
     psst::RegisterProfilePrefs(prefs_.registry());
     rule_registry_ = std::make_unique<MockPsstRuleRegistry>();
 
@@ -253,14 +259,20 @@ class PsstTabWebContentsObserverUnitTestBase
     variations_service_ = std::make_unique<variations::TestVariationsService>(
         &variations_local_state_, metrics_state_manager_.get());
 
-    psst_web_contents_observer_ = base::WrapUnique<PsstTabWebContentsObserver>(
-        new PsstTabWebContentsObserver(
-            mock_tab, rule_registry_.get(), psst_settings_service_,
-            variations_service_.get(), std::move(ui_delegate)));
-    psst_web_contents_observer_->SetInjectScriptCallback(
-        inject_script_callback_.Get());
-    psst_web_contents_observer_->SetInjectAsyncScriptCallback(
-        inject_async_script_callback_.Get());
+    // psst_settings_service_ is null when the PSST feature flag is disabled
+    // (see PsstSettingsServiceFactory::BuildServiceInstanceForBrowserContext),
+    // in which case there's nothing to construct the observer against.
+    if (psst_settings_service_) {
+      psst_web_contents_observer_ =
+          base::WrapUnique<PsstTabWebContentsObserver>(
+              new PsstTabWebContentsObserver(
+                  mock_tab, rule_registry_.get(), psst_settings_service_,
+                  variations_service_.get(), std::move(ui_delegate)));
+      psst_web_contents_observer_->SetInjectScriptCallback(
+          inject_script_callback_.Get());
+      psst_web_contents_observer_->SetInjectAsyncScriptCallback(
+          inject_async_script_callback_.Get());
+    }
   }
 
   void TearDown() override {
@@ -312,6 +324,10 @@ class PsstTabWebContentsObserverUnitTestBase
 
  protected:
   base::test::ScopedFeatureList feature_list_;
+
+  // Override to configure profile prefs prior to PsstSettingsService's
+  // creation, e.g. to test its startup-time behavior.
+  virtual void ConfigurePrefsBeforeServiceCreation() {}
 
  private:
   raw_ptr<MockUiDelegate> ui_delegate_;
@@ -726,8 +742,16 @@ TEST_F(PsstTabWebContentsObserverUnitTest,
   EXPECT_EQ(base::Value(), user_script_insert_future.Take());
 }
 
-TEST_F(PsstTabWebContentsObserverUnitTest, PrefDisabledDontProcess) {
-  psst_settings_service()->SetPsstEnabled(false);
+class PsstTabWebContentsObserverPrefDisabledAtStartupUnitTest
+    : public PsstTabWebContentsObserverUnitTest {
+ public:
+  void ConfigurePrefsBeforeServiceCreation() override {
+    profile()->GetPrefs()->SetBoolean(prefs::kPsstEnabled, false);
+  }
+};
+
+TEST_F(PsstTabWebContentsObserverPrefDisabledAtStartupUnitTest,
+       PrefDisabledDontProcess) {
   EXPECT_CALL(psst_rule_registry(), CheckIfMatch(url_, _)).Times(0);
   DocumentOnLoadObserver observer(web_contents());
   content::NavigationSimulator::NavigateAndCommitFromBrowser(web_contents(),
@@ -1282,11 +1306,7 @@ class PsstTabWebContentsObserverFeatureDisabledUnitTest
 };
 
 TEST_F(PsstTabWebContentsObserverFeatureDisabledUnitTest, DontCreate) {
-  EXPECT_EQ(PsstTabWebContentsObserver::MaybeCreateForWebContents(
-                mock_tab_interface(), browser_context(),
-                std::make_unique<MockUiDelegate>(), psst_settings_service(),
-                variations_service(), 2),
-            nullptr);
+  EXPECT_EQ(psst_settings_service(), nullptr);
 }
 
 }  // namespace psst

--- a/browser/psst/psst_ui_delegate_impl.cc
+++ b/browser/psst/psst_ui_delegate_impl.cc
@@ -8,6 +8,7 @@
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "brave/components/psst/core/browser/pref_names.h"
+#include "brave/components/psst/core/common/constants.h"
 #include "brave/components/psst/core/common/psst_metadata_schema.h"
 #include "components/prefs/pref_service.h"
 
@@ -176,8 +177,12 @@ void PsstUiDelegateImpl::OnUserAcceptedInfobar(const bool is_accepted) {
 
     ui_presenter_->ShowConsentDialog();
   } else {
-    // Disable PSST if user declined the infobar
-    psst_settings_service_->SetPsstEnabled(false);
+    if (!psst_settings_service_->IsManagedPreference()) {
+      // Disable PSST if user declined the infobar and PSST is not managed by
+      // policy
+      psst_settings_service_->SetPsstEnabled(false);
+    }
+    psst_settings_service_->SetInfobarShowCounter(kMaxPsstInfobarShownCounter);
   }
 }
 
@@ -203,6 +208,12 @@ void PsstUiDelegateImpl::OnDisablePrivacySettingsTuning() {
 
 void PsstUiDelegateImpl::OnPsstEnableChange(bool new_value) {
   if (new_value) {
+    return;
+  }
+
+  // Do not remove the omnibar icon infobar and consent dialog when it is in
+  // managed preferences mode (e.g., admin or Brave Origin policies)
+  if (psst_settings_service_->IsManagedPreference()) {
     return;
   }
 

--- a/browser/psst/psst_ui_delegate_impl.cc
+++ b/browser/psst/psst_ui_delegate_impl.cc
@@ -214,7 +214,7 @@ void PsstUiDelegateImpl::OnPsstEnableChange(bool new_value) {
   // managed preferences mode and was enabled at startup (e.g., admin or Brave
   // Origin policies)
   if (psst_settings_service_->IsManagedPreference() &&
-      psst_settings_service_->WasPsstEnabledAtStartup()) {
+      psst_settings_service_->was_enabled_at_startup()) {
     return;
   }
 

--- a/browser/psst/psst_ui_delegate_impl.cc
+++ b/browser/psst/psst_ui_delegate_impl.cc
@@ -8,7 +8,6 @@
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "brave/components/psst/core/browser/pref_names.h"
-#include "brave/components/psst/core/common/constants.h"
 #include "brave/components/psst/core/common/psst_metadata_schema.h"
 #include "components/prefs/pref_service.h"
 

--- a/browser/psst/psst_ui_delegate_impl.cc
+++ b/browser/psst/psst_ui_delegate_impl.cc
@@ -211,8 +211,10 @@ void PsstUiDelegateImpl::OnPsstEnableChange(bool new_value) {
   }
 
   // Do not remove the omnibar icon infobar and consent dialog when it is in
-  // managed preferences mode (e.g., admin or Brave Origin policies)
-  if (psst_settings_service_->IsManagedPreference()) {
+  // managed preferences mode and was enabled at startup (e.g., admin or Brave
+  // Origin policies)
+  if (psst_settings_service_->IsManagedPreference() &&
+      psst_settings_service_->WasPsstEnabledAtStartup()) {
     return;
   }
 

--- a/browser/psst/psst_ui_delegate_impl.cc
+++ b/browser/psst/psst_ui_delegate_impl.cc
@@ -181,7 +181,6 @@ void PsstUiDelegateImpl::OnUserAcceptedInfobar(const bool is_accepted) {
       // policy
       psst_settings_service_->SetPsstEnabled(false);
     }
-    psst_settings_service_->SetInfobarShowCounter(kMaxPsstInfobarShownCounter);
   }
 }
 

--- a/browser/psst/psst_ui_desktop_presenter.cc
+++ b/browser/psst/psst_ui_desktop_presenter.cc
@@ -216,8 +216,6 @@ void PsstUiDesktopPresenter::ShowConsentDialog() {
     return;
   }
 
-  HideInfoBar();
-
   if (psst_action_controller_) {
     psst_action_controller_->SetShowBadge(false);
   }
@@ -242,6 +240,7 @@ bool PsstUiDesktopPresenter::IsDialogShown() const {
 }
 
 void PsstUiDesktopPresenter::OnShowConsentDialogSelected() {
+  HideInfoBar();
   ShowConsentDialog();
 }
 

--- a/browser/ui/tabs/brave_tab_features.cc
+++ b/browser/ui/tabs/brave_tab_features.cc
@@ -101,8 +101,8 @@ void BraveTabFeatures::Init(TabInterface& tab, Profile* profile) {
                   tab, profile,
                   std::make_unique<psst::PsstUiDelegateImpl>(
                       psst_settings_service,
-                PsstReporterServiceFactory::GetForProfile(profile),
-                profile->GetPrefs(),
+                      PsstReporterServiceFactory::GetForProfile(profile),
+                      profile->GetPrefs(),
                       std::make_unique<psst::PsstUiDesktopPresenter>(
                           tab.GetContents()->GetWeakPtr(),
                           psst_action_controller_->AsWeakPtr())),

--- a/browser/ui/tabs/brave_tab_features.cc
+++ b/browser/ui/tabs/brave_tab_features.cc
@@ -84,31 +84,26 @@ void BraveTabFeatures::Init(TabInterface& tab, Profile* profile) {
       page_action_controller()->ActionExists(kActionShowPsstIcon)) {
     auto* psst_settings_service =
         PsstSettingsServiceFactory::GetForProfile(profile);
-    psst_action_controller_ =
-        std::make_unique<page_actions::PsstActionController>(
-            tab, *page_action_controller(),
-            psst_settings_service &&
-                psst_settings_service->IsManagedPreference());
-    auto* variations_service = g_browser_process->variations_service();
-    // `psst_settings_service` can be null when the PSST feature is
-    // controlled by admin's or Brave Origin policy: both require a
-    // browser restart to take effect, so the service only exists if the
-    // feature was already enabled at browser start, and the PSST flow only
-    // runs in that case.
-    psst_web_contents_observer_ =
-        psst_settings_service
-            ? psst::PsstTabWebContentsObserver::MaybeCreateForWebContents(
-                  tab, profile,
-                  std::make_unique<psst::PsstUiDelegateImpl>(
-                      psst_settings_service,
-                      PsstReporterServiceFactory::GetForProfile(profile),
-                      profile->GetPrefs(),
-                      std::make_unique<psst::PsstUiDesktopPresenter>(
-                          tab.GetContents()->GetWeakPtr(),
-                          psst_action_controller_->AsWeakPtr())),
-                  psst_settings_service, variations_service,
-                  ISOLATED_WORLD_ID_BRAVE_INTERNAL)
-            : nullptr;
+    if (psst_settings_service) {
+      psst_action_controller_ =
+          std::make_unique<page_actions::PsstActionController>(
+              tab, *page_action_controller(),
+              psst_settings_service &&
+                  psst_settings_service->IsManagedPreference());
+      auto* variations_service = g_browser_process->variations_service();
+      psst_web_contents_observer_ =
+          psst::PsstTabWebContentsObserver::MaybeCreateForWebContents(
+              tab, profile,
+              std::make_unique<psst::PsstUiDelegateImpl>(
+                  psst_settings_service,
+                  PsstReporterServiceFactory::GetForProfile(profile),
+                  profile->GetPrefs(),
+                  std::make_unique<psst::PsstUiDesktopPresenter>(
+                      tab.GetContents()->GetWeakPtr(),
+                      psst_action_controller_->AsWeakPtr())),
+              psst_settings_service, variations_service,
+              ISOLATED_WORLD_ID_BRAVE_INTERNAL);
+    }
   }
 #endif
 

--- a/browser/ui/tabs/brave_tab_features.cc
+++ b/browser/ui/tabs/brave_tab_features.cc
@@ -82,24 +82,33 @@ void BraveTabFeatures::Init(TabInterface& tab, Profile* profile) {
   if (base::FeatureList::IsEnabled(features::kPageActionsMigration) &&
       base::FeatureList::IsEnabled(psst::features::kEnablePsst) &&
       page_action_controller()->ActionExists(kActionShowPsstIcon)) {
-    psst_action_controller_ =
-        std::make_unique<page_actions::PsstActionController>(
-            tab, *page_action_controller());
     auto* psst_settings_service =
         PsstSettingsServiceFactory::GetForProfile(profile);
+    psst_action_controller_ =
+        std::make_unique<page_actions::PsstActionController>(
+            tab, *page_action_controller(),
+            psst_settings_service &&
+                psst_settings_service->IsManagedPreference());
     auto* variations_service = g_browser_process->variations_service();
+    // `psst_settings_service` can be null when the PSST feature is
+    // controlled by admin's or Brave Origin policy: both require a
+    // browser restart to take effect, so the service only exists if the
+    // feature was already enabled at browser start, and the PSST flow only
+    // runs in that case.
     psst_web_contents_observer_ =
-        psst::PsstTabWebContentsObserver::MaybeCreateForWebContents(
-            tab, profile,
-            std::make_unique<psst::PsstUiDelegateImpl>(
-                psst_settings_service,
+        psst_settings_service
+            ? psst::PsstTabWebContentsObserver::MaybeCreateForWebContents(
+                  tab, profile,
+                  std::make_unique<psst::PsstUiDelegateImpl>(
+                      psst_settings_service,
                 PsstReporterServiceFactory::GetForProfile(profile),
                 profile->GetPrefs(),
-                std::make_unique<psst::PsstUiDesktopPresenter>(
-                    tab.GetContents()->GetWeakPtr(),
-                    psst_action_controller_->AsWeakPtr())),
-            psst_settings_service, variations_service,
-            ISOLATED_WORLD_ID_BRAVE_INTERNAL);
+                      std::make_unique<psst::PsstUiDesktopPresenter>(
+                          tab.GetContents()->GetWeakPtr(),
+                          psst_action_controller_->AsWeakPtr())),
+                  psst_settings_service, variations_service,
+                  ISOLATED_WORLD_ID_BRAVE_INTERNAL)
+            : nullptr;
   }
 #endif
 

--- a/browser/ui/views/page_action/psst_action_controller.cc
+++ b/browser/ui/views/page_action/psst_action_controller.cc
@@ -65,7 +65,7 @@ namespace page_actions {
 PsstActionController::PsstActionController(
     tabs::TabInterface& tab,
     page_actions::PageActionController& page_action_controller,
-    const bool hide_disable_psst_menu_item)
+    bool hide_disable_psst_menu_item)
     : tab_(tab),
       page_action_controller_(
           static_cast<page_actions::PageActionControllerImpl&>(

--- a/browser/ui/views/page_action/psst_action_controller.cc
+++ b/browser/ui/views/page_action/psst_action_controller.cc
@@ -71,7 +71,7 @@ PsstActionController::PsstActionController(
           static_cast<page_actions::PageActionControllerImpl&>(
               page_action_controller)),
       hide_disable_psst_menu_item_(hide_disable_psst_menu_item) {
-  CHECK(psst::features::IsPsstEnabled());
+  CHECK(psst::features::IsPsstFeatureFlagEnabled());
 }
 
 PsstActionController::~PsstActionController() = default;

--- a/browser/ui/views/page_action/psst_action_controller.cc
+++ b/browser/ui/views/page_action/psst_action_controller.cc
@@ -64,12 +64,14 @@ namespace page_actions {
 
 PsstActionController::PsstActionController(
     tabs::TabInterface& tab,
-    page_actions::PageActionController& page_action_controller)
+    page_actions::PageActionController& page_action_controller,
+    const bool hide_disable_psst_menu_item)
     : tab_(tab),
       page_action_controller_(
           static_cast<page_actions::PageActionControllerImpl&>(
-              page_action_controller)) {
-  CHECK(base::FeatureList::IsEnabled(psst::features::kEnablePsst));
+              page_action_controller)),
+      hide_disable_psst_menu_item_(hide_disable_psst_menu_item) {
+  CHECK(psst::features::IsPsstEnabled());
 }
 
 PsstActionController::~PsstActionController() = default;
@@ -165,9 +167,16 @@ void PsstActionController::BuildMenuItems() {
   psst_menu_model_->AddItem(
       IDC_PSST_DONT_SHOW_FOR_THIS_SITE,
       l10n_util::GetStringUTF16(IDS_IDC_PSST_DONT_SHOW_FOR_THIS_SITE));
-  psst_menu_model_->AddItem(
-      IDC_PSST_DISABLE_PRIVACY_SETTINGS_TUNING,
-      l10n_util::GetStringUTF16(IDS_IDC_PSST_DISABLE_PRIVACY_SETTINGS_TUNING));
+
+  // If Brave preferences are under management, disabling the PSST feature via
+  // the omnibar icon's menu is ineffective, as it must be controlled by the
+  // Brave Origin feature toggle or administrator's policy
+  if (!hide_disable_psst_menu_item_) {
+    psst_menu_model_->AddItem(
+        IDC_PSST_DISABLE_PRIVACY_SETTINGS_TUNING,
+        l10n_util::GetStringUTF16(
+            IDS_IDC_PSST_DISABLE_PRIVACY_SETTINGS_TUNING));
+  }
 }
 
 void PsstActionController::UpdatePageAction() {

--- a/browser/ui/views/page_action/psst_action_controller.h
+++ b/browser/ui/views/page_action/psst_action_controller.h
@@ -34,7 +34,7 @@ class PsstActionController : public ui::SimpleMenuModel::Delegate {
   PsstActionController(
       tabs::TabInterface& tab,
       page_actions::PageActionController& page_action_controller,
-      const bool hide_disable_psst_menu_item);
+      bool hide_disable_psst_menu_item);
   PsstActionController(const PsstActionController&) = delete;
   PsstActionController& operator=(const PsstActionController&) = delete;
   ~PsstActionController() override;

--- a/browser/ui/views/page_action/psst_action_controller.h
+++ b/browser/ui/views/page_action/psst_action_controller.h
@@ -33,7 +33,8 @@ class PsstActionController : public ui::SimpleMenuModel::Delegate {
 
   PsstActionController(
       tabs::TabInterface& tab,
-      page_actions::PageActionController& page_action_controller);
+      page_actions::PageActionController& page_action_controller,
+      const bool hide_disable_psst_menu_item);
   PsstActionController(const PsstActionController&) = delete;
   PsstActionController& operator=(const PsstActionController&) = delete;
   ~PsstActionController() override;
@@ -62,6 +63,7 @@ class PsstActionController : public ui::SimpleMenuModel::Delegate {
   const raw_ref<tabs::TabInterface> tab_;
   const raw_ref<page_actions::PageActionControllerImpl> page_action_controller_;
   base::CallbackListSubscription did_activate_subscription_;
+  bool hide_disable_psst_menu_item_;
 
   std::unique_ptr<ui::SimpleMenuModel> psst_menu_model_;
   std::unique_ptr<views::MenuModelAdapter> menu_model_adapter_;

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -309,8 +309,7 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
               profile));
 #endif
 #if BUILDFLAG(ENABLE_PSST)
-  html_source->AddBoolean("isPsstEnabled", base::FeatureList::IsEnabled(
-                                               psst::features::kEnablePsst));
+  html_source->AddBoolean("isPsstEnabled", psst::features::IsPsstEnabled());
 #endif
 #if BUILDFLAG(ENABLE_CONTAINERS)
   html_source->AddBoolean(

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -309,7 +309,8 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
               profile));
 #endif
 #if BUILDFLAG(ENABLE_PSST)
-  html_source->AddBoolean("isPsstEnabled", psst::features::IsPsstEnabled());
+  html_source->AddBoolean("isPsstEnabled",
+                          psst::features::IsPsstFeatureFlagEnabled());
 #endif
 #if BUILDFLAG(ENABLE_CONTAINERS)
   html_source->AddBoolean(

--- a/components/psst/core/browser/pref_names.cc
+++ b/components/psst/core/browser/pref_names.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/psst/core/browser/pref_names.h"
 
+#include "brave/components/psst/core/common/features.h"
 #include "components/prefs/pref_registry_simple.h"
 
 namespace psst {
@@ -12,6 +13,11 @@ namespace psst {
 void RegisterProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterBooleanPref(prefs::kPsstEnabled, true);
   registry->RegisterIntegerPref(prefs::kPsstInfobarShownCounter, 0);
+}
+
+bool IsPsstEnabledForProfile(PrefService& pref_service) {
+  return features::IsPsstEnabled() &&
+         pref_service.GetBoolean(prefs::kPsstEnabled);
 }
 
 }  // namespace psst

--- a/components/psst/core/browser/pref_names.cc
+++ b/components/psst/core/browser/pref_names.cc
@@ -5,7 +5,6 @@
 
 #include "brave/components/psst/core/browser/pref_names.h"
 
-#include "brave/components/psst/core/common/features.h"
 #include "components/prefs/pref_registry_simple.h"
 
 namespace psst {
@@ -15,9 +14,12 @@ void RegisterProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterIntegerPref(prefs::kPsstInfobarShownCounter, 0);
 }
 
-bool IsPsstEnabledForProfile(const PrefService& pref_service) {
-  return features::IsPsstEnabled() &&
-         pref_service.GetBoolean(prefs::kPsstEnabled);
+bool IsPsstSettingPrefEnabled(const PrefService& pref_service) {
+  return pref_service.GetBoolean(prefs::kPsstEnabled);
+}
+
+bool IsPsstManaged(const PrefService& pref_service) {
+  return pref_service.IsManagedPreference(prefs::kPsstEnabled);
 }
 
 }  // namespace psst

--- a/components/psst/core/browser/pref_names.cc
+++ b/components/psst/core/browser/pref_names.cc
@@ -15,7 +15,7 @@ void RegisterProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterIntegerPref(prefs::kPsstInfobarShownCounter, 0);
 }
 
-bool IsPsstEnabledForProfile(PrefService& pref_service) {
+bool IsPsstEnabledForProfile(const PrefService& pref_service) {
   return features::IsPsstEnabled() &&
          pref_service.GetBoolean(prefs::kPsstEnabled);
 }

--- a/components/psst/core/browser/pref_names.h
+++ b/components/psst/core/browser/pref_names.h
@@ -20,6 +20,8 @@ inline constexpr char kPsstInfobarShownCounter[] =
 
 void RegisterProfilePrefs(PrefRegistrySimple* registry);
 
+bool IsPsstEnabledForProfile(PrefService& pref_service);
+
 }  // namespace psst
 
 #endif  // BRAVE_COMPONENTS_PSST_CORE_BROWSER_PREF_NAMES_H_

--- a/components/psst/core/browser/pref_names.h
+++ b/components/psst/core/browser/pref_names.h
@@ -20,7 +20,9 @@ inline constexpr char kPsstInfobarShownCounter[] =
 
 void RegisterProfilePrefs(PrefRegistrySimple* registry);
 
-bool IsPsstEnabledForProfile(const PrefService& pref_service);
+bool IsPsstSettingPrefEnabled(const PrefService& pref_service);
+
+bool IsPsstManaged(const PrefService& pref_service);
 
 }  // namespace psst
 

--- a/components/psst/core/browser/pref_names.h
+++ b/components/psst/core/browser/pref_names.h
@@ -20,7 +20,7 @@ inline constexpr char kPsstInfobarShownCounter[] =
 
 void RegisterProfilePrefs(PrefRegistrySimple* registry);
 
-bool IsPsstEnabledForProfile(PrefService& pref_service);
+bool IsPsstEnabledForProfile(const PrefService& pref_service);
 
 }  // namespace psst
 

--- a/components/psst/core/browser/psst_settings_service.cc
+++ b/components/psst/core/browser/psst_settings_service.cc
@@ -8,6 +8,7 @@
 #include "base/check.h"
 #include "base/functional/bind.h"
 #include "brave/components/psst/core/browser/pref_names.h"
+#include "brave/components/psst/core/common/features.h"
 #include "components/prefs/pref_service.h"
 #include "url/gurl.h"
 
@@ -128,11 +129,19 @@ void PsstSettingsService::SetPsstWebsiteSettings(
 }
 
 bool PsstSettingsService::IsPsstEnabled() const {
-  return prefs_->GetBoolean(prefs::kPsstEnabled);
+  return IsPsstEnabledForProfile(*prefs_);
 }
 
 void PsstSettingsService::SetPsstEnabled(bool enabled) {
   prefs_->SetBoolean(prefs::kPsstEnabled, enabled);
+}
+
+bool PsstSettingsService::IsManagedPreference() const {
+  return prefs_->IsManagedPreference(prefs::kPsstEnabled);
+}
+
+void PsstSettingsService::SetInfobarShowCounter(int value) {
+  prefs_->SetInteger(prefs::kPsstInfobarShownCounter, value);
 }
 
 void PsstSettingsService::OnPreferenceChanged(const std::string& pref_name) {

--- a/components/psst/core/browser/psst_settings_service.cc
+++ b/components/psst/core/browser/psst_settings_service.cc
@@ -8,6 +8,7 @@
 #include "base/check.h"
 #include "base/functional/bind.h"
 #include "brave/components/psst/core/browser/pref_names.h"
+#include "brave/components/psst/core/common/features.h"
 #include "components/prefs/pref_service.h"
 #include "url/gurl.h"
 
@@ -128,7 +129,8 @@ void PsstSettingsService::SetPsstWebsiteSettings(
 }
 
 bool PsstSettingsService::IsPsstEnabled() const {
-  return IsPsstEnabledForProfile(*prefs_);
+  return features::IsPsstFeatureFlagEnabled() &&
+         IsPsstSettingPrefEnabled(*prefs_);
 }
 
 void PsstSettingsService::SetPsstEnabled(bool enabled) {
@@ -136,7 +138,7 @@ void PsstSettingsService::SetPsstEnabled(bool enabled) {
 }
 
 bool PsstSettingsService::IsManagedPreference() const {
-  return prefs_->IsManagedPreference(prefs::kPsstEnabled);
+  return IsPsstManaged(*prefs_);
 }
 
 void PsstSettingsService::SetInfobarShowCounter(int value) {

--- a/components/psst/core/browser/psst_settings_service.cc
+++ b/components/psst/core/browser/psst_settings_service.cc
@@ -45,7 +45,9 @@ base::DictValue CreatePsstSettingsObject(PsstWebsiteSettings psst_metadata) {
 PsstSettingsService::PsstSettingsService(
     HostContentSettingsMap& host_content_settings_map,
     PrefService* prefs)
-    : host_content_settings_map_(host_content_settings_map), prefs_(prefs) {
+    : host_content_settings_map_(host_content_settings_map),
+      prefs_(prefs),
+      was_enabled_at_startup_(prefs_ && IsPsstEnabled()) {
   CHECK(prefs_);
 
   pref_change_registrar_.Init(prefs_);
@@ -53,7 +55,6 @@ PsstSettingsService::PsstSettingsService(
       prefs::kPsstEnabled,
       base::BindRepeating(&PsstSettingsService::OnPreferenceChanged,
                           weak_ptr_factory_.GetWeakPtr()));
-  was_enabled_at_startup_ = IsPsstEnabled();
 }
 
 PsstSettingsService::~PsstSettingsService() = default;
@@ -136,10 +137,6 @@ bool PsstSettingsService::IsPsstEnabled() const {
 
 void PsstSettingsService::SetPsstEnabled(bool enabled) {
   prefs_->SetBoolean(prefs::kPsstEnabled, enabled);
-}
-
-bool PsstSettingsService::WasPsstEnabledAtStartup() const {
-  return was_enabled_at_startup_;
 }
 
 bool PsstSettingsService::IsManagedPreference() const {

--- a/components/psst/core/browser/psst_settings_service.cc
+++ b/components/psst/core/browser/psst_settings_service.cc
@@ -8,7 +8,6 @@
 #include "base/check.h"
 #include "base/functional/bind.h"
 #include "brave/components/psst/core/browser/pref_names.h"
-#include "brave/components/psst/core/common/features.h"
 #include "components/prefs/pref_service.h"
 #include "url/gurl.h"
 

--- a/components/psst/core/browser/psst_settings_service.cc
+++ b/components/psst/core/browser/psst_settings_service.cc
@@ -53,6 +53,7 @@ PsstSettingsService::PsstSettingsService(
       prefs::kPsstEnabled,
       base::BindRepeating(&PsstSettingsService::OnPreferenceChanged,
                           weak_ptr_factory_.GetWeakPtr()));
+  was_enabled_at_startup_ = IsPsstEnabled();
 }
 
 PsstSettingsService::~PsstSettingsService() = default;
@@ -135,6 +136,10 @@ bool PsstSettingsService::IsPsstEnabled() const {
 
 void PsstSettingsService::SetPsstEnabled(bool enabled) {
   prefs_->SetBoolean(prefs::kPsstEnabled, enabled);
+}
+
+bool PsstSettingsService::WasPsstEnabledAtStartup() const {
+  return was_enabled_at_startup_;
 }
 
 bool PsstSettingsService::IsManagedPreference() const {

--- a/components/psst/core/browser/psst_settings_service.h
+++ b/components/psst/core/browser/psst_settings_service.h
@@ -59,6 +59,11 @@ class PsstSettingsService : public KeyedService {
   bool IsPsstEnabled() const;
   void SetPsstEnabled(bool enabled);
 
+  // Latched once, at construction (i.e. at profile/browser startup). If
+  // policy disables PSST mid-session, this keeps returning the value it had
+  // at startup so already-managed-enabled users aren't cut off until restart.
+  bool WasPsstEnabledAtStartup() const;
+
   bool IsManagedPreference() const;
 
   void SetInfobarShowCounter(int value);
@@ -71,6 +76,7 @@ class PsstSettingsService : public KeyedService {
   raw_ptr<PrefService> prefs_ = nullptr;  // NOT OWNED
   base::ObserverList<PrefObserver> observers_;
   PrefChangeRegistrar pref_change_registrar_;
+  bool was_enabled_at_startup_;
   base::WeakPtrFactory<PsstSettingsService> weak_ptr_factory_{this};
 };
 

--- a/components/psst/core/browser/psst_settings_service.h
+++ b/components/psst/core/browser/psst_settings_service.h
@@ -62,7 +62,7 @@ class PsstSettingsService : public KeyedService {
   // Latched once, at construction (i.e. at profile/browser startup). If
   // policy disables PSST mid-session, this keeps returning the value it had
   // at startup so already-managed-enabled users aren't cut off until restart.
-  bool WasPsstEnabledAtStartup() const;
+  bool was_enabled_at_startup() const { return was_enabled_at_startup_; }
 
   bool IsManagedPreference() const;
 
@@ -76,7 +76,7 @@ class PsstSettingsService : public KeyedService {
   raw_ptr<PrefService> prefs_ = nullptr;  // NOT OWNED
   base::ObserverList<PrefObserver> observers_;
   PrefChangeRegistrar pref_change_registrar_;
-  bool was_enabled_at_startup_;
+  const bool was_enabled_at_startup_;
   base::WeakPtrFactory<PsstSettingsService> weak_ptr_factory_{this};
 };
 

--- a/components/psst/core/browser/psst_settings_service.h
+++ b/components/psst/core/browser/psst_settings_service.h
@@ -59,6 +59,10 @@ class PsstSettingsService : public KeyedService {
   bool IsPsstEnabled() const;
   void SetPsstEnabled(bool enabled);
 
+  bool IsManagedPreference() const;
+
+  void SetInfobarShowCounter(int value);
+
  private:
   void OnPreferenceChanged(const std::string& pref_name);
 

--- a/components/psst/core/common/features.cc
+++ b/components/psst/core/common/features.cc
@@ -9,4 +9,8 @@ namespace psst::features {
 
 BASE_FEATURE(kEnablePsst, base::FEATURE_DISABLED_BY_DEFAULT);
 
+bool IsPsstEnabled() {
+  return base::FeatureList::IsEnabled(psst::features::kEnablePsst);
+}
+
 }  // namespace psst::features

--- a/components/psst/core/common/features.cc
+++ b/components/psst/core/common/features.cc
@@ -9,7 +9,7 @@ namespace psst::features {
 
 BASE_FEATURE(kEnablePsst, base::FEATURE_DISABLED_BY_DEFAULT);
 
-bool IsPsstEnabled() {
+bool IsPsstFeatureFlagEnabled() {
   return base::FeatureList::IsEnabled(psst::features::kEnablePsst);
 }
 

--- a/components/psst/core/common/features.h
+++ b/components/psst/core/common/features.h
@@ -12,6 +12,8 @@ namespace psst::features {
 
 BASE_DECLARE_FEATURE(kEnablePsst);
 
+bool IsPsstEnabled();
+
 }  // namespace psst::features
 
 #endif  // BRAVE_COMPONENTS_PSST_CORE_COMMON_FEATURES_H_

--- a/components/psst/core/common/features.h
+++ b/components/psst/core/common/features.h
@@ -12,7 +12,7 @@ namespace psst::features {
 
 BASE_DECLARE_FEATURE(kEnablePsst);
 
-bool IsPsstEnabled();
+bool IsPsstFeatureFlagEnabled();
 
 }  // namespace psst::features
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58187

- Fixes a crash on accepting the PSST infobar: PsstUiDesktopPresenter called HideInfoBar() itself when opening the consent dialog, racing with upstream's own infobar removal on close.

- Also makes enabling/disabling PSST via the Brave Origin toggle or enterprise policy take effect only after a browser restart instead of partially applying at runtime. This also fixes the infobar/location bar icon staying visible after PSST was disabled via the Origin toggle while the feature flag was still on.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
