### PR TITLE
[Android] Nala themed Brave News screen

### DIFF
--- a/android/java/brave-res/layout/brave_news_settings.xml
+++ b/android/java/brave-res/layout/brave_news_settings.xml
@@ -7,6 +7,7 @@
  <ScrollView android:id="@+id/brave_news_settings"
      xmlns:android="http://schemas.android.com/apk/res/android"
      xmlns:app="http://schemas.android.com/apk/res-auto"
+     android:fillViewport="true"
      android:layout_height="match_parent"
      android:layout_width="match_parent">
 
@@ -16,75 +17,89 @@
           android:layout_height="wrap_content"
           android:orientation="vertical">
 
-          <LinearLayout
+          <androidx.constraintlayout.widget.ConstraintLayout
                android:id="@+id/layout_optin_card"
                android:layout_width="match_parent"
-               android:layout_height="wrap_content"
-               android:layout_marginHorizontal="20dp"
-               android:orientation="vertical"
+               android:layout_height="match_parent"
                android:visibility="gone">
 
-               <com.airbnb.lottie.LottieAnimationView
-                    android:id="@+id/animation_view"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:gravity="center"
+               <ImageView
+                    android:id="@+id/optin_icon"
+                    android:layout_width="88dp"
+                    android:layout_height="88dp"
+                    android:layout_marginTop="48dp"
                     android:contentDescription="@null"
-                    android:layout_gravity="center_horizontal"
-                    app:lottie_loop="true"
-                    app:lottie_fileName="ntp_news_optin_icon_animation.json"
-                    app:lottie_autoPlay="true" />
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:srcCompat="@drawable/ic_product_brave_news"
+                    app:tint="@color/primitive_orange_60" />
 
                <TextView
-                    android:layout_width="match_parent"
+                    android:id="@+id/optin_title"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="20dp"
-                    android:paddingHorizontal="20dp"
+                    android:layout_marginHorizontal="16dp"
+                    android:layout_marginTop="24dp"
+                    android:gravity="center"
                     android:text="@string/brave_news_settings_optin_title"
-                    android:gravity="center"
                     android:textColor="@color/news_settings_title_color"
-                    android:textSize="18sp"
-                    android:textStyle="bold" />
+                    android:textSize="22sp"
+                    android:textStyle="bold"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/optin_icon" />
 
                <TextView
-                    android:layout_width="match_parent"
+                    android:id="@+id/optin_subtitle"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
-                    android:text="@string/brave_news_settings_optin_subtitle"
+                    android:layout_marginHorizontal="16dp"
+                    android:layout_marginTop="24dp"
                     android:gravity="center"
-                    android:textColor="@color/news_settings_subtitle_color"
-                    android:textSize="15sp" />
+                    android:text="@string/brave_news_settings_optin_subtitle"
+                    android:textColor="@color/news_settings_title_color"
+                    android:textSize="15sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/optin_title" />
 
                <Button
                     android:id="@+id/btn_turn_on_news"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
-                    android:layout_marginTop="30dp"
+                    android:layout_width="0dp"
+                    android:layout_height="48dp"
+                    android:layout_marginHorizontal="16dp"
+                    android:layout_marginBottom="16dp"
                     android:background="@drawable/themed_button_48_rounded_bg"
-                    app:backgroundTint="@null"
+                    android:minHeight="0dp"
+                    android:paddingHorizontal="20dp"
+                    android:paddingVertical="4dp"
                     android:text="@string/turn_on_brave_news"
                     android:textAllCaps="false"
                     android:textColor="?attr/globalFilledButtonTextColor"
                     android:textSize="16sp"
-                    android:paddingVertical="4dp"
-                    android:paddingHorizontal="20dp"
-                    android:minHeight="0dp"
+                    app:backgroundTint="@null"
+                    app:layout_constraintBottom_toTopOf="@id/btn_learn_more"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     style="?android:attr/borderlessButtonStyle"/>
 
                 <Button
                     android:id="@+id/btn_learn_more"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_horizontal"
+                    android:layout_height="48dp"
+                    android:layout_marginBottom="16dp"
                     android:background="@android:color/transparent"
                     android:text="@string/brave_news_optin_learn_more"
                     android:textAllCaps="false"
-                    android:textColor="?attr/globalTextButtonTextColor"
+                    android:textColor="@color/default_text_color_list_baseline"
                     android:textSize="14sp"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     style="?android:attr/borderlessButtonStyle"/>
 
-          </LinearLayout>
+          </androidx.constraintlayout.widget.ConstraintLayout>
 
           <androidx.constraintlayout.widget.ConstraintLayout
                android:id="@+id/layout_switch"

