### PR TITLE
Hide PSST toggle when managed and add sub-label to Origin toggle

### DIFF
--- a/browser/psst/psst_reporter_service_factory.cc
+++ b/browser/psst/psst_reporter_service_factory.cc
@@ -63,7 +63,6 @@ PsstReporterServiceFactory::PsstReporterServiceFactory()
           "PsstReporterService",
           ProfileSelections::Builder()
               .WithRegular(ProfileSelection::kOriginalOnly)
-              .WithGuest(ProfileSelection::kOwnInstance)
               .Build()) {}
 
 PsstReporterServiceFactory::~PsstReporterServiceFactory() = default;

--- a/browser/psst/psst_reporter_service_factory.cc
+++ b/browser/psst/psst_reporter_service_factory.cc
@@ -63,6 +63,7 @@ PsstReporterServiceFactory::PsstReporterServiceFactory()
           "PsstReporterService",
           ProfileSelections::Builder()
               .WithRegular(ProfileSelection::kOriginalOnly)
+              .WithGuest(ProfileSelection::kOwnInstance)
               .Build()) {}
 
 PsstReporterServiceFactory::~PsstReporterServiceFactory() = default;

--- a/browser/resources/settings/br/page_visibility.ts
+++ b/browser/resources/settings/br/page_visibility.ts
@@ -38,10 +38,7 @@ declare module '../page_visibility.js' {
     // </if>
     surveyPanelist?: boolean,
     braveTor?: boolean,
-    emailAliases?: boolean,
-    // <if expr="enable_psst">
-    psst?: boolean,
-    // </if>
+    emailAliases?: boolean
   }
 }
 
@@ -82,9 +79,6 @@ function getPageVisibility () {
       surveyPanelist: false,
       braveTor: false,
       emailAliases: false,
-      // <if expr="enable_psst">
-      psst: false,
-      // </if>
     }
   }
   // We need to specify values for every attribute in pageVisibility instead of
@@ -134,9 +128,6 @@ function getPageVisibility () {
     // </if>
     // <if expr="enable_email_aliases">
     emailAliases: loadTimeData.getBoolean('isEmailAliasesEnabled'),
-    // </if>
-    // <if expr="enable_psst">
-    psst: loadTimeData.getBoolean('isPsstEnabled'),
     // </if>
     origin: loadTimeData.getBoolean('isBraveOriginPurchased') &&
             !loadTimeData.getBoolean('isBraveOriginBrandedBuild'),

--- a/browser/resources/settings/brave_origin_page/brave_origin_page.html
+++ b/browser/resources/settings/brave_origin_page/brave_origin_page.html
@@ -205,11 +205,14 @@
   </if>
 
   <if expr="enable_psst">
-    <origin-toggle-button id="togglePsstButton"
-        policy-key="PsstEnabled"
-        label="$i18n{bravePsstToggleTitle}"
-        icon="psst">
-    </origin-toggle-button> 
+    <template is="dom-if" if="[[isPsstEnabled_]]">
+      <origin-toggle-button id="togglePsstButton"
+          policy-key="PsstEnabled"
+          label="$i18n{bravePsstToggleTitle}"
+          sub-label="$i18n{bravePsstToggleSubLabel}"
+          icon="psst">
+      </origin-toggle-button> 
+    </template>
   </if>
 
   <if expr="enable_web_discovery">

--- a/browser/resources/settings/brave_origin_page/brave_origin_page.ts
+++ b/browser/resources/settings/brave_origin_page/brave_origin_page.ts
@@ -65,12 +65,17 @@ export class SettingsBraveOriginPageElement
         type: Boolean,
         value: () => loadTimeData.getBoolean('isPlaylistFeatureEnabled'),
       },
+      isPsstEnabled_: {
+        type: Boolean,
+        value: () => loadTimeData.getBoolean('isPsstEnabled'),
+      },
     }
   }
 
   declare private isPurchased_: boolean
   declare private showRestartToast_: boolean
   declare private isPlaylistFeatureEnabled_: boolean
+  declare private isPsstEnabled_: boolean
   private braveOriginHandler_: BraveOriginMojom.BraveOriginSettingsHandlerRemote
   private boundOnVisibilityChange_: (() => void) | null = null
   private boundOnPolicyValueChanged_: (() => void) | null = null

--- a/browser/resources/settings/brave_origin_page/brave_origin_page.ts
+++ b/browser/resources/settings/brave_origin_page/brave_origin_page.ts
@@ -65,17 +65,21 @@ export class SettingsBraveOriginPageElement
         type: Boolean,
         value: () => loadTimeData.getBoolean('isPlaylistFeatureEnabled'),
       },
+      // <if expr="enable_psst">
       isPsstEnabled_: {
         type: Boolean,
         value: () => loadTimeData.getBoolean('isPsstEnabled'),
       },
+      // </if>
     }
   }
 
   declare private isPurchased_: boolean
   declare private showRestartToast_: boolean
   declare private isPlaylistFeatureEnabled_: boolean
+  // <if expr="enable_psst">
   declare private isPsstEnabled_: boolean
+  // </if>
   private braveOriginHandler_: BraveOriginMojom.BraveOriginSettingsHandlerRemote
   private boundOnVisibilityChange_: (() => void) | null = null
   private boundOnPolicyValueChanged_: (() => void) | null = null

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -59,6 +59,7 @@
 #include "chrome/browser/regional_capabilities/regional_capabilities_service_factory.h"
 #include "chrome/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/webui/settings/metrics_reporting_handler.h"
+#include "components/policy/policy_constants.h"
 #include "components/regional_capabilities/regional_capabilities_country_id.h"
 #include "components/regional_capabilities/regional_capabilities_service.h"
 #include "components/sync/base/command_line_switches.h"

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -144,7 +144,10 @@
 #endif
 
 #if BUILDFLAG(ENABLE_PSST)
+#include "brave/browser/brave_origin/brave_origin_service_factory.h"
+#include "brave/components/brave_origin/brave_origin_service.h"
 #include "brave/components/psst/core/common/features.h"
+#include "components/policy/policy_constants.h"
 #endif
 
 namespace {
@@ -313,8 +316,18 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
               profile));
 #endif
 #if BUILDFLAG(ENABLE_PSST)
+  auto* brave_origin_service =
+      brave_origin::BraveOriginServiceFactory::GetForProfile(profile);
+  bool is_managed_by_brave_origin = false;
+  if (brave_origin_service) {
+    is_managed_by_brave_origin =
+        brave_origin_service->IsPolicyControlledByBraveOrigin(
+            policy::key::kPsstEnabled);
+  }
+
   html_source->AddBoolean("isPsstEnabled", base::FeatureList::IsEnabled(
-                                               psst::features::kEnablePsst));
+                                               psst::features::kEnablePsst) &&
+                                               is_managed_by_brave_origin);
 #endif
 #if BUILDFLAG(ENABLE_CONTAINERS)
   html_source->AddBoolean(

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -144,10 +144,7 @@
 #endif
 
 #if BUILDFLAG(ENABLE_PSST)
-#include "brave/browser/brave_origin/brave_origin_service_factory.h"
-#include "brave/components/brave_origin/brave_origin_service.h"
 #include "brave/components/psst/core/common/features.h"
-#include "components/policy/policy_constants.h"
 #endif
 
 namespace {

--- a/browser/ui/webui/settings/brave_privacy_handler.cc
+++ b/browser/ui/webui/settings/brave_privacy_handler.cc
@@ -45,6 +45,7 @@
 #endif
 
 #if BUILDFLAG(ENABLE_PSST)
+#include "brave/components/psst/core/browser/pref_names.h"
 #include "brave/components/psst/core/common/features.h"
 #endif
 
@@ -133,7 +134,8 @@ void BravePrivacyHandler::AddLoadTimeData(content::WebUIDataSource* data_source,
   data_source->AddBoolean(
       "isPsstFeatureEnabled",
 #if BUILDFLAG(ENABLE_PSST)
-      base::FeatureList::IsEnabled(psst::features::kEnablePsst));
+      base::FeatureList::IsEnabled(psst::features::kEnablePsst) &&
+          !profile->GetPrefs()->IsManagedPreference(psst::prefs::kPsstEnabled));
 #else
       false);
 #endif

--- a/browser/ui/webui/settings/brave_privacy_handler.cc
+++ b/browser/ui/webui/settings/brave_privacy_handler.cc
@@ -45,8 +45,10 @@
 #endif
 
 #if BUILDFLAG(ENABLE_PSST)
-#include "brave/components/psst/core/browser/pref_names.h"
+#include "brave/browser/brave_origin/brave_origin_service_factory.h"
+#include "brave/components/brave_origin/brave_origin_service.h"
 #include "brave/components/psst/core/common/features.h"
+#include "components/policy/policy_constants.h"
 #endif
 
 BravePrivacyHandler::BravePrivacyHandler() {
@@ -131,11 +133,23 @@ void BravePrivacyHandler::AddLoadTimeData(content::WebUIDataSource* data_source,
       "isRequestOTRFeatureEnabled",
       base::FeatureList::IsEnabled(request_otr::features::kBraveRequestOTRTab));
 #endif
+
+#if BUILDFLAG(ENABLE_PSST)
+  auto* brave_origin_service =
+      brave_origin::BraveOriginServiceFactory::GetForProfile(profile);
+  bool is_managed_by_brave_origin = false;
+  if (brave_origin_service) {
+    is_managed_by_brave_origin =
+        brave_origin_service->IsPolicyControlledByBraveOrigin(
+            policy::key::kPsstEnabled);
+  }
+#endif
+
   data_source->AddBoolean(
       "isPsstFeatureEnabled",
 #if BUILDFLAG(ENABLE_PSST)
       base::FeatureList::IsEnabled(psst::features::kEnablePsst) &&
-          !profile->GetPrefs()->IsManagedPreference(psst::prefs::kPsstEnabled));
+          !is_managed_by_brave_origin);
 #else
       false);
 #endif

