### PR TITLE
(Wallet) Prevent transaction and show error message on insufficient balance

### DIFF
--- a/android/java/brave-res/layout/approve_tx_actions.xml
+++ b/android/java/brave-res/layout/approve_tx_actions.xml
@@ -45,6 +45,19 @@
         app:layout_constraintTop_toBottomOf="@id/navigation_view_pager"
         app:layout_constraintBottom_toBottomOf="parent">
 
+        <TextView
+            android:id="@+id/insufficient_balance_error"
+            style="@style/BraveWalletTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="24dp"
+            android:layout_marginBottom="8dp"
+            android:drawablePadding="8dp"
+            android:padding="12dp"
+            android:textColor="@color/brave_theme_error_txt"
+            android:visibility="gone"
+            app:drawableStartCompat="@drawable/ic_warning" />
+
         <Button
             android:id="@+id/btn_reject_transactions"
             style="@style/Widget.MaterialComponents.Button.TextButton"
@@ -84,6 +97,7 @@
                 android:layout_marginEnd="12dp"
                 android:layout_weight="1"
                 android:background="@drawable/crypto_wallet_blue_button"
+                android:enabled="false"
                 android:gravity="center"
                 android:paddingStart="16dp"
                 android:paddingTop="8dp"

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/ApproveTxBottomSheetDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/ApproveTxBottomSheetDialogFragment.java
@@ -75,6 +75,8 @@ public class ApproveTxBottomSheetDialogFragment extends WalletBottomSheetDialogF
 
     @MonotonicNonNull private TransactionListener mTransactionListener;
     @MonotonicNonNull private Button mRejectAllTx;
+    @MonotonicNonNull private Button mApprove;
+    @MonotonicNonNull private TextView mInsufficientBalanceError;
 
     @Nullable private TransactionInfo mTxInfo;
 
@@ -141,6 +143,8 @@ public class ApproveTxBottomSheetDialogFragment extends WalletBottomSheetDialogF
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         mRejectAllTx = view.findViewById(R.id.btn_reject_transactions);
+        mApprove = view.findViewById(R.id.approve);
+        mInsufficientBalanceError = view.findViewById(R.id.insufficient_balance_error);
 
         if (mTxInfo == null) {
             return;
@@ -250,8 +254,7 @@ public class ApproveTxBottomSheetDialogFragment extends WalletBottomSheetDialogF
                         });
         Button reject = view.findViewById(R.id.reject);
         reject.setOnClickListener(v -> rejectTransaction());
-        Button approve = view.findViewById(R.id.approve);
-        approve.setOnClickListener(v -> approveTransaction());
+        mApprove.setOnClickListener(v -> approveTransaction());
         if (mPendingTransactions.size() > 1) {
             // TODO: next button is not functional. Update next button text based on position in
             //  mTransactionInfos list.
@@ -311,16 +314,97 @@ public class ApproveTxBottomSheetDialogFragment extends WalletBottomSheetDialogF
                 false,
                 (assetPrices, fullTokenList, nativeAssetsBalances, blockchainTokensBalances) -> {
                     if (!canUpdateUi() || mTxInfo == null) return;
-                    fillAssetDependentControls(
+                    ParsedTransaction parsedTx =
+                            fillAssetDependentControls(
+                                    mTxInfo,
+                                    view,
+                                    txNetwork,
+                                    txAccountInfo,
+                                    accounts,
+                                    assetPrices,
+                                    fullTokenList,
+                                    mSolanaEstimatedTxFee);
+                    updateInsufficientBalanceUi(
                             mTxInfo,
-                            view,
+                            parsedTx,
                             txNetwork,
                             txAccountInfo,
-                            accounts,
-                            assetPrices,
-                            fullTokenList,
-                            mSolanaEstimatedTxFee);
+                            nativeAssetsBalances,
+                            blockchainTokensBalances);
                 });