--- a/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferencesV2.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferencesV2.java
@@ -7,8 +7,6 @@ package org.chromium.chrome.browser.settings;
 
 import static org.chromium.base.ThreadUtils.runOnUiThread;
 
-import android.graphics.PorterDuff;
-import android.graphics.PorterDuffColorFilter;
 import android.os.Bundle;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -19,11 +17,6 @@ import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import androidx.core.content.ContextCompat;
-
-import com.airbnb.lottie.LottieAnimationView;
-import com.airbnb.lottie.LottieProperty;
-import com.airbnb.lottie.model.KeyPath;
 import com.google.android.material.materialswitch.MaterialSwitch;
 
 import org.chromium.base.BravePreferenceKeys;
@@ -41,7 +34,6 @@ import org.chromium.chrome.browser.BraveConstants;
 import org.chromium.chrome.browser.brave_news.BraveNewsControllerFactory;
 import org.chromium.chrome.browser.brave_news.BraveNewsUtils;
 import org.chromium.chrome.browser.customtabs.CustomTabActivity;
-import org.chromium.chrome.browser.night_mode.GlobalNightModeStateProviderHolder;
 import org.chromium.chrome.browser.preferences.BravePrefServiceBridge;
 import org.chromium.chrome.browser.preferences.ChromeSharedPreferences;
 import org.chromium.chrome.browser.theme.BraveDynamicColors;
@@ -56,11 +48,12 @@ import java.util.List;
 public class BraveNewsPreferencesV2 extends BravePreferenceFragment
         implements BraveNewsPreferencesDataListener,
                 ConnectionErrorHandler,
