### PR TITLE
Disables upstream's IPH popup for vertical tabs. (uplift to 1.94.x)

### DIFF
--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -150,6 +150,7 @@ TEST(FeatureDefaultsTest, DisabledFeatures) {
       &feature_engagement::kIPHReadingListInSidePanelFeature,
       &feature_engagement::kIPHSideBySidePinnableFeature,
       &feature_engagement::kIPHSideBySideTabSwitchFeature,
+      &feature_engagement::kIPHVerticalTabstripTutorialFeature,
 #endif
       &features::kBookmarkTriggerForPrefetch,
       &features::kChromeStructuredMetrics,

--- a/chromium_src/components/feature_engagement/public/feature_constants.cc
+++ b/chromium_src/components/feature_engagement/public/feature_constants.cc
@@ -31,6 +31,7 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
     {kIPHSideBySidePinnableFeature, base::FEATURE_DISABLED_BY_DEFAULT},
     {kIPHSideBySideTabSwitchFeature, base::FEATURE_DISABLED_BY_DEFAULT},
     {kIPHTabGroupsSaveV2IntroFeature, base::FEATURE_DISABLED_BY_DEFAULT},
+    {kIPHVerticalTabstripTutorialFeature, base::FEATURE_DISABLED_BY_DEFAULT},
 #endif
 }});
 


### PR DESCRIPTION
Uplift of #38978
Resolves https://github.com/brave/brave-browser/issues/58036

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.