### PR TITLE
[recipes] Disable git gc maintainance with git cache

### DIFF
--- a/tools/recipes/recipe_modules/chromium_checkout/__init__.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/__init__.py
@@ -5,6 +5,6 @@
 """`chromium_checkout` module: clone / sync / validate a Chromium src/ tree."""
 
 DEPS = [
-    'path', 'raw_io', 'json', 'step', 'context', 'depot_tools', 'env',
+    'path', 'raw_io', 'json', 'step', 'context', 'depot_tools', 'env', 'git',
     'git_cache', 'platform'
 ]

--- a/tools/recipes/recipe_modules/chromium_checkout/api.py
+++ b/tools/recipes/recipe_modules/chromium_checkout/api.py
@@ -219,7 +219,7 @@ class ChromiumCheckoutApi(RecipeApi):
                 'git', 'clone', '--no-checkout', '--local', '--shared',
                 *depth_args, mirror_dir, chromium_src
             ])
-            self._disable_git_gc(chromium_src)
+            self.m.git.disable_auto_gc(chromium_src)
 
             if is_qualified_ref:
                 # `ref` is a fully-qualified ref outside `refs/heads/*` and
@@ -381,14 +381,3 @@ class ChromiumCheckoutApi(RecipeApi):
                                   commit=commit,
                                   step_name=populate_step)
         return self.m.git_cache.mirror_dir(url, step_name=exists_step)
-
-    def _disable_git_gc(self, chromium_src: str | Path) -> None:
-        """Disable background gc in *chromium_src*.
-
-        A shared, long-lived checkout can have several tools touching it
-        around the same time, and an auto-triggered `git gc` racing with them
-        (or being killed midway) can corrupt the repo.
-        """
-        for key in ('gc.auto', 'gc.autodetach', 'gc.autopacklimit'):
-            self.m.step(f'git config {key}=0', ['git', 'config', key, '0'],
-                        cwd=chromium_src)

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/existing_branch.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/existing_branch.json
@@ -40,6 +40,21 @@
     "cmd": [
       "git",
       "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
       "populate",
       "--cache-dir",
       "/b/cache",
@@ -53,6 +68,21 @@
       "CHROME_HEADLESS": "1"
     },
     "name": "git cache populate for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref exists (after)"
   },
   {
     "cmd": [

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/existing_commit.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/existing_commit.json
@@ -40,6 +40,21 @@
     "cmd": [
       "git",
       "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
       "populate",
       "--cache-dir",
       "/b/cache",
@@ -53,6 +68,21 @@
       "CHROME_HEADLESS": "1"
     },
     "name": "git cache populate for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref exists (after)"
   },
   {
     "cmd": [

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/existing_tag.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/existing_tag.json
@@ -40,6 +40,21 @@
     "cmd": [
       "git",
       "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
       "populate",
       "--cache-dir",
       "/b/cache",
@@ -53,6 +68,21 @@
       "CHROME_HEADLESS": "1"
     },
     "name": "git cache populate for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref exists (after)"
   },
   {
     "cmd": [

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/fresh_commit.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/fresh_commit.json
@@ -41,6 +41,21 @@
     "cmd": [
       "git",
       "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
       "populate",
       "--cache-dir",
       "/b/cache",
@@ -54,6 +69,21 @@
       "CHROME_HEADLESS": "1"
     },
     "name": "git cache populate"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (after)"
   },
   {
     "cmd": [
@@ -96,7 +126,7 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.auto=0"
+    "name": "disable auto-gc: gc.auto=0"
   },
   {
     "cmd": [
@@ -109,7 +139,7 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.autodetach=0"
+    "name": "disable auto-gc: gc.autodetach=0"
   },
   {
     "cmd": [
@@ -122,7 +152,20 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.autopacklimit=0"
+    "name": "disable auto-gc: gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "maintenance.gc.enabled",
+      "false"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "disable auto-gc: maintenance.gc.enabled=false"
   },
   {
     "cmd": [

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/fresh_no_ref.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/fresh_no_ref.json
@@ -41,6 +41,21 @@
     "cmd": [
       "git",
       "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
       "populate",
       "--cache-dir",
       "/b/cache",
@@ -52,6 +67,21 @@
       "CHROME_HEADLESS": "1"
     },
     "name": "git cache populate"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (after)"
   },
   {
     "cmd": [
@@ -94,7 +124,7 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.auto=0"
+    "name": "disable auto-gc: gc.auto=0"
   },
   {
     "cmd": [
@@ -107,7 +137,7 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.autodetach=0"
+    "name": "disable auto-gc: gc.autodetach=0"
   },
   {
     "cmd": [
@@ -120,7 +150,20 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.autopacklimit=0"
+    "name": "disable auto-gc: gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "maintenance.gc.enabled",
+      "false"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "disable auto-gc: maintenance.gc.enabled=false"
   },
   {
     "cmd": [

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/fresh_release_branch.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/fresh_release_branch.json
@@ -41,6 +41,21 @@
     "cmd": [
       "git",
       "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
       "populate",
       "--cache-dir",
       "/b/cache",
@@ -54,6 +69,21 @@
       "CHROME_HEADLESS": "1"
     },
     "name": "git cache populate"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (after)"
   },
   {
     "cmd": [
@@ -96,7 +126,7 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.auto=0"
+    "name": "disable auto-gc: gc.auto=0"
   },
   {
     "cmd": [
@@ -109,7 +139,7 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.autodetach=0"
+    "name": "disable auto-gc: gc.autodetach=0"
   },
   {
     "cmd": [
@@ -122,7 +152,20 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.autopacklimit=0"
+    "name": "disable auto-gc: gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "maintenance.gc.enabled",
+      "false"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "disable auto-gc: maintenance.gc.enabled=false"
   },
   {
     "cmd": [

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/fresh_tag.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/fresh_tag.json
@@ -41,6 +41,21 @@
     "cmd": [
       "git",
       "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
       "populate",
       "--cache-dir",
       "/b/cache",
@@ -54,6 +69,21 @@
       "CHROME_HEADLESS": "1"
     },
     "name": "git cache populate"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (after)"
   },
   {
     "cmd": [
@@ -96,7 +126,7 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.auto=0"
+    "name": "disable auto-gc: gc.auto=0"
   },
   {
     "cmd": [
@@ -109,7 +139,7 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.autodetach=0"
+    "name": "disable auto-gc: gc.autodetach=0"
   },
   {
     "cmd": [
@@ -122,7 +152,20 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.autopacklimit=0"
+    "name": "disable auto-gc: gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "maintenance.gc.enabled",
+      "false"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "disable auto-gc: maintenance.gc.enabled=false"
   },
   {
     "cmd": [

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_hermetic_toolchain.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_hermetic_toolchain.json
@@ -40,6 +40,21 @@
     "cmd": [
       "git",
       "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
       "populate",
       "--cache-dir",
       "/b/cache",
@@ -53,6 +68,21 @@
       "CHROME_HEADLESS": "1"
     },
     "name": "git cache populate for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref exists (after)"
   },
   {
     "cmd": [

--- a/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_toolchain_hash_pinned.json
+++ b/tools/recipes/recipe_modules/chromium_checkout/examples/full.expected/windows_toolchain_hash_pinned.json
@@ -40,6 +40,21 @@
     "cmd": [
       "git",
       "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
       "populate",
       "--cache-dir",
       "/b/cache",
@@ -53,6 +68,21 @@
       "CHROME_HEADLESS": "1"
     },
     "name": "git cache populate for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref exists (after)"
   },
   {
     "cmd": [

--- a/tools/recipes/recipe_modules/git/__init__.py
+++ b/tools/recipes/recipe_modules/git/__init__.py
@@ -2,11 +2,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""`git_cache` module.
+"""`git` module: low-level git repository maintenance shared across modules.
 """
 
-from PB.recipe_modules.brave.git_cache.properties import EnvProperties
-
-DEPS = ['env', 'git', 'path', 'raw_io', 'step']
-
-ENV_PROPERTIES = EnvProperties
+DEPS = ['step']

--- a/tools/recipes/recipe_modules/git/api.py
+++ b/tools/recipes/recipe_modules/git/api.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""The `git` module API."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from recipe_api import RecipeApi
+
+# When disabling auto-gc, the keys we want to set.
+_DISABLE_AUTO_GC_CONFIG = (
+    ('gc.auto', '0'),
+    ('gc.autodetach', '0'),
+    ('gc.autopacklimit', '0'),
+    # New versions of git requrire this to be set too on what used to be under
+    # gc functionality.
+    ('maintenance.gc.enabled', 'false'),
+)
+
+
+class GitApi(RecipeApi):
+    """Generic git repository operations shared by modules that own one.
+    """
+
+    def disable_auto_gc(self,
+                        repo: str | Path,
+                        *,
+                        step_name: str = 'disable auto-gc') -> None:
+        """Stop git's own automatic gc/maintenance from running in *repo*.
+
+        Disabling auto-gc/maintenance is useful in our infra, as a lot of
+        workspaces have a limited lifetime, and gc work means resources spent on
+        a repo that will be discarded at some point.
+
+        Args:
+            repo: Path to the git repository, working tree or bare mirror
+                alike; passed as `cwd`, so git's own repository discovery
+                resolves it either way.
+            step_name: Prefix for each `git config` step's name, so callers
+                setting this up at multiple points (e.g. before and after
+                another step) can tell them apart in the step list.
+        """
+        for key, value in _DISABLE_AUTO_GC_CONFIG:
+            self.m.step(f'{step_name}: {key}={value}',
+                        ['git', 'config', key, value],
+                        cwd=repo)

--- a/tools/recipes/recipe_modules/git/examples/__init__.py
+++ b/tools/recipes/recipe_modules/git/examples/__init__.py
@@ -2,11 +2,4 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""`git_cache` module.
-"""
-
-from PB.recipe_modules.brave.git_cache.properties import EnvProperties
-
-DEPS = ['env', 'git', 'path', 'raw_io', 'step']
-
-ENV_PROPERTIES = EnvProperties
+"""Example recipes exercising the `git` module."""

--- a/tools/recipes/recipe_modules/git/examples/full.expected/disables_every_auto-gc_knob.json
+++ b/tools/recipes/recipe_modules/git/examples/full.expected/disables_every_auto-gc_knob.json
@@ -1,0 +1,85 @@
+[
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.auto",
+      "0"
+    ],
+    "cwd": "/b/checkout",
+    "name": "disable auto-gc: gc.auto=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autodetach",
+      "0"
+    ],
+    "cwd": "/b/checkout",
+    "name": "disable auto-gc: gc.autodetach=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autopacklimit",
+      "0"
+    ],
+    "cwd": "/b/checkout",
+    "name": "disable auto-gc: gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "maintenance.gc.enabled",
+      "false"
+    ],
+    "cwd": "/b/checkout",
+    "name": "disable auto-gc: maintenance.gc.enabled=false"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.auto",
+      "0"
+    ],
+    "cwd": "/b/cache/some-mirror",
+    "name": "disable mirror auto-gc: gc.auto=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autodetach",
+      "0"
+    ],
+    "cwd": "/b/cache/some-mirror",
+    "name": "disable mirror auto-gc: gc.autodetach=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autopacklimit",
+      "0"
+    ],
+    "cwd": "/b/cache/some-mirror",
+    "name": "disable mirror auto-gc: gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "maintenance.gc.enabled",
+      "false"
+    ],
+    "cwd": "/b/cache/some-mirror",
+    "name": "disable mirror auto-gc: maintenance.gc.enabled=false"
+  },
+  {
+    "name": "$result"
+  }
+]

--- a/tools/recipes/recipe_modules/git/examples/full.py
+++ b/tools/recipes/recipe_modules/git/examples/full.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Example recipe exercising the `git` module."""
+
+from __future__ import annotations
+
+import post_process
+
+DEPS = ['git', 'step']
+
+
+def RunSteps(api):
+    api.git.disable_auto_gc('/b/checkout')
+    api.git.disable_auto_gc('/b/cache/some-mirror',
+                            step_name='disable mirror auto-gc')
+
+
+def GenTests(api):
+    yield api.test(
+        'disables every auto-gc knob',
+        api.post_process(post_process.StepCommandContains,
+                         'disable auto-gc: gc.auto=0',
+                         ['config', 'gc.auto', '0']),
+        api.post_process(post_process.StepCommandContains,
+                         'disable auto-gc: gc.autodetach=0',
+                         ['config', 'gc.autodetach', '0']),
+        api.post_process(post_process.StepCommandContains,
+                         'disable auto-gc: gc.autopacklimit=0',
+                         ['config', 'gc.autopacklimit', '0']),
+        api.post_process(post_process.StepCommandContains,
+                         'disable auto-gc: maintenance.gc.enabled=false',
+                         ['config', 'maintenance.gc.enabled', 'false']),
+        # Every step runs with `cwd` set to the repo, not `--git-dir`, so the
+        # same call works against a working tree or a bare mirror alike.
+        api.post_process(post_process.StepCommandDoesNotContain,
+                         'disable auto-gc: gc.auto=0', ['--git-dir']),
+        # A custom step_name prefix keeps repeat calls (e.g. before/after
+        # another step) distinguishable in the step list.
+        api.post_process(
+            post_process.MustRun,
+            'disable mirror auto-gc: maintenance.gc.enabled=false'),
+        api.post_process(post_process.StatusSuccess),
+    )

--- a/tools/recipes/recipe_modules/git_cache/api.py
+++ b/tools/recipes/recipe_modules/git_cache/api.py
@@ -60,6 +60,10 @@ class GitCacheApi(RecipeApi):
             no_fetch_tags: Skip fetching tags that point at fetched objects.
             step_name: Step name for the `git cache populate` call.
         """
+        # Disable auto-gc before the populate() call, to avoid long maintainance
+        # tasks running. No-op if the mirror doesn't exist in git cache.
+        git_config_updated = self._disable_auto_gc(url, step_name, 'before')
+
         cmd = [
             'git', 'cache', 'populate', '--cache-dir', self._path, url,
             '--reset-fetch-config'
@@ -71,6 +75,41 @@ class GitCacheApi(RecipeApi):
         if commit:
             cmd.extend(['--commit', commit])
         self.m.step(step_name, cmd)
+
+        # Apply the auto-gc disabling if it has not been done yet. (There is
+        # a small chance for git cache to wipe the shared repo and build again,
+        # but then we can skip seting the config for that particular run, and
+        # leave it for the next one)
+        if not git_config_updated:
+            self._disable_auto_gc(url, step_name, 'after')
+
+    def _disable_auto_gc(self, url: str, step_name: str, when: str) -> bool:
+        """Stop git's own automatic gc from ever running against this mirror.
+
+        A `git fetch` into the mirror can trigger git's built-in auto-gc,
+        which on a repo the size of chromium/src can OOM or take hours (see
+        the `git` module's `disable_auto_gc` for what exactly this disables
+        and why). A no-op when the mirror doesn't exist yet: a
+        freshly-created mirror won't have accumulated enough packs to hit
+        this on its own first fetch, and the config set here takes effect
+        from its next one.
+
+        Args:
+            when: Distinguishes the pre- and post-populate call sites in step
+                names (`populate()` runs this twice per call).
+        """
+        result = self.m.step(f'{step_name} exists ({when})', [
+            'git', 'cache', 'exists', '--quiet', '--cache-dir', self._path, url
+        ],
+                             stdout=self.m.raw_io.output_text(),
+                             check=False)
+        mirror_dir = result.stdout.strip()
+        if not mirror_dir:
+            return False
+
+        self.m.git.disable_auto_gc(mirror_dir,
+                                   step_name=f'{step_name} disable ({when})')
+        return True
 
     def mirror_dir(self,
                    url: str,

--- a/tools/recipes/recipe_modules/git_cache/examples/full.expected/cache_from_environment.json
+++ b/tools/recipes/recipe_modules/git_cache/examples/full.expected/cache_from_environment.json
@@ -10,6 +10,58 @@
     "cmd": [
       "git",
       "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "name": "git cache populate exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.auto",
+      "0"
+    ],
+    "cwd": "/b/cache/chromium.googlesource.com-chromium-src",
+    "name": "git cache populate disable (before): gc.auto=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autodetach",
+      "0"
+    ],
+    "cwd": "/b/cache/chromium.googlesource.com-chromium-src",
+    "name": "git cache populate disable (before): gc.autodetach=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autopacklimit",
+      "0"
+    ],
+    "cwd": "/b/cache/chromium.googlesource.com-chromium-src",
+    "name": "git cache populate disable (before): gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "maintenance.gc.enabled",
+      "false"
+    ],
+    "cwd": "/b/cache/chromium.googlesource.com-chromium-src",
+    "name": "git cache populate disable (before): maintenance.gc.enabled=false"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
       "populate",
       "--cache-dir",
       "/b/cache",
@@ -18,6 +70,18 @@
       "--no-fetch-tags"
     ],
     "name": "git cache populate"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "name": "populate with tags exists (before)"
   },
   {
     "cmd": [
@@ -34,6 +98,58 @@
       "c0ffeec0ffeec0ffeec0ffeec0ffeec0ffee"
     ],
     "name": "populate with tags"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "name": "populate with tags exists (after)"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.auto",
+      "0"
+    ],
+    "cwd": "/b/cache/chromium.googlesource.com-chromium-src",
+    "name": "populate with tags disable (after): gc.auto=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autodetach",
+      "0"
+    ],
+    "cwd": "/b/cache/chromium.googlesource.com-chromium-src",
+    "name": "populate with tags disable (after): gc.autodetach=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autopacklimit",
+      "0"
+    ],
+    "cwd": "/b/cache/chromium.googlesource.com-chromium-src",
+    "name": "populate with tags disable (after): gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "maintenance.gc.enabled",
+      "false"
+    ],
+    "cwd": "/b/cache/chromium.googlesource.com-chromium-src",
+    "name": "populate with tags disable (after): maintenance.gc.enabled=false"
   },
   {
     "cmd": [

--- a/tools/recipes/recipe_modules/git_cache/examples/full.py
+++ b/tools/recipes/recipe_modules/git_cache/examples/full.py
@@ -38,6 +38,18 @@ def GenTests(api):
         'cache from environment',
         api.env.set('GIT_CACHE_PATH', '/b/cache'),
         api.path.dirs('/b/cache'),
+        # The first populate() call's mirror already exists *before* it
+        # runs (as it would on any second-or-later run in production) --
+        # this is the case that matters: auto-gc must be disabled ahead of
+        # that call's own `git fetch`, not after it, since that fetch is
+        # exactly what can trigger the OOM-prone auto-maintenance.
+        api.step_data('git cache populate exists (before)',
+                      stdout=api.raw_io.output_text(f'{_mirror}\n')),
+        # The second populate() call's mirror doesn't exist yet going in
+        # (unseeded "before" check, so empty stdout) but does by the time
+        # that call returns -- simulating a call that bootstraps it fresh.
+        api.step_data('populate with tags exists (after)',
+                      stdout=api.raw_io.output_text(f'{_mirror}\n')),
         api.step_data('git cache exists',
                       stdout=api.raw_io.output_text(f'{_mirror}\n')),
         api.post_process(post_process.StepCommandContains, 'cache path',
@@ -54,6 +66,30 @@ def GenTests(api):
                          'populate with tags', ['--no-fetch-tags']),
         api.post_process(post_process.StepCommandContains, 'mirror',
                          [_mirror]),
+        # The already-existing mirror gets auto-gc disabled *before* its
+        # fetch, not just after -- otherwise a fetch that hangs or gets
+        # OOM-killed would mean the disable step downstream never runs. The
+        # actual config-setting is the `git` module's `disable_auto_gc`
+        # (see its own example), invoked here with `cwd=_mirror` rather than
+        # `--git-dir` -- git's own repository discovery resolves a bare
+        # mirror from `cwd` just as well as a working tree.
+        api.post_process(post_process.StepCommandContains,
+                         'git cache populate disable (before): gc.auto=0',
+                         ['config', 'gc.auto', '0']),
+        api.post_process(
+            post_process.StepCommandContains,
+            'git cache populate disable (before): '
+            'maintenance.gc.enabled=false',
+            ['config', 'maintenance.gc.enabled', 'false']),
+        # Nothing to configure before the first fetch of a mirror that
+        # doesn't exist yet...
+        api.post_process(post_process.DoesNotRun,
+                         'populate with tags disable (before): gc.auto=0'),
+        # ...but it exists once that call bootstraps it, so the *next* use
+        # of this mirror is still protected.
+        api.post_process(post_process.StepCommandContains,
+                         'populate with tags disable (after): gc.auto=0',
+                         ['config', 'gc.auto', '0']),
         api.post_process(post_process.StatusSuccess),
     )
     # No cache at all is a hard error rather than an uncached run.

--- a/tools/recipes/recipes/gerrit/refresh_mirrors.expected/fresh_checkout.json
+++ b/tools/recipes/recipes/gerrit/refresh_mirrors.expected/fresh_checkout.json
@@ -41,6 +41,21 @@
     "cmd": [
       "git",
       "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
       "populate",
       "--cache-dir",
       "/b/cache",
@@ -54,6 +69,21 @@
       "CHROME_HEADLESS": "1"
     },
     "name": "git cache populate"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (after)"
   },
   {
     "cmd": [
@@ -96,7 +126,7 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.auto=0"
+    "name": "disable auto-gc: gc.auto=0"
   },
   {
     "cmd": [
@@ -109,7 +139,7 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.autodetach=0"
+    "name": "disable auto-gc: gc.autodetach=0"
   },
   {
     "cmd": [
@@ -122,7 +152,20 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.autopacklimit=0"
+    "name": "disable auto-gc: gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "maintenance.gc.enabled",
+      "false"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "disable auto-gc: maintenance.gc.enabled=false"
   },
   {
     "cmd": [
@@ -168,6 +211,58 @@
       "CHROME_HEADLESS": "1"
     },
     "name": "gclient sync"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "name": "fetch tags exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.auto",
+      "0"
+    ],
+    "cwd": "/b/cache/chromium.googlesource.com-chromium-src",
+    "name": "fetch tags disable (before): gc.auto=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autodetach",
+      "0"
+    ],
+    "cwd": "/b/cache/chromium.googlesource.com-chromium-src",
+    "name": "fetch tags disable (before): gc.autodetach=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autopacklimit",
+      "0"
+    ],
+    "cwd": "/b/cache/chromium.googlesource.com-chromium-src",
+    "name": "fetch tags disable (before): gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "maintenance.gc.enabled",
+      "false"
+    ],
+    "cwd": "/b/cache/chromium.googlesource.com-chromium-src",
+    "name": "fetch tags disable (before): maintenance.gc.enabled=false"
   },
   {
     "cmd": [

--- a/tools/recipes/recipes/gerrit/refresh_mirrors.expected/reused_checkout_at_explicit_ref.json
+++ b/tools/recipes/recipes/gerrit/refresh_mirrors.expected/reused_checkout_at_explicit_ref.json
@@ -40,6 +40,21 @@
     "cmd": [
       "git",
       "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
       "populate",
       "--cache-dir",
       "/b/cache",
@@ -53,6 +68,21 @@
       "CHROME_HEADLESS": "1"
     },
     "name": "git cache populate for ref"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate for ref exists (after)"
   },
   {
     "cmd": [
@@ -145,6 +175,18 @@
     "cmd": [
       "git",
       "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "name": "fetch tags exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
       "populate",
       "--cache-dir",
       "/b/cache",
@@ -154,6 +196,18 @@
       "refs/tags/*"
     ],
     "name": "fetch tags"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "name": "fetch tags exists (after)"
   },
   {
     "cmd": [

--- a/tools/recipes/recipes/gerrit/refresh_mirrors.py
+++ b/tools/recipes/recipes/gerrit/refresh_mirrors.py
@@ -15,7 +15,9 @@ from PB.recipes.brave.gerrit.refresh_mirrors import InputProperties
 if TYPE_CHECKING:
     from engine import RecipeScriptApi
 
-DEPS = ['path', 'step', 'chromium_checkout', 'depot_tools', 'git_cache']
+DEPS = [
+    'path', 'step', 'chromium_checkout', 'depot_tools', 'git_cache', 'raw_io'
+]
 
 PROPERTIES = InputProperties
 
@@ -51,11 +53,20 @@ def GenTests(api):
         api.chromium_checkout.with_git_cache(),
         api.chromium_checkout.git_cache_populated(),
         api.properties(gerrit_user='chromium-mirror-bot'),
+        api.step_data('fetch tags exists (before)',
+                      stdout=api.raw_io.output_text(
+                          '/b/cache/chromium.googlesource'
+                          '.com-chromium-src\n')),
         api.post_process(post_process.MustRun, 'clone from git cache'),
         api.post_process(post_process.StepCommandContains, 'fetch tags',
                          ['--ref', 'refs/tags/*']),
         api.post_process(post_process.StepCommandDoesNotContain, 'fetch tags',
                          ['--no-fetch-tags']),
+        api.post_process(post_process.MustRun,
+                         'fetch tags disable (before): gc.auto=0'),
+        api.post_process(
+            post_process.MustRun,
+            'fetch tags disable (before): maintenance.gc.enabled=false'),
         api.post_process(post_process.MustRun, 'refresh gerrit mirrors'),
         api.post_process(post_process.StepCommandContains,
                          'refresh gerrit mirrors',

--- a/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
@@ -41,6 +41,21 @@
     "cmd": [
       "git",
       "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
       "populate",
       "--cache-dir",
       "/b/cache",
@@ -54,6 +69,21 @@
       "CHROME_HEADLESS": "1"
     },
     "name": "git cache populate"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (after)"
   },
   {
     "cmd": [
@@ -98,7 +128,7 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.auto=0"
+    "name": "disable auto-gc: gc.auto=0"
   },
   {
     "cmd": [
@@ -111,7 +141,7 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.autodetach=0"
+    "name": "disable auto-gc: gc.autodetach=0"
   },
   {
     "cmd": [
@@ -124,7 +154,20 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.autopacklimit=0"
+    "name": "disable auto-gc: gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "maintenance.gc.enabled",
+      "false"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "disable auto-gc: maintenance.gc.enabled=false"
   },
   {
     "cmd": [

--- a/tools/recipes/recipes/toolchains/rust/package_rust.expected/mac.json
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.expected/mac.json
@@ -41,6 +41,21 @@
     "cmd": [
       "git",
       "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
       "populate",
       "--cache-dir",
       "/b/cache",
@@ -54,6 +69,21 @@
       "CHROME_HEADLESS": "1"
     },
     "name": "git cache populate"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (after)"
   },
   {
     "cmd": [
@@ -98,7 +128,7 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.auto=0"
+    "name": "disable auto-gc: gc.auto=0"
   },
   {
     "cmd": [
@@ -111,7 +141,7 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.autodetach=0"
+    "name": "disable auto-gc: gc.autodetach=0"
   },
   {
     "cmd": [
@@ -124,7 +154,20 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.autopacklimit=0"
+    "name": "disable auto-gc: gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "maintenance.gc.enabled",
+      "false"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "disable auto-gc: maintenance.gc.enabled=false"
   },
   {
     "cmd": [

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/linux.json
@@ -41,6 +41,21 @@
     "cmd": [
       "git",
       "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
       "populate",
       "--cache-dir",
       "/b/cache",
@@ -54,6 +69,21 @@
       "CHROME_HEADLESS": "1"
     },
     "name": "git cache populate"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (after)"
   },
   {
     "cmd": [
@@ -98,7 +128,7 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.auto=0"
+    "name": "disable auto-gc: gc.auto=0"
   },
   {
     "cmd": [
@@ -111,7 +141,7 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.autodetach=0"
+    "name": "disable auto-gc: gc.autodetach=0"
   },
   {
     "cmd": [
@@ -124,7 +154,20 @@
     "env": {
       "CHROME_HEADLESS": "1"
     },
-    "name": "git config gc.autopacklimit=0"
+    "name": "disable auto-gc: gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "maintenance.gc.enabled",
+      "false"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "disable auto-gc: maintenance.gc.enabled=false"
   },
   {
     "cmd": [


### PR DESCRIPTION
We recently rolled out a new git update, and that ended up bringing the
gerrit refresh job to a halt, due to `git` now introducing some new
setting that uses the gc, even when it is disabled, and that led to a
very bad outcome with the combined gc disable settings we already had.

This PR introduces a `git` recipe module, that provides a function to
disable the gc in a given repo. The new settings are:

```py
_DISABLE_AUTO_GC_CONFIG = (
    ('gc.auto', '0'),
    ('gc.autodetach', '0'),
    ('gc.autopacklimit', '0'),
    ('maintenance.gc.enabled', 'false'),
)
```

`maintenance.gc.enabled` in particular is the new setting that had to be
introduced to further disable the gc.

Bug: https://github.com/brave/brave-browser/issues/55044
