### PR TITLE
[iptc] Connect iptc removal in downloads flow

### DIFF
--- a/browser/download/BUILD.gn
+++ b/browser/download/BUILD.gn
@@ -27,6 +27,7 @@ source_set("browser_tests") {
     ":download",
     "//base",
     "//base/test:test_support",
+    "//brave/components/constants",
     "//brave/components/image_metadata_stripper/common",
     "//chrome/browser/download",
     "//chrome/browser/profiles:profile",
@@ -40,6 +41,8 @@ source_set("browser_tests") {
     "//testing/gtest",
     "//url",
   ]
+
+  data = [ "//brave/test/data/image_metadata_stripper/" ]
 
   defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
 }

--- a/browser/download/BUILD.gn
+++ b/browser/download/BUILD.gn
@@ -27,7 +27,6 @@ source_set("browser_tests") {
     ":download",
     "//base",
     "//base/test:test_support",
-    "//brave/components/constants",
     "//brave/components/image_metadata_stripper/common",
     "//chrome/browser/download",
     "//chrome/browser/profiles:profile",

--- a/browser/download/brave_download_manager_delegate.cc
+++ b/browser/download/brave_download_manager_delegate.cc
@@ -111,14 +111,30 @@ void BraveDownloadManagerDelegate::OnImageMetadataStripped(
     image_metadata_stripper::StrippingResultCode result) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
+  // Debug logs.
   switch (result) {
-    case image_metadata_stripper::StrippingResultCode::kStrippingFailed: {
-      DVLOG(1) << "Failed to strip image metadata from download file.";
+    case image_metadata_stripper::StrippingResultCode::kFileNotFound: {
+      DVLOG(1) << "Stripping skipped as the download file does not exist.";
       break;
     }
 
-    case image_metadata_stripper::StrippingResultCode::kIgnored: {
+    case image_metadata_stripper::StrippingResultCode::kFileReadFailed: {
+      DVLOG(1) << "Failed to read the download file to check for metadata.";
+      break;
+    }
+
+    case image_metadata_stripper::StrippingResultCode::kFileWriteFailed: {
+      DVLOG(1) << "Failed to rewrite the download file without the metadata.";
+      break;
+    }
+
+    case image_metadata_stripper::StrippingResultCode::kMetadataNotFound: {
       DVLOG(1) << "Stripping ignored as FBMD metadata may not be present.";
+      break;
+    }
+
+    case image_metadata_stripper::StrippingResultCode::kStrippingFailed: {
+      DVLOG(1) << "Failed to strip image metadata from download file.";
       break;
     }
 

--- a/browser/download/brave_download_manager_delegate.cc
+++ b/browser/download/brave_download_manager_delegate.cc
@@ -14,7 +14,6 @@
 #include "base/functional/callback.h"
 #include "base/location.h"
 #include "base/logging.h"
-#include "base/memory/ptr_util.h"
 #include "base/task/task_traits.h"
 #include "base/task/thread_pool.h"
 #include "brave/components/image_metadata_stripper/common/features.h"
@@ -23,6 +22,46 @@
 #include "components/download/public/common/download_item.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/download_manager.h"
+
+namespace {
+
+void LogStrippingResult(
+    const image_metadata_stripper::StrippingResultCode result) {
+  // Debug logs.
+  switch (result) {
+    case image_metadata_stripper::StrippingResultCode::kFileNotFound: {
+      DVLOG(1) << "Stripping skipped as the download file does not exist.";
+      return;
+    }
+
+    case image_metadata_stripper::StrippingResultCode::kFileReadFailed: {
+      DVLOG(1) << "Failed to read the download file to check for metadata.";
+      return;
+    }
+
+    case image_metadata_stripper::StrippingResultCode::kFileWriteFailed: {
+      DVLOG(1) << "Failed to rewrite the download file without the metadata.";
+      return;
+    }
+
+    case image_metadata_stripper::StrippingResultCode::kMetadataNotFound: {
+      DVLOG(1) << "Stripping ignored as FBMD metadata may not be present.";
+      return;
+    }
+
+    case image_metadata_stripper::StrippingResultCode::kStrippingFailed: {
+      DVLOG(1) << "Failed to strip image metadata from download file.";
+      return;
+    }
+
+    case image_metadata_stripper::StrippingResultCode::kStripped: {
+      DVLOG(1) << "FBMD found and stripped from image metadata.";
+      return;
+    }
+  }
+  NOTREACHED();
+}
+}  // namespace
 
 // Factory used by the plastered download_core_service_impl.cc construction
 // site. Keeping the Brave header out of chrome/browser/download avoids pulling
@@ -111,42 +150,7 @@ void BraveDownloadManagerDelegate::OnImageMetadataStripped(
     image_metadata_stripper::StrippingResultCode result) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
-  // Debug logs.
-  switch (result) {
-    case image_metadata_stripper::StrippingResultCode::kFileNotFound: {
-      DVLOG(1) << "Stripping skipped as the download file does not exist.";
-      break;
-    }
-
-    case image_metadata_stripper::StrippingResultCode::kFileReadFailed: {
-      DVLOG(1) << "Failed to read the download file to check for metadata.";
-      break;
-    }
-
-    case image_metadata_stripper::StrippingResultCode::kFileWriteFailed: {
-      DVLOG(1) << "Failed to rewrite the download file without the metadata.";
-      break;
-    }
-
-    case image_metadata_stripper::StrippingResultCode::kMetadataNotFound: {
-      DVLOG(1) << "Stripping ignored as FBMD metadata may not be present.";
-      break;
-    }
-
-    case image_metadata_stripper::StrippingResultCode::kStrippingFailed: {
-      DVLOG(1) << "Failed to strip image metadata from download file.";
-      break;
-    }
-
-    case image_metadata_stripper::StrippingResultCode::kStripped: {
-      DVLOG(1) << "FBMD found and stripped from image metadata.";
-      break;
-    }
-
-    default: {
-      NOTREACHED();
-    }
-  }
+  LogStrippingResult(result);
 
   // The download may have been removed while the stripping task was running, so
   // the item and its keyed state have to be looked up again.

--- a/browser/download/brave_download_manager_delegate.cc
+++ b/browser/download/brave_download_manager_delegate.cc
@@ -48,10 +48,12 @@ bool BraveDownloadManagerDelegate::IsDownloadReadyForCompletion(
         item, std::move(internal_complete_callback));
   }
 
-  // IPTC metadata stripping only available for png/jpeg types. So, for non
+  // IPTC metadata stripping only available for jpeg types. So, for non
   // types rely on upstream flow.
+  // TODO(https://github.com/brave/brave-browser/issues/5238): PNG formats needs
+  // more investigation whether FBMD is present or not. So, tackling only jpeg.
   const std::string mime_type = item->GetMimeType();
-  if (mime_type != "image/png" && mime_type != "image/jpeg") {
+  if (mime_type != "image/jpeg") {
     return ChromeDownloadManagerDelegate::IsDownloadReadyForCompletion(
         item, std::move(internal_complete_callback));
   }
@@ -104,12 +106,30 @@ bool BraveDownloadManagerDelegate::IsDownloadReadyForCompletion(
   return false;
 }
 
-void BraveDownloadManagerDelegate::OnImageMetadataStripped(uint32_t download_id,
-                                                           bool success) {
+void BraveDownloadManagerDelegate::OnImageMetadataStripped(
+    uint32_t download_id,
+    image_metadata_stripper::StrippingResultCode result) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
-  if (!success) {
-    DVLOG(1) << "Failed to strip image metadata from download file.";
+  switch (result) {
+    case image_metadata_stripper::StrippingResultCode::kStrippingFailed: {
+      DVLOG(1) << "Failed to strip image metadata from download file.";
+      break;
+    }
+
+    case image_metadata_stripper::StrippingResultCode::kIgnored: {
+      DVLOG(1) << "Stripping ignored as FBMD metadata may not be present.";
+      break;
+    }
+
+    case image_metadata_stripper::StrippingResultCode::kStripped: {
+      DVLOG(1) << "FBMD found and stripped from image metadata.";
+      break;
+    }
+
+    default: {
+      NOTREACHED();
+    }
   }
 
   // The download may have been removed while the stripping task was running, so

--- a/browser/download/brave_download_manager_delegate.h
+++ b/browser/download/brave_download_manager_delegate.h
@@ -9,6 +9,7 @@
 #include <stdint.h>
 
 #include "base/memory/weak_ptr.h"
+#include "brave/components/image_metadata_stripper/image_metadata_stripper.h"
 #include "chrome/browser/download/chrome_download_manager_delegate.h"
 
 class Profile;
@@ -40,7 +41,9 @@ class BraveDownloadManagerDelegate : public ChromeDownloadManagerDelegate {
  protected:
   // Marks the download as completed once the iptc metadata is stripped. Virtual
   // for testing purposes.
-  virtual void OnImageMetadataStripped(uint32_t download_id, bool success);
+  virtual void OnImageMetadataStripped(
+      uint32_t download_id,
+      image_metadata_stripper::StrippingResultCode result);
 
  private:
   // ChromeDownloadManagerDelegate override.

--- a/browser/download/brave_download_manager_delegate_browsertest.cc
+++ b/browser/download/brave_download_manager_delegate_browsertest.cc
@@ -11,6 +11,7 @@
 #include <string_view>
 #include <utility>
 
+#include "base/base_paths.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/files/scoped_temp_dir.h"
@@ -20,7 +21,6 @@
 #include "base/test/scoped_feature_list.h"
 #include "base/test/test_future.h"
 #include "base/threading/thread_restrictions.h"
-#include "brave/components/constants/brave_paths.h"
 #include "brave/components/image_metadata_stripper/common/features.h"
 #include "chrome/browser/download/download_core_service.h"
 #include "chrome/browser/download/download_core_service_factory.h"
@@ -144,8 +144,8 @@ class BraveDownloadManagerDelegateBrowserTestBase : public PlatformBrowserTest {
     {
       base::ScopedAllowBlockingForTesting allow_blocking;
       const base::FilePath fbmd_path =
-          base::PathService::CheckedGet(brave::DIR_TEST_DATA)
-              .AppendASCII("image_metadata_stripper")
+          base::PathService::CheckedGet(base::DIR_SRC_TEST_DATA_ROOT)
+              .AppendASCII("brave/test/data/image_metadata_stripper")
               .AppendASCII(kFbmdJpegImageFileName);
       ASSERT_TRUE(base::ReadFileToString(fbmd_path, &fbmd_jpeg_contents_));
     }

--- a/browser/download/brave_download_manager_delegate_browsertest.cc
+++ b/browser/download/brave_download_manager_delegate_browsertest.cc
@@ -227,23 +227,6 @@ class BraveDownloadManagerDelegateFeatureDisabledBrowserTest
 #define NON_ANDROID_TEST(test) test
 #endif
 
-IN_PROC_BROWSER_TEST_F(
-    BraveDownloadManagerDelegateBrowserTest,
-    NON_ANDROID_TEST(StripsMetadataFromDownloadedJpegImage)) {
-  base::test::TestFuture<void> iptc_metadata_stripper_future;
-  GetDownloadManagerDelegate()->SetOnImageMetadataStrippedCallback(
-      iptc_metadata_stripper_future.GetCallback());
-
-  DownloadURL(
-      embedded_test_server()->GetURL(std::string("/") + kJpegImageFileName));
-
-  // RemoveIptcMetadata() ran for the download, and the download still made it
-  // to disk afterwards.
-  EXPECT_TRUE(iptc_metadata_stripper_future.Wait());
-  // Check the download was completed.
-  AssertFileWasDownloaded(kJpegImageFileName);
-}
-
 // End-to-end coverage: downloading a real JPEG that carries a Facebook FBMD
 // IPTC record results in the record being scrubbed from the file on disk.
 IN_PROC_BROWSER_TEST_F(

--- a/browser/download/brave_download_manager_delegate_browsertest.cc
+++ b/browser/download/brave_download_manager_delegate_browsertest.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/download/brave_download_manager_delegate.h"
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -15,9 +16,11 @@
 #include "base/files/scoped_temp_dir.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
+#include "base/path_service.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/test_future.h"
 #include "base/threading/thread_restrictions.h"
+#include "brave/components/constants/brave_paths.h"
 #include "brave/components/image_metadata_stripper/common/features.h"
 #include "chrome/browser/download/download_core_service.h"
 #include "chrome/browser/download/download_core_service_factory.h"
@@ -40,26 +43,40 @@
 
 namespace {
 
-constexpr char kPngImageFileName[] = "test.png";
 constexpr char kJpegImageFileName[] = "test.jpeg";
 constexpr char kTextFileName[] = "test.txt";
+// Real JPEG fixture in //brave/test/data/image_metadata_stripper that contains
+// a Facebook FBMD record inside its IPTC metadata.
+constexpr char kFbmdJpegImageFileName[] = "fbmd_test_image.jpg";
+
+// The ASCII marker that begins the Facebook FBMD IPTC record. The stripper
+// zeroes the whole record (including this marker), so its absence in the
+// downloaded file signals a successful scrub.
+constexpr std::string_view kFbmdMarker = "FBMD";
+
+// Mirrors the ContainsFbmd() helper in jpeg_iptc_metadata_stripper_unittest.cc:
+// the FBMD record is detected purely by the presence of its ASCII marker.
+bool ContainsFbmd(std::string_view data) {
+  return data.find(kFbmdMarker) != std::string_view::npos;
+}
 
 // The stripping only reads the file, so an image signature followed by filler
 // is enough to stand in for a real image.
-constexpr std::string_view kFakePngContents = "\x89PNG\r\n\x1a\n-not-a-png-";
 constexpr std::string_view kFakeJpegContents = "\xff\xd8\xff\xe0-not-a-jpeg-";
 constexpr std::string_view kTextFileContents = "not-an-image";
 
 std::unique_ptr<net::test_server::HttpResponse> HandleDownloadRequest(
+    const std::string& fbmd_jpeg_contents,
     const net::test_server::HttpRequest& request) {
   std::string mime_type;
   std::string_view contents;
-  if (request.relative_url == std::string("/") + kPngImageFileName) {
-    mime_type = "image/png";
-    contents = kFakePngContents;
-  } else if (request.relative_url == std::string("/") + kJpegImageFileName) {
+  if (request.relative_url == std::string("/") + kJpegImageFileName) {
     mime_type = "image/jpeg";
     contents = kFakeJpegContents;
+  } else if (request.relative_url ==
+             std::string("/") + kFbmdJpegImageFileName) {
+    mime_type = "image/jpeg";
+    contents = fbmd_jpeg_contents;
   } else if (request.relative_url == std::string("/") + kTextFileName) {
     mime_type = "text/plain";
     contents = kTextFileContents;
@@ -88,8 +105,10 @@ class TestBraveDownloadManagerDelegate : public BraveDownloadManagerDelegate {
   }
 
  protected:
-  void OnImageMetadataStripped(uint32_t download_id, bool success) override {
-    BraveDownloadManagerDelegate::OnImageMetadataStripped(download_id, success);
+  void OnImageMetadataStripped(
+      uint32_t download_id,
+      image_metadata_stripper::StrippingResultCode result) override {
+    BraveDownloadManagerDelegate::OnImageMetadataStripped(download_id, result);
     if (on_image_metadata_stripped_callback_) {
       std::move(on_image_metadata_stripped_callback_).Run();
     }
@@ -119,14 +138,30 @@ class BraveDownloadManagerDelegateBrowserTestBase : public PlatformBrowserTest {
     DownloadCoreServiceFactory::GetForBrowserContext(profile)
         ->SetDownloadManagerDelegateForTesting(std::move(test_delegate));
 
+    // Preload the real FBMD fixture so the request handler (which runs on the
+    // test server's background thread) does not have to touch disk. It is kept
+    // around so tests can compare the downloaded file against the original.
+    {
+      base::ScopedAllowBlockingForTesting allow_blocking;
+      const base::FilePath fbmd_path =
+          base::PathService::CheckedGet(brave::DIR_TEST_DATA)
+              .AppendASCII("image_metadata_stripper")
+              .AppendASCII(kFbmdJpegImageFileName);
+      ASSERT_TRUE(base::ReadFileToString(fbmd_path, &fbmd_jpeg_contents_));
+    }
+    // Sanity check the fixture actually carries an FBMD record to strip.
+    ASSERT_TRUE(ContainsFbmd(fbmd_jpeg_contents_));
+
     embedded_test_server()->RegisterRequestHandler(
-        base::BindRepeating(&HandleDownloadRequest));
+        base::BindRepeating(&HandleDownloadRequest, fbmd_jpeg_contents_));
     ASSERT_TRUE(embedded_test_server()->Start());
   }
 
   const base::FilePath& downloads_directory() const {
     return downloads_directory_.GetPath();
   }
+
+  const std::string& fbmd_jpeg_contents() const { return fbmd_jpeg_contents_; }
 
   TestBraveDownloadManagerDelegate* GetDownloadManagerDelegate() {
     return static_cast<TestBraveDownloadManagerDelegate*>(
@@ -164,11 +199,10 @@ class BraveDownloadManagerDelegateBrowserTestBase : public PlatformBrowserTest {
 
  private:
   base::ScopedTempDir downloads_directory_;
+  std::string fbmd_jpeg_contents_;
   base::test::ScopedFeatureList feature_list_;
 };
 
-// TODO(https://github.com/brave/brave-browser/issues/5238): Add tests to see we
-// actually scrub the FBMD metadata once the logic is in-place.
 class BraveDownloadManagerDelegateBrowserTest
     : public BraveDownloadManagerDelegateBrowserTestBase {
  public:
@@ -193,22 +227,6 @@ class BraveDownloadManagerDelegateFeatureDisabledBrowserTest
 #define NON_ANDROID_TEST(test) test
 #endif
 
-IN_PROC_BROWSER_TEST_F(BraveDownloadManagerDelegateBrowserTest,
-                       NON_ANDROID_TEST(StripsMetadataFromDownloadedPngImage)) {
-  base::test::TestFuture<void> iptc_metadata_stripper_future;
-  GetDownloadManagerDelegate()->SetOnImageMetadataStrippedCallback(
-      iptc_metadata_stripper_future.GetCallback());
-
-  DownloadURL(
-      embedded_test_server()->GetURL(std::string("/") + kPngImageFileName));
-
-  // RemoveIptcMetadata() ran for the download, and the download still made it
-  // to disk afterwards.
-  EXPECT_TRUE(iptc_metadata_stripper_future.Wait());
-  // Check the download was completed.
-  AssertFileWasDownloaded(kPngImageFileName);
-}
-
 IN_PROC_BROWSER_TEST_F(
     BraveDownloadManagerDelegateBrowserTest,
     NON_ANDROID_TEST(StripsMetadataFromDownloadedJpegImage)) {
@@ -224,6 +242,39 @@ IN_PROC_BROWSER_TEST_F(
   EXPECT_TRUE(iptc_metadata_stripper_future.Wait());
   // Check the download was completed.
   AssertFileWasDownloaded(kJpegImageFileName);
+}
+
+// End-to-end coverage: downloading a real JPEG that carries a Facebook FBMD
+// IPTC record results in the record being scrubbed from the file on disk.
+IN_PROC_BROWSER_TEST_F(
+    BraveDownloadManagerDelegateBrowserTest,
+    NON_ANDROID_TEST(RemovesFbmdMetadataFromDownloadedJpegImage)) {
+  base::test::TestFuture<void> iptc_metadata_stripper_future;
+  GetDownloadManagerDelegate()->SetOnImageMetadataStrippedCallback(
+      iptc_metadata_stripper_future.GetCallback());
+
+  DownloadURL(embedded_test_server()->GetURL(std::string("/") +
+                                             kFbmdJpegImageFileName));
+
+  // RemoveIptcMetadata() ran for the download, and the download still made it
+  // to disk afterwards.
+  EXPECT_TRUE(iptc_metadata_stripper_future.Wait());
+  AssertFileWasDownloaded(kFbmdJpegImageFileName);
+
+  base::ScopedAllowBlockingForTesting allow_blocking;
+  std::string downloaded_contents;
+  ASSERT_TRUE(base::ReadFileToString(
+      downloads_directory().AppendASCII(kFbmdJpegImageFileName),
+      &downloaded_contents));
+
+  // Same before/after invariants as StripsFbmdFromTestImage in
+  // jpeg_iptc_metadata_stripper_unittest.cc: the source carried an FBMD record,
+  // and the stripper zeroes it in place, so the marker is gone from the saved
+  // file without changing its size.
+  EXPECT_TRUE(ContainsFbmd(fbmd_jpeg_contents()));
+  EXPECT_FALSE(ContainsFbmd(downloaded_contents))
+      << "FBMD metadata should have been stripped from the download";
+  EXPECT_EQ(downloaded_contents.size(), fbmd_jpeg_contents().size());
 }
 
 IN_PROC_BROWSER_TEST_F(
@@ -251,8 +302,8 @@ IN_PROC_BROWSER_TEST_F(
       iptc_metadata_stripper_future.GetCallback());
 
   DownloadURL(
-      embedded_test_server()->GetURL(std::string("/") + kPngImageFileName));
+      embedded_test_server()->GetURL(std::string("/") + kJpegImageFileName));
 
   EXPECT_FALSE(iptc_metadata_stripper_future.IsReady());
-  AssertFileWasDownloaded(kPngImageFileName);
+  AssertFileWasDownloaded(kJpegImageFileName);
 }

--- a/components/image_metadata_stripper/image_metadata_stripper.cc
+++ b/components/image_metadata_stripper/image_metadata_stripper.cc
@@ -18,21 +18,21 @@ namespace image_metadata_stripper {
 StrippingResultCode RemoveIptcMetadata(const base::FilePath& file_path) {
   if (!base::PathExists(file_path)) {
     DVLOG(1) << "IPTC strip skipped; file missing: " << file_path;
-    return StrippingResultCode::kIgnored;
+    return StrippingResultCode::kFileNotFound;
   }
 
   std::optional<std::vector<uint8_t>> file_bytes =
       base::ReadFileToBytes(file_path);
   if (!file_bytes.has_value()) {
     DVLOG(1) << "IPTC strip failed; could not read: " << file_path;
-    return StrippingResultCode::kIgnored;
+    return StrippingResultCode::kFileReadFailed;
   }
 
   jpeg::FbmdStripResult result =
       jpeg::RemoveFbmdIptcMetadata(file_bytes.value());
   switch (result) {
     case jpeg::FbmdStripResult::kNotFound:
-      return StrippingResultCode::kIgnored;
+      return StrippingResultCode::kMetadataNotFound;
     case jpeg::FbmdStripResult::kFailed:
       return StrippingResultCode::kStrippingFailed;
     case jpeg::FbmdStripResult::kRemoved:
@@ -41,7 +41,7 @@ StrippingResultCode RemoveIptcMetadata(const base::FilePath& file_path) {
 
   if (!base::WriteFile(file_path, file_bytes.value())) {
     DVLOG(1) << "IPTC strip failed; could not write: " << file_path;
-    return StrippingResultCode::kStrippingFailed;
+    return StrippingResultCode::kFileWriteFailed;
   }
 
   return StrippingResultCode::kStripped;

--- a/components/image_metadata_stripper/image_metadata_stripper.cc
+++ b/components/image_metadata_stripper/image_metadata_stripper.cc
@@ -11,26 +11,40 @@
 
 #include "base/files/file_util.h"
 #include "base/logging.h"
+#include "brave/components/image_metadata_stripper/internal/jpeg_iptc_metadata_stripper.h"
 
 namespace image_metadata_stripper {
 
-bool RemoveIptcMetadata(const base::FilePath& file_path) {
+StrippingResultCode RemoveIptcMetadata(const base::FilePath& file_path) {
   if (!base::PathExists(file_path)) {
     DVLOG(1) << "IPTC strip skipped; file missing: " << file_path;
-    return false;
+    return StrippingResultCode::kIgnored;
   }
 
   std::optional<std::vector<uint8_t>> file_bytes =
       base::ReadFileToBytes(file_path);
   if (!file_bytes.has_value()) {
     DVLOG(1) << "IPTC strip failed; could not read: " << file_path;
-    return false;
+    return StrippingResultCode::kIgnored;
   }
 
-  // TODO(https://github.com/brave/brave-browser/issues/5238): Add the core
-  // logic to remove the IPTC metadata here.
-  DVLOG(1) << "IPTC strip skipped; not implemented yet: " << file_path;
-  return false;
+  jpeg::FbmdStripResult result =
+      jpeg::RemoveFbmdIptcMetadata(file_bytes.value());
+  switch (result) {
+    case jpeg::FbmdStripResult::kNotFound:
+      return StrippingResultCode::kIgnored;
+    case jpeg::FbmdStripResult::kFailed:
+      return StrippingResultCode::kStrippingFailed;
+    case jpeg::FbmdStripResult::kRemoved:
+      break;
+  }
+
+  if (!base::WriteFile(file_path, file_bytes.value())) {
+    DVLOG(1) << "IPTC strip failed; could not write: " << file_path;
+    return StrippingResultCode::kStrippingFailed;
+  }
+
+  return StrippingResultCode::kStripped;
 }
 
 }  // namespace image_metadata_stripper

--- a/components/image_metadata_stripper/image_metadata_stripper.h
+++ b/components/image_metadata_stripper/image_metadata_stripper.h
@@ -10,13 +10,14 @@
 
 namespace image_metadata_stripper {
 
+// This class lets the client know on a very high level what happened to their
+// stripping request.
+enum class StrippingResultCode { kStripped, kStrippingFailed, kIgnored };
+
 // Removes the FBMD metadata from the IPTC Instructions field
 // (https://www.iptc.org/std/photometadata/documentation/userguide/#_instructions)
 // for an image file in |file_path|.
-// TODO(https://github.com/brave/brave-browser/issues/5238): Add the core
-// logic to remove the IPTC metadata and update the return type bool to a proper
-// result code.
-bool RemoveIptcMetadata(const base::FilePath& file_path);
+StrippingResultCode RemoveIptcMetadata(const base::FilePath& file_path);
 
 }  // namespace image_metadata_stripper
 

--- a/components/image_metadata_stripper/image_metadata_stripper.h
+++ b/components/image_metadata_stripper/image_metadata_stripper.h
@@ -10,9 +10,22 @@
 
 namespace image_metadata_stripper {
 
-// This class lets the client know on a very high level what happened to their
-// stripping request.
-enum class StrippingResultCode { kStripped, kStrippingFailed, kIgnored };
+// This enum lets the client know the result of their stripping request.
+enum class StrippingResultCode {
+  // The input file does not exist.
+  kFileNotFound,
+  // Initial file read failed to check for metadata.
+  kFileReadFailed,
+  // File rewrite failed with the stripped out metadata.
+  kFileWriteFailed,
+
+  // Metadata was not found.
+  kMetadataNotFound,
+  // Metadata was found but not able to be stripped.
+  kStrippingFailed,
+  // Metadata was found and stripped.
+  kStripped,
+};
 
 // Removes the FBMD metadata from the IPTC Instructions field
 // (https://www.iptc.org/std/photometadata/documentation/userguide/#_instructions)


### PR DESCRIPTION
This change:

a) Connects the internal jpeg stripper component, with the public stripping API to complete the download circuit. This results in FBMD IPTC data to be removed from the downloaded image when `kStripImageMetadataV1` is on. 

b) Updates the public result code given to the download client about the status of the stripping. This facilitates finer grained logging at the client side to know whether the stripping was ignored, failed, or stripped. 

### Demo

#### `kStripImageMetadataV1` feature flag - off 

https://github.com/user-attachments/assets/64ad9faf-d04a-4490-b9db-746cb30bebea

#### `kStripImageMetadataV1` feature flag - on

https://github.com/user-attachments/assets/cd5de6d4-d050-44ec-b610-206b9ef83aa6

Related https://github.com/brave/brave-browser/issues/5238

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
