### PR TITLE
[plaster] Adding `set_blink_runtime_enabled_feature_state`

### DIFF
--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -136,19 +136,20 @@ YAML).
 The keyed rewrite (`regex:` above) is a **rewriter**. There is on-going work to
 introduce more rewriters. These are the ones we have supported for now.
 
-| Rewriter                         | Namespace | Kind  | Description                                       |
-| -------------------------------- | --------- | ----- | ------------------------------------------------- |
-| `regex`                          | `all`     | text  | A Python `re.subn` substitution (the default).    |
-| `make_virtual`                   | `cxx`     | AST   | Prepends `virtual ` to a C++ method declaration.  |
-| `add_friend`                     | `cxx`     | AST   | Adds a `friend` declaration to a private section. |
-| `drop_final`                     | `cxx`     | AST   | Removes `final` from a C++ class declaration.     |
-| `preempt_function_impl`          | `cxx`     | AST   | Inserts at the top of a C++ function body.        |
-| `after_function_impl`            | `cxx`     | AST   | Wraps a C++ function body and runs code after.    |
-| `rename_class`                   | `cxx`     | AST   | Renames a C++ class.                              |
-| `add_to_protected`               | `cxx`     | AST   | Adds a member to a class `protected:` section.    |
-| `add_to_public`                  | `cxx`     | AST   | Appends a member to a class `public:` section.    |
-| `add_enum_entries`               | `cxx`     | AST   | Appends entries to the end of a C++ enum.         |
-| `set_feature_flag_default_state` | `cxx`     | macro | Sets a `BASE_FEATURE`'s default state.            |
+| Rewriter                                  | Namespace | Kind  | Description                                           |
+| ----------------------------------------- | --------- | ----- | ----------------------------------------------------- |
+| `regex`                                   | `all`     | text  | A Python `re.subn` substitution (the default).        |
+| `make_virtual`                            | `cxx`     | AST   | Prepends `virtual ` to a C++ method declaration.      |
+| `add_friend`                              | `cxx`     | AST   | Adds a `friend` declaration to a private section.     |
+| `drop_final`                              | `cxx`     | AST   | Removes `final` from a C++ class declaration.         |
+| `preempt_function_impl`                   | `cxx`     | AST   | Inserts at the top of a C++ function body.            |
+| `after_function_impl`                     | `cxx`     | AST   | Wraps a C++ function body and runs code after.        |
+| `rename_class`                            | `cxx`     | AST   | Renames a C++ class.                                  |
+| `add_to_protected`                        | `cxx`     | AST   | Adds a member to a class `protected:` section.        |
+| `add_to_public`                           | `cxx`     | AST   | Appends a member to a class `public:` section.        |
+| `add_enum_entries`                        | `cxx`     | AST   | Appends entries to the end of a C++ enum.             |
+| `set_feature_flag_default_state`          | `cxx`     | macro | Sets a `BASE_FEATURE`'s default state.                |
+| `set_blink_runtime_enabled_feature_state` | `js`      | AST   | Sets a Blink runtime feature's `base_feature_status`. |
 
 Use `plaster --help` to discover rewriters and read their full docs:
 

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -539,6 +539,11 @@ _NAMESPACES: Final = (
                           '.h', '.hpp', '.hxx', '.h++', '.cc', '.cpp', '.cxx',
                           '.c++', '.mm'
                       })),
+    # We include JSON5 with js because `ast-grep` has no tree-sitter for it, but
+    # the JS one works just fine.
+    RewriterNamespace(name='js',
+                      ast_grep_language='js',
+                      suffixes=frozenset({'.js', '.json5'})),
 )
 
 _NAMESPACE_BY_NAME: Final = MappingProxyType(
@@ -2108,6 +2113,95 @@ class CxxAddEnumEntriesRewriter(_AstGrepRewriter):
         return list(entries)
 
 
+class JsSetBlinkRuntimeEnabledFeatureStateRewriter(_AstGrepRewriter):
+    """Override a value `base::Feature` for a `runtime_enabled_features.json5`.
+
+    This rewriter has the same purpose as the one used for C++,
+    `CxxSetFeatureFlagDefaultStateRewriter`, which is override the default state
+    of a particular flag. It is named for the field it sets rather than after
+    that rewriter, since the flag it overrides is one Blink generates from
+    this file rather than one declared in C++.
+    """
+
+    NAME: Final = 'set_blink_runtime_enabled_feature_state'
+
+    # Two ops share the work (see `apply`); this names the namespace and a
+    # representative op for the base's helpers.
+    OP_ID: Final = 'js.set_blink_runtime_enabled_feature_state'
+
+    SUMMARY: Final = "Force a runtime feature's `base::Feature` default state."
+
+    # Authored in Markdown; `Help` renders it with rich.
+    HELP: Final = r"""
+        Sets `base_feature_status` on a `runtime_enabled_features.json5`
+        feature entry, overriding it.
+
+        Fields:
+
+        - `feature_name` — the entry's `name`, unquoted, e.g. `MyFeature`.
+        - `value` — `enabled` or `disabled`.
+
+        Example:
+
+        ```yaml
+        substitutions:
+          - description: Ship MyFeature's base feature disabled.
+            set_blink_runtime_enabled_feature_state:
+              feature_name: MyFeature
+              value: disabled
+        ```
+
+        ```diff
+         {
+           name: "MyFeature",
+        +  base_feature_status: "disabled",  // feature state is enforced via plaster rewrite.
+           status: "stable",
+         },
+        ```
+    """
+
+    # Replaces the value of a `base_feature_status` the entry already has.
+    _SET_EXISTING: Final = 'js.set_blink_runtime_enabled_feature_state'
+
+    # Adds the field to an entry that lacks it.
+    _ADD_NEW: Final = 'js.add_blink_runtime_enabled_feature_state'
+
+    @classmethod
+    def validate_count(cls, count: int, description: str) -> None:
+        # One entry, one field, set once, so no other count means anything.
+        if count != 1:
+            raise ValueError(f'{cls.NAME} sets the field exactly once and '
+                             f'does not accept a count other than 1 '
+                             f'(in "{description}")')
+
+    def apply(
+        self,
+        contents: str,
+        *,
+        count: int,
+        description: str,
+        blank_for_parse: BlankForParseOptions = BlankForParseOptions()
+    ) -> tuple[str, list[str]]:
+        # Which op applies turns on whether the entry already declares the
+        # field, so `count` -- already validated as 1 -- says nothing here.
+        del count, description
+        engine = AstRewriter(RewritersEval.load(),
+                             contents,
+                             blank_for_parse=blank_for_parse)
+        # Locating the entry first is what tells the two apart. A missing
+        # entry leaves `has_field` False, and the add op then reports the
+        # shortfall through the usual count check.
+        entry = engine.first_match(Operation(self.OP_ID, self._inputs))
+        source = contents.encode('utf-8')
+        has_field = (entry is not None and b'base_feature_status:'
+                     in source[entry.start:entry.end])
+        op = Operation(self._SET_EXISTING if has_field else self._ADD_NEW,
+                       self._inputs, MatchExpectation.exactly(1))
+        changes = engine.run(op)
+        error = op.expectation.error_for(changes)
+        return engine.content, [error] if error else []
+
+
 # The hand-written rewriters. `_REWRITERS` is assembled from these plus the
 # ones generated from `rewriters.pyl` for `RegexMacro`.
 _DECLARED_REWRITERS: Final = (AllRegexRewriter, CxxMakeVirtualRewriter,
@@ -2117,7 +2211,8 @@ _DECLARED_REWRITERS: Final = (AllRegexRewriter, CxxMakeVirtualRewriter,
                               CxxRenameClassRewriter,
                               CxxAddToProtectedRewriter,
                               CxxAddToPublicRewriter,
-                              CxxAddEnumEntriesRewriter)
+                              CxxAddEnumEntriesRewriter,
+                              JsSetBlinkRuntimeEnabledFeatureStateRewriter)
 
 
 class RewriterRegistry:

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -3847,6 +3847,165 @@ class RewriterFormsTest(unittest.TestCase):
             "      replace: 'Brave'\n")
         self.assertEqual(result, 'A Brave thing.\n')
 
+    # -- js.set_blink_runtime_enabled_feature_state op (real ast-grep) ------
+    #
+    # Targets `runtime_enabled_features.json5`, parsed with ast-grep's `js`
+    # grammar. The rewriter is composite: per entry, it works out at apply
+    # time whether to add the field or override the one already there.
+
+    _FEATURE_YAML = ('substitutions:\n'
+                     '  - description: Ship MyFeature disabled.\n'
+                     '    set_blink_runtime_enabled_feature_state:\n'
+                     '      feature_name: MyFeature\n'
+                     '      value: disabled\n')
+
+    def test_blink_runtime_enabled_feature_state_adds_a_missing_field(self):
+        result = self._apply(
+            'runtime_enabled_features.json5', '[\n'
+            '  {\n'
+            '    name: "MyFeature",\n'
+            '    status: "stable",\n'
+            '  },\n'
+            '];\n', self._FEATURE_YAML)
+        self.assertEqual(
+            result, '[\n'
+            '  {\n'
+            '    name: "MyFeature",\n'
+            '    base_feature_status: "disabled",  '
+            '// feature state is enforced via plaster rewrite.\n'
+            '    status: "stable",\n'
+            '  },\n'
+            '];\n')
+
+    def test_blink_runtime_enabled_feature_state_overrides_an_existing_field(
+            self):
+        # Upstream puts the field last, by the origin-trial keys rather than
+        # by `name`; it is overridden where it stands, not moved.
+        result = self._apply(
+            'runtime_enabled_features.json5', '[\n'
+            '  {\n'
+            '    name: "MyFeature",\n'
+            '    origin_trial_feature_name: "MyFeature",\n'
+            '    base_feature_status: "enabled",\n'
+            '    copied_from_base_feature_if: "overridden",\n'
+            '  },\n'
+            '];\n', self._FEATURE_YAML)
+        self.assertEqual(
+            result, '[\n'
+            '  {\n'
+            '    name: "MyFeature",\n'
+            '    origin_trial_feature_name: "MyFeature",\n'
+            '    base_feature_status: "disabled",  '
+            '// feature state is enforced via plaster rewrite.\n'
+            '    copied_from_base_feature_if: "overridden",\n'
+            '  },\n'
+            '];\n')
+
+    def test_blink_runtime_enabled_feature_state_survives_a_leading_comment(
+            self):
+        # A comment before `name` -- common upstream -- must not defeat the
+        # match, as a positional `{name: "...", $$$REST}` pattern would.
+        result = self._apply(
+            'runtime_enabled_features.json5', '[\n'
+            '  {\n'
+            '    // PARAKEET ad serving runtime flag/JS API.\n'
+            '    name: "MyFeature",\n'
+            '    status: "stable",\n'
+            '  },\n'
+            '];\n', self._FEATURE_YAML)
+        self.assertIn(
+            '    name: "MyFeature",\n'
+            '    base_feature_status: "disabled",  '
+            '// feature state is enforced via plaster rewrite.\n', result)
+
+    def test_blink_runtime_enabled_feature_state_ignores_a_longer_name_field(
+            self):
+        # `origin_trial_feature_name` ends in the same characters as `name`
+        # and often carries the same value; the field must land after the
+        # real `name`, not after that one.
+        result = self._apply(
+            'runtime_enabled_features.json5', '[\n'
+            '  {\n'
+            '    name: "MyFeature",\n'
+            '    origin_trial_feature_name: "MyFeature",\n'
+            '  },\n'
+            '];\n', self._FEATURE_YAML)
+        self.assertEqual(
+            result, '[\n'
+            '  {\n'
+            '    name: "MyFeature",\n'
+            '    base_feature_status: "disabled",  '
+            '// feature state is enforced via plaster rewrite.\n'
+            '    origin_trial_feature_name: "MyFeature",\n'
+            '  },\n'
+            '];\n')
+
+    def test_blink_runtime_enabled_feature_state_leaves_sibling_entries_alone(
+            self):
+        result = self._apply(
+            'runtime_enabled_features.json5', '[\n'
+            '  {\n'
+            '    name: "OtherFeature",\n'
+            '    status: "stable",\n'
+            '  },\n'
+            '  {\n'
+            '    name: "MyFeature",\n'
+            '    status: "stable",\n'
+            '  },\n'
+            '];\n', self._FEATURE_YAML)
+        self.assertEqual(
+            result, '[\n'
+            '  {\n'
+            '    name: "OtherFeature",\n'
+            '    status: "stable",\n'
+            '  },\n'
+            '  {\n'
+            '    name: "MyFeature",\n'
+            '    base_feature_status: "disabled",  '
+            '// feature state is enforced via plaster rewrite.\n'
+            '    status: "stable",\n'
+            '  },\n'
+            '];\n')
+
+    def test_blink_runtime_enabled_feature_state_reapplies_unchanged(self):
+        # Rerunning over already-migrated text takes the override branch and
+        # must not stack up a second comment.
+        once = self._apply(
+            'runtime_enabled_features.json5', '[\n'
+            '  {\n'
+            '    name: "MyFeature",\n'
+            '    status: "stable",\n'
+            '  },\n'
+            '];\n', self._FEATURE_YAML)
+        twice = self._apply('runtime_enabled_features.json5', once,
+                            self._FEATURE_YAML)
+        self.assertEqual(once, twice)
+        self.assertEqual(
+            twice.count('// feature state is enforced via plaster rewrite.'),
+            1)
+
+    def test_blink_runtime_enabled_feature_state_unknown_feature_fails(self):
+        with self.assertRaises(plaster.PlasterApplyError):
+            self._apply(
+                'runtime_enabled_features.json5', '[\n'
+                '  {\n'
+                '    name: "OtherFeature",\n'
+                '    status: "stable",\n'
+                '  },\n'
+                '];\n', self._FEATURE_YAML)
+
+    def test_blink_runtime_enabled_feature_state_count_other_than_one_rejected(
+            self):
+        self._expect_value_error(
+            'substitutions:\n'
+            '  - description: bogus count\n'
+            '    count: 2\n'
+            '    set_blink_runtime_enabled_feature_state:\n'
+            '      feature_name: MyFeature\n'
+            '      value: disabled\n',
+            'does not accept a count other than 1',
+            name='validation.json5')
+
     # -- validation ---------------------------------------------------------
 
     def test_two_op_keys_rejected(self):
