### PR TITLE
[VPN 2.0] Endpoint-based API for multihop

### DIFF
--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client.cc
@@ -33,6 +33,7 @@ using brave_account::endpoint_client::WithHeaders;
 namespace brave_vpn::v2 {
 
 using endpoints::CreateSupportTicket;
+using endpoints::GetAvailableMultihopExitRegions;
 using endpoints::GetHostnamesForRegion;
 using endpoints::GetProfileCredentials;
 using endpoints::GetServerRegions;
@@ -40,6 +41,7 @@ using endpoints::GetSubscriberCredential;
 using endpoints::GetSubscriberCredentialV12;
 using endpoints::GetTimezonesForRegions;
 using endpoints::InvalidateCredentials;
+using endpoints::SetMultihopExitRegion;
 using endpoints::VerifyCredentials;
 using endpoints::VerifyPurchaseToken;
 
@@ -326,6 +328,67 @@ void BraveVpnApiClient::InvalidateCredentials(
                     endpoints::kDeviceApiInvalidateCredentialsSuffix}));
 
   Client<endpoints::InvalidateCredentials>::Send(
+      url_loader_factory_, std::move(request),
+      base::BindOnce(&BraveVpnApiClient::OnRawJsonResponse,
+                     weak_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void BraveVpnApiClient::GetAvailableMultihopExitRegions(
+    RawJsonCallback callback,
+    const std::string& hostname,
+    const std::string& client_id,
+    const std::string& api_auth_token) {
+  auto request =
+      MakeRequest<WithHeaders<GetAvailableMultihopExitRegions::Request>>();
+  request.headers.SetHeader(endpoints::kHeaderGrdApiAuthToken, api_auth_token);
+  request.url_replacements.SetHost(hostname);
+  request.url_replacements.SetPath(base::StrCat(
+      {GetAvailableMultihopExitRegions::URL().path(), "/", client_id, "/",
+       endpoints::kDeviceApiConfigMultihopSuffix}));
+
+  Client<endpoints::GetAvailableMultihopExitRegions>::Send(
+      url_loader_factory_, std::move(request),
+      base::BindOnce(&BraveVpnApiClient::OnRawJsonResponse,
+                     weak_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void BraveVpnApiClient::SetMultihopExitRegion(
+    RawJsonCallback callback,
+    const std::string& hostname,
+    const std::string& client_id,
+    const std::string& api_auth_token,
+    const std::string& multihop_exit_region) {
+  CHECK(!multihop_exit_region.empty());
+  CHECK_NE(multihop_exit_region, endpoints::kMultihopDisabledValue)
+      << "Use ClearMultihopExitRegion() to disable multihop.";
+  DoSetMultihopExitRegion(std::move(callback), hostname, client_id,
+                          api_auth_token, multihop_exit_region);
+}
+
+void BraveVpnApiClient::ClearMultihopExitRegion(
+    RawJsonCallback callback,
+    const std::string& hostname,
+    const std::string& client_id,
+    const std::string& api_auth_token) {
+  DoSetMultihopExitRegion(std::move(callback), hostname, client_id,
+                          api_auth_token, endpoints::kMultihopDisabledValue);
+}
+
+void BraveVpnApiClient::DoSetMultihopExitRegion(
+    RawJsonCallback callback,
+    const std::string& hostname,
+    const std::string& client_id,
+    const std::string& api_auth_token,
+    const std::string& multihop_exit_region) {
+  auto request = MakeRequest<SetMultihopExitRegion::Request>();
+  request.body.api_auth_token = api_auth_token;
+  request.body.multihop_exit_region = multihop_exit_region;
+  request.url_replacements.SetHost(hostname);
+  request.url_replacements.SetPath(
+      base::StrCat({SetMultihopExitRegion::URL().path(), "/", client_id, "/",
+                    endpoints::kDeviceApiConfigMultihopSuffix}));
+
+  Client<endpoints::SetMultihopExitRegion>::Send(
       url_loader_factory_, std::move(request),
       base::BindOnce(&BraveVpnApiClient::OnRawJsonResponse,
                      weak_factory_.GetWeakPtr(), std::move(callback)));

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h
@@ -137,6 +137,33 @@ class BraveVpnApiClient {
                                      const std::string& api_auth_token,
                                      const std::string& subscriber_credential);
 
+  // SGW API: GetAvailableMultihopExitRegions.
+  // Returns the current multihop exit region and the destinations available
+  // to choose from, as the server's JSON response verbatim.
+  virtual void GetAvailableMultihopExitRegions(
+      RawJsonCallback callback,
+      const std::string& hostname,
+      const std::string& client_id,
+      const std::string& api_auth_token);
+
+  // SGW API: SetMultihopExitRegion.
+  // Configures the multihop egress destination |multihop_exit_region|, which
+  // must be non-empty and must not be Guardian's wire sentinel for "disabled".
+  // Violating either crashes rather than returning an error. Use
+  // ClearMultihopExitRegion() instead to disable multihop.
+  virtual void SetMultihopExitRegion(RawJsonCallback callback,
+                                     const std::string& hostname,
+                                     const std::string& client_id,
+                                     const std::string& api_auth_token,
+                                     const std::string& multihop_exit_region);
+
+  // SGW API: ClearMultihopExitRegion.
+  // Disables multihop by clearing the egress destination.
+  virtual void ClearMultihopExitRegion(RawJsonCallback callback,
+                                       const std::string& hostname,
+                                       const std::string& client_id,
+                                       const std::string& api_auth_token);
+
  private:
   void OnRawJsonResponse(RawJsonCallback callback, RawJsonResponse response);
   void OnGetSubscriberCredentialResponse(
@@ -145,6 +172,12 @@ class BraveVpnApiClient {
   void OnVerifyPurchaseTokenResponse(
       VerifyPurchaseTokenCallback callback,
       endpoints::VerifyPurchaseToken::Response response);
+
+  void DoSetMultihopExitRegion(RawJsonCallback callback,
+                               const std::string& hostname,
+                               const std::string& client_id,
+                               const std::string& api_auth_token,
+                               const std::string& multihop_exit_region);
 
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   base::WeakPtrFactory<BraveVpnApiClient> weak_factory_{this};

--- a/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
+++ b/components/brave_vpn/browser/v2/api/brave_vpn_api_client_unittest.cc
@@ -6,11 +6,14 @@
 #include "brave/components/brave_vpn/browser/v2/api/brave_vpn_api_client.h"
 
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
 #include "base/containers/extend.h"
 #include "base/functional/callback.h"
+#include "base/json/json_reader.h"
+#include "base/test/bind.h"
 #include "base/test/task_environment.h"
 #include "base/test/test_future.h"
 #include "base/types/expected.h"
@@ -63,8 +66,7 @@ constexpr char kTestSuccessJson[] = R"({"receipt":"valid"})";
 constexpr char kTestErrorJson[] = R"({"error":"invalid"})";
 }  // namespace
 
-template <typename TestCase>
-class BraveVpnApiClientTest : public testing::TestWithParam<TestCase> {
+class BraveVpnApiClientTestBase : public testing::Test {
  public:
   // Fires a client API method and blocks until its callback runs, returning the
   // result the callback was invoked with. Works for any method shaped like
@@ -86,6 +88,10 @@ class BraveVpnApiClientTest : public testing::TestWithParam<TestCase> {
   network::TestURLLoaderFactory url_loader_factory_;
   BraveVpnApiClient client_{url_loader_factory_.GetSafeWeakWrapper()};
 };
+
+template <typename TestCase>
+class BraveVpnApiClientTest : public BraveVpnApiClientTestBase,
+                              public testing::WithParamInterface<TestCase> {};
 
 // The two "unrecoverable response" cases are identical for every endpoint.
 template <typename TestCase>
@@ -470,5 +476,144 @@ INSTANTIATE_TEST_SUITE_P(
         WithCommonUnrecoverableCases<InvalidateCredentialsTestCase>(
             WithCommonRawJsonCases<InvalidateCredentialsTestCase>({}))),
     [](const auto& info) { return info.param.test_name; });
+
+struct GetAvailableMultihopExitRegionsTestCase {
+  std::string test_name;
+  endpoints::GetAvailableMultihopExitRegions::Response response;
+  base::expected<std::string, std::string> expected;
+};
+
+using BraveVpnApiClientGetAvailableMultihopExitRegionsTest =
+    BraveVpnApiClientTest<GetAvailableMultihopExitRegionsTestCase>;
+
+TEST_P(BraveVpnApiClientGetAvailableMultihopExitRegionsTest,
+       MapsResponseToResult) {
+  const auto& test_case = GetParam();
+  brave_account::endpoint_client::UrlReplacements url_replacements;
+  url_replacements.SetHost(kTestHostname);
+  url_replacements.SetPath(
+      base::StrCat({endpoints::GetAvailableMultihopExitRegions::URL().path(),
+                    "/", kTestClientId, "/config/multihop"}));
+  MockResponseFor<endpoints::GetAvailableMultihopExitRegions>(
+      url_loader_factory_, test_case.response, url_replacements);
+  EXPECT_EQ(CallClientApi(&BraveVpnApiClient::GetAvailableMultihopExitRegions,
+                          kTestHostname, kTestClientId, kTestApiAuthToken),
+            test_case.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BraveVpnApiClientTests,
+    BraveVpnApiClientGetAvailableMultihopExitRegionsTest,
+    testing::ValuesIn(
+        WithCommonUnrecoverableCases<GetAvailableMultihopExitRegionsTestCase>(
+            WithCommonRawJsonCases<GetAvailableMultihopExitRegionsTestCase>(
+                {}))),
+    [](const auto& info) { return info.param.test_name; });
+
+struct SetMultihopExitRegionTestCase {
+  std::string test_name;
+  endpoints::SetMultihopExitRegion::Response response;
+  base::expected<std::string, std::string> expected;
+};
+
+using BraveVpnApiClientSetMultihopExitRegionTest =
+    BraveVpnApiClientTest<SetMultihopExitRegionTestCase>;
+
+TEST_P(BraveVpnApiClientSetMultihopExitRegionTest, MapsResponseToResult) {
+  const auto& test_case = GetParam();
+  brave_account::endpoint_client::UrlReplacements url_replacements;
+  url_replacements.SetHost(kTestHostname);
+  url_replacements.SetPath(
+      base::StrCat({endpoints::SetMultihopExitRegion::URL().path(), "/",
+                    kTestClientId, "/config/multihop"}));
+  MockResponseFor<endpoints::SetMultihopExitRegion>(
+      url_loader_factory_, test_case.response, url_replacements);
+  EXPECT_EQ(
+      CallClientApi(&BraveVpnApiClient::SetMultihopExitRegion, kTestHostname,
+                    kTestClientId, kTestApiAuthToken, kTestMultihopExitRegion),
+      test_case.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BraveVpnApiClientTests,
+    BraveVpnApiClientSetMultihopExitRegionTest,
+    testing::ValuesIn(
+        WithCommonUnrecoverableCases<SetMultihopExitRegionTestCase>(
+            WithCommonRawJsonCases<SetMultihopExitRegionTestCase>({}))),
+    [](const auto& info) { return info.param.test_name; });
+
+struct ClearMultihopExitRegionTestCase {
+  std::string test_name;
+  endpoints::SetMultihopExitRegion::Response response;
+  base::expected<std::string, std::string> expected;
+};
+
+using BraveVpnApiClientClearMultihopExitRegionTest =
+    BraveVpnApiClientTest<ClearMultihopExitRegionTestCase>;
+
+TEST_P(BraveVpnApiClientClearMultihopExitRegionTest, MapsResponseToResult) {
+  const auto& test_case = GetParam();
+  brave_account::endpoint_client::UrlReplacements url_replacements;
+  url_replacements.SetHost(kTestHostname);
+  url_replacements.SetPath(
+      base::StrCat({endpoints::SetMultihopExitRegion::URL().path(), "/",
+                    kTestClientId, "/config/multihop"}));
+  MockResponseFor<endpoints::SetMultihopExitRegion>(
+      url_loader_factory_, test_case.response, url_replacements);
+  EXPECT_EQ(CallClientApi(&BraveVpnApiClient::ClearMultihopExitRegion,
+                          kTestHostname, kTestClientId, kTestApiAuthToken),
+            test_case.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    BraveVpnApiClientTests,
+    BraveVpnApiClientClearMultihopExitRegionTest,
+    testing::ValuesIn(
+        WithCommonUnrecoverableCases<ClearMultihopExitRegionTestCase>(
+            WithCommonRawJsonCases<ClearMultihopExitRegionTestCase>({}))),
+    [](const auto& info) { return info.param.test_name; });
+
+// Verifies request construction independent of the response, unlike
+// BraveVpnApiClientTest<> parameterized suites, which verify response-to-result
+// mapping independent of the request.
+class BraveVpnApiClientRequestBodyTest : public BraveVpnApiClientTestBase {};
+
+TEST_F(BraveVpnApiClientRequestBodyTest,
+       ClearMultihopExitRegionSendsDisabledSentinel) {
+  brave_account::endpoint_client::UrlReplacements url_replacements;
+  url_replacements.SetHost(kTestHostname);
+  url_replacements.SetPath(
+      base::StrCat({endpoints::SetMultihopExitRegion::URL().path(), "/",
+                    kTestClientId, "/config/multihop"}));
+
+  std::optional<std::string> sent_body;
+  url_loader_factory_.SetInterceptor(
+      base::BindLambdaForTesting([&](const network::ResourceRequest& request) {
+        if (request.request_body) {
+          const auto& elements = *request.request_body->elements();
+          ASSERT_EQ(elements.size(), 1u);
+          sent_body = std::string(
+              elements[0].As<network::DataElementBytes>().AsStringPiece());
+        }
+      }));
+
+  // The mocked response's content is irrelevant.
+  MockResponseFor<endpoints::SetMultihopExitRegion>(
+      url_loader_factory_,
+      endpoints::SetMultihopExitRegion::Response{
+          .net_error = net::OK,
+          .status_code = net::HTTP_OK,
+          .body = base::ok(endpoints::RawJsonResponseBody{.json = "{}"})},
+      url_replacements);
+
+  std::ignore = CallClientApi(&BraveVpnApiClient::ClearMultihopExitRegion,
+                              kTestHostname, kTestClientId, kTestApiAuthToken);
+
+  ASSERT_TRUE(sent_body.has_value());
+  const auto parsed =
+      base::JSONReader::ReadDict(*sent_body, base::JSON_PARSE_RFC);
+  ASSERT_TRUE(parsed);
+  EXPECT_EQ(*parsed->FindString("multihop-exit-region"), "disabled");
+}
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/api/device_endpoints.h
+++ b/components/brave_vpn/browser/v2/api/device_endpoints.h
@@ -112,6 +112,48 @@ struct InvalidateCredentials {
   }
 };
 
+// GetAvailableMultihopExitRegions API returns the currently configured multihop
+// exit region and the destinations available to choose from (identified by a
+// client-id path segment and an api auth token). Response is forwarded
+// verbatim.
+struct GetAvailableMultihopExitRegions {
+  using Request = brave_account::endpoint_client::GET<EmptyRequestBody>;
+  using Response = brave_account::endpoint_client::Response<RawJsonResponseBody,
+                                                            VpnErrorBody>;
+
+  static GURL URL() {
+    return GURL(base::StrCat({url::kHttpsScheme, url::kStandardSchemeSeparator,
+                              kDeviceHostPlaceholder}))
+        .Resolve(kDeviceApi);
+  }
+};
+
+// SetMultihopExitRegion API configures the multihop egress destination
+// (identified by a client-id path segment and an api auth token).
+struct SetMultihopExitRegionRequestBody {
+  std::string api_auth_token;
+  std::string multihop_exit_region;
+
+  base::DictValue ToValue() const {
+    return base::DictValue()
+        .Set(kApiAuthTokenKey, api_auth_token)
+        .Set(kMultihopExitRegionKey, multihop_exit_region);
+  }
+};
+
+struct SetMultihopExitRegion {
+  using Request =
+      brave_account::endpoint_client::POST<SetMultihopExitRegionRequestBody>;
+  using Response = brave_account::endpoint_client::Response<RawJsonResponseBody,
+                                                            VpnErrorBody>;
+
+  static GURL URL() {
+    return GURL(base::StrCat({url::kHttpsScheme, url::kStandardSchemeSeparator,
+                              kDeviceHostPlaceholder}))
+        .Resolve(kDeviceApi);
+  }
+};
+
 }  // namespace brave_vpn::v2::endpoints
 
 #endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_API_DEVICE_ENDPOINTS_H_

--- a/components/brave_vpn/browser/v2/api/device_endpoints_unittest.cc
+++ b/components/brave_vpn/browser/v2/api/device_endpoints_unittest.cc
@@ -70,4 +70,14 @@ TEST(DeviceEndpointsTest, InvalidateCredentialsRequestBodyToValue) {
                 .Set("subscriber-credential", kTestSubscriberCredential));
 }
 
+TEST(DeviceEndpointsTest, SetMultihopExitRegionRequestBodyToValue) {
+  const SetMultihopExitRegionRequestBody body{
+      .api_auth_token = kTestApiAuthToken,
+      .multihop_exit_region = kTestMultihopExitRegion};
+  EXPECT_EQ(body.ToValue(),
+            base::DictValue()
+                .Set("api-auth-token", kTestApiAuthToken)
+                .Set("multihop-exit-region", kTestMultihopExitRegion));
+}
+
 }  // namespace brave_vpn::v2::endpoints

--- a/components/brave_vpn/browser/v2/api/endpoint_constants.h
+++ b/components/brave_vpn/browser/v2/api/endpoint_constants.h
@@ -35,6 +35,7 @@ inline constexpr char kDeviceApiVerifyCredentialsSuffix[] =
     "verify-credentials";
 inline constexpr char kDeviceApiInvalidateCredentialsSuffix[] =
     "invalidate-credentials";
+inline constexpr char kDeviceApiConfigMultihopSuffix[] = "config/multihop";
 
 // Endpoint request JSON keys that can be shared between multiple APIs.
 inline constexpr char kProductTypeKey[] = "product-type";
@@ -59,6 +60,10 @@ inline constexpr char kApiAuthTokenKey[] = "api-auth-token";
 
 // Default payment validation method used by Brave.
 inline constexpr char kValidationMethodDefaultValue[] = "brave-premium";
+
+// Value that disables multihop when sent as SetMultihopExitRegion's
+// "multihop-exit-region".
+inline constexpr char kMultihopDisabledValue[] = "disabled";
 
 }  // namespace brave_vpn::v2::endpoints
 


### PR DESCRIPTION
Add two new multihop SGW endpoints not present in V1. Both share Guardian's `"/config/multihop"` path, disambiguated by method (POST vs GET). Responses are forwarded verbatim.

Split disabling multihop into a separate `ClearMultihopExitRegion` method rather than overloading `SetMultihopExitRegion` with a hardcoded constant is done to ensure callers never need to know or pass Guardian-owned constants themselves.

Implements part of https://github.com/brave/brave-browser/issues/54600

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