-                FragmentSettingsNavigation {
+                FragmentSettingsNavigation,
+                BottomInsetViewProvider {
     public static final String PREF_SHOW_OPTIN = "show_optin";
 
     private LinearLayout mParentLayout;
-    private LinearLayout mOptinLayout;
+    private View mOptinLayout;
     private MaterialSwitch mSwitchShowNews;
     private TextView mTvSearch;
     private TextView mTvFollowingCount;
@@ -91,6 +84,11 @@ public class BraveNewsPreferencesV2 extends BravePreferenceFragment
     }
 
     @Override
+    public View getBottomInsetView(View fragmentView) {
+        return fragmentView;
+    }
+
+    @Override
     public void onActivityCreated(Bundle savedInstanceState) {
         mPageTitle.set(getString(R.string.brave_news_title));
 
@@ -99,7 +97,7 @@ public class BraveNewsPreferencesV2 extends BravePreferenceFragment
         View view = getView();
         if (view != null) {
             mParentLayout = (LinearLayout) view.findViewById(R.id.layout_parent);
-            mOptinLayout = (LinearLayout) view.findViewById(R.id.layout_optin_card);
+            mOptinLayout = view.findViewById(R.id.layout_optin_card);
             mSwitchShowNews = (MaterialSwitch) view.findViewById(R.id.switch_show_news);
             mDivider = view.findViewById(R.id.divider);
             mLayoutSwitch = view.findViewById(R.id.layout_switch);
@@ -142,23 +140,6 @@ public class BraveNewsPreferencesV2 extends BravePreferenceFragment
     }
 
     private void setData() {
-        if (!GlobalNightModeStateProviderHolder.getInstance().isInNightMode()
-                && getView() != null) {
-            LottieAnimationView lottieAnimationVIew =
-                    (LottieAnimationView) getView().findViewById(R.id.animation_view);
-
-            try {
-                lottieAnimationVIew.addValueCallback(new KeyPath("newspaper", "**"),
-                        LottieProperty.COLOR_FILTER,
-                        frameInfo
-                        -> new PorterDuffColorFilter(ContextCompat.getColor(getActivity(),
-                                                             R.color.news_settings_optin_color),
-                                PorterDuff.Mode.SRC_ATOP));
-            } catch (Exception exception) {
-                // if newspaper keypath changed in animation json
-            }
-        }
-
         if (!BraveNewsUtils.getLocale().isEmpty()
                 && BraveNewsUtils.getSuggestionsPublisherList().size() > 0) {
             mIsSuggestionAvailable = true;
@@ -264,7 +245,8 @@ public class BraveNewsPreferencesV2 extends BravePreferenceFragment
             }
 
         } else {
-            parentLayoutParams.gravity = Gravity.CENTER_VERTICAL;
+            parentLayoutParams.height = FrameLayout.LayoutParams.MATCH_PARENT;
+            parentLayoutParams.gravity = Gravity.NO_GRAVITY;
             mParentLayout.setLayoutParams(parentLayoutParams);
             mOptinLayout.setVisibility(View.VISIBLE);
             mLayoutSwitch.setVisibility(View.GONE);

--- a/android/java/res/values/brave_colors.xml
+++ b/android/java/res/values/brave_colors.xml
@@ -161,7 +161,6 @@
     <color name="news_settings_icon_bg_color">#0D000000</color>
     <color name="news_settings_following_count_color">#D9495057</color>
     <color name="news_settings_following_count_bg_color">#1A000000</color>
-    <color name="news_settings_optin_color">#CCCCCC</color>
     <color name="news_settings_item_highlight">@color/material_primary_95</color>
 
     <!-- Incognito mode colors -->

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -493,13 +493,13 @@ This file contains all "about" strings.  It is set to NOT be translated, in tran
         Today’s top stories in a private feed, just for you.
       </message>
       <message name="IDS_BRAVE_NEWS_SETTINGS_OPTIN_TITLE" desc="Text for opt in card title in settings">
-        Turn on Brave News, and never miss a story
+        Turn on Brave News and never miss a story
       </message>
       <message name="IDS_BRAVE_NEWS_OPTIN_SUBTITLE" desc="Text for opt in card subtitle">
         Brave News is ad-supported with private and anonymized ads matched on your device.
       </message>
       <message name="IDS_BRAVE_NEWS_SETTINGS_OPTIN_SUBTITLE" desc="Text for opt in card subtitle in settings">
-        Follow your favorite sources, in a single feed. Just open a tab in Brave, scroll down, and... voila!\nBrave News is ad-supported with private, anonymized ads.
+        Follow your favorite sources in a single feed. Just open a tab in Brave, scroll down, and… voila?
       </message>
       <message name="IDS_TURN_ON_BRAVE_NEWS" desc="Text for opt in card button in settings">
         Turn on Brave News

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -499,7 +499,7 @@ This file contains all "about" strings.  It is set to NOT be translated, in tran
         Brave News is ad-supported with private and anonymized ads matched on your device.
       </message>
       <message name="IDS_BRAVE_NEWS_SETTINGS_OPTIN_SUBTITLE" desc="Text for opt in card subtitle in settings">
-        Follow your favorite sources in a single feed. Just open a tab in Brave, scroll down, and… voila?
+        Follow your favorite sources in a single feed. Just open a tab in Brave, scroll down, and… voila!
       </message>
       <message name="IDS_TURN_ON_BRAVE_NEWS" desc="Text for opt in card button in settings">
         Turn on Brave News

--- a/browser/ui/android/strings/translations/android_brave_strings_en-GB.xtb
+++ b/browser/ui/android/strings/translations/android_brave_strings_en-GB.xtb
@@ -109,7 +109,7 @@
 <translation id="6920492760024499150">Today’s top stories in a private feed, just for you.</translation>
 <translation id="8300751939969131609">Turn on Brave News and never miss a story</translation>
 <translation id="7627131190984957214">Brave News is ad-supported with private and anonymised ads matched on your device.</translation>
-<translation id="7699565323725789472">Follow your favourite sources, in a single feed. Just open a tab in Brave, scroll down, and … voila!\nBrave News is ad-supported with private, anonymised ads.</translation>
+<translation id="7699565323725789472">Follow your favourite sources in a single feed. Just open a tab in Brave, scroll down, and… voila?</translation>
 <translation id="1765217911817124376">Turn on Brave News</translation>
 <translation id="8981973962043893066">Search for site, topic or RSS feed</translation>
 <translation id="3225021799163709119">Popular</translation>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58370.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

## Changes

**Update strings**

**Update BraveNewsPreferencesV2 UI**
- update `brave_news_settings.xml` to match Nala design
- remove usage of the Lottie `animate_view` - this asset is still in use on the NTP
- implement BottomInsetViewProvider to work with transparent nav bar
- remove unused `news_settings_optin_color`

## Screenshots

`Light`|`Dark`|`dynamic-colors` + `Light`|`dynamic-colors` + `Dark`
--|--|--|--
<img width="1344" height="2992" alt="sdk-gphone16k-arm64_2026-08-24_111542_433" src="https://github.com/user-attachments/assets/05216b47-b531-41bd-9f15-04a13b5c9ad7" />|<img width="1344" height="2992" alt="sdk-gphone16k-arm64_2026-08-24_110901_069" src="https://github.com/user-attachments/assets/5df3519f-fb65-48f0-8913-819bb17da06f" />|<img width="1344" height="2992" alt="sdk-gphone16k-arm64_2026-08-24_110941_561" src="https://github.com/user-attachments/assets/c63f59fe-d90b-4ee0-ae15-6754724ec545" />|<img width="1344" height="2992" alt="sdk-gphone16k-arm64_2026-08-24_110923_663" src="https://github.com/user-attachments/assets/794ca86a-f71c-4fcc-89db-910d5ed9773e" />


https://github.com/user-attachments/assets/38775703-02c4-4526-b71a-35bbb0f79f01