@@ -4050,7 +4209,8 @@ class RegexMacroDispatchTest(unittest.TestCase):
             result, '// kFoo feature state is enforced via plaster rewrite.\n'
             'BASE_FEATURE(kFoo, base::FEATURE_DISABLED_BY_DEFAULT);')
 
-    def test_rejected_on_a_non_cxx_source(self):
+    def test_rejected_on_a_source_outside_every_namespace_it_serves(self):
+        # The name belongs to `cxx` alone, and a `.idl` target is not in it.
         with self.assertRaises(ValueError) as cm:
             self._apply(
                 'feature.idl', 'irrelevant', 'substitutions:\n'
@@ -4060,8 +4220,8 @@ class RegexMacroDispatchTest(unittest.TestCase):
                 '      value: base::FEATURE_DISABLED_BY_DEFAULT\n')
         self.assertIn(
             'the `set_feature_flag_default_state` rewriter is not available '
-            'for this source, which is not in any namespace it serves (cxx)',
-            str(cm.exception))
+            'for this source, which is not in any namespace it serves '
+            '(cxx)', str(cm.exception))
 
     def _expect_value_error(self, yaml_body: str, substr: str):
         with self.assertRaises(ValueError) as ctx:

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -380,6 +380,29 @@ regex: ^{class_name}$
                 "node": "identifier",
             },
         },
+
+        # A `runtime_enabled_features.json5` feature entry: the object, in
+        # that file's list of features, whose `name` field is `feature_name`.
+        #
+        # Matched through `has`/`all` rather than a `{name: "...", $$$REST}`
+        # as preceeding comments confuse the parser.
+        "js.find_runtime_feature_entry": {
+            "template": """\
+kind: object
+has:
+  kind: pair
+  all:
+    - has:
+        field: key
+        regex: ^name$
+    - has:
+        field: value
+        regex: ^"{feature_name}"$
+""",
+            "result": {
+                "node": "object",
+            },
+        },
     },
     "ast.rewriter": {
 
@@ -615,6 +638,57 @@ regex: ^{class_name}$
             },
             "result": {
                 "node": "enumerator",
+            },
+        },
+
+        # Both ops below set a feature entry's `base_feature_status`, which is
+        # what forces the default state of the `base::Feature` the entry
+        # generates. Which one applies depends on whether the entry already
+        # declares the field, so the two are paired and chosen between by
+        # `js.set_blink_runtime_enabled_feature_state`'s frontend rewriter.
+        #
+        # We leave a trailing comment on the field, so the substitution always
+        # produces a diff even when upstream's own value already agrees with
+        # ours, as feature flags are preemtively overridden most of the time.
+
+        # The field is absent, so it is inserted directly after `name`. The
+        # negative lookahead is what establishes absence; with the field
+        # present this op matches nothing, and the count check reports it.
+        "js.add_blink_runtime_enabled_feature_state": {
+            "matcher": "js.find_runtime_feature_entry",
+            "inputs": ["feature_name", "value"],
+            "replace": {
+                "re_pattern":
+                    "([ \\t]*)((?<![A-Za-z0-9_])name:\\s*\"[^\"]*\",)"
+                    "(?![\\s\\S]*?(?<![A-Za-z0-9_])base_feature_status:)",
+                "replace":
+                    "\\1\\2\\n\\1base_feature_status: \"{value}\",  "
+                    "// feature state is enforced via plaster rewrite.",
+            },
+            "result": {
+                "node": "object",
+            },
+        },
+
+        # The field is already declared, so only its value changes, wherever
+        # in the entry it sits. Upstream tends to put it last, next to
+        # `copied_from_base_feature_if`, rather than beside `name`. The
+        # optional trailing group swallows a comment an earlier run left, so
+        # reapplying does not stack up copies of it.
+        "js.set_blink_runtime_enabled_feature_state": {
+            "matcher": "js.find_runtime_feature_entry",
+            "inputs": ["feature_name", "value"],
+            "replace": {
+                "re_pattern":
+                    "((?<![A-Za-z0-9_])base_feature_status:\\s*\")[^\"]*(\",)"
+                    "(?:[ \\t]*// feature state is enforced via plaster "
+                    "rewrite\\.)?",
+                "replace":
+                    "\\1{value}\\2  "
+                    "// feature state is enforced via plaster rewrite.",
+            },
+            "result": {
+                "node": "object",
             },
         },
     },


### PR DESCRIPTION
This rewriter is being introduced as a counter part to the `cxx` one
that does the same thing. All uses of `OVERRIDE_FEATURE_DEFAULT_STATES`
have already been migrated, and the only remaining ones are in blink,
for `runtime_enabled_features.json5` compile generated features. This
rewriter will allow those cases to be migrated too.

Bug: https://github.com/brave/brave-browser/issues/45050
