### PR TITLE
[ads] Reword sponsored sites UI text to use “new tab page ads”

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.test.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.test.tsx
@@ -22,7 +22,7 @@ import { TopSitesPanel } from './top_sites_panel'
 jest.mock('$web-common/locale', () => ({
   getLocale: (key: string) => {
     if (key === 'NEW_TAB_SPONSORED_SITES_DESCRIPTION') {
-      return 'Sponsored sites help keep Brave free. $1Learn more/$1.'
+      return 'New tab page ads help keep Brave free. $1Learn more/$1.'
     }
     return key
   },
@@ -86,7 +86,7 @@ describe('TopSitesPanel', () => {
   it('should render the sponsored sites description with a learn more link', () => {
     renderPanel({ showTopSites: true })
     expect(
-      screen.getByText('Sponsored sites help keep Brave free.', {
+      screen.getByText('New tab page ads help keep Brave free.', {
         exact: false,
       }),
     ).toBeInTheDocument()

--- a/components/resources/brave_new_tab_page_strings.grdp
+++ b/components/resources/brave_new_tab_page_strings.grdp
@@ -134,7 +134,7 @@
   </message>
 
   <message name="IDS_NEW_TAB_REMOVE_SPONSORED_SITES_LABEL" desc="Label for button that disables sponsored sites" formatter_data="webui=BraveNewTabPage">
-    Remove sponsored sites
+    Remove new tab page ads
   </message>
 
   <message name="IDS_NEW_TAB_REMOVE_TOP_SITE_LABEL" desc="Label for button that removes a top site" formatter_data="webui=BraveNewTabPage">
@@ -262,7 +262,7 @@
   </message>
 
   <message name="IDS_NEW_TAB_SHOW_SPONSORED_SITES_LABEL" desc="Label for control that toggles sponsored site visibility in top sites" formatter_data="webui=BraveNewTabPage">
-    Show sponsored sites
+    Show new tab page ads
   </message>
 
   <message name="IDS_NEW_TAB_SHOW_STATS_LABEL" desc="Label for showing or hiding Brave Stats on the NTP" formatter_data="webui=BraveNewTabPage">
@@ -286,11 +286,11 @@
   </message>
 
   <message name="IDS_NEW_TAB_SPONSORED_SITE_TOOLTIP_TEXT" desc="Tooltip text shown when hovering a sponsored site tile. $1 is the site name." formatter_data="webui=BraveNewTabPage">
-    Sponsored sites help keep Brave free. If you use <ph name="SITE_NAME">$1<ex>Amazon</ex></ph>, you're supporting Brave's mission. Disable them anytime. <ph name="LINK_BEGIN">$2</ph>Learn more<ph name="LINK_END">/$2</ph>.
+    New tab page ads help keep Brave free. If you use <ph name="SITE_NAME">$1<ex>Amazon</ex></ph>, you're supporting Brave's mission. Disable them anytime. <ph name="LINK_BEGIN">$2</ph>Learn more<ph name="LINK_END">/$2</ph>.
   </message>
 
   <message name="IDS_NEW_TAB_SPONSORED_SITES_DESCRIPTION" desc="Description shown below the toggle that controls sponsored site visibility in top sites, explaining what sponsored sites are." formatter_data="webui=BraveNewTabPage">
-    Sponsored sites help keep Brave free. If you use them, you're supporting Brave's mission. <ph name="LINK_BEGIN">$1</ph>Learn more<ph name="LINK_END">/$1</ph>.
+    New tab page ads help keep Brave free. If you use them, you're supporting Brave's mission. <ph name="LINK_BEGIN">$1</ph>Learn more<ph name="LINK_END">/$1</ph>.
   </message>
 
   <message name="IDS_NEW_TAB_STATS_ADS_BLOCKED_TEXT" desc="Text for trackers and ads blocked stat" formatter_data="webui=BraveNewTabPage">


### PR DESCRIPTION
The PR changes the sponsored tile toggle, the sponsored tile context menu and the tooltip wording to use "new tab page ads" rather than "sponsored sites" to to describe that both now control the consolidated opt-out sponsored ads preference.


**Top Site settings screenshot:**
<img width="500" alt="image" src="https://github.com/user-attachments/assets/777d7527-bb9f-491a-bfb2-038a60c2ee66" />


**Sponsored site context menu screenshot:**
<img width="300" alt="image" src="https://github.com/user-attachments/assets/b77f3fc7-7d78-44f3-9a82-0dd01f01ff7b" />

**Sponsored site tooltip screenshot:**
<img width="300" alt="image" src="https://github.com/user-attachments/assets/048357f8-d0e0-4e4c-968b-669cb96dd44e" />

<!-- Add brave-browser issue below that this PR will resolve -->
Part of https://github.com/brave/brave-browser/issues/57204

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