+    }
+
+    /**
+     * Blocks the approval when the sending account cannot cover the transaction. Approving it would
+     * broadcast a transaction that fails on chain and still costs the network fee, which is what
+     * happens when the whole balance of the asset that also pays the fee is sent.
+     *
+     * <p>The approve button starts disabled in the layout and is enabled here, once the balances
+     * are known, so it never flips from enabled to disabled while they load.
+     */
+    private void updateInsufficientBalanceUi(
+            final TransactionInfo txInfo,
+            final ParsedTransaction parsedTx,
+            final NetworkInfo txNetwork,
+            final AccountInfo txAccountInfo,
+            final HashMap<String, Double> nativeAssetsBalances,
+            final HashMap<String, HashMap<String, Double>> blockchainTokensBalances) {
+        if (mApprove == null || mInsufficientBalanceError == null) {
+            return;
+        }
+        // Balances are keyed by lower case account address, see BalanceHelper.
+        final String accountAddress = txAccountInfo.address.toLowerCase(Locale.ENGLISH);
+        final Double nativeBalance = knownBalance(nativeAssetsBalances.get(accountAddress));
+        final BlockchainToken token =
+                parsedTx.getIsSwap() ? parsedTx.getSellToken() : parsedTx.getToken();
+        Double tokenBalance = null;
+        if (token != null && !Utils.isNativeToken(txNetwork, token)) {
+            final HashMap<String, Double> accountTokensBalances =
+                    blockchainTokensBalances.get(accountAddress);
+            if (accountTokensBalances != null) {
+                tokenBalance = knownBalance(accountTokensBalances.get(Utils.tokenToString(token)));
+            }
+        }
+
+        final boolean hasError =
+                setInsufficientBalanceError(
+                        mInsufficientBalanceError, txInfo, parsedTx, nativeBalance, tokenBalance);
+        mInsufficientBalanceError.setVisibility(hasError ? View.VISIBLE : View.GONE);
+        mApprove.setEnabled(!hasError);
+    }
+
+    /**
+     * Sets on {@code errorView} the error describing why the balance of the sending account does
+     * not cover the transaction. The view is left untouched when the balance covers it.
+     *
+     * @return {@code true} when an error was set.
+     */
+    private static boolean setInsufficientBalanceError(
+            final TextView errorView,
+            final TransactionInfo txInfo,
+            final ParsedTransaction parsedTx,
+            @Nullable final Double nativeBalance,
+            @Nullable final Double tokenBalance) {
+        if (TransactionUtils.hasInsufficientBalanceForGas(txInfo, parsedTx, nativeBalance)) {
+            errorView.setText(R.string.brave_wallet_insufficient_funds_for_gas);
+            return true;
+        }
+        if (TransactionUtils.hasInsufficientBalance(
+                txInfo, parsedTx, nativeBalance, tokenBalance)) {
+            errorView.setText(R.string.brave_wallet_insufficient_balance);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * A balance that failed to load is reported as zero, so a zero balance is treated as unknown.
+     * It keeps a transaction the account can actually cover from being blocked when a balance
+     * lookup fails.
+     */
+    @Nullable
+    private static Double knownBalance(@Nullable final Double balance) {
+        return balance != null && balance > 0d ? balance : null;
     }
 
     private void refreshListContentUi() {

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/TransactionUtils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/TransactionUtils.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
 import org.chromium.brave_wallet.mojom.CoinType;
@@ -39,6 +40,24 @@ public class TransactionUtils {
         } else {
             return CoinType.ETH;
         }
+    }
+
+    /**
+     * Checks whether the sending account can cover the network fee of a transaction. Adapted from
+     * {@code accountHasInsufficientFundsForGas} in components/brave_wallet_ui/utils/tx-utils.ts.
+     *
+     * @param txInfo Transaction to verify.
+     * @param parsedTx Parsed {@code txInfo}, holding the network fee.
+     * @param nativeBalance Native asset balance of the sending account, {@code null} when unknown.
+     * @return {@code true} when the balance does not cover the network fee.
+     */
+    public static boolean hasInsufficientBalanceForGas(
+            @NonNull final TransactionInfo txInfo,
+            @NonNull final ParsedTransaction parsedTx,
+            @Nullable final Double nativeBalance) {
+        return isBalanceCheckSupported(txInfo)
+                && nativeBalance != null
+                && parsedTx.getGasFee() > nativeBalance;
     }
 
     /**

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/TransactionUtils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/TransactionUtils.java
@@ -43,6 +43,52 @@ public class TransactionUtils {
     }
 
     /**
+     * Checks whether the sending account can cover the amount of a transaction and its network fee.
+     * Adapted from {@code accountHasInsufficientFundsForTransaction} in
+     * components/brave_wallet_ui/utils/tx-utils.ts.
+     *
+     * @param txInfo Transaction to verify.
+     * @param parsedTx Parsed {@code txInfo}, holding the amount sent and the network fee.
+     * @param nativeBalance Native asset balance of the sending account, {@code null} when unknown.
+     * @param tokenBalance Balance of the token sent, {@code null} when the transaction does not
+     *     send a token or when the balance is unknown.
+     * @return {@code true} when the balance does not cover the transaction.
+     */
+    public static boolean hasInsufficientBalance(
+            @NonNull final TransactionInfo txInfo,
+            @NonNull final ParsedTransaction parsedTx,
+            @Nullable final Double nativeBalance,
+            @Nullable final Double tokenBalance) {
+        if (!isBalanceCheckSupported(txInfo)) {
+            return false;
+        }
+
+        switch (txInfo.txType) {
+            // Spending can be approved for more tokens than the account holds, and NFT
+            // transfers move a single token that the account is known to own.
+            case TransactionType.ERC20_APPROVE:
+            case TransactionType.ERC721_TRANSFER_FROM:
+            case TransactionType.ERC721_SAFE_TRANSFER_FROM:
+                return false;
+            case TransactionType.ERC20_TRANSFER:
+            case TransactionType.SOLANA_SPL_TOKEN_TRANSFER:
+            case TransactionType.SOLANA_SPL_TOKEN_TRANSFER_WITH_ASSOCIATED_TOKEN_ACCOUNT_CREATION:
+                return tokenBalance != null && parsedTx.getValue() > tokenBalance;
+            default:
+                break;
+        }
+
+        // Swaps selling a token are limited by the balance of the token sold. Swaps selling the
+        // native asset fall through to the check below.
+        if (parsedTx.getIsSwap() && tokenBalance != null) {
+            return parsedTx.getValue() > tokenBalance;
+        }
+
+        // The native asset also pays the network fee, so the balance must cover both.
+        return nativeBalance != null && parsedTx.getValue() + parsedTx.getGasFee() > nativeBalance;
+    }
+
+    /**
      * Checks whether the sending account can cover the network fee of a transaction. Adapted from
      * {@code accountHasInsufficientFundsForGas} in components/brave_wallet_ui/utils/tx-utils.ts.
      *

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/TransactionUtils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/TransactionUtils.java
@@ -41,6 +41,23 @@ public class TransactionUtils {
         }
     }
 
+    /**
+     * Balance checks only cover the coins Android fetches balances for. UTXO based coins are left
+     * out as well, since their transactions are created only once inputs covering both the amount
+     * and the fee have been found.
+     */
+    private static boolean isBalanceCheckSupported(@NonNull final TransactionInfo txInfo) {
+        switch (txInfo.txDataUnion.which()) {
+            case TxDataUnion.Tag.EthTxData:
+            case TxDataUnion.Tag.EthTxData1559:
+            case TxDataUnion.Tag.SolanaTxData:
+            case TxDataUnion.Tag.FilTxData:
+                return true;
+            default:
+                return false;
+        }
+    }
+
     public static @StringRes int getTxType(TransactionInfo info) {
         if (info == null) return R.string.wallet_details_function_type_other;
         switch (info.txType) {

--- a/android/junit/BUILD.gn
+++ b/android/junit/BUILD.gn
@@ -97,6 +97,7 @@ if (is_android) {
         "src/org/chromium/chrome/browser/crypto_wallet/ApproveTxBottomSheetDialogFragmentTest.java",
         "src/org/chromium/chrome/browser/crypto_wallet/TwoLineItemBottomSheetFragmentTest.java",
         "src/org/chromium/chrome/browser/crypto_wallet/WalletBottomSheetDialogFragmentTest.java",
+        "src/org/chromium/chrome/browser/crypto_wallet/util/TransactionUtilsTest.java",
       ]
 
       deps = [

--- a/android/junit/src/org/chromium/chrome/browser/crypto_wallet/util/TransactionUtilsTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/crypto_wallet/util/TransactionUtilsTest.java
@@ -1,0 +1,215 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.crypto_wallet.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.brave_wallet.mojom.AccountId;
+import org.chromium.brave_wallet.mojom.AccountInfo;
+import org.chromium.brave_wallet.mojom.BlockchainToken;
+import org.chromium.brave_wallet.mojom.BtcTxData;
+import org.chromium.brave_wallet.mojom.CoinType;
+import org.chromium.brave_wallet.mojom.NetworkInfo;
+import org.chromium.brave_wallet.mojom.TransactionInfo;
+import org.chromium.brave_wallet.mojom.TransactionType;
+import org.chromium.brave_wallet.mojom.TxData;
+import org.chromium.brave_wallet.mojom.TxData1559;
+import org.chromium.brave_wallet.mojom.TxDataUnion;
+
+import java.util.ArrayList;
+
+/** Tests for the balance checks of {@link TransactionUtils}. */
+@RunWith(BaseRobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class TransactionUtilsTest {
+    private static final String ACCOUNT_ADDRESS = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045";
+    private static final String RECIPIENT_ADDRESS = "0xbc7c0ec6b0e1a4f4f66b6c58f1a3e2d5a0a3f5f2";
+    // 1 ETH in wei.
+    private static final String ONE_ETH = "0xde0b6b3a7640000";
+    // 21000 gas at 1 Gwei, that is 0.000021 ETH.
+    private static final String GAS_LIMIT = "0x5208";
+    private static final String GAS_PRICE = "0x3b9aca00";
+    private static final double GAS_FEE = 0.000021d;
+
+    @Test
+    public void hasInsufficientBalance_wholeNativeBalanceSent_isInsufficient() {
+        // The fee is paid with the asset being sent, so sending the whole balance leaves nothing
+        // to pay it with.
+        TransactionInfo txInfo = createEthTransaction(TransactionType.ETH_SEND, ONE_ETH);
+        ParsedTransaction parsedTx = parse(txInfo, createEthNetwork());
+
+        assertTrue(TransactionUtils.hasInsufficientBalance(txInfo, parsedTx, 1.0d, null));
+    }
+
+    @Test
+    public void hasInsufficientBalance_nativeBalanceCoversAmountAndFee_isSufficient() {
+        TransactionInfo txInfo = createEthTransaction(TransactionType.ETH_SEND, ONE_ETH);
+        ParsedTransaction parsedTx = parse(txInfo, createEthNetwork());
+
+        assertFalse(
+                TransactionUtils.hasInsufficientBalance(txInfo, parsedTx, 1.0d + GAS_FEE, null));
+    }
+
+    @Test
+    public void hasInsufficientBalance_unknownNativeBalance_isSufficient() {
+        TransactionInfo txInfo = createEthTransaction(TransactionType.ETH_SEND, ONE_ETH);
+        ParsedTransaction parsedTx = parse(txInfo, createEthNetwork());
+
+        assertFalse(TransactionUtils.hasInsufficientBalance(txInfo, parsedTx, null, null));
+    }
+
+    @Test
+    public void hasInsufficientBalance_tokenTransferAboveTokenBalance_isInsufficient() {
+        TransactionInfo txInfo = createEthTransaction(TransactionType.ERC20_TRANSFER, "0x0");
+        txInfo.txArgs = new String[] {RECIPIENT_ADDRESS, ONE_ETH};
+        ParsedTransaction parsedTx = parse(txInfo, createEthNetwork());
+
+        assertTrue(TransactionUtils.hasInsufficientBalance(txInfo, parsedTx, 1.0d, 0.5d));
+        assertFalse(TransactionUtils.hasInsufficientBalance(txInfo, parsedTx, 1.0d, 1.0d));
+    }
+
+    @Test
+    public void hasInsufficientBalance_tokenApprovalAboveTokenBalance_isSufficient() {
+        // Spending can be approved for more tokens than the account holds.
+        TransactionInfo txInfo = createEthTransaction(TransactionType.ERC20_APPROVE, "0x0");
+        txInfo.txArgs = new String[] {RECIPIENT_ADDRESS, ONE_ETH};
+        ParsedTransaction parsedTx = parse(txInfo, createEthNetwork());
+
+        assertFalse(TransactionUtils.hasInsufficientBalance(txInfo, parsedTx, 1.0d, 0d));
+    }
+
+    @Test
+    public void hasInsufficientBalance_utxoTransaction_isSufficient() {
+        // UTXO based transactions are created only once inputs covering both the amount and the
+        // fee have been found.
+        TransactionInfo txInfo = createBtcTransaction();
+        ParsedTransaction parsedTx = parse(txInfo, createBtcNetwork());
+
+        assertFalse(TransactionUtils.hasInsufficientBalance(txInfo, parsedTx, 0d, null));
+        assertFalse(TransactionUtils.hasInsufficientBalanceForGas(txInfo, parsedTx, 0d));
+    }
+
+    @Test
+    public void hasInsufficientBalanceForGas_nativeBalanceBelowFee_isInsufficient() {
+        TransactionInfo txInfo = createEthTransaction(TransactionType.ERC20_TRANSFER, "0x0");
+        txInfo.txArgs = new String[] {RECIPIENT_ADDRESS, ONE_ETH};
+        ParsedTransaction parsedTx = parse(txInfo, createEthNetwork());
+
+        assertTrue(TransactionUtils.hasInsufficientBalanceForGas(txInfo, parsedTx, GAS_FEE / 2.0d));
+        assertFalse(TransactionUtils.hasInsufficientBalanceForGas(txInfo, parsedTx, GAS_FEE));
+    }
+
+    private static ParsedTransaction parse(TransactionInfo txInfo, NetworkInfo network) {
+        return ParsedTransaction.parseTransaction(
+                txInfo,
+                network,
+                new AccountInfo[] {createAccount(network.coin)},
+                new ArrayList<>(),
+                /* solFeeEstimatesFee= */ 0,
+                new BlockchainToken[0]);
+    }
+
+    private static TransactionInfo createEthTransaction(
+            @TransactionType.EnumType int txType, String value) {
+        TxData baseData = new TxData();
+        baseData.chainId = "0x1";
+        baseData.nonce = "0x1";
+        baseData.gasPrice = GAS_PRICE;
+        baseData.gasLimit = GAS_LIMIT;
+        baseData.to = RECIPIENT_ADDRESS;
+        baseData.value = value;
+        baseData.data = new byte[0];
+
+        TxData1559 txData1559 = new TxData1559();
+        txData1559.baseData = baseData;
+        txData1559.maxPriorityFeePerGas = "";
+        txData1559.maxFeePerGas = "";
+
+        TxDataUnion txDataUnion = new TxDataUnion();
+        txDataUnion.setEthTxData1559(txData1559);
+
+        return createTransaction(CoinType.ETH, "0x1", txType, txDataUnion);
+    }
+
+    private static TransactionInfo createBtcTransaction() {
+        BtcTxData btcTxData = new BtcTxData();
+        btcTxData.to = RECIPIENT_ADDRESS;
+        btcTxData.amount = 100000L;
+        btcTxData.fee = 1000L;
+
+        TxDataUnion txDataUnion = new TxDataUnion();
+        txDataUnion.setBtcTxData(btcTxData);
+
+        return createTransaction(
+                CoinType.BTC, "bitcoin_mainnet", TransactionType.OTHER, txDataUnion);
+    }
+
+    private static TransactionInfo createTransaction(
+            @CoinType.EnumType int coin,
+            String chainId,
+            @TransactionType.EnumType int txType,
+            TxDataUnion txDataUnion) {
+        TransactionInfo txInfo = new TransactionInfo();
+        txInfo.id = "tx-id";
+        txInfo.txHash = "";
+        txInfo.chainId = chainId;
+        txInfo.txType = txType;
+        txInfo.txArgs = new String[0];
+        txInfo.txParams = new String[0];
+        txInfo.txDataUnion = txDataUnion;
+        txInfo.fromAccountId = createAccountId(coin);
+        return txInfo;
+    }
+
+    private static AccountInfo createAccount(@CoinType.EnumType int coin) {
+        AccountInfo accountInfo = new AccountInfo();
+        accountInfo.accountId = createAccountId(coin);
+        accountInfo.address = ACCOUNT_ADDRESS;
+        accountInfo.name = "Account 1";
+        return accountInfo;
+    }
+
+    private static AccountId createAccountId(@CoinType.EnumType int coin) {
+        AccountId accountId = new AccountId();
+        accountId.coin = coin;
+        accountId.address = ACCOUNT_ADDRESS;
+        accountId.uniqueKey = "unique-key";
+        return accountId;
+    }
+
+    private static NetworkInfo createEthNetwork() {
+        return createNetwork("0x1", "Ethereum Mainnet", "ETH", 18, CoinType.ETH);
+    }
+
+    private static NetworkInfo createBtcNetwork() {
+        return createNetwork("bitcoin_mainnet", "Bitcoin Mainnet", "BTC", 8, CoinType.BTC);
+    }
+
+    private static NetworkInfo createNetwork(
+            String chainId,
+            String chainName,
+            String symbol,
+            int decimals,
+            @CoinType.EnumType int coin) {
+        NetworkInfo network = new NetworkInfo();
+        network.chainId = chainId;
+        network.chainName = chainName;
+        network.symbol = symbol;
+        network.symbolName = chainName;
+        network.decimals = decimals;
+        network.coin = coin;
+        network.blockExplorerUrls = new String[0];
+        network.iconUrls = new String[0];
+        network.supportedKeyrings = new int[0];
+        return network;
+    }
+}

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -2337,6 +2337,12 @@ If you don't accept this request, VPN will not reconnect and your internet conne
     <message name="IDS_BRAVE_WALLET_CONFIRM_TRANSACTION_AMOUNT_FEE" desc="Confirm transaction panel total fee label">
       Amount + fee
     </message>
+    <message name="IDS_BRAVE_WALLET_INSUFFICIENT_BALANCE" desc="Confirm transaction panel error shown when the account balance does not cover the transaction">
+      Insufficient balance
+    </message>
+    <message name="IDS_BRAVE_WALLET_INSUFFICIENT_FUNDS_FOR_GAS" desc="Confirm transaction panel error shown when the account balance does not cover the network fee">
+      Insufficient funds for gas
+    </message>
     <message name="IDS_TRANSACTION" desc="Brave crypto wallet transaction title">
       Transaction
     </message>


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/58273

Approve transaction sheet never checked the account balance, so a transaction the account cannot pay for could be approved, and it then failed on chain after spending the network fee. It is easy to hit by sending the Max amount of the asset that also pays the fee: the amount takes the whole balance and nothing is left for gas. Desktop already blocks this in the confirm panel via `accountHasInsufficientFundsForTransaction` and `accountHasInsufficientFundsForGas`, which disable the confirm button and show a warning. Android had no equivalent.

## Changes

* `TransactionUtils.hasInsufficientBalance()` and `TransactionUtils.hasInsufficientBalanceForGas()` are ported from `components/brave_wallet_ui/utils/tx-utils.ts`. Token transfers compare against the token balance, spending approvals and NFT transfers are never blocked, everything else compares the amount plus the fee against the native balance. Only ETH, SOL and FIL are checked, since those are the coins Android fetches balances for. UTXO based coins are skipped because their transactions are built only once inputs covering both the amount and the fee have been found.
* `ApproveTxBottomSheetDialogFragment` now keeps the balances returned by `Utils.getTxExtraInfo`, which were previously discarded, runs the checks and shows a warning above the action buttons. A balance that fails to load is reported as zero, so a zero balance is treated as unknown and never blocks an approval.
* The approve button starts disabled in the layout and is enabled only once the balances are known, so it never flips from enabled to disabled while they load. Reject stays available at all times.
* Two new Android strings, worded as on desktop: "Insufficient balance" and "Insufficient funds for gas".
* junit coverage for the new checks, including the reported case of sending the whole native balance.

## Screenshots

<img width="698" height="1448" alt="Screenshot 2026-08-24 at 3 39 34 PM" src="https://github.com/user-attachments/assets/be3a07eb-094e-42bd-aeda-8d5b549287fa" />

<img width="698" height="1448" alt="Screenshot 2026-08-24 at 6 13 16 PM" src="https://github.com/user-attachments/assets/823c0fb7-5dc0-4699-ad2e-34e6ecd47351" />


## Test plan

1. Create a Send transaction for the asset that also pays the network fee, for example ETH on Sepolia.
2. Set the amount to Max and continue to the approve sheet.
3. Approve is disabled and "Insufficient balance" is shown. Reject still dismisses the transaction.
4. Repeat with an amount that leaves room for the fee. Approve is enabled and the transaction is submitted and confirmed.
5. Send an ERC20 token from an account holding no native asset. Approve is disabled and "Insufficient funds for gas" is shown.
6. Approve a dApp transaction that the account can cover and confirm nothing regressed.



<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
