### PR TITLE
Fix crash occured by .m3u8 file saved for Playlist

### DIFF
--- a/browser/playlist/playlist_data_source.cc
+++ b/browser/playlist/playlist_data_source.cc
@@ -149,7 +149,12 @@ PlaylistDataSource::DataRequest::DataRequest(const GURL& url) {
   const auto full_path = content::URLDataSource::URLToRequestPath(url);
   const auto paths = base::SplitStringPiece(
       full_path, "/", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
-  CHECK_EQ(paths.size(), 2u) << url.spec();
+  if (paths.size() != 2) {
+    LOG(ERROR) << "Invalid playlist data source URL, might be routed from "
+                  "saved .m3u8 file:  "
+               << url.spec();
+    return;
+  }
 
   id = paths.at(0);
   const auto& type_string = paths.at(1);
@@ -160,7 +165,10 @@ PlaylistDataSource::DataRequest::DataRequest(const GURL& url) {
   } else if (type_string == "favicon") {
     type = DataRequest::Type::kFavicon;
   } else {
-    NOTREACHED() << "type is not in {thumbnail,media,favicon}: " << type_string;
+    type = DataRequest::Type::kNone;
+    LOG(ERROR) << "Invalid playlist data source URL, might be routed from "
+                  "saved .m3u8 file:  "
+               << url.spec();
   }
 }
 
@@ -187,6 +195,9 @@ void PlaylistDataSource::StartDataRequest(
   }
 
   switch (DataRequest data_request(url); data_request.type) {
+    case DataRequest::Type::kNone:
+      std::move(got_data_callback).Run(nullptr);
+      break;
     case DataRequest::Type::kThumbnail:
       GetThumbnail(data_request, wc_getter, std::move(got_data_callback));
       break;
@@ -204,8 +215,10 @@ void PlaylistDataSource::StartRangeDataRequest(
     const net::HttpByteRange& range,
     GotRangeDataCallback callback) {
   DataRequest data_request(url);
-  CHECK_EQ(data_request.type, DataRequest::Type::kMedia);
-  CHECK(range.IsValid());
+  if (data_request.type != DataRequest::Type::kMedia || !range.IsValid()) {
+    std::move(callback).Run({});
+    return;
+  }
   GetMediaFile(data_request, wc_getter, range, std::move(callback));
 }
 
@@ -281,6 +294,8 @@ std::string PlaylistDataSource::GetMimeType(const GURL& url) {
                            //  actual file extension in WebUIUrlLoader.
     case DataRequest::Type::kFavicon:
       return FaviconSource::GetMimeType(url);
+    case DataRequest::Type::kNone:
+      return {};
   }
 }
 

--- a/browser/playlist/playlist_data_source.h
+++ b/browser/playlist/playlist_data_source.h
@@ -43,6 +43,7 @@ class PlaylistDataSource : public FaviconSource {
  private:
   struct DataRequest {
     enum class Type {
+      kNone,
       kThumbnail,
       kMedia,
       kFavicon,
@@ -54,7 +55,7 @@ class PlaylistDataSource : public FaviconSource {
     ~DataRequest();
 
     std::string id;
-    Type type;
+    Type type = Type::kNone;
   };
 
   void GetThumbnail(const DataRequest& request,


### PR DESCRIPTION
When a saved .m3u8 points some other relative url,
PlaylistDataSource might be requested to serve unknown url.

For example, in a media.m3u8
```
/amplify_video/2091454598288449536/pl/avc1/480x270/ESjKu9eJEx6jexZe.m3u8
```

The relative url is resolvd to
"chrome-untrusted://playlist-data/amplyfy_video..." inheriting
origin from the source url.

So instead of crashing the browser, fallback to unknown type.

Resolved https://github.com/brave/brave-browser/issues/58180