### PR TITLE
[bootstrap] Adding `fetch_brave.py`

### DIFF
--- a/tools/cr/bootstrap/README.md
+++ b/tools/cr/bootstrap/README.md
@@ -59,10 +59,11 @@ cd /tmp
 node --version                    # falls back to the system node
 ```
 
-## The chicken-and-egg `node` problem
+## Bootstrapping a fresh checkout
 
-The shims for `node`/`npm` run cheap checks for the tarball installations, to
-determine if a new file needs to be downloaded. This is done through the
-`EXTRA_DEPS` mechanism itself, which makes this a lightweight sync check. For
-repos with no mechanism for self-updating, the path resolution degrades back to
-whatever is the system underlying binaries.
+A fresh checkout can be fetched simply by doing:
+
+```
+mkdir brave-browser
+curl -fsSL https://raw.githubusercontent.com/brave/brave-core/master/tools/cr/bootstrap/fetch_brave.py | python3 -
+```

--- a/tools/cr/bootstrap/fetch_brave.py
+++ b/tools/cr/bootstrap/fetch_brave.py
@@ -1,0 +1,165 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Fetches `brave-core`, using git cache if possible.
+
+To start out a workspace, just run:
+
+  curl -fsSL https://raw.githubusercontent.com/brave/brave-core/master/tools/cr/bootstrap/fetch_brave.py | python3 -
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import platform
+import subprocess
+import sys
+
+# Default remotes for the two repos this script bootstraps.
+BRAVE_CORE_URL = 'https://github.com/brave/brave-core.git'
+DEPOT_TOOLS_URL = (
+    'https://chromium.googlesource.com/chromium/tools/depot_tools.git')
+
+# Template for the bootstrap `.gclient` to have `depot_tools` clone `brave-core`
+# into `src/brave`, which permits git cache to be reused if present.
+_GCLIENT_TEMPLATE = """\
+solutions = [
+  {
+    "managed": False,
+    "name": "src/brave",
+    "url": %(url)s
+  }
+]
+target_os = []
+target_cpu = []
+"""
+
+# The git cache mirror path for depot_tools. We hardcode it because we cannot
+# rely on `git cache exists` to check for it when deploy depot_tools.
+_DEPOT_TOOLS_MIRROR_DIR = 'chromium.googlesource.com-chromium-tools-depot_tools'
+
+# The path to bootstrap, to be added to `PATH`. This path is relative from the
+# checkout root, as this script can be used standalone, so we don't rely on a
+# relative position from `__file__`.
+_BOOTSTRAP_RELATIVE_DIR = Path('src') / 'brave' / 'tools' / 'cr' / 'bootstrap'
+
+GCLIENT_NAME = 'gclient.bat' if platform.system() == 'Windows' else 'gclient'
+
+
+def prepend_to_path(path: str, *dirs: Path) -> str:
+    """`path` with each of `dirs` prepended to it.
+    """
+    new_entries = [str(d) for d in dirs]
+    if not path:
+        return os.pathsep.join(new_entries)
+    return os.pathsep.join([*new_entries, path])
+
+
+def ensure_depot_tools(brave_core_dir: Path, cache_dir: Path | None) -> Path:
+    """Clones depot_tools into `brave_core_dir/vendor/depot_tools`.
+
+    This function attempts to clone depot_tools first from git cache, if a path
+    is provided, and if that fails, it falls back to cloning it from the remote.
+    """
+    dest = brave_core_dir / 'vendor' / 'depot_tools'
+    if (dest / '.git').exists():
+        return dest
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    cache_repo = cache_dir / _DEPOT_TOOLS_MIRROR_DIR if cache_dir else None
+    if cache_repo is not None and not (cache_repo / 'config').is_file():
+        cache_repo = None
+    if cache_repo is None:
+        subprocess.check_call(['git', 'clone', DEPOT_TOOLS_URL, str(dest)])
+        return dest
+    subprocess.check_call([
+        'git', 'clone', '--no-checkout', '--local', '--shared',
+        str(cache_repo),
+        str(dest)
+    ])
+    subprocess.check_call(['git', 'checkout', '--force', 'HEAD'], cwd=dest)
+
+    # Setting the remote URL to the official repo.
+    subprocess.check_call(
+        ['git', 'remote', 'set-url', 'origin', DEPOT_TOOLS_URL], cwd=dest)
+    return dest
+
+
+def fetch_brave_core(depot_tools_dir: Path, root: Path,
+                     ref: str | None) -> None:
+    """Clones brave-core into `root/src/brave` via `gclient sync`.
+
+    This function writes a `.gclient` file in order to get `gclient sync` to
+    clone brave-core into `src/brave`, which allows the use of git cache, if
+    available, for `brave-core`.
+    """
+    gclient_text = _GCLIENT_TEMPLATE % {'url': json.dumps(BRAVE_CORE_URL)}
+    # Using `write_bytes` for consistent line endings across platforms. Using
+    # `newline='\n'` with `write_text` can run into issues with certain Python
+    # versions, and this script has to run with the system Python.
+    (root / '.gclient').write_bytes(gclient_text.encode('utf-8'))
+    sync_args = ['sync', '--nohooks']
+    if ref:
+        sync_args += ['--revision', f'src/brave@{ref}']
+
+    subprocess.check_call([str(depot_tools_dir / GCLIENT_NAME), *sync_args],
+                          cwd=root)
+
+
+def run_pnpm(brave_core_dir: Path, pnpm_args: list[str]) -> None:
+    """Runs `pnpm <pnpm_args>` from `brave_core_dir`, via the bootstrap shim
+    on `$PATH` (see `main()`).
+    """
+    subprocess.check_call(['pnpm', *pnpm_args], cwd=brave_core_dir)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Bootstrap a fresh brave-core + Chromium checkout in the '
+        'current directory.')
+    parser.add_argument(
+        '--ref',
+        default=None,
+        help='brave-core branch/tag to check out (default: remote HEAD)')
+    parser.add_argument(
+        '--no-sync',
+        action='store_true',
+        help='clone brave-core (and vendor depot_tools) but skip `pnpm '
+        'install`/`pnpm run init` -- which is what brings in Chromium')
+    args = parser.parse_args()
+
+    root = Path.cwd()
+    brave_core_dir = root / 'src' / 'brave'
+    if (brave_core_dir / '.git').exists():
+        # Fetch should be used exclusively from an empty directory to start a
+        # new workspace.
+        sys.stderr.write(
+            f'{brave_core_dir} already looks like a checkout.\n'
+            'Please run this script from an empty directory. Aborting.\n')
+        return 1
+
+    configured_cache_dir = os.environ.get('GIT_CACHE_PATH')
+    cache_dir = (Path(configured_cache_dir).expanduser()
+                 if configured_cache_dir else None)
+
+    depot_tools_dir = ensure_depot_tools(brave_core_dir, cache_dir)
+
+    # We add depot_tools and bootstrap to path for the duration of this script.
+    bootstrap_dir = root / _BOOTSTRAP_RELATIVE_DIR
+    os.environ['PATH'] = prepend_to_path(os.environ.get('PATH', ''),
+                                         depot_tools_dir, bootstrap_dir)
+
+    fetch_brave_core(depot_tools_dir, root, args.ref)
+
+    if args.no_sync:
+        return 0
+
+    run_pnpm(brave_core_dir, ['run', 'init'])
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/cr/bootstrap/fetch_brave_test.py
+++ b/tools/cr/bootstrap/fetch_brave_test.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Unit tests for tools/cr/bootstrap/fetch_brave.py."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+import fetch_brave
+
+
+class EnsureDepotToolsTest(unittest.TestCase):
+    """Exercises vendoring depot_tools -- the only place it ever lives.
+
+    The mirror lookup deliberately never shells out to `git cache exists`
+    (depot_tools' own subcommand): it's checked before any depot_tools is
+    available to run that with, directly against the hardcoded
+    `_DEPOT_TOOLS_MIRROR_DIR` name instead.
+    """
+
+    def test_plain_clones_when_no_cache_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            brave_core_dir = Path(tmp) / 'src' / 'brave'
+            brave_core_dir.mkdir(parents=True)
+
+            with mock.patch('subprocess.run') as run, \
+                 mock.patch('subprocess.check_call') as check_call:
+                dest = fetch_brave.ensure_depot_tools(brave_core_dir, None)
+
+            run.assert_not_called()  # never shells out to `git cache exists`
+            self.assertEqual(dest, brave_core_dir / 'vendor' / 'depot_tools')
+            check_call.assert_called_once_with(
+                ['git', 'clone', fetch_brave.DEPOT_TOOLS_URL,
+                 str(dest)])
+
+    def test_plain_clones_when_cache_dir_has_no_depot_tools_mirror(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            brave_core_dir = Path(tmp) / 'src' / 'brave'
+            brave_core_dir.mkdir(parents=True)
+            cache_dir = Path(tmp) / 'cache'  # exists, but no mirror inside it
+            cache_dir.mkdir()
+
+            with mock.patch('subprocess.run') as run, \
+                 mock.patch('subprocess.check_call') as check_call:
+                dest = fetch_brave.ensure_depot_tools(brave_core_dir,
+                                                      cache_dir)
+
+            run.assert_not_called()
+            check_call.assert_called_once_with(
+                ['git', 'clone', fetch_brave.DEPOT_TOOLS_URL,
+                 str(dest)])
+
+    def test_reuses_a_cached_mirror(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            brave_core_dir = Path(tmp) / 'src' / 'brave'
+            brave_core_dir.mkdir(parents=True)
+            cache_dir = Path(tmp) / 'cache'
+            cache_repo_dir = cache_dir / fetch_brave._DEPOT_TOOLS_MIRROR_DIR  # pylint: disable=protected-access
+            cache_repo_dir.mkdir(parents=True)
+            (cache_repo_dir / 'config').write_text('', encoding='utf-8')
+
+            with mock.patch('subprocess.check_call') as check_call:
+                dest = fetch_brave.ensure_depot_tools(brave_core_dir,
+                                                      cache_dir)
+
+            self.assertEqual(check_call.call_args_list, [
+                mock.call([
+                    'git', 'clone', '--no-checkout', '--local', '--shared',
+                    str(cache_repo_dir),
+                    str(dest)
+                ]),
+                mock.call(['git', 'checkout', '--force', 'HEAD'], cwd=dest),
+                mock.call([
+                    'git', 'remote', 'set-url', 'origin',
+                    fetch_brave.DEPOT_TOOLS_URL
+                ],
+                          cwd=dest),
+            ])
+
+    def test_skips_when_already_vendored(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            brave_core_dir = Path(tmp) / 'src' / 'brave'
+            dest = brave_core_dir / 'vendor' / 'depot_tools'
+            (dest / '.git').mkdir(parents=True)
+
+            with mock.patch('subprocess.check_call') as check_call:
+                result = fetch_brave.ensure_depot_tools(
+                    brave_core_dir, Path('/cache'))
+
+            check_call.assert_not_called()
+            self.assertEqual(result, dest)
+
+
+class FetchBraveCoreTest(unittest.TestCase):
+    """Exercises the bootstrap (brave-core-only) `gclient sync` pass."""
+
+    def _parse_gclient(self, root: Path) -> dict:
+        text = (root / '.gclient').read_text(encoding='utf-8')
+        out: dict = {}
+        exec(compile(text, '.gclient', 'exec'), None, out)  # pylint: disable=exec-used
+        return out
+
+    def test_writes_a_valid_gclient_and_syncs_with_revision(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with mock.patch('subprocess.check_call') as check_call:
+                fetch_brave.fetch_brave_core(Path('/depot_tools'), root,
+                                             'release')
+
+            parsed = self._parse_gclient(root)
+            self.assertEqual(parsed['solutions'], [{
+                'managed': False,
+                'name': 'src/brave',
+                'url': fetch_brave.BRAVE_CORE_URL,
+            }])
+            self.assertEqual(parsed['target_os'], [])
+            self.assertEqual(parsed['target_cpu'], [])
+            # No `cache_dir`: `main()` sets `$GIT_CACHE_PATH` instead, which
+            # depot_tools already falls back to on its own.
+            self.assertNotIn('cache_dir', parsed)
+            check_call.assert_called_once_with([
+                f'/depot_tools/{fetch_brave.GCLIENT_NAME}', 'sync',
+                '--nohooks', '--revision', 'src/brave@release'
+            ],
+                                               cwd=root)
+
+    def test_omits_revision_when_no_ref_given(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with mock.patch('subprocess.check_call') as check_call:
+                fetch_brave.fetch_brave_core(Path('/depot_tools'), root, None)
+            check_call.assert_called_once_with([
+                f'/depot_tools/{fetch_brave.GCLIENT_NAME}', 'sync', '--nohooks'
+            ],
+                                               cwd=root)
+
+    def test_uses_the_bat_wrapper_on_windows(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            with mock.patch('fetch_brave.GCLIENT_NAME', 'gclient.bat'), \
+                 mock.patch('subprocess.check_call') as check_call:
+                fetch_brave.fetch_brave_core(Path('/depot_tools'), root, None)
+            check_call.assert_called_once_with(
+                [str(Path('/depot_tools/gclient.bat')), 'sync', '--nohooks'],
+                cwd=root)
+
+
+class PrependToPathTest(unittest.TestCase):
+    """Exercises prepending dirs to a `$PATH` string."""
+
+    def test_prepends_dirs_in_order(self):
+        result = fetch_brave.prepend_to_path('/usr/bin', Path('/a'),
+                                             Path('/b'))
+        self.assertEqual(result, f'/a{os.pathsep}/b{os.pathsep}/usr/bin')
+
+    def test_handles_an_empty_path(self):
+        result = fetch_brave.prepend_to_path('', Path('/a'), Path('/b'))
+        self.assertEqual(result, f'/a{os.pathsep}/b')
+
+    def test_leaves_an_odd_existing_path_untouched(self):
+        # A leading `:` means "include the current directory" on POSIX --
+        # rebuilding the string from parsed entries would silently drop it.
+        odd = f':/a{os.pathsep}/usr/bin'
+        result = fetch_brave.prepend_to_path(odd, Path('/new'))
+        self.assertEqual(result, f'/new{os.pathsep}{odd}')
+
+
+class RunPnpmTest(unittest.TestCase):
+    """Exercises the `pnpm` invocation: cwd and args."""
+
+    def test_runs_pnpm(self):
+        brave_core_dir = Path('/checkout/src/brave')
+        with mock.patch('subprocess.check_call') as check_call:
+            fetch_brave.run_pnpm(brave_core_dir,
+                                 ['install', '--frozen-lockfile'])
+        check_call.assert_called_once_with(
+            ['pnpm', 'install', '--frozen-lockfile'], cwd=brave_core_dir)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is an initial implementation for a simple way to get `gclient` to
download `brave-core`. For normal users this doesn't make any difference
in practive, however it does mean a huge improvement for those using
`git-cache`, as this means `brave-core` gets cloned from `git-cached` if
already there, or placed into `git-cache` if not there yet.

Bug: https://github.com/brave/brave-browser/issues/56529
