### PR TITLE
Added EA hint toggle on settings page even if not logged-in. (uplift to 1.95.x) (uplift to 1.94.x)

### DIFF
--- a/browser/email_aliases/email_aliases_browsertest.cc
+++ b/browser/email_aliases/email_aliases_browsertest.cc
@@ -566,15 +566,26 @@ IN_PROC_BROWSER_TEST_F(EmailAliasesBrowserTest, ContextMenuAuthorizedCancel) {
   EXPECT_TRUE(AwaitText("#type-email", ""));  // text not changed
 }
 IN_PROC_BROWSER_TEST_F(EmailAliasesBrowserTest, LogInLogOut) {
+  browser()->GetProfile()->GetPrefs()->SetBoolean(prefs::kPromoShown, false);
+
   SetBraveAccountLoggedIn();
+
+  // Login stops promo showing.
+  EXPECT_TRUE(
+      browser()->GetProfile()->GetPrefs()->GetBoolean(prefs::kPromoShown));
 
   // Settings in logged-in state
   Navigate(GURL("chrome://settings/email-aliases"));
   InjectHelpers(ActiveWebContents());
   Wait("#create-new-item-button");
+  Wait("settings-toggle-button[icon='email-shield']");
 
   SetBraveAccountLoggedOut();
   WaitDisappear("#create-new-item-button");  // Settings in sing-in state.
+  // Still showing the toggle.
+  Wait("settings-toggle-button[icon='email-shield']");
+  EXPECT_TRUE(
+      browser()->GetProfile()->GetPrefs()->GetBoolean(prefs::kPromoShown));
 
   SetBraveAccountLoggedIn();
   Wait("#create-new-item-button");  // Logged-in state.

--- a/browser/resources/settings/email_aliases_page/email_aliases_page.ts
+++ b/browser/resources/settings/email_aliases_page/email_aliases_page.ts
@@ -65,8 +65,9 @@ class SettingsEmailAliasesPageElement extends PrefsMixin(PolymerElement) {
       const bundlePath = '/email_aliases.bundle.js'
       import(bundlePath).then(({mount}) => {
         mount(this.$.signInRoot, this.$.manageSection, {
-          onLoggedInChange: (loggedIn: boolean) => {
-            this.showEmailAliasesSettings_ = loggedIn;
+          onLoggedInChange: (_: boolean) => {
+            // Show even if not logged-in.
+            this.showEmailAliasesSettings_ = true;
           },
         });
       });

--- a/browser/ui/brave_browser_command_controller_browsertest.cc
+++ b/browser/ui/brave_browser_command_controller_browsertest.cc
@@ -829,7 +829,7 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerWithEmailAliasesTest,
   auto* controller = browser()->GetFeatures().email_aliases_controller();
   ASSERT_NE(nullptr, controller->GetBubbleForTesting());
 
-  // Closing the promo should record it as shown and navigate to settings.
+  // Closing navigates to settings.
   controller->CloseBubble();
 
   ASSERT_TRUE(base::test::RunUntil([&]() {
@@ -838,5 +838,9 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerWithEmailAliasesTest,
                ->GetActiveWebContents()
                ->GetVisibleURL() == chrome::GetSettingsUrl("email-aliases");
   }));
+
+  // Continue to show the promo until the first login
+  EXPECT_FALSE(browser()->GetProfile()->GetPrefs()->GetBoolean(
+      email_aliases::prefs::kPromoShown));
 }
 #endif  // BUILDFLAG(ENABLE_EMAIL_ALIASES)

--- a/browser/ui/email_aliases/email_aliases_controller.cc
+++ b/browser/ui/email_aliases/email_aliases_controller.cc
@@ -285,7 +285,6 @@ void EmailAliasesController::ShowPromoBubble(content::WebContents* initiator) {
 
 void EmailAliasesController::OnPromoBubbleClosed(const std::string&) {
   OnBubbleClosed({});
-  email_aliases_service_->MarkPromoShown();
   ShowSingletonTabOverwritingNTP(browser_view_->browser(),
                                  GURL(kEmailAliasesSettingsURL));
 }

--- a/components/email_aliases/email_aliases_service.cc
+++ b/components/email_aliases/email_aliases_service.cc
@@ -157,6 +157,9 @@ std::string EmailAliasesService::GetAuthEmail() const {
 }
 
 void EmailAliasesService::OnAuthChanged() {
+  if (IsAuthenticated() && ShouldShowPromo()) {
+    MarkPromoShown();
+  }
   RefreshAliases();
 }
 


### PR DESCRIPTION
Uplift of #39298
Resolves https://github.com/brave/brave-browser/issues/58291

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.