### PR TITLE
Disable kTLSTrustAnchorIDs feature flag (uplift to 1.94.x)

### DIFF
--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -218,6 +218,7 @@ TEST(FeatureDefaultsTest, DisabledFeatures) {
       &metrics::structured::kPhoneHubStructuredMetrics,
       &multistep_filter::kMultistepFilter,
       &net::features::kEnableWebTransportDraft07,
+      &net::features::kTLSTrustAnchorIDs,
       &network::features::kBrowsingTopics,
       &network::features::kSharedStorageAPI,
       &network_time::kNetworkTimeServiceQuerying,

--- a/chromium_src/net/base/features.cc
+++ b/chromium_src/net/base/features.cc
@@ -15,6 +15,7 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
     // Enable NIK-partitioning by default.
     {kPartitionConnectionsByNetworkIsolationKey,
      base::FEATURE_ENABLED_BY_DEFAULT},
+    {kTLSTrustAnchorIDs, base::FEATURE_DISABLED_BY_DEFAULT},
 }});
 
 BASE_FEATURE(kBraveEphemeralStorageKeepAlive,

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -2438,6 +2438,13 @@
 # in CR152), see https://issues.chromium.org/issues/539681873
 -ContextualSearchboxHandlerBrowserTest.WaitForTabFaviconLoad_Cached
 
+# These tests fail because we disable `net::features::kTLSTrustAnchorIDs`. The
+# /1 (kVerifyMTCs=true) variants expect the server to select certs by TAI, which
+# no longer happens; the /0 variants pass because they already expect the no-TAI
+# fallback behavior.
+-PKIMetadataComponentChromeRootStoreMtcMetadataTest.EndToEnd/1
+-PKIMetadataComponentChromeRootStoreMtcMetadataTest.Revocation/1
+
 # Tests below this point have not been diagnosed or had issues created yet.
 -All/DeclarativeNetRequestBrowserTest.RendererCacheCleared/*
 -All/FromGWSNavigationAndKeepAliveRequestBrowserTest.TwoDifferentCategoryRequestAndTwoDifferentCategoryNavigationsFromSRP/*


### PR DESCRIPTION
Uplift of #39274
Resolves https://github.com/brave/brave-browser/issues/58306

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.