### PR TITLE
[bots][infra] Adding `secrets.gni` rendering

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -672,6 +672,22 @@ def CheckJson5ParseErrors(input_api, output_api):
     return results
 
 
+def CheckNoCommittedSecretsFiles(input_api, output_api):
+    """Refuses a committed `secrets.gni` anywhere in the tree.
+    """
+    offending = [
+        f.LocalPath() for f in input_api.AffectedFiles(include_deletes=False)
+        if f.LocalPath().endswith('secrets.gni')
+    ]
+    if not offending:
+        return []
+    return [
+        output_api.PresubmitError(
+            'secret values must never be checked in; found:\n  ' +
+            '\n  '.join(offending))
+    ]
+
+
 # DON'T ADD NEW BRAVE CHECKS AFTER THIS LINE.
 #
 # This call inlines Chromium checks into current scope from src/PRESUBMIT.py. We

--- a/PRESUBMIT_test.py
+++ b/PRESUBMIT_test.py
@@ -152,6 +152,46 @@ class CheckJson5ParseErrorsTest(unittest.TestCase):
         self.assertEqual([], errors)
 
 
+class CheckNoCommittedSecretsFilesTest(unittest.TestCase):
+
+    def testFlagsASecretsGniFile(self):
+        input_api = MockInputApi()
+        input_api.files = [
+            MockAffectedFile('out/linux-x64-asan-brave/secrets.gni',
+                             ['fake_secret_key = "abc123"']),
+        ]
+
+        errors = PRESUBMIT.CheckNoCommittedSecretsFiles(
+            input_api, MockOutputApi())
+
+        self.assertEqual(1, len(errors))
+        self.assertIn('secrets.gni', errors[0].message)
+
+    def testIgnoresOtherGniFiles(self):
+        input_api = MockInputApi()
+        input_api.files = [
+            MockAffectedFile('brave/build/args/brave_defaults.gni',
+                             ['is_asan = true']),
+        ]
+
+        errors = PRESUBMIT.CheckNoCommittedSecretsFiles(
+            input_api, MockOutputApi())
+
+        self.assertEqual([], errors)
+
+    def testIgnoresDeletedSecretsFiles(self):
+        input_api = MockInputApi()
+        input_api.files = [
+            MockAffectedFile('out/linux-x64-asan-brave/secrets.gni', [],
+                             action='D'),
+        ]
+
+        errors = PRESUBMIT.CheckNoCommittedSecretsFiles(
+            input_api, MockOutputApi())
+
+        self.assertEqual([], errors)
+
+
 class CheckTodoBugReferencesTest(unittest.TestCase):
 
     def _Check(self, line):

--- a/infra/bots/dotenv.py
+++ b/infra/bots/dotenv.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Reads the secrets `.env` file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import gen_paths
+
+_CHROMIUM_SRC_DIR = gen_paths.BOTS_DIR.parents[2]
+DEFAULT_PATH = _CHROMIUM_SRC_DIR / 'brave' / '.env'
+
+
+def parse(text: str) -> dict[str, str]:
+    """Returns a dictionary of `KEY=VALUE` pairs parsed from the given text."""
+    result: dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        key, sep, value = line.partition('=')
+        if not sep:
+            continue
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"',
+                                                                      "'"):
+            value = value[1:-1]
+        result[key] = value
+    return result
+
+
+def read(path: Path | None = None) -> dict[str, str]:
+    """Reads and parses the `.env` file.
+
+    Returns a dictionary of `KEY=VALUE` pairs with the contents of the file or
+    {} if no file exists.
+    """
+    path = path if path is not None else DEFAULT_PATH
+    if not path.is_file():
+        return {}
+    return parse(path.read_bytes().decode('utf-8'))

--- a/infra/bots/dotenv_test.py
+++ b/infra/bots/dotenv_test.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Tests for dotenv.py: parsing the secrets `.env` file CI writes."""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import dotenv
+
+
+class ParseTest(unittest.TestCase):
+
+    def test_plain_key_value_lines(self):
+        self.assertEqual(
+            dotenv.parse('fake_secret_key=abc123\n'
+                         'other_fake_secret_key=def456\n'), {
+                             'fake_secret_key': 'abc123',
+                             'other_fake_secret_key': 'def456',
+                         })
+
+    def test_blank_lines_and_comments_are_skipped(self):
+        self.assertEqual(
+            dotenv.parse('\n# a comment\nfake_secret_key=abc123\n'
+                         '\n'), {'fake_secret_key': 'abc123'})
+
+    def test_surrounding_whitespace_is_stripped(self):
+        self.assertEqual(dotenv.parse('  fake_secret_key = abc123 \n'),
+                         {'fake_secret_key': 'abc123'})
+
+    def test_matching_quotes_are_stripped(self):
+        self.assertEqual(dotenv.parse('a="double"\nb=\'single\'\n'), {
+            'a': 'double',
+            'b': 'single',
+        })
+
+    def test_mismatched_quote_is_left_alone(self):
+        self.assertEqual(dotenv.parse('a="mismatched\'\n'),
+                         {'a': '"mismatched\''})
+
+    def test_line_without_equals_is_ignored(self):
+        self.assertEqual(dotenv.parse('not-a-valid-line\na=b\n'), {'a': 'b'})
+
+    def test_empty_text_is_empty(self):
+        self.assertEqual(dotenv.parse(''), {})
+
+
+class ReadTest(unittest.TestCase):
+
+    def test_missing_file_returns_empty(self):
+        self.assertEqual(
+            dotenv.read(Path(tempfile.mkdtemp()) / 'does-not-exist'), {})
+
+    def test_reads_and_parses_existing_file(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        path = Path(tmp.name) / '.env'
+        path.write_text('fake_secret_key=abc123\n', encoding='utf-8')
+
+        self.assertEqual(dotenv.read(path), {'fake_secret_key': 'abc123'})
+
+    def test_defaults_to_default_path(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        path = Path(tmp.name) / '.env'
+        path.write_text('fake_secret_key=abc123\n', encoding='utf-8')
+
+        original = dotenv.DEFAULT_PATH
+        dotenv.DEFAULT_PATH = path
+        try:
+            self.assertEqual(dotenv.read(), {'fake_secret_key': 'abc123'})
+        finally:
+            dotenv.DEFAULT_PATH = original
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/infra/bots/gen.py
+++ b/infra/bots/gen.py
@@ -13,6 +13,7 @@ import subprocess
 
 import gen_paths
 import generated_output
+import dotenv
 
 _CHROMIUM_SRC_DIR = gen_paths.BOTS_DIR.parents[2]
 
@@ -37,27 +38,46 @@ class BuildDirGenerator(generated_output.OutputGenerator):
         which is not necessarily the default `out/<builder>` once
         `--out-dir` overrides it, so the import must follow it there.
         """
-        return '//%s/brave_secrets.gni' % self.out_dir.relative_to(
+        return '//%s/secrets.gni' % self.out_dir.relative_to(
             _CHROMIUM_SRC_DIR).as_posix()
 
-    @staticmethod
-    def render_secrets_gni_stub(secrets: dict[str, str]) -> str:
-        """Renders a placeholder `brave_secrets.gni` for a `secrets` map.
+    def resolve_secrets(self, secrets: dict[str, str]) -> dict[str, str]:
+        """Resolves every declared secret's real value.
 
-        This stub exists so a builder that declares secrets still gets a
-        `gn gen` that succeeds. Every declared GN arg gets a "dummy" value, the
-        same placeholder `gn_args.py` already uses for `brave_google_api_key`.
+        This function reads the secrets from the `.env` file as usual and
+        returns a dictionary for them.
+
+        Raises:
+            BotsError: the secrets `.env` file has no entry for one of the
+                declared names.
         """
-        return ''.join('%s = "dummy"\n' % name for name in sorted(secrets))
+        env = dotenv.read()
+        missing = sorted(name for name in secrets if name not in env)
+        if missing:
+            raise generated_output.BotsError(
+                'builder %r declares secret(s) %s with no matching entry in '
+                '%s.' %
+                (self.builder_name, ', '.join(missing), dotenv.DEFAULT_PATH))
+        return {name: env[name] for name in secrets}
+
+    @staticmethod
+    def render_secrets_gni(secrets: dict[str, str]) -> str:
+        """Renders `secrets.gni` from resolved secret values."""
+        return ''.join('%s = %s\n' %
+                       (name, generated_output.gn_helpers.ToGNString(value))
+                       for name, value in sorted(secrets.items()))
 
     def write_build_dir(self) -> str:
-        """Writes `args.gn` (and a secrets stub, if the builder declares
-        any) into `self.out_dir`, creating it if needed.
+        """Writes `args.gn` and a resolved `secrets.gni` into `self.out_dir`.
 
         Returns:
             The rendered `args.gn` text.
         """
         resolved = self.read_generated_gn_args()
+        declared_secrets = resolved.get('secrets')
+        secrets = (self.resolve_secrets(declared_secrets)
+                   if declared_secrets else None)
+
         args_gn = self.render_args_gn(resolved)
 
         self.out_dir.mkdir(parents=True, exist_ok=True)
@@ -65,24 +85,18 @@ class BuildDirGenerator(generated_output.OutputGenerator):
                                               encoding='utf-8',
                                               newline='\n')
 
-        secrets = resolved.get('secrets')
         if secrets:
-            (self.out_dir / 'brave_secrets.gni').write_text(
-                self.render_secrets_gni_stub(secrets),
-                encoding='utf-8',
-                newline='\n')
+            secrets_path = self.out_dir / 'secrets.gni'
+            secrets_path.write_text(self.render_secrets_gni(secrets),
+                                    encoding='utf-8',
+                                    newline='\n')
+            # Restrictive permissions: this file carries real secret values.
+            secrets_path.chmod(0o600)
 
         return args_gn
 
     def run_gn_gen(self) -> int:
         """Runs `gn gen` against `self.out_dir`.
-
-        `args.gn` is already on disk (`write_build_dir`), so, as `mb.py gen`
-        does, this only ever needs to name the directory; `--check` runs the
-        header checker over the whole graph, matching `mb.py`'s own default.
-        GN resolves the build directory against the source root it finds
-        from the working directory, so this always runs from
-        `_CHROMIUM_SRC_DIR`.
         """
         return subprocess.call([
             'gn', 'gen',

--- a/infra/bots/gen_test.py
+++ b/infra/bots/gen_test.py
@@ -3,8 +3,8 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Tests for gen.py's own logic: `BuildDirGenerator`'s secrets stub, its
-writing of a build directory's `args.gn`/`brave_secrets.gni`, and
+"""Tests for gen.py's own logic: `BuildDirGenerator`'s secret resolution, its
+writing of a build directory's `args.gn`/`secrets.gni`, and
 `cmd_gen()`'s validation and dispatch. `BuildDirGenerator.run_gn_gen()`
 shells out to a real `gn` binary and is exercised manually, not here;
 `cmd_gen()`'s tests stub it out. `bots.py`'s CLI wiring for the `gen`
@@ -12,6 +12,7 @@ subcommand is exercised in bots_test.py instead."""
 
 import argparse
 import os
+import stat
 import sys
 import tempfile
 import unittest
@@ -22,34 +23,72 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import gen
 import gen_paths
 import generated_output
+import dotenv
 from generated_output_test import _make_generated_output_dir
 
 
-class RenderSecretsGniStubTest(unittest.TestCase):
+def _patch_dotenv(test_case, contents: str) -> None:
+    """Points `dotenv.DEFAULT_PATH` at a temp file with `contents` for
+    the duration of `test_case`."""
+    tmp = tempfile.TemporaryDirectory()
+    test_case.addCleanup(tmp.cleanup)
+    path = Path(tmp.name) / '.env'
+    path.write_text(contents, encoding='utf-8')
+
+    original = dotenv.DEFAULT_PATH
+    dotenv.DEFAULT_PATH = path
+    test_case.addCleanup(lambda: setattr(dotenv, 'DEFAULT_PATH', original))
+
+
+class ResolveSecretsTest(unittest.TestCase):
+
+    def test_empty_secrets_resolves_empty(self):
+        self.assertEqual(gen.BuildDirGenerator('b').resolve_secrets({}), {})
+
+    def test_resolves_from_dotenv_by_gn_arg_name(self):
+        _patch_dotenv(
+            self, 'fake_secret_key=abc123\nother_fake_secret_key=def456\n')
+
+        resolved = gen.BuildDirGenerator('b').resolve_secrets({
+            'fake_secret_key': 'FAKE_SECRET_ENV_VAR',
+            'other_fake_secret_key': 'OTHER_FAKE_SECRET_ENV_VAR',
+        })
+
+        self.assertEqual(resolved, {
+            'fake_secret_key': 'abc123',
+            'other_fake_secret_key': 'def456',
+        })
+
+    def test_missing_secret_raises(self):
+        _patch_dotenv(self, '')
+
+        with self.assertRaises(generated_output.BotsError) as ctx:
+            gen.BuildDirGenerator('b').resolve_secrets(
+                {'fake_secret_key': 'FAKE_SECRET_ENV_VAR'})
+
+        self.assertIn('fake_secret_key', str(ctx.exception))
+
+
+class RenderSecretsGniTest(unittest.TestCase):
 
     def test_empty_secrets_renders_empty(self):
-        self.assertEqual(gen.BuildDirGenerator.render_secrets_gni_stub({}), '')
+        self.assertEqual(gen.BuildDirGenerator.render_secrets_gni({}), '')
 
-    def test_every_declared_arg_gets_a_dummy_value(self):
-        rendered = gen.BuildDirGenerator.render_secrets_gni_stub({
-            'brave_services_key': 'BRAVE_SERVICES_KEY',
-            'brave_stats_api_key': 'BRAVE_STATS_API_KEY',
+    def test_renders_real_values(self):
+        rendered = gen.BuildDirGenerator.render_secrets_gni({
+            'fake_secret_key': 'abc123',
+            'other_fake_secret_key': 'def456',
         })
         self.assertEqual(
-            rendered, 'brave_services_key = "dummy"\n'
-            'brave_stats_api_key = "dummy"\n')
-
-    def test_no_env_var_name_appears(self):
-        rendered = gen.BuildDirGenerator.render_secrets_gni_stub(
-            {'brave_services_key': 'BRAVE_SERVICES_KEY'})
-        self.assertNotIn('BRAVE_SERVICES_KEY', rendered)
+            rendered, 'fake_secret_key = "abc123"\n'
+            'other_fake_secret_key = "def456"\n')
 
     def test_keys_are_sorted(self):
-        rendered = gen.BuildDirGenerator.render_secrets_gni_stub({
-            'z': 'Z',
-            'a': 'A'
+        rendered = gen.BuildDirGenerator.render_secrets_gni({
+            'z': 'z-value',
+            'a': 'a-value'
         })
-        self.assertEqual(rendered, 'a = "dummy"\nz = "dummy"\n')
+        self.assertEqual(rendered, 'a = "a-value"\nz = "z-value"\n')
 
 
 class DefaultOutDirTest(unittest.TestCase):
@@ -114,21 +153,22 @@ class WriteBuildDirTest(unittest.TestCase):
         finally:
             gen_paths.BUILDERS_OUTPUT_DIR = original
 
-        self.assertFalse((Path(out_tmp.name) / 'brave_secrets.gni').is_file())
+        self.assertFalse((Path(out_tmp.name) / 'secrets.gni').is_file())
 
-    def test_declared_secrets_get_a_dummy_stub_file(self):
+    def test_declared_secrets_get_their_real_value(self):
         tmp = tempfile.TemporaryDirectory()
         self.addCleanup(tmp.cleanup)
         builder_dir = Path(tmp.name) / 'b'
         builder_dir.mkdir()
         (builder_dir / 'gn-args.json').write_text(
             '{"gn_args": {"is_asan": true}, '
-            '"secrets": {"brave_services_key": "BRAVE_SERVICES_KEY"}}',
+            '"secrets": {"fake_secret_key": "FAKE_SECRET_ENV_VAR"}}',
             encoding='utf-8')
         fake_src_root = tempfile.TemporaryDirectory()
         self.addCleanup(fake_src_root.cleanup)
         fake_src_root_path = Path(fake_src_root.name).resolve()
         out_dir = fake_src_root_path / 'out' / 'b'
+        _patch_dotenv(self, 'fake_secret_key=abc123\n')
 
         original_output_dir = gen_paths.BUILDERS_OUTPUT_DIR
         gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
@@ -140,9 +180,65 @@ class WriteBuildDirTest(unittest.TestCase):
             gen_paths.BUILDERS_OUTPUT_DIR = original_output_dir
             gen._CHROMIUM_SRC_DIR = original_src_dir
 
-        self.assertEqual(
-            (out_dir / 'brave_secrets.gni').read_text(encoding='utf-8'),
-            'brave_services_key = "dummy"\n')
+        secrets_path = out_dir / 'secrets.gni'
+        self.assertEqual(secrets_path.read_text(encoding='utf-8'),
+                         'fake_secret_key = "abc123"\n')
+
+    def test_secrets_file_is_readable_only_by_owner(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        builder_dir = Path(tmp.name) / 'b'
+        builder_dir.mkdir()
+        (builder_dir / 'gn-args.json').write_text(
+            '{"gn_args": {"is_asan": true}, '
+            '"secrets": {"fake_secret_key": "FAKE_SECRET_ENV_VAR"}}',
+            encoding='utf-8')
+        fake_src_root = tempfile.TemporaryDirectory()
+        self.addCleanup(fake_src_root.cleanup)
+        fake_src_root_path = Path(fake_src_root.name).resolve()
+        out_dir = fake_src_root_path / 'out' / 'b'
+        _patch_dotenv(self, 'fake_secret_key=abc123\n')
+
+        original_output_dir = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
+        original_src_dir = gen._CHROMIUM_SRC_DIR
+        gen._CHROMIUM_SRC_DIR = fake_src_root_path
+        try:
+            gen.BuildDirGenerator('b', out_dir).write_build_dir()
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original_output_dir
+            gen._CHROMIUM_SRC_DIR = original_src_dir
+
+        mode = stat.S_IMODE((out_dir / 'secrets.gni').stat().st_mode)
+        self.assertEqual(mode, 0o600)
+
+    def test_missing_declared_secret_raises(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        builder_dir = Path(tmp.name) / 'b'
+        builder_dir.mkdir()
+        (builder_dir / 'gn-args.json').write_text(
+            '{"gn_args": {"is_asan": true}, '
+            '"secrets": {"fake_secret_key": "FAKE_SECRET_ENV_VAR"}}',
+            encoding='utf-8')
+        fake_src_root = tempfile.TemporaryDirectory()
+        self.addCleanup(fake_src_root.cleanup)
+        fake_src_root_path = Path(fake_src_root.name).resolve()
+        out_dir = fake_src_root_path / 'out' / 'b'
+        _patch_dotenv(self, '')  # No matching entry.
+
+        original_output_dir = gen_paths.BUILDERS_OUTPUT_DIR
+        gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
+        original_src_dir = gen._CHROMIUM_SRC_DIR
+        gen._CHROMIUM_SRC_DIR = fake_src_root_path
+        try:
+            with self.assertRaises(generated_output.BotsError):
+                gen.BuildDirGenerator('b', out_dir).write_build_dir()
+        finally:
+            gen_paths.BUILDERS_OUTPUT_DIR = original_output_dir
+            gen._CHROMIUM_SRC_DIR = original_src_dir
+
+        self.assertFalse((out_dir / 'args.gn').exists())
 
     def test_secrets_import_path_follows_a_non_default_out_dir(self):
         tmp = tempfile.TemporaryDirectory()
@@ -151,13 +247,14 @@ class WriteBuildDirTest(unittest.TestCase):
         builder_dir.mkdir()
         (builder_dir / 'gn-args.json').write_text(
             '{"gn_args": {"is_asan": true}, '
-            '"secrets": {"brave_services_key": "BRAVE_SERVICES_KEY"}}',
+            '"secrets": {"fake_secret_key": "FAKE_SECRET_ENV_VAR"}}',
             encoding='utf-8')
         fake_src_root = tempfile.TemporaryDirectory()
         self.addCleanup(fake_src_root.cleanup)
         fake_src_root_path = Path(fake_src_root.name).resolve()
         # Deliberately not the default `out/b` layout.
         out_dir = fake_src_root_path / 'custom' / 'out-dir'
+        _patch_dotenv(self, 'fake_secret_key=abc123\n')
 
         original_output_dir = gen_paths.BUILDERS_OUTPUT_DIR
         gen_paths.BUILDERS_OUTPUT_DIR = Path(tmp.name)
@@ -170,8 +267,8 @@ class WriteBuildDirTest(unittest.TestCase):
             gen._CHROMIUM_SRC_DIR = original_src_dir
 
         self.assertEqual(args_gn.splitlines()[0],
-                         'import("//custom/out-dir/brave_secrets.gni")')
-        self.assertTrue((out_dir / 'brave_secrets.gni').is_file())
+                         'import("//custom/out-dir/secrets.gni")')
+        self.assertTrue((out_dir / 'secrets.gni').is_file())
 
     def test_unknown_builder_raises(self):
         generator = gen.BuildDirGenerator('no-such-builder',

--- a/infra/bots/generated_output.py
+++ b/infra/bots/generated_output.py
@@ -61,7 +61,7 @@ class OutputGenerator:
     def secrets_import_path(self) -> str:
         """The `//`-prefixed GN label `render_args_gn()` imports secrets from.
         """
-        return '//out/%s/brave_secrets.gni' % self.builder_name
+        return '//out/%s/secrets.gni' % self.builder_name
 
     def render_args_gn(self, resolved: dict) -> str:
         """Renders a resolved `gn-args.json` payload as `args.gn` text."""

--- a/infra/bots/generated_output_test.py
+++ b/infra/bots/generated_output_test.py
@@ -103,8 +103,8 @@ class RenderArgsGnTest(unittest.TestCase):
                 },
             })
         lines = rendered.split('\n')
-        self.assertEqual(
-            lines[0], 'import("//out/linux-x64-asan-brave/brave_secrets.gni")')
+        self.assertEqual(lines[0],
+                         'import("//out/linux-x64-asan-brave/secrets.gni")')
         self.assertNotIn('BRAVE_SERVICES_KEY', rendered)
         self.assertNotIn('brave_services_key', rendered)
 

--- a/infra/bots/validate.py
+++ b/infra/bots/validate.py
@@ -12,16 +12,19 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 from pathlib import Path
 
 import gen_paths
 import generated_output
+import dotenv
 
 _CHROMIUM_SRC_DIR = gen_paths.BOTS_DIR.parents[2]
 
 # The three files `bots.py snapshot` writes for every builder.
 _REQUIRED_FILES = ('gn-args.json', 'sync.json', 'targets.json')
+
+# The placeholder value an unset secret carries.
+_UNSET_SECRET_PLACEHOLDER = 'dummy'
 
 
 def _list_builder_dirs() -> list[Path]:
@@ -153,20 +156,25 @@ class _Validator:
                                   gn_args_json: dict) -> None:
         """Checks a declared secret's real value never made it into
         `gn_args`.
+
+        The secrets `.env` file (`dotenv.py`) is a list of `gn` values.
         """
         secrets = gn_args_json.get('secrets') or {}
         gn_args = gn_args_json.get('gn_args') or {}
-        for gn_arg_name, env_var_name in secrets.items():
-            value = os.environ.get(env_var_name)
-            if not value:
+        if not secrets:
+            return
+        secret_values = dotenv.read()
+        for gn_arg_name in secrets:
+            value = secret_values.get(gn_arg_name)
+            if not value or value == _UNSET_SECRET_PLACEHOLDER:
                 continue
             for other_name, other_value in gn_args.items():
                 if isinstance(other_value, str) and value in other_value:
                     self._errs.append(
                         '%s: gn_args[%r] appears to contain the value of '
-                        'secret %r (from $%s); secret values must never be '
-                        'checked in' %
-                        (gn_args_path, other_name, gn_arg_name, env_var_name))
+                        'secret %r (from %s). Secret values MUST NEVER be '
+                        'checked in' % (gn_args_path, other_name, gn_arg_name,
+                                        dotenv.DEFAULT_PATH))
 
     def _check_sync_schema(self, sync_path: Path, sync_json: dict) -> None:
         for required in ('target_os', 'target_cpu', 'gclient_overrides'):

--- a/infra/bots/validate_test.py
+++ b/infra/bots/validate_test.py
@@ -22,7 +22,21 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import gen_paths
 import generated_output
+import dotenv
 import validate
+
+
+def _patch_dotenv(test_case, contents: str) -> None:
+    """Points `dotenv.DEFAULT_PATH` at a temp file with `contents` for
+    the duration of `test_case`."""
+    tmp = tempfile.TemporaryDirectory()
+    test_case.addCleanup(tmp.cleanup)
+    path = Path(tmp.name) / '.env'
+    path.write_text(contents, encoding='utf-8')
+
+    original = dotenv.DEFAULT_PATH
+    dotenv.DEFAULT_PATH = path
+    test_case.addCleanup(lambda: setattr(dotenv, 'DEFAULT_PATH', original))
 
 
 def _write_builder(output_dir,
@@ -199,29 +213,46 @@ class ValidatorRunTest(_OutputDirTestCase):
         self.assertIn('source-absolute', errs[0])
 
     def test_leaked_secret_value_is_reported(self):
-        self.addCleanup(os.environ.pop, 'FAKE_SECRET_ENV_VAR', None)
-        os.environ['FAKE_SECRET_ENV_VAR'] = 'super-secret-value'
+        _patch_dotenv(self, 'fake_secret_key=super-secret-value\n')
         _write_builder(self.output_dir,
                        'b',
                        gn_args={
                            'gn_args': {
                                'target_os': 'linux',
                                'target_cpu': 'x64',
-                               'brave_google_api_key': 'super-secret-value',
+                               'unrelated_gn_arg': 'super-secret-value',
                            },
                            'secrets': {
-                               'brave_services_key': 'FAKE_SECRET_ENV_VAR',
+                               'fake_secret_key': 'FAKE_SECRET_ENV_VAR',
                            },
                        })
         errs = validate._Validator().run()
         self.assertEqual(len(errs), 1)
-        self.assertIn('brave_google_api_key', errs[0])
-        self.assertIn('brave_services_key', errs[0])
+        self.assertIn('unrelated_gn_arg', errs[0])
+        self.assertIn('fake_secret_key', errs[0])
         self.assertNotIn('super-secret-value', errs[0])
 
-    def test_secret_declared_but_env_var_unset_is_fine(self):
-        self.addCleanup(os.environ.pop, 'FAKE_SECRET_ENV_VAR', None)
-        os.environ.pop('FAKE_SECRET_ENV_VAR', None)
+    def test_unset_dummy_placeholder_is_not_flagged_as_leaked(self):
+        # An unset secret and an unrelated gn_arg can both legitimately be
+        # "dummy", and that coincidence must not read as one leaking into the
+        # other.
+        _patch_dotenv(self, 'fake_secret_key=dummy\n')
+        _write_builder(self.output_dir,
+                       'b',
+                       gn_args={
+                           'gn_args': {
+                               'target_os': 'linux',
+                               'target_cpu': 'x64',
+                               'unrelated_gn_arg': 'dummy',
+                           },
+                           'secrets': {
+                               'fake_secret_key': 'FAKE_SECRET_ENV_VAR',
+                           },
+                       })
+        self.assertEqual(validate._Validator().run(), [])
+
+    def test_secret_declared_but_not_in_dotenv_is_fine(self):
+        _patch_dotenv(self, '')  # No matching entry.
         _write_builder(self.output_dir,
                        'b',
                        gn_args={
@@ -230,7 +261,7 @@ class ValidatorRunTest(_OutputDirTestCase):
                                'target_cpu': 'x64',
                            },
                            'secrets': {
-                               'brave_services_key': 'FAKE_SECRET_ENV_VAR',
+                               'fake_secret_key': 'FAKE_SECRET_ENV_VAR',
                            },
                        })
         self.assertEqual(validate._Validator().run(), [])


### PR DESCRIPTION
This change adds the code handling generation for `secret.gni`. This
particular file will stay as close as to what we already have in CI at
the moment, which means we will read these values straight out of the
`.env` file for resolution.

Bug: https://github.com/brave/brave-browser/issues/56449
