### PR TITLE
[Android] Guard Origin subscription prefs against destroyed profiles

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -1384,7 +1384,10 @@ public abstract class BraveActivity extends ChromeActivity
             BraveOriginSubscriptionPrefs.requestCredentialSummary(
                     profile,
                     (isActive) -> {
-                        if (!BraveOriginSubscriptionPrefs.getIsSubscriptionActive(profile)
+                        // The summary request is asynchronous, so the profile captured above may
+                        // already be destroyed by the time this runs.
+                        if (BraveOriginSubscriptionPrefs.isProfileUsable(profile)
+                                && !BraveOriginSubscriptionPrefs.getIsSubscriptionActive(profile)
                                 && !isActive) {
                             BraveOriginSubscriptionPrefs.verifyPurchase(profile);
                         }

--- a/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSubscriptionPrefs.java
+++ b/android/java/org/chromium/chrome/browser/brave_origin/BraveOriginSubscriptionPrefs.java
@@ -26,6 +26,7 @@ import org.chromium.brave.browser.skus.SkusServiceFactory;
 import org.chromium.brave.browser.util.BraveDomainsUtils;
 import org.chromium.brave.browser.util.ServicesEnvironment;
 import org.chromium.brave_origin.mojom.BraveOriginSettingsHandler;
+import org.chromium.build.annotations.Contract;
 import org.chromium.build.annotations.NullMarked;
 import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.browser.billing.InAppPurchaseWrapper;
@@ -83,6 +84,32 @@ public class BraveOriginSubscriptionPrefs {
     private static boolean sFetchInProgress;
 
     /**
+     * True while {@code profile} can still be used to reach native prefs and services.
+     *
+     * <p>Every Origin flow here spans a long async chain (Play Store billing queries, Skus mojo
+     * round-trips), so a profile captured when the chain started can be destroyed before a callback
+     * runs. A destroyed profile keeps its Java object alive, so a plain null check still passes
+     * while {@code UserPrefs.get()} returns null.
+     */
+    @Contract("null -> false")
+    public static boolean isProfileUsable(@Nullable Profile profile) {
+        return profile != null && !profile.shutdownStarted();
+    }
+
+    /**
+     * Returns the {@link PrefService} for {@code profile}, or null when prefs are out of reach.
+     *
+     * <p>{@link UserPrefs#get} is declared non-null but returns null for a destroyed
+     * BrowserContext, so its result is checked as well as the profile.
+     */
+    private static @Nullable PrefService getPrefs(@Nullable Profile profile) {
+        if (!isProfileUsable(profile)) {
+            return null;
+        }
+        return UserPrefs.get(profile);
+    }
+
+    /**
      * Registers a one-shot callback that will be invoked on the UI thread when
      * fetchOrderCredentials finishes. Any previously registered callback is replaced.
      *
@@ -107,10 +134,10 @@ public class BraveOriginSubscriptionPrefs {
      * has not yet completed (order ID is still empty).
      */
     public static boolean isFetchingCredentials(@Nullable Profile profile) {
-        if (profile == null) {
+        PrefService prefService = getPrefs(profile);
+        if (prefService == null) {
             return false;
         }
-        PrefService prefService = UserPrefs.get(profile);
         return prefService.getBoolean(BravePref.BRAVE_ORIGIN_SUBSCRIPTION_ACTIVE_ANDROID)
                 && prefService.getString(BravePref.BRAVE_ORIGIN_ORDER_ID_ANDROID).isEmpty()
                 && !prefService.getString(BravePref.BRAVE_ORIGIN_PURCHASE_TOKEN_ANDROID).isEmpty();
@@ -131,12 +158,16 @@ public class BraveOriginSubscriptionPrefs {
      * @param profile The profile to use for the operation.
      */
     public static void resumeCredentialFetchIfNeeded(@Nullable Profile profile) {
-        if (profile == null || sFetchInProgress || !isFetchingCredentials(profile)) {
+        if (sFetchInProgress || !isFetchingCredentials(profile)) {
             return;
         }
-        // isFetchingCredentials() already guarantees the purchase token is non-empty.
-        String purchaseToken =
-                UserPrefs.get(profile).getString(BravePref.BRAVE_ORIGIN_PURCHASE_TOKEN_ANDROID);
+        // isFetchingCredentials() already guarantees the prefs are reachable and that the purchase
+        // token is non-empty.
+        PrefService prefService = getPrefs(profile);
+        if (prefService == null) {
+            return;
+        }
+        String purchaseToken = prefService.getString(BravePref.BRAVE_ORIGIN_PURCHASE_TOKEN_ANDROID);
         createFetchOrder(profile, purchaseToken);
         // Mirror verifyPurchase(): open the Origin settings screen so the user sees the spinner
         // while credentials finish fetching and is then prompted to restart, since the enforced
@@ -204,12 +235,12 @@ public class BraveOriginSubscriptionPrefs {
      * @param value The subscription active status
      */
     public static void setIsSubscriptionActive(@Nullable Profile profile, boolean value) {
-        if (profile == null) {
-            Log.e(TAG, "setIsSubscriptionActive profile is null");
+        PrefService prefService = getPrefs(profile);
+        if (prefService == null) {
+            Log.e(TAG, "setIsSubscriptionActive prefs are unavailable");
             return;
         }
-        UserPrefs.get(profile)
-                .setBoolean(BravePref.BRAVE_ORIGIN_SUBSCRIPTION_ACTIVE_ANDROID, value);
+        prefService.setBoolean(BravePref.BRAVE_ORIGIN_SUBSCRIPTION_ACTIVE_ANDROID, value);
     }
 
     /**
@@ -223,15 +254,15 @@ public class BraveOriginSubscriptionPrefs {
      * #requestCredentialSummary} (async, via the Skus mojo service).
      *
      * @param profile The profile to use for preference retrieval
-     * @return The Play Store subscription active status, or false if profile is null
+     * @return The Play Store subscription active status, or false if the profile is unusable
      */
     public static boolean getIsSubscriptionActive(@Nullable Profile profile) {
-        if (profile == null) {
-            Log.e(TAG, "getIsSubscriptionActive profile is null");
+        PrefService prefService = getPrefs(profile);
+        if (prefService == null) {
+            Log.e(TAG, "getIsSubscriptionActive prefs are unavailable");
             return false;
         }
-        return UserPrefs.get(profile)
-                .getBoolean(BravePref.BRAVE_ORIGIN_SUBSCRIPTION_ACTIVE_ANDROID);
+        return prefService.getBoolean(BravePref.BRAVE_ORIGIN_SUBSCRIPTION_ACTIVE_ANDROID);
     }
 
     /**
@@ -241,11 +272,11 @@ public class BraveOriginSubscriptionPrefs {
      * @param token The purchase token
      */
     public static void setOriginPurchaseToken(@Nullable Profile profile, String token) {
-        if (profile == null) {
-            Log.e(TAG, "setOriginPurchaseToken profile is null");
+        PrefService prefService = getPrefs(profile);
+        if (prefService == null) {
+            Log.e(TAG, "setOriginPurchaseToken prefs are unavailable");
             return;
         }
-        PrefService prefService = UserPrefs.get(profile);
         if (prefService.getString(BravePref.BRAVE_ORIGIN_PURCHASE_TOKEN_ANDROID).equals(token)
                 && !prefService.getString(BravePref.BRAVE_ORIGIN_ORDER_ID_ANDROID).isEmpty()) {
             return;
@@ -266,14 +297,14 @@ public class BraveOriginSubscriptionPrefs {
      * @param profile The profile to use for preference storage
      */
     public static void setOriginPackageName(@Nullable Profile profile) {
-        if (profile == null) {
-            Log.e(TAG, "setOriginPackageName profile is null");
+        PrefService prefService = getPrefs(profile);
+        if (prefService == null) {
+            Log.e(TAG, "setOriginPackageName prefs are unavailable");
             return;
         }
-        UserPrefs.get(profile)
-                .setString(
-                        BravePref.BRAVE_ORIGIN_PACKAGE_NAME_ANDROID,
-                        ContextUtils.getApplicationContext().getPackageName());
+        prefService.setString(
+                BravePref.BRAVE_ORIGIN_PACKAGE_NAME_ANDROID,
+                ContextUtils.getApplicationContext().getPackageName());
     }
 
     /**
@@ -283,11 +314,12 @@ public class BraveOriginSubscriptionPrefs {
      * @param productId The product ID
      */
     public static void setOriginProductId(@Nullable Profile profile, String productId) {
-        if (profile == null) {
-            Log.e(TAG, "setOriginProductId profile is null");
+        PrefService prefService = getPrefs(profile);
+        if (prefService == null) {
+            Log.e(TAG, "setOriginProductId prefs are unavailable");
             return;
         }
-        UserPrefs.get(profile).setString(BravePref.BRAVE_ORIGIN_PRODUCT_ID_ANDROID, productId);
+        prefService.setString(BravePref.BRAVE_ORIGIN_PRODUCT_ID_ANDROID, productId);
     }
 
     /**
@@ -297,14 +329,13 @@ public class BraveOriginSubscriptionPrefs {
      * @return True if subscription is linked, false otherwise
      */
     public static boolean isSubscriptionLinked(@Nullable Profile profile) {
-        if (profile == null) {
-            Log.e(TAG, "isSubscriptionLinked profile is null");
+        PrefService prefService = getPrefs(profile);
+        if (prefService == null) {
+            Log.e(TAG, "isSubscriptionLinked prefs are unavailable");
             return false;
         }
 
-        return UserPrefs.get(profile)
-                        .getInteger(BravePref.BRAVE_ORIGIN_SUBSCRIPTION_LINK_STATUS_ANDROID)
-                != 0;
+        return prefService.getInteger(BravePref.BRAVE_ORIGIN_SUBSCRIPTION_LINK_STATUS_ANDROID) != 0;
     }
 
     /**
@@ -313,12 +344,12 @@ public class BraveOriginSubscriptionPrefs {
      * @param profile The profile to use for preference storage
      */
     private static void resetSubscriptionLinkedStatus(@Nullable Profile profile) {
-        if (profile == null) {
-            Log.e(TAG, "resetSubscriptionLinkedStatus profile is null");
+        PrefService prefService = getPrefs(profile);
+        if (prefService == null) {
+            Log.e(TAG, "resetSubscriptionLinkedStatus prefs are unavailable");
             return;
         }
-        UserPrefs.get(profile)
-                .setInteger(BravePref.BRAVE_ORIGIN_SUBSCRIPTION_LINK_STATUS_ANDROID, 0);
+        prefService.setInteger(BravePref.BRAVE_ORIGIN_SUBSCRIPTION_LINK_STATUS_ANDROID, 0);
     }
 
     /**
@@ -327,9 +358,13 @@ public class BraveOriginSubscriptionPrefs {
      * @param profile The profile to use for the operation
      * @param purchaseToken The purchase token to use for the operation
      */
-    private static void createFetchOrder(Profile profile, String purchaseToken) {
+    private static void createFetchOrder(@Nullable Profile profile, String purchaseToken) {
+        PrefService prefService = getPrefs(profile);
+        if (prefService == null) {
+            Log.e(TAG, "createFetchOrder prefs are unavailable");
+            return;
+        }
         sFetchInProgress = true;
-        PrefService prefService = UserPrefs.get(profile);
         String packageName = prefService.getString(BravePref.BRAVE_ORIGIN_PACKAGE_NAME_ANDROID);
         String productId = prefService.getString(BravePref.BRAVE_ORIGIN_PRODUCT_ID_ANDROID);
 
@@ -361,6 +396,13 @@ public class BraveOriginSubscriptionPrefs {
                     PostTask.postTask(
                             TaskTraits.UI_DEFAULT,
                             () -> {
+                                // Hopping threads gave the profile a chance to go away, and the
+                                // service factory dereferences its native handle.
+                                if (!isProfileUsable(profile)) {
+                                    Log.e(TAG, "createFetchOrder profile is destroyed");
+                                    notifyCredentialsFetched(false);
+                                    return;
+                                }
                                 SkusService skusService =
                                         SkusServiceFactory.getInstance()
                                                 .getSkusService(profile, null);
@@ -431,9 +473,13 @@ public class BraveOriginSubscriptionPrefs {
                                             + (result != null ? result.message : "null result"));
                             return;
                         }
+                        PrefService prefService = getPrefs(profile);
+                        if (prefService == null) {
+                            Log.e(TAG, "fetchOrderCredentials prefs are unavailable");
+                            return;
+                        }
                         // Store the order ID
-                        UserPrefs.get(profile)
-                                .setString(BravePref.BRAVE_ORIGIN_ORDER_ID_ANDROID, orderId);
+                        prefService.setString(BravePref.BRAVE_ORIGIN_ORDER_ID_ANDROID, orderId);
                         // A successful Play Store order fetch is an authoritative "Origin is
                         // active" signal; prime the sync cache immediately so promo gates honor
                         // it without waiting for the next credential summary refresh.
@@ -455,8 +501,8 @@ public class BraveOriginSubscriptionPrefs {
      */
     public static void requestCredentialSummary(
             @Nullable Profile profile, @Nullable Callback<Boolean> callback) {
-        if (profile == null) {
-            Log.e(TAG, "requestCredentialSummary profile is null");
+        if (!isProfileUsable(profile)) {
+            Log.e(TAG, "requestCredentialSummary profile is null or destroyed");
             if (callback != null) {
                 callback.onResult(false);
             }
@@ -566,12 +612,12 @@ public class BraveOriginSubscriptionPrefs {
      * @param profile The profile to use for preference clearing
      */
     public static void clearOriginSubscriptionPrefs(@Nullable Profile profile) {
-        if (profile == null) {
-            Log.e(TAG, "clearOriginSubscriptionPrefs profile is null");
+        PrefService prefService = getPrefs(profile);
+        if (prefService == null) {
+            Log.e(TAG, "clearOriginSubscriptionPrefs prefs are unavailable");
             return;
         }
 
-        PrefService prefService = UserPrefs.get(profile);
         prefService.setBoolean(BravePref.BRAVE_ORIGIN_SUBSCRIPTION_ACTIVE_ANDROID, false);
         prefService.setString(BravePref.BRAVE_ORIGIN_PURCHASE_TOKEN_ANDROID, "");
         prefService.setString(BravePref.BRAVE_ORIGIN_PRODUCT_ID_ANDROID, "");
@@ -647,8 +693,10 @@ public class BraveOriginSubscriptionPrefs {
             return;
         }
 
-        // If Brave Origin feature is not enabled or profile is null, policies are not applicable
-        if (!ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_ORIGIN) || profile == null) {
+        // If Brave Origin feature is not enabled or the profile is gone, policies are not
+        // applicable
+        if (!ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_ORIGIN)
+                || !isProfileUsable(profile)) {
             for (Callback<Boolean> callback : policyCallbacks.values()) {
                 if (callback != null) {
                     callback.onResult(false);
@@ -661,8 +709,9 @@ public class BraveOriginSubscriptionPrefs {
         requestCredentialSummary(
                 profile,
                 (isSubscriptionActive) -> {
-                    // If subscription is not active, all features are enabled (not disabled)
-                    if (!isSubscriptionActive) {
+                    // If subscription is not active, all features are enabled (not disabled). The
+                    // profile is re-checked because the summary request is asynchronous.
+                    if (!isSubscriptionActive || !isProfileUsable(profile)) {
                         for (Callback<Boolean> callback : policyCallbacks.values()) {
                             if (callback != null) {
                                 callback.onResult(false);

--- a/android/junit/BUILD.gn
+++ b/android/junit/BUILD.gn
@@ -116,9 +116,15 @@ if (is_android) {
 
   robolectric_library(
       "brave_junit_tests_org.chromium.chrome.browser.brave_origin") {
-    sources = [ "src/org/chromium/chrome/browser/brave_origin/BraveOriginDeepLinkHandlerTest.java" ]
+    sources = [
+      "src/org/chromium/chrome/browser/brave_origin/BraveOriginDeepLinkHandlerTest.java",
+      "src/org/chromium/chrome/browser/brave_origin/BraveOriginSubscriptionPrefsTest.java",
+    ]
 
-    deps = [ "//chrome/android/junit:chrome_junit_tests_helper" ]
+    deps = [
+      "//brave/browser/android/preferences:pref_names_java",
+      "//chrome/android/junit:chrome_junit_tests_helper",
+    ]
   }
 
   robolectric_library("brave_junit_tests_org.chromium.chrome.browser") {

--- a/android/junit/src/org/chromium/chrome/browser/brave_origin/BraveOriginSubscriptionPrefsTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/brave_origin/BraveOriginSubscriptionPrefsTest.java
@@ -1,0 +1,106 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.brave_origin;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import androidx.test.filters.SmallTest;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.chrome.browser.preferences.BravePref;
+import org.chromium.chrome.browser.profiles.Profile;
+import org.chromium.components.prefs.PrefService;
+import org.chromium.components.user_prefs.UserPrefs;
+
+/** Unit tests for {@link BraveOriginSubscriptionPrefs}. */
+@RunWith(BaseRobolectricTestRunner.class)
+public class BraveOriginSubscriptionPrefsTest {
+    @Rule public MockitoRule mMockitoRule = MockitoJUnit.rule();
+
+    @Mock private Profile mProfile;
+    @Mock private PrefService mPrefService;
+
+    @Before
+    public void setUp() {
+        UserPrefs.setPrefServiceForTesting(mPrefService);
+    }
+
+    @Test
+    @SmallTest
+    public void isProfileUsable_nullProfile_returnsFalse() {
+        assertFalse(BraveOriginSubscriptionPrefs.isProfileUsable(null));
+    }
+
+    @Test
+    @SmallTest
+    public void isProfileUsable_destroyedProfile_returnsFalse() {
+        when(mProfile.shutdownStarted()).thenReturn(true);
+
+        assertFalse(BraveOriginSubscriptionPrefs.isProfileUsable(mProfile));
+    }
+
+    @Test
+    @SmallTest
+    public void isProfileUsable_liveProfile_returnsTrue() {
+        when(mProfile.shutdownStarted()).thenReturn(false);
+
+        assertTrue(BraveOriginSubscriptionPrefs.isProfileUsable(mProfile));
+    }
+
+    /**
+     * A profile destroyed while an async Origin flow was in flight must not reach the prefs: its
+     * native BrowserContext is gone, so UserPrefs.get() returns null despite being declared
+     * non-null. See https://github.com/brave/brave-browser/issues/NNNNN.
+     */
+    @Test
+    @SmallTest
+    public void setIsSubscriptionActive_destroyedProfile_doesNotWritePrefs() {
+        when(mProfile.shutdownStarted()).thenReturn(true);
+
+        BraveOriginSubscriptionPrefs.setIsSubscriptionActive(mProfile, true);
+
+        verifyNoInteractions(mPrefService);
+    }
+
+    @Test
+    @SmallTest
+    public void setIsSubscriptionActive_nullProfile_doesNotWritePrefs() {
+        BraveOriginSubscriptionPrefs.setIsSubscriptionActive(null, true);
+
+        verifyNoInteractions(mPrefService);
+    }
+
+    @Test
+    @SmallTest
+    public void setIsSubscriptionActive_liveProfile_writesPref() {
+        when(mProfile.shutdownStarted()).thenReturn(false);
+
+        BraveOriginSubscriptionPrefs.setIsSubscriptionActive(mProfile, true);
+
+        verify(mPrefService).setBoolean(BravePref.BRAVE_ORIGIN_SUBSCRIPTION_ACTIVE_ANDROID, true);
+    }
+
+    @Test
+    @SmallTest
+    public void getIsSubscriptionActive_destroyedProfile_returnsFalseWithoutReadingPrefs() {
+        when(mProfile.shutdownStarted()).thenReturn(true);
+
+        assertFalse(BraveOriginSubscriptionPrefs.getIsSubscriptionActive(mProfile));
+        verifyNoInteractions(mPrefService);
+    }
+}


### PR DESCRIPTION
`setIsSubscriptionActive()` crashed on `UserPrefs.get(profile).setBoolean()`: `UserPrefs.get()` is declared non-null but returns null once the profile's native `BrowserContext` is gone, so the plain null check on the Profile let it through. The profile is captured at startup and then held across the Play Store billing query, leaving time for it to be destroyed before the callback runs.

Route every pref access through `getPrefs()`, which checks both `Profile.shutdownStarted()` and the `UserPrefs.get()` result, and re-check the profile at the async hops that pass it to the Skus and Origin service factories.

https://github.com/brave/brave-browser/issues/58386

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