--- a/browser/ui/webui/settings/brave_privacy_handler.cc
+++ b/browser/ui/webui/settings/brave_privacy_handler.cc
@@ -24,6 +24,7 @@
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
 #include "components/gcm_driver/gcm_buildflags.h"
+#include "components/policy/policy_constants.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/web_ui.h"
 #include "content/public/browser/web_ui_data_source.h"

--- a/browser/ui/webui/settings/brave_privacy_handler.cc
+++ b/browser/ui/webui/settings/brave_privacy_handler.cc
@@ -9,7 +9,9 @@
 #include "base/check_op.h"
 #include "base/functional/bind.h"
 #include "base/values.h"
+#include "brave/browser/brave_origin/brave_origin_service_factory.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_origin/brave_origin_service.h"
 #include "brave/components/brave_origin/buildflags/buildflags.h"
 #include "brave/components/brave_shields/core/common/features.h"
 #include "brave/components/constants/pref_names.h"
@@ -45,10 +47,7 @@
 #endif
 
 #if BUILDFLAG(ENABLE_PSST)
-#include "brave/browser/brave_origin/brave_origin_service_factory.h"
-#include "brave/components/brave_origin/brave_origin_service.h"
 #include "brave/components/psst/core/common/features.h"
-#include "components/policy/policy_constants.h"
 #endif
 
 BravePrivacyHandler::BravePrivacyHandler() {

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -230,6 +230,7 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
        IDS_SETTINGS_BRAVE_ORIGIN_EMAIL_ALIASES_TOGGLE_TITLE},
 #if BUILDFLAG(ENABLE_PSST)
       {"bravePsstToggleTitle", IDS_SETTINGS_BRAVE_ORIGIN_PSST_TOGGLE_TITLE},
+      {"bravePsstToggleSubLabel", IDS_SETTINGS_PSST_SUB_LABEL},
 #endif
       {"braveOriginWebDiscoveryProjectToggleTitle",
        IDS_SETTINGS_BRAVE_ORIGIN_WEB_DISCOVERY_PROJECT_TOGGLE_TITLE},


### PR DESCRIPTION
- Hides the PSST toggle in brave://settings/privacy, which is redundant, once the feature is controlled by the Brave Origin toggle or an enterprise policy. 
- Adds a sub-label to the PSST toggle on the Brave Origin page, matching the privacy settings page, and only shows that toggle when the PSST feature flag is enabled.
- Removes the unnecessary mention of psst from `page_visibility.ts`, as it does not have its own settings page.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58366

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
