### PR TITLE
[plaster] Build scripts for `tree-sitter-gn`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ patches/**/*.patchinfo
 /third_party/wintun/
 /third_party/ast-grep-intermediate/
 /third_party/ast-grep-src/
+/third_party/tree-sitter-gn-src/
 /third_party/ast-grep/ast-grep-*
 /third_party/updater/mac/
 *.xcodeproj

--- a/third_party/ast-grep/README.md
+++ b/third_party/ast-grep/README.md
@@ -1,7 +1,9 @@
 # `third_party/ast-grep`
 
 Clones [ast-grep](https://github.com/ast-grep/ast-grep) and builds it with the
-Rust toolchain Chromium already ships using Chromium's rust toolchain.
+Rust toolchain Chromium already ships using Chromium's rust toolchain. Also
+compiles [tree-sitter-gn](https://github.com/tree-sitter-grammars/tree-sitter-gn)
+into a shared library ast-grep loads at runtime.
 
 ## Run
 
@@ -15,15 +17,16 @@ Useful flags: `--clean` (wipe source and build dirs, start fresh), `-j N`,
 ## Prerequisites
 
 The Chromium Rust toolchain must be available at
-`src/third_party/rust-toolchain/`, so only vanilla Chromium is required.
-
-No other OS-level dependencies are needed — ast-grep's tree-sitter parser builds
-use the C compiler already in the developer environment.
+`src/third_party/rust-toolchain/`, and Chromium's clang/lld at
+`src/third_party/llvm-build/`, so only vanilla Chromium is required.
 
 ## Outputs
 
-| Path                                           | Contents                 |
-| ---------------------------------------------- | ------------------------ |
-| `third_party/ast-grep-src/`                    | ast-grep source clone    |
-| `third_party/ast-grep-intermediate/`           | `cargo-home/`, `target/` |
-| `third_party/ast-grep/ast-grep-<os>/bin/ast-grep` | final ast-grep binary |
+| Path                                                 | Contents                     |
+| ----------------------------------------------------- | ---------------------------- |
+| `third_party/ast-grep-src/`                          | ast-grep source clone         |
+| `third_party/tree-sitter-gn-src/`                    | tree-sitter-gn source clone   |
+| `third_party/ast-grep-intermediate/`                 | `cargo-home/`, `target/`      |
+| `third_party/ast-grep/ast-grep-<os>/bin/ast-grep`    | final ast-grep binary         |
+| `third_party/ast-grep/ast-grep-<os>/lib/gn.<ext>`    | `gn` custom-language library  |
+| `third_party/ast-grep/ast-grep-<os>/sgconfig.yml`    | registers `gn` for ast-grep   |

--- a/third_party/ast-grep/build_ast_grep.py
+++ b/third_party/ast-grep/build_ast_grep.py
@@ -4,7 +4,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 """Build [ast-grep](https://github.com/ast-grep/ast-grep) using the Rust
-toolchain Chromium ships under `src/third_party/rust-toolchain/`.
+toolchain Chromium ships under `src/third_party/rust-toolchain/`, then compile
+the `gn` custom-language grammar with Chromium's bundled clang/lld.
 
 """
 
@@ -13,19 +14,23 @@ from __future__ import annotations
 import argparse
 import logging
 import os
-import platform
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 
-# Anchoring a few paths
-_BRAVE_ROOT = Path(__file__).resolve().parents[2]
-_CHROMIUM_ROOT = _BRAVE_ROOT.parent
+import build_utils
+from build_utils import AST_GREP_DIR, AST_GREP_PLATFORM_DIR, CHROMIUM_ROOT, \
+    THIRD_PARTY
 
 # We reuse Chromium's cargo wrapper.
-sys.path.insert(0, str((_CHROMIUM_ROOT / 'tools' / 'crates').resolve()))
+sys.path.insert(0, str((CHROMIUM_ROOT / 'tools' / 'crates').resolve()))
 from run_cargo import DEFAULT_SYSROOT, RunCargo  # noqa: E402
+
+# The `gn` custom-language grammar (GN has no built-in ast-grep grammar) is
+# built by a sibling script, since it uses a different toolchain (Chromium's
+# clang/lld) than ast-grep itself (Chromium's Rust).
+import build_tree_sitter_gn  # noqa: E402  pylint: disable=wrong-import-position
 
 # ast-grep upstream details.
 AST_GREP_GIT_URL = 'https://github.com/ast-grep/ast-grep.git'
@@ -36,28 +41,11 @@ AST_GREP_REF = '51496f3b161ba077ad680451062deb4d09da848a'
 
 # Additional paths under `third_party/` for the source checkout, intermediate
 # build state, and final binary output.
-_THIRD_PARTY = _BRAVE_ROOT / 'third_party'
-AST_GREP_SRC_DIR: Path = _THIRD_PARTY / 'ast-grep-src'
-AST_GREP_DIR: Path = _THIRD_PARTY / 'ast-grep'
-AST_GREP_INTERMEDIATE_DIR: Path = (_THIRD_PARTY / 'ast-grep-intermediate')
+AST_GREP_SRC_DIR: Path = THIRD_PARTY / 'ast-grep-src'
+AST_GREP_INTERMEDIATE_DIR: Path = (THIRD_PARTY / 'ast-grep-intermediate')
 
 _RUST_EXE = '.exe' if sys.platform == 'win32' else ''
 
-
-def _platform_dir() -> str:
-    """Host-OS token used in the per-platform subdirectory name.
-
-    The binary is installed under `ast-grep-<os>/`.
-    """
-    if sys.platform == 'darwin':
-        return 'mac_arm64' if platform.machine() == 'arm64' else 'mac'
-    if sys.platform == 'win32':
-        return 'win'
-    return 'linux'
-
-
-# Per-OS install root, so e.g. Linux and mac builds land in sibling dirs.
-AST_GREP_PLATFORM_DIR: Path = AST_GREP_DIR / f'ast-grep-{_platform_dir()}'
 AST_GREP_BIN: Path = AST_GREP_PLATFORM_DIR / 'bin' / f'ast-grep{_RUST_EXE}'
 
 # Third-party cargo subcommands (cargo-audit) are installed here with the
@@ -80,23 +68,10 @@ def _check_rust_toolchain() -> None:
 def _clone_ast_grep() -> None:
     """Shallow-fetch ast-grep at `AST_GREP_REF` if not already present.
 
-    Pre-existing checkouts are left alone so local edits / a custom
-    branch survive across runs. `--clean` wipes and re-fetches.
+    `--clean` wipes `AST_GREP_SRC_DIR` first to force a re-fetch.
     """
-    if AST_GREP_SRC_DIR.is_dir():
-        logging.info('ast-grep source already present at %s', AST_GREP_SRC_DIR)
-        return
-
-    AST_GREP_SRC_DIR.mkdir(parents=True, exist_ok=True)
-    logging.info('Fetching ast-grep (%s) into %s', AST_GREP_REF,
-                 AST_GREP_SRC_DIR)
-    git = ['git', '-C', str(AST_GREP_SRC_DIR)]
-    subprocess.run([*git, 'init', '-q'], check=True)
-    subprocess.run([*git, 'remote', 'add', 'origin', AST_GREP_GIT_URL],
-                   check=True)
-    subprocess.run([*git, 'fetch', '--depth=1', 'origin', AST_GREP_REF],
-                   check=True)
-    subprocess.run([*git, 'checkout', '-q', 'FETCH_HEAD'], check=True)
+    build_utils.shallow_clone_pinned(AST_GREP_GIT_URL, AST_GREP_REF,
+                                     AST_GREP_SRC_DIR)
 
 
 def _run_cargo_in_src(cargo_args: list[str]) -> int:
@@ -188,7 +163,9 @@ def _clean() -> None:
 
 
 def build(jobs: int, clean: bool = False) -> None:
-    """Audit ast-grep's dependencies, then build it into `third_party/ast-grep/`.
+    """Audit and build ast-grep, then compile the `gn` custom-language grammar.
+
+    Everything lands under `third_party/ast-grep/ast-grep-<os>/`.
     """
     if clean:
         _clean()
@@ -196,6 +173,7 @@ def build(jobs: int, clean: bool = False) -> None:
     _clone_ast_grep()
     _audit_ast_grep()
     _build_ast_grep(jobs)
+    build_tree_sitter_gn.build(clean=clean)
 
 
 def main() -> int:
@@ -204,6 +182,7 @@ def main() -> int:
     parser.add_argument('--clean',
                         action='store_true',
                         help='Remove third_party/ast-grep-src/, '
+                        'third_party/tree-sitter-gn-src/, '
                         'third_party/ast-grep/ and '
                         'third_party/ast-grep-intermediate/ before building.')
     parser.add_argument('-j',
@@ -223,6 +202,7 @@ def main() -> int:
 
     logging.info('Done.')
     logging.info('ast-grep: %s', AST_GREP_BIN)
+    logging.info('gn sgconfig: %s', AST_GREP_PLATFORM_DIR / 'sgconfig.yml')
     return 0
 
 

--- a/third_party/ast-grep/build_tree_sitter_gn.py
+++ b/third_party/ast-grep/build_tree_sitter_gn.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""A script to build the tree-sitter-gn grammar for ast-grep.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import build_utils
+from build_utils import AST_GREP_PLATFORM_DIR, CHROMIUM_ROOT, LLVM_BIN_DIR, \
+    THIRD_PARTY
+
+# Pinning the `v1.0.0` tag's commit.
+TREE_SITTER_GN_GIT_URL = (
+    'https://github.com/tree-sitter-grammars/tree-sitter-gn.git')
+TREE_SITTER_GN_REF = 'bc06955bc1e3c9ff8e9b2b2a55b38b94da923c05'
+
+TREE_SITTER_GN_SRC_DIR: Path = THIRD_PARTY / 'tree-sitter-gn-src'
+
+_SHARED_LIB_EXT = {'win32': 'dll', 'darwin': 'dylib'}.get(sys.platform, 'so')
+
+# `The file providing details of how to load the custom tree-sitter.
+_SGCONFIG_TEMPLATE = """\
+customLanguages:
+  gn:
+    libraryPath: %(library_path)s
+    extensions: [gn, gni]
+    expandoChar: _
+"""
+
+
+def _windows_sdk_lib_dirs() -> list[Path]:
+    """VC tools + Windows SDK import-library directories.
+    """
+    sys.path.insert(0, str(CHROMIUM_ROOT / 'build'))
+    from vs_toolchain import (
+        FindVCComponentRoot,  # noqa: E402
+        SDK_VERSION,
+        SetEnvironmentAndGetSDKDir)
+    sdk_dir = Path(SetEnvironmentAndGetSDKDir())
+    return [
+        Path(FindVCComponentRoot('Tools')) / 'lib' / 'x64',
+        sdk_dir / 'Lib' / SDK_VERSION / 'um' / 'x64',
+        sdk_dir / 'Lib' / SDK_VERSION / 'ucrt' / 'x64',
+    ]
+
+
+def _compile(output: Path) -> None:
+    """Compile `parser.c` + `scanner.c` into the shared library at `output`.
+
+    `parser.c`'s pre-generated ABI (14) sits within ast-grep's tree-sitter
+    compatible range ([13, 15] as of tree-sitter 0.26), so it is used as-is,
+    with no `tree-sitter generate` step.
+    """
+    src_dir = TREE_SITTER_GN_SRC_DIR / 'src'
+    sources = [src_dir / 'parser.c', src_dir / 'scanner.c']
+
+    env = dict(os.environ)
+    if sys.platform == 'win32':
+        clang_cl = LLVM_BIN_DIR / 'clang-cl.exe'
+        cmd = [
+            str(clang_cl), '/LD', '/O2', f'-I{src_dir}', *map(str, sources),
+            f'-Fe:{output}', '-fuse-ld=lld', '-link', '/EXPORT:tree_sitter_gn'
+        ]
+        env['LIB'] = os.pathsep.join(str(p) for p in _windows_sdk_lib_dirs())
+    else:
+        clang = LLVM_BIN_DIR / 'clang'
+        shared_flag = '-dynamiclib' if sys.platform == 'darwin' else '-shared'
+        cmd = [
+            str(clang), shared_flag, '-fPIC', '-O2', '-fuse-ld=lld',
+            f'-I{src_dir}', *map(str, sources), '-o',
+            str(output)
+        ]
+        if sys.platform == 'darwin':
+            sdk_path = subprocess.run(['xcrun', '--show-sdk-path'],
+                                      check=True,
+                                      capture_output=True,
+                                      text=True).stdout.strip()
+            cmd += ['-isysroot', sdk_path]
+
+    logging.info('Compiling tree-sitter-gn -> %s', output)
+    subprocess.run(cmd, check=True, env=env)
+
+
+def build(clean: bool = False) -> Path:
+    """Build the `gn` custom-language library into `AST_GREP_PLATFORM_DIR/lib/`.
+
+    Also (re)writes `AST_GREP_PLATFORM_DIR/sgconfig.yml` registering it.
+    Returns the compiled library's path.
+    """
+    if clean and TREE_SITTER_GN_SRC_DIR.exists():
+        logging.info('Removing %s', TREE_SITTER_GN_SRC_DIR)
+        shutil.rmtree(TREE_SITTER_GN_SRC_DIR)
+
+    build_utils.shallow_clone_pinned(TREE_SITTER_GN_GIT_URL,
+                                     TREE_SITTER_GN_REF,
+                                     TREE_SITTER_GN_SRC_DIR)
+
+    lib_dir = AST_GREP_PLATFORM_DIR / 'lib'
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    output = lib_dir / f'gn.{_SHARED_LIB_EXT}'
+    _compile(output)
+
+    # Write the `sgconfig.yml` registering the library, so ast-grep can find it.
+    sgconfig_path = AST_GREP_PLATFORM_DIR / 'sgconfig.yml'
+    lib_rel = output.relative_to(AST_GREP_PLATFORM_DIR)
+    sgconfig_path.write_text(_SGCONFIG_TEMPLATE %
+                             {'library_path': lib_rel.as_posix()},
+                             newline='\n')
+    return output
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Compile the tree-sitter-gn grammar for ast-grep.')
+    parser.add_argument('--clean',
+                        action='store_true',
+                        help='Remove third_party/tree-sitter-gn-src/ before '
+                        'building.')
+    parser.add_argument('--verbose',
+                        action='store_true',
+                        help='Enable debug logging.')
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO,
+                        force=True)
+
+    gn_lib = build(clean=args.clean)
+
+    logging.info('Done.')
+    logging.info('gn library: %s', gn_lib)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/third_party/ast-grep/build_utils.py
+++ b/third_party/ast-grep/build_utils.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Shared paths and build helpers for `build_ast_grep.py` and
+`build_tree_sitter_gn.py`, so the two scripts can't disagree on where things
+live.
+"""
+
+from __future__ import annotations
+
+import logging
+import platform
+import subprocess
+import sys
+from pathlib import Path
+
+BRAVE_ROOT: Path = Path(__file__).resolve().parents[2]
+CHROMIUM_ROOT: Path = BRAVE_ROOT.parent
+THIRD_PARTY: Path = BRAVE_ROOT / 'third_party'
+
+# Chromium's own clang/lld, fetched by `tools/clang/scripts/update.py` as part
+# of `gclient sync`.
+LLVM_BIN_DIR: Path = (CHROMIUM_ROOT / 'third_party' / 'llvm-build' /
+                      'Release+Asserts' / 'bin')
+
+
+def platform_dir() -> str:
+    """Host-OS token used in ast-grep's per-platform dir name (`ast-grep-<os>`)."""
+    if sys.platform == 'darwin':
+        return 'mac_arm64' if platform.machine() == 'arm64' else 'mac'
+    if sys.platform == 'win32':
+        return 'win'
+    return 'linux'
+
+
+AST_GREP_DIR: Path = THIRD_PARTY / 'ast-grep'
+# Per-OS install root: the `ast-grep` binary, the `gn` custom-language
+# library, and its `sgconfig.yml` all live side by side under here.
+AST_GREP_PLATFORM_DIR: Path = AST_GREP_DIR / f'ast-grep-{platform_dir()}'
+
+
+def shallow_clone_pinned(git_url: str, ref: str, dest: Path) -> None:
+    """Shallow-fetch `ref` from `git_url` into `dest`, if not already present.
+
+    A pre-existing checkout is left alone so local edits / a custom branch
+    survive across runs. Callers remove `dest` first (e.g. on `--clean`) to
+    force a re-fetch.
+    """
+    if dest.is_dir():
+        logging.info('%s source already present at %s', git_url, dest)
+        return
+
+    dest.mkdir(parents=True, exist_ok=True)
+    logging.info('Fetching %s (%s) into %s', git_url, ref, dest)
+    git = ['git', '-C', str(dest)]
+    subprocess.run([*git, 'init', '-q'], check=True)
+    subprocess.run([*git, 'remote', 'add', 'origin', git_url], check=True)
+    subprocess.run([*git, 'fetch', '--depth=1', 'origin', ref], check=True)
+    subprocess.run([*git, 'checkout', '-q', 'FETCH_HEAD'], check=True)

--- a/third_party/ast-grep/package_ast_grep.py
+++ b/third_party/ast-grep/package_ast_grep.py
@@ -17,7 +17,6 @@ import argparse
 import logging
 import os
 from pathlib import Path
-import platform
 import re
 import subprocess
 import sys
@@ -29,16 +28,22 @@ sys.path.insert(
 
 # pylint: disable=wrong-import-position
 import build_ast_grep
+import build_utils
 from upload import S3Uploader, sha256_file, summarise
+
+# GCS-style host platform tag, mirroring build_rust_toolchain.py. Keyed off
+# `build_utils.platform_dir()` so there's a single place deciding which OS/arch
+# this host is.
+_PLATFORM_TAGS = {
+    'mac_arm64': 'mac-arm64',
+    'mac': 'mac',
+    'win': 'win',
+    'linux': 'linux-x64',
+}
 
 
 def _platform_tag() -> str:
-    """GCS-style host platform tag, mirroring build_rust_toolchain.py."""
-    if sys.platform == 'darwin':
-        return 'mac-arm64' if platform.machine() == 'arm64' else 'mac'
-    if sys.platform == 'win32':
-        return 'win'
-    return 'linux-x64'
+    return _PLATFORM_TAGS[build_utils.platform_dir()]
 
 
 def _ast_grep_version() -> str:
@@ -71,7 +76,7 @@ def _create_archive(out_dir: Path) -> Path:
     Raises:
         RuntimeError: If the ast-grep build output directory is missing.
     """
-    source = build_ast_grep.AST_GREP_PLATFORM_DIR
+    source = build_utils.AST_GREP_PLATFORM_DIR
     if not source.is_dir():
         raise RuntimeError(f'ast-grep build output not found at {source}')
 

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/mac.json
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.expected/mac.json
@@ -1,0 +1,334 @@
+[
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "1",
+      "https://chromium.googlesource.com/chromium/tools/depot_tools",
+      "[WORKSPACE]/b/src/third_party/depot_tools"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "clone depot_tools"
+  },
+  {
+    "cmd": [
+      "gclient"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "verify gclient"
+  },
+  {
+    "cmd": [
+      "gclient",
+      "config",
+      "--name",
+      "src",
+      "--unmanaged",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "cwd": "[WORKSPACE]/b",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "gclient config"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (before)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "populate",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git",
+      "--reset-fetch-config",
+      "--no-fetch-tags",
+      "--ref",
+      "refs/tags/151.0.7917.1"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache populate exists (after)"
+  },
+  {
+    "cmd": [
+      "git",
+      "cache",
+      "exists",
+      "--quiet",
+      "--cache-dir",
+      "/b/cache",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "git cache exists"
+  },
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--no-checkout",
+      "--local",
+      "--shared",
+      "--depth",
+      "1",
+      "/b/cache/chromium.googlesource.com-chromium-src",
+      "[WORKSPACE]/b/src"
+    ],
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "clone from git cache"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.auto",
+      "0"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "disable auto-gc: gc.auto=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autodetach",
+      "0"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "disable auto-gc: gc.autodetach=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "gc.autopacklimit",
+      "0"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "disable auto-gc: gc.autopacklimit=0"
+  },
+  {
+    "cmd": [
+      "git",
+      "config",
+      "maintenance.gc.enabled",
+      "false"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "disable auto-gc: maintenance.gc.enabled=false"
+  },
+  {
+    "cmd": [
+      "git",
+      "checkout",
+      "--force",
+      "refs/tags/151.0.7917.1",
+      "--"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "checkout tag"
+  },
+  {
+    "cmd": [
+      "git",
+      "remote",
+      "set-url",
+      "--push",
+      "origin",
+      "https://chromium.googlesource.com/chromium/src.git"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "restore origin push url"
+  },
+  {
+    "cmd": [
+      "gclient",
+      "sync",
+      "--force",
+      "-D"
+    ],
+    "cwd": "[WORKSPACE]/b/src",
+    "env": {
+      "CHROME_HEADLESS": "1"
+    },
+    "name": "gclient sync"
+  },
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "2",
+      "--filter=blob:none",
+      "--sparse",
+      "--branch",
+      "master",
+      "git@github.com:brave/brave-core.git",
+      "[WORKSPACE]/b/src/brave"
+    ],
+    "name": "clone brave-core (shallow, sparse)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "sparse-checkout",
+      "list"
+    ],
+    "name": "sparse-checkout list"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "sparse-checkout",
+      "add",
+      "third_party/ast-grep",
+      "tools/cr/toolchains"
+    ],
+    "name": "sparse-checkout add"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "-u",
+      "RECIPE_MODULE[osx_sdk]/resources/read_mac_sdk_gni.py",
+      "[WORKSPACE]/b/src/build/config/mac/mac_sdk.gni",
+      "--json-output",
+      "/path/to/tmp/json"
+    ],
+    "name": "read mac_sdk.gni"
+  },
+  {
+    "cmd": [
+      "git",
+      "clone",
+      "--depth",
+      "2",
+      "--filter=blob:none",
+      "--sparse",
+      "--branch",
+      "master",
+      "git@github.com:brave/brave-core.git",
+      "[WORKSPACE]/b/src/brave"
+    ],
+    "name": "clone brave-core (shallow, sparse) (2)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "sparse-checkout",
+      "list"
+    ],
+    "name": "sparse-checkout list (2)"
+  },
+  {
+    "cmd": [
+      "git",
+      "-C",
+      "[WORKSPACE]/b/src/brave",
+      "sparse-checkout",
+      "add",
+      "tools/cr/toolchains"
+    ],
+    "name": "sparse-checkout add (2)"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/brave/tools/cr/toolchains/ephemeral_xcode.py",
+      "--sdk-version",
+      "26.5",
+      "--sdk-build",
+      "25F70",
+      "--json-output",
+      "/path/to/tmp/json",
+      "--no-developer-mode-check"
+    ],
+    "name": "install xcode"
+  },
+  {
+    "cmd": [
+      "[WORKSPACE]/b/src/third_party/depot_tools/vpython3",
+      "[WORKSPACE]/b/src/brave/third_party/ast-grep/package_ast_grep.py",
+      "--clean",
+      "--out-dir",
+      "[WORKSPACE]/out",
+      "--upload"
+    ],
+    "name": "package ast-grep"
+  },
+  {
+    "cmd": [
+      "sudo",
+      "/usr/bin/xcode-select",
+      "--reset"
+    ],
+    "name": "reset xcode"
+  },
+  {
+    "name": "$result"
+  }
+]

--- a/tools/recipes/recipes/tools/ast_grep/package_ast_grep.py
+++ b/tools/recipes/recipes/tools/ast_grep/package_ast_grep.py
@@ -14,15 +14,16 @@ if TYPE_CHECKING:
     from engine import RecipeScriptApi
 
 DEPS = [
-    'path', 'step', 'depot_tools', 'chromium_checkout', 'brave_core_checkout'
+    'path', 'step', 'depot_tools', 'chromium_checkout', 'brave_core_checkout',
+    'osx_sdk', 'platform'
 ]
 
 PROPERTIES = InputProperties
 
 
 def RunSteps(api: RecipeScriptApi, properties: InputProperties) -> None:
-    api.chromium_checkout.ensure_checkout(ref=properties.chromium_ref,
-                                          depth=1)
+    chromium_src = api.chromium_checkout.ensure_checkout(
+        ref=properties.chromium_ref, depth=1)
 
     brave_root = api.brave_core_checkout.deploy([
         'third_party/ast-grep',
@@ -30,25 +31,51 @@ def RunSteps(api: RecipeScriptApi, properties: InputProperties) -> None:
     ])
 
     vpython3 = api.depot_tools.vpython3()
-    api.step('package ast-grep', [
-        vpython3,
-        brave_root / 'third_party/ast-grep/package_ast_grep.py',
-        '--clean',
-        '--out-dir',
-        api.path.out,
-        '--upload',
-    ])
+    with api.osx_sdk.ensure(chromium_src):
+        api.step('package ast-grep', [
+            vpython3,
+            brave_root / 'third_party/ast-grep/package_ast_grep.py',
+            '--clean',
+            '--out-dir',
+            api.path.out,
+            '--upload',
+        ])
 
 
 def GenTests(api):
+    # Happy path: checkout (with a seeded git cache), deploy the build
+    # scripts, then package. Non-mac: osx_sdk.ensure() is a no-op, so no
+    # Xcode install/reset around the packaging step.
     yield api.test(
         'linux',
+        api.platform.name('linux'),
         api.chromium_checkout.with_git_cache(),
         api.chromium_checkout.git_cache_populated(),
         api.brave_core_checkout.deployed('third_party/ast-grep',
                                          'tools/cr/toolchains'),
         api.properties(chromium_ref='151.0.7917.1'),
         api.post_process(post_process.MustRun, 'clone from git cache'),
+        api.post_process(post_process.DoesNotRun, 'read mac_sdk.gni'),
+        api.post_process(post_process.DoesNotRun, 'install xcode'),
         api.post_process(post_process.MustRun, 'package ast-grep'),
+        api.post_process(post_process.DoesNotRun, 'reset xcode'),
+        api.post_process(post_process.StatusSuccess),
+    )
+    # On mac, the checkout's pinned Xcode is installed/selected around the
+    # packaging step, then reset afterward -- ast-grep's build compiles the
+    # tree-sitter-gn grammar with Chromium's clang, which needs a valid Xcode
+    # SDK to find (`xcrun --show-sdk-path`).
+    yield api.test(
+        'mac',
+        api.platform.name('mac'),
+        api.chromium_checkout.with_git_cache(),
+        api.chromium_checkout.git_cache_populated(),
+        api.brave_core_checkout.deployed('third_party/ast-grep',
+                                         'tools/cr/toolchains'),
+        api.osx_sdk.installed(),
+        api.properties(chromium_ref='151.0.7917.1'),
+        api.post_process(post_process.MustRun, 'install xcode'),
+        api.post_process(post_process.MustRun, 'package ast-grep'),
+        api.post_process(post_process.MustRun, 'reset xcode'),
         api.post_process(post_process.StatusSuccess),
     )


### PR DESCRIPTION
This is the initial implementation support to have `tree-sitter-gn`
built with `ast-grep` and bundled with it. Once this is delivered, we
can publish a new `ast-grep` package with this parser, and start rolling
out integration for it inside plaster.

Bug: https://github.com/brave/brave-browser/issues/58378
