### PR TITLE
Attempt to locally process omnibox input if suggestion is suppressed and it looks like arithmetic

### DIFF
--- a/components/omnibox/browser/BUILD.gn
+++ b/components/omnibox/browser/BUILD.gn
@@ -7,6 +7,18 @@ import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 import("//brave/components/commander/common/buildflags/buildflags.gni")
 import("//brave/components/omnibox/buildflags/buildflags.gni")
 
+source_set("arithmetic_evaluator") {
+  sources = [
+    "arithmetic_evaluator.cc",
+    "arithmetic_evaluator.h",
+  ]
+
+  deps = [
+    "//base",
+    "//base:i18n",
+  ]
+}
+
 source_set("unit_tests") {
   testonly = true
 
@@ -41,6 +53,7 @@ source_set("unit_tests") {
     "//brave/components/brave_search_conversion",
     "//brave/components/constants",
     "//brave/components/l10n/common:test_support",
+    "//brave/components/omnibox/browser:arithmetic_evaluator",
     "//brave/components/omnibox/buildflags",
     "//brave/components/search_engines",
     "//chrome/browser/history",

--- a/components/omnibox/browser/BUILD.gn
+++ b/components/omnibox/browser/BUILD.gn
@@ -95,6 +95,7 @@ source_set("unit_tests") {
     ]
 
     deps += [
+      "//base:i18n",
       "//brave/components/omnibox/browser:arithmetic_evaluator",
       "//brave/components/omnibox/browser/search_suggestions",
     ]

--- a/components/omnibox/browser/BUILD.gn
+++ b/components/omnibox/browser/BUILD.gn
@@ -7,23 +7,26 @@ import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 import("//brave/components/commander/common/buildflags/buildflags.gni")
 import("//brave/components/omnibox/buildflags/buildflags.gni")
 
-source_set("arithmetic_evaluator") {
-  sources = [
-    "arithmetic_evaluator.cc",
-    "arithmetic_evaluator.h",
-  ]
+# Only reachable from the strict query check, which stands in for the suggest
+# results it withholds.
+if (enable_strict_query_check_for_search_suggestions) {
+  source_set("arithmetic_evaluator") {
+    sources = [
+      "arithmetic_evaluator.cc",
+      "arithmetic_evaluator.h",
+    ]
 
-  deps = [
-    "//base",
-    "//base:i18n",
-  ]
+    deps = [
+      "//base",
+      "//base:i18n",
+    ]
+  }
 }
 
 source_set("unit_tests") {
   testonly = true
 
   sources = [
-    "//brave/components/omnibox/browser/arithmetic_evaluator_unittest.cc",
     "//brave/components/omnibox/browser/brave_bookmark_provider_unittest.cc",
     "//brave/components/omnibox/browser/brave_fake_autocomplete_provider_client.cc",
     "//brave/components/omnibox/browser/brave_fake_autocomplete_provider_client.h",
@@ -53,7 +56,6 @@ source_set("unit_tests") {
     "//brave/components/brave_search_conversion",
     "//brave/components/constants",
     "//brave/components/l10n/common:test_support",
-    "//brave/components/omnibox/browser:arithmetic_evaluator",
     "//brave/components/omnibox/buildflags",
     "//brave/components/search_engines",
     "//components/bookmarks/browser",
@@ -88,7 +90,14 @@ source_set("unit_tests") {
   }
 
   if (enable_strict_query_check_for_search_suggestions) {
-    deps += [ "//brave/components/omnibox/browser/search_suggestions" ]
+    sources += [
+      "//brave/components/omnibox/browser/arithmetic_evaluator_unittest.cc",
+    ]
+
+    deps += [
+      "//brave/components/omnibox/browser:arithmetic_evaluator",
+      "//brave/components/omnibox/browser/search_suggestions",
+    ]
   }
 
   if (enable_commander) {

--- a/components/omnibox/browser/BUILD.gn
+++ b/components/omnibox/browser/BUILD.gn
@@ -56,7 +56,6 @@ source_set("unit_tests") {
     "//brave/components/omnibox/browser:arithmetic_evaluator",
     "//brave/components/omnibox/buildflags",
     "//brave/components/search_engines",
-    "//chrome/browser/history",
     "//components/bookmarks/browser",
     "//components/bookmarks/test",
     "//components/omnibox/browser",
@@ -75,8 +74,12 @@ source_set("unit_tests") {
     deps += [ "//brave/components/ai_chat/core/common" ]
   }
 
+  # This target isn't built on iOS, but GN still defines it there and resolves
+  # these labels, and //chrome/... asserts it isn't reachable from an iOS
+  # build. Keep every //chrome dep in here.
   if (!is_ios) {
     deps += [
+      "//chrome/browser/history",
       "//chrome/browser/search_engines",
       "//chrome/test:test_support",
       "//content/test:test_support",

--- a/components/omnibox/browser/BUILD.gn
+++ b/components/omnibox/browser/BUILD.gn
@@ -11,6 +11,7 @@ source_set("unit_tests") {
   testonly = true
 
   sources = [
+    "//brave/components/omnibox/browser/arithmetic_evaluator_unittest.cc",
     "//brave/components/omnibox/browser/brave_bookmark_provider_unittest.cc",
     "//brave/components/omnibox/browser/brave_fake_autocomplete_provider_client.cc",
     "//brave/components/omnibox/browser/brave_fake_autocomplete_provider_client.h",

--- a/components/omnibox/browser/arithmetic_evaluator.cc
+++ b/components/omnibox/browser/arithmetic_evaluator.cc
@@ -1,0 +1,325 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/omnibox/browser/arithmetic_evaluator.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <numeric>
+
+#include "base/i18n/number_formatting.h"
+#include "base/numerics/checked_math.h"
+#include "base/strings/string_util.h"
+
+namespace omnibox {
+
+namespace {
+
+// Fractional answers are rendered through a double, so their significant
+// digits are capped at what a double round-trips exactly. Integer answers are
+// formatted straight from the int64 and aren't subject to this.
+constexpr int kMaxSignificantDigits = 15;
+
+// Bounds recursion on untrusted omnibox input.
+constexpr int kMaxParenDepth = 16;
+
+// Well below what would overflow: a larger power is more likely a typo than a
+// calculation, and evaluating it is pointless once the result can't be shown.
+constexpr int64_t kMaxExponent = 64;
+
+using CheckedInt = base::CheckedNumeric<int64_t>;
+
+// An exact rational. `den` is always positive, gcd(|num|, den) == 1, and
+// neither field is int64 min, so both can always be negated.
+struct Rational {
+  int64_t num = 0;
+  int64_t den = 1;
+};
+
+std::optional<Rational> MakeRational(CheckedInt numerator,
+                                     CheckedInt denominator) {
+  int64_t num = 0;
+  int64_t den = 0;
+  if (!numerator.AssignIfValid(&num) || !denominator.AssignIfValid(&den)) {
+    return std::nullopt;
+  }
+  // int64 min is excluded so negation and std::gcd are always well defined.
+  constexpr int64_t kMin = std::numeric_limits<int64_t>::min();
+  if (den == 0 || num == kMin || den == kMin) {
+    return std::nullopt;
+  }
+  if (den < 0) {
+    num = -num;
+    den = -den;
+  }
+  const int64_t divisor = std::gcd(num, den);
+  return Rational{num / divisor, den / divisor};
+}
+
+std::optional<Rational> Add(const Rational& a, const Rational& b) {
+  return MakeRational(CheckedInt(a.num) * b.den + CheckedInt(b.num) * a.den,
+                      CheckedInt(a.den) * b.den);
+}
+
+std::optional<Rational> Subtract(const Rational& a, const Rational& b) {
+  return MakeRational(CheckedInt(a.num) * b.den - CheckedInt(b.num) * a.den,
+                      CheckedInt(a.den) * b.den);
+}
+
+std::optional<Rational> Multiply(const Rational& a, const Rational& b) {
+  return MakeRational(CheckedInt(a.num) * b.num, CheckedInt(a.den) * b.den);
+}
+
+std::optional<Rational> Divide(const Rational& a, const Rational& b) {
+  if (b.num == 0) {
+    return std::nullopt;
+  }
+  return MakeRational(CheckedInt(a.num) * b.den, CheckedInt(a.den) * b.num);
+}
+
+std::optional<Rational> Power(const Rational& base, const Rational& exponent) {
+  // A fractional exponent gives an irrational result for all but a handful of
+  // inputs, so don't try.
+  if (exponent.den != 1) {
+    return std::nullopt;
+  }
+  // Negation is safe: `Rational` excludes int64 min.
+  const int64_t magnitude = std::abs(exponent.num);
+  if (magnitude > kMaxExponent) {
+    return std::nullopt;
+  }
+
+  Rational result{1, 1};
+  for (int64_t i = 0; i < magnitude; ++i) {
+    auto next = Multiply(result, base);
+    if (!next) {
+      return std::nullopt;
+    }
+    result = *next;
+  }
+  if (exponent.num < 0) {
+    return Divide(Rational{1, 1}, result);
+  }
+  return result;
+}
+
+// Recursive descent over:
+//   sum     := product (('+' | '-') product)*
+//   product := unary (('*' | '/') unary)*
+//   unary   := ('+' | '-')* power
+//   power   := primary ('^' unary)?
+//   primary := '(' sum ')' | number
+class Parser {
+ public:
+  explicit Parser(std::u16string_view text) : text_(text) {}
+
+  std::optional<Rational> Parse() {
+    auto value = ParseSum();
+    SkipWhitespace();
+    // Trailing junk means this wasn't an expression after all.
+    if (!value || pos_ != text_.size()) {
+      return std::nullopt;
+    }
+    return value;
+  }
+
+ private:
+  void SkipWhitespace() {
+    while (pos_ < text_.size() && base::IsUnicodeWhitespace(text_[pos_])) {
+      ++pos_;
+    }
+  }
+
+  bool ConsumeIf(char16_t c) {
+    SkipWhitespace();
+    if (pos_ < text_.size() && text_[pos_] == c) {
+      ++pos_;
+      return true;
+    }
+    return false;
+  }
+
+  std::optional<Rational> ParseSum() {
+    auto value = ParseProduct();
+    while (value) {
+      if (ConsumeIf(u'+')) {
+        auto rhs = ParseProduct();
+        value = rhs ? Add(*value, *rhs) : std::nullopt;
+      } else if (ConsumeIf(u'-')) {
+        auto rhs = ParseProduct();
+        value = rhs ? Subtract(*value, *rhs) : std::nullopt;
+      } else {
+        break;
+      }
+    }
+    return value;
+  }
+
+  std::optional<Rational> ParseProduct() {
+    auto value = ParseUnary();
+    while (value) {
+      if (ConsumeIf(u'*')) {
+        auto rhs = ParseUnary();
+        value = rhs ? Multiply(*value, *rhs) : std::nullopt;
+      } else if (ConsumeIf(u'/')) {
+        auto rhs = ParseUnary();
+        value = rhs ? Divide(*value, *rhs) : std::nullopt;
+      } else {
+        break;
+      }
+    }
+    return value;
+  }
+
+  std::optional<Rational> ParseUnary() {
+    if (ConsumeIf(u'-')) {
+      auto value = ParseUnary();
+      // Negating in place is exact: `Rational` is reduced and excludes int64
+      // min, so the sign flip can't overflow or need re-reducing.
+      return value ? std::make_optional(Rational{-value->num, value->den})
+                   : std::nullopt;
+    }
+    if (ConsumeIf(u'+')) {
+      return ParseUnary();
+    }
+    return ParsePower();
+  }
+
+  // Right associative, and binds tighter than unary minus, so -2^2 is -4.
+  std::optional<Rational> ParsePower() {
+    auto base = ParsePrimary();
+    if (!base || !ConsumeIf(u'^')) {
+      return base;
+    }
+    auto exponent = ParseUnary();
+    return exponent ? Power(*base, *exponent) : std::nullopt;
+  }
+
+  std::optional<Rational> ParsePrimary() {
+    if (ConsumeIf(u'(')) {
+      if (++depth_ > kMaxParenDepth) {
+        return std::nullopt;
+      }
+      auto value = ParseSum();
+      --depth_;
+      if (!value || !ConsumeIf(u')')) {
+        return std::nullopt;
+      }
+      return value;
+    }
+    return ParseNumber();
+  }
+
+  // Only ASCII digits and '.' as the decimal mark. Grouping separators are
+  // deliberately unsupported: "1,5" means different things in different
+  // locales, and guessing wrong would produce a confidently wrong answer.
+  std::optional<Rational> ParseNumber() {
+    SkipWhitespace();
+    CheckedInt digits = 0;
+    CheckedInt scale = 1;
+    bool any_digits = false;
+
+    while (pos_ < text_.size() && base::IsAsciiDigit(text_[pos_])) {
+      digits = digits * 10 + (text_[pos_] - u'0');
+      ++pos_;
+      any_digits = true;
+    }
+    if (pos_ < text_.size() && text_[pos_] == u'.') {
+      ++pos_;
+      while (pos_ < text_.size() && base::IsAsciiDigit(text_[pos_])) {
+        digits = digits * 10 + (text_[pos_] - u'0');
+        scale = scale * 10;
+        ++pos_;
+        any_digits = true;
+      }
+    }
+    if (!any_digits) {
+      return std::nullopt;
+    }
+    return MakeRational(digits, scale);
+  }
+
+  std::u16string_view text_;
+  size_t pos_ = 0;
+  int depth_ = 0;
+};
+
+// '-' and '/' are used to delimit card numbers, phone numbers, SSN, and dates.
+// They should only be counted as operators with spaces around them -- otherwise
+// "1234-5678-9012-3456" would be answered as "= -13912". '+', '*' and '^' are
+// unambiguous anywhere.
+//
+// This only decides whether evaluating is worth attempting; the parser is what
+// decides whether the text is actually an expression.
+bool LooksLikeArithmetic(std::u16string_view text) {
+  for (size_t i = 0; i < text.size(); ++i) {
+    const char16_t c = text[i];
+    if (c == u'+' || c == u'*' || c == u'^') {
+      return true;
+    }
+    if ((c == u'-' || c == u'/') && i > 0 && i + 1 < text.size() &&
+        base::IsUnicodeWhitespace(text[i - 1]) &&
+        base::IsUnicodeWhitespace(text[i + 1])) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+std::optional<std::u16string> Format(const Rational& value) {
+  if (value.den == 1) {
+    // Exact across the whole int64 range; no double involved.
+    return base::FormatNumber(value.num);
+  }
+
+  // A fraction can only be shown if its decimal expansion terminates, i.e. the
+  // reduced denominator is 2^twos * 5^fives.
+  int64_t remaining = value.den;
+  int twos = 0;
+  int fives = 0;
+  while (remaining % 2 == 0) {
+    remaining /= 2;
+    ++twos;
+  }
+  while (remaining % 5 == 0) {
+    remaining /= 5;
+    ++fives;
+  }
+  if (remaining != 1) {
+    return std::nullopt;  // e.g. 10/3.
+  }
+
+  const int fraction_digits = std::max(twos, fives);
+  int integer_digits = 1;
+  for (int64_t whole = value.num / value.den; whole >= 10 || whole <= -10;
+       whole /= 10) {
+    ++integer_digits;
+  }
+  if (integer_digits + fraction_digits > kMaxSignificantDigits) {
+    return std::nullopt;
+  }
+
+  return base::FormatDouble(static_cast<double>(value.num) / value.den,
+                            /*min_fractional_digits=*/0, fraction_digits);
+}
+
+}  // namespace
+
+std::optional<std::u16string> EvaluateArithmeticExpression(
+    std::u16string_view text) {
+  if (!LooksLikeArithmetic(text)) {
+    return std::nullopt;
+  }
+  auto value = Parser(text).Parse();
+  if (!value) {
+    return std::nullopt;
+  }
+  return Format(*value);
+}
+
+}  // namespace omnibox

--- a/components/omnibox/browser/arithmetic_evaluator.cc
+++ b/components/omnibox/browser/arithmetic_evaluator.cc
@@ -265,10 +265,26 @@ class Parser {
   int depth_ = 0;
 };
 
-// '-' and '/' are used to delimit card numbers, phone numbers, SSN, and dates.
-// They should only be counted as operators with spaces around them -- otherwise
-// "1234-5678-9012-3456" would be answered as "= -13912". '+', '*' and '^' are
-// unambiguous anywhere.
+// Whether something an operator could apply to ends at `pos`, which is what
+// separates a binary operator from a leading sign.
+bool HasLeftOperand(std::u16string_view text, size_t pos) {
+  while (pos > 0) {
+    const char16_t c = text[--pos];
+    if (base::IsUnicodeWhitespace(c)) {
+      continue;
+    }
+    return base::IsAsciiDigit(c) || c == u')';
+  }
+  return false;
+}
+
+// Every operator must be binary, because a leading sign on a bare number is
+// how phone numbers are written: "+15551234567" is not a calculation, and it
+// is exactly the kind of input this path exists to keep off the network.
+//
+// '-' and '/' additionally need spaces around them, since they also delimit
+// card numbers, SSNs and dates -- otherwise "1234-5678-9012-3456" would be
+// answered as "= -13912".
 //
 // This only decides whether evaluating is worth attempting; the parser is what
 // decides whether the text is actually an expression.
@@ -276,11 +292,13 @@ bool LooksLikeArithmetic(std::u16string_view text) {
   for (size_t i = 0; i < text.size(); ++i) {
     const char16_t c = text[i];
     if (c == u'+' || c == u'*' || c == u'^') {
-      return true;
+      if (HasLeftOperand(text, i)) {
+        return true;
+      }
     }
     if ((c == u'-' || c == u'/') && i > 0 && i + 1 < text.size() &&
         base::IsUnicodeWhitespace(text[i - 1]) &&
-        base::IsUnicodeWhitespace(text[i + 1])) {
+        base::IsUnicodeWhitespace(text[i + 1]) && HasLeftOperand(text, i)) {
       return true;
     }
   }

--- a/components/omnibox/browser/arithmetic_evaluator.cc
+++ b/components/omnibox/browser/arithmetic_evaluator.cc
@@ -24,8 +24,10 @@ namespace {
 // formatted straight from the int64 and aren't subject to this.
 constexpr int kMaxSignificantDigits = 15;
 
-// Bounds recursion on untrusted omnibox input.
-constexpr int kMaxParenDepth = 16;
+// Bounds recursion on untrusted omnibox input. Operator runs are folded
+// iteratively, so this only has to cover the two constructs that genuinely
+// nest: parentheses, and the right-associative '^'.
+constexpr int kMaxRecursionDepth = 16;
 
 // Well below what would overflow: a larger power is more likely a typo than a
 // calculation, and evaluating it is pointless once the result can't be shown.
@@ -176,17 +178,24 @@ class Parser {
   }
 
   std::optional<Rational> ParseUnary() {
-    if (ConsumeIf(u'-')) {
-      auto value = ParseUnary();
-      // Negating in place is exact: `Rational` is reduced and excludes int64
-      // min, so the sign flip can't overflow or need re-reducing.
-      return value ? std::make_optional(Rational{-value->num, value->den})
-                   : std::nullopt;
+    // Signs are folded in a loop rather than by recursing per sign, so that a
+    // long run of them ("+++...+1") can't exhaust the stack.
+    bool negate = false;
+    while (true) {
+      if (ConsumeIf(u'-')) {
+        negate = !negate;
+      } else if (!ConsumeIf(u'+')) {
+        break;
+      }
     }
-    if (ConsumeIf(u'+')) {
-      return ParseUnary();
+
+    auto value = ParsePower();
+    if (!value || !negate) {
+      return value;
     }
-    return ParsePower();
+    // Negating in place is exact: `Rational` is reduced and excludes int64
+    // min, so the sign flip can't overflow or need re-reducing.
+    return Rational{-value->num, value->den};
   }
 
   // Right associative, and binds tighter than unary minus, so -2^2 is -4.
@@ -195,13 +204,19 @@ class Parser {
     if (!base || !ConsumeIf(u'^')) {
       return base;
     }
+    // Right associativity means recursing per '^', so this needs the same
+    // depth bound that nested parentheses get.
+    if (++depth_ > kMaxRecursionDepth) {
+      return std::nullopt;
+    }
     auto exponent = ParseUnary();
+    --depth_;
     return exponent ? Power(*base, *exponent) : std::nullopt;
   }
 
   std::optional<Rational> ParsePrimary() {
     if (ConsumeIf(u'(')) {
-      if (++depth_ > kMaxParenDepth) {
+      if (++depth_ > kMaxRecursionDepth) {
         return std::nullopt;
       }
       auto value = ParseSum();

--- a/components/omnibox/browser/arithmetic_evaluator.cc
+++ b/components/omnibox/browser/arithmetic_evaluator.cc
@@ -17,6 +17,8 @@
 
 namespace omnibox {
 
+BASE_FEATURE(kBraveLocalCalculator, base::FEATURE_ENABLED_BY_DEFAULT);
+
 namespace {
 
 // Fractional answers are rendered through a double, so their significant

--- a/components/omnibox/browser/arithmetic_evaluator.h
+++ b/components/omnibox/browser/arithmetic_evaluator.h
@@ -1,0 +1,30 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_OMNIBOX_BROWSER_ARITHMETIC_EVALUATOR_H_
+#define BRAVE_COMPONENTS_OMNIBOX_BROWSER_ARITHMETIC_EVALUATOR_H_
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace omnibox {
+
+// Evaluates `text` as an arithmetic expression, returning the answer formatted
+// for the user's locale.
+//
+// Returns nullopt when `text` can't be evaluated. For example, when it isn't
+// containing an expression, doesn't parse, divides by zero, overflows int64,
+// or would need more precision than can be displayed (e.g. "10/3"). Callers
+// must treat that as unsupported and fall back to their default behavior.
+//
+// The goal here is to handle basic calculator expressions in the omnibox and
+// resolve them without making outbound calls to the search suggest API.
+std::optional<std::u16string> EvaluateArithmeticExpression(
+    std::u16string_view text);
+
+}  // namespace omnibox
+
+#endif  // BRAVE_COMPONENTS_OMNIBOX_BROWSER_ARITHMETIC_EVALUATOR_H_

--- a/components/omnibox/browser/arithmetic_evaluator.h
+++ b/components/omnibox/browser/arithmetic_evaluator.h
@@ -10,7 +10,18 @@
 #include <string>
 #include <string_view>
 
+#include "base/feature_list.h"
+
 namespace omnibox {
+
+// Kill switch for answering arithmetic locally. Disabling it leaves the
+// queries the long-number check withholds from the suggest server with no
+// answer, as they were before this existed.
+//
+// Declared here rather than with the other omnibox features because this
+// target is only built when the strict query check is, which is the only
+// caller.
+BASE_DECLARE_FEATURE(kBraveLocalCalculator);
 
 // Evaluates `text` as an arithmetic expression, returning the answer formatted
 // for the user's locale.

--- a/components/omnibox/browser/arithmetic_evaluator_unittest.cc
+++ b/components/omnibox/browser/arithmetic_evaluator_unittest.cc
@@ -1,0 +1,108 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/omnibox/browser/arithmetic_evaluator.h"
+
+#include "base/i18n/number_formatting.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace omnibox {
+
+namespace {
+
+// Expectations are built with the same formatters the evaluator uses, so the
+// tests assert the arithmetic rather than the active locale's separators.
+std::optional<std::u16string> Integer(int64_t value) {
+  return base::FormatNumber(value);
+}
+
+std::optional<std::u16string> Decimal(double value, int fractional_digits) {
+  return base::FormatDouble(value, 0, fractional_digits);
+}
+
+}  // namespace
+
+TEST(ArithmeticEvaluatorTest, EvaluatesExactly) {
+  // The reported bug: the trailing digit pushed this past the suspicious-query
+  // digit limit, so it was answered from a stale prefix as "9500+780 = 10280".
+  EXPECT_EQ(Integer(17304), EvaluateArithmeticExpression(u"9500+7804"));
+  EXPECT_EQ(Integer(10280), EvaluateArithmeticExpression(u"9500+780"));
+
+  // Operands longer than the digit heuristic allows.
+  EXPECT_EQ(Integer(246913578),
+            EvaluateArithmeticExpression(u"123456789 + 123456789"));
+  EXPECT_EQ(Integer(1000000000001),
+            EvaluateArithmeticExpression(u"1000000000000 + 1"));
+
+  EXPECT_EQ(Integer(4), EvaluateArithmeticExpression(u"2+2"));
+  EXPECT_EQ(Integer(17304), EvaluateArithmeticExpression(u"  9500 + 7804  "));
+}
+
+TEST(ArithmeticEvaluatorTest, RespectsPrecedenceAndAssociativity) {
+  EXPECT_EQ(Integer(14), EvaluateArithmeticExpression(u"2 + 3 * 4"));
+  EXPECT_EQ(Integer(10), EvaluateArithmeticExpression(u"2 * 3 + 4"));
+  EXPECT_EQ(Integer(20), EvaluateArithmeticExpression(u"(2+3)*4"));
+  EXPECT_EQ(Integer(1024), EvaluateArithmeticExpression(u"2^10"));
+
+  // '^' binds tighter than unary minus.
+  EXPECT_EQ(Integer(-4), EvaluateArithmeticExpression(u"-2^2"));
+}
+
+TEST(ArithmeticEvaluatorTest, EvaluatesTerminatingFractions) {
+  EXPECT_EQ(Decimal(2.5, 1), EvaluateArithmeticExpression(u"10 / 4"));
+  EXPECT_EQ(Decimal(3.75, 2), EvaluateArithmeticExpression(u"1.5 + 2.25"));
+  EXPECT_EQ(Decimal(0.25, 2), EvaluateArithmeticExpression(u"2^-2"));
+}
+
+// Anything we can't answer exactly falls through to the caller's normal
+// behavior, which for the omnibox means asking the suggest server as before.
+TEST(ArithmeticEvaluatorTest, DeclinesWhatItCannotAnswerExactly) {
+  // Non-terminating decimal.
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"10 / 3"));
+  // Division by zero.
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"1 / 0"));
+  // int64 overflow.
+  EXPECT_EQ(std::nullopt,
+            EvaluateArithmeticExpression(u"9223372036854775807 + 1"));
+  // Exponents that are unbounded or would give an irrational result.
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"2^1000"));
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"2^0.5"));
+}
+
+TEST(ArithmeticEvaluatorTest, DeclinesMalformedExpressions) {
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"1 + "));
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"2 + apples"));
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"(1 + 2"));
+  // Grouping separators are ambiguous across locales, so they aren't parsed.
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"1,5 + 2"));
+}
+
+// '-' and '/' are used to delimit card numbers, phone numbers, SSN, and dates.
+// We don't want those to evaluated as arithmetic because the user shouldn't be
+// expecting this and the result wouldn't have any value. Spaces should be used
+// between the operators to be explicit.
+TEST(ArithmeticEvaluatorTest, DeclinesFormattedIdentifiers) {
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"1234-5678-9012-3456"));
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"555-123-4567"));
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"123-45-6789"));
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"24/7"));
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"9/11"));
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"12/25/2024"));
+
+  // Input with spaces, the same operators are unambiguous.
+  EXPECT_EQ(Integer(250000), EvaluateArithmeticExpression(u"1000000 / 4"));
+  EXPECT_EQ(Integer(-4444), EvaluateArithmeticExpression(u"1234 - 5678"));
+}
+
+TEST(ArithmeticEvaluatorTest, DeclinesNonArithmetic) {
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u""));
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"9500"));
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"hello world"));
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"+"));
+  // Parentheses alone aren't an operator, so this stays a plain query.
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"(1234567890)"));
+}
+
+}  // namespace omnibox

--- a/components/omnibox/browser/arithmetic_evaluator_unittest.cc
+++ b/components/omnibox/browser/arithmetic_evaluator_unittest.cc
@@ -80,9 +80,9 @@ TEST(ArithmeticEvaluatorTest, DeclinesMalformedExpressions) {
 }
 
 // '-' and '/' are used to delimit card numbers, phone numbers, SSN, and dates.
-// We don't want those to evaluated as arithmetic because the user shouldn't be
-// expecting this and the result wouldn't have any value. Spaces should be used
-// between the operators to be explicit.
+// We don't want those to be evaluated as arithmetic because the user shouldn't
+// be expecting this and the result wouldn't have any value. Spaces should be
+// used between the operators to be explicit.
 TEST(ArithmeticEvaluatorTest, DeclinesFormattedIdentifiers) {
   EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"1234-5678-9012-3456"));
   EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"555-123-4567"));
@@ -94,6 +94,41 @@ TEST(ArithmeticEvaluatorTest, DeclinesFormattedIdentifiers) {
   // Input with spaces, the same operators are unambiguous.
   EXPECT_EQ(Integer(250000), EvaluateArithmeticExpression(u"1000000 / 4"));
   EXPECT_EQ(Integer(-4444), EvaluateArithmeticExpression(u"1234 - 5678"));
+}
+
+// Pasted input can be long, so no construct may recurse once per character.
+// These must decline (or fold) rather than exhaust the stack.
+TEST(ArithmeticEvaluatorTest, HandlesLongOperatorRuns) {
+  constexpr size_t kRunLength = 100000;
+
+  // Unary signs are folded iteratively, so a run of them is just a sign. Note
+  // every case here needs an unambiguous operator to get past
+  // `LooksLikeArithmetic`: a run of '-' alone is an identifier, not a sum.
+  EXPECT_EQ(Integer(1), EvaluateArithmeticExpression(
+                            std::u16string(kRunLength, u'+') + u"1"));
+  EXPECT_EQ(Integer(-1), EvaluateArithmeticExpression(
+                             std::u16string(kRunLength - 1, u'-') + u"1+0"));
+
+  // The sign loop breaks at the first non-sign character, handing the rest of
+  // the expression back to the binary operator loops. A run followed by more
+  // expression must still parse, and signs must not be confused with the
+  // binary operators that follow.
+  EXPECT_EQ(Integer(2), EvaluateArithmeticExpression(
+                            std::u16string(kRunLength, u'+') + u"1+1"));
+  EXPECT_EQ(Integer(-4), EvaluateArithmeticExpression(
+                             std::u16string(kRunLength - 1, u'-') + u"4+4-4"));
+  EXPECT_EQ(Integer(-4), EvaluateArithmeticExpression(u"-4+4-4"));
+  EXPECT_EQ(Integer(8), EvaluateArithmeticExpression(u"4 - -4"));
+  EXPECT_EQ(Integer(5), EvaluateArithmeticExpression(u"-+-5"));
+
+  // Nesting constructs are depth-bounded instead.
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(
+                              std::u16string(kRunLength, u'(') + u"1+1"));
+  std::u16string powers = u"2";
+  for (size_t i = 0; i < kRunLength; ++i) {
+    powers += u"^2";
+  }
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(powers));
 }
 
 TEST(ArithmeticEvaluatorTest, DeclinesNonArithmetic) {

--- a/components/omnibox/browser/arithmetic_evaluator_unittest.cc
+++ b/components/omnibox/browser/arithmetic_evaluator_unittest.cc
@@ -56,8 +56,8 @@ TEST(ArithmeticEvaluatorTest, EvaluatesTerminatingFractions) {
   EXPECT_EQ(Decimal(0.25, 2), EvaluateArithmeticExpression(u"2^-2"));
 }
 
-// Anything we can't answer exactly falls through to the caller's normal
-// behavior, which for the omnibox means asking the suggest server as before.
+// Anything we can't answer exactly produces no local calculator result; the
+// caller continues with its normal privacy-preserving behavior.
 TEST(ArithmeticEvaluatorTest, DeclinesWhatItCannotAnswerExactly) {
   // Non-terminating decimal.
   EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"10 / 3"));

--- a/components/omnibox/browser/arithmetic_evaluator_unittest.cc
+++ b/components/omnibox/browser/arithmetic_evaluator_unittest.cc
@@ -91,6 +91,13 @@ TEST(ArithmeticEvaluatorTest, DeclinesFormattedIdentifiers) {
   EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"9/11"));
   EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"12/25/2024"));
 
+  // A leading sign is how international dialling codes are written, so an
+  // operator only counts when it has something on its left to apply to.
+  // Without this, "+15551234567" would be restated as "= 15,551,234,567".
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"+15551234567"));
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"+1 555 123 4567"));
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"+442071234567"));
+
   // Input with spaces, the same operators are unambiguous.
   EXPECT_EQ(Integer(250000), EvaluateArithmeticExpression(u"1000000 / 4"));
   EXPECT_EQ(Integer(-4444), EvaluateArithmeticExpression(u"1234 - 5678"));
@@ -101,11 +108,14 @@ TEST(ArithmeticEvaluatorTest, DeclinesFormattedIdentifiers) {
 TEST(ArithmeticEvaluatorTest, HandlesLongOperatorRuns) {
   constexpr size_t kRunLength = 100000;
 
-  // Unary signs are folded iteratively, so a run of them is just a sign. Note
-  // every case here needs an unambiguous operator to get past
-  // `LooksLikeArithmetic`: a run of '-' alone is an identifier, not a sum.
-  EXPECT_EQ(Integer(1), EvaluateArithmeticExpression(
-                            std::u16string(kRunLength, u'+') + u"1"));
+  // A run of signs with nothing to add to is not a calculation, so these are
+  // turned away by `LooksLikeArithmetic` before the parser sees them.
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(
+                              std::u16string(kRunLength, u'+') + u"1"));
+  EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(u"-+-5"));
+
+  // With a binary operator present the run is reached, and folded iteratively
+  // rather than by recursing per sign.
   EXPECT_EQ(Integer(-1), EvaluateArithmeticExpression(
                              std::u16string(kRunLength - 1, u'-') + u"1+0"));
 
@@ -119,7 +129,6 @@ TEST(ArithmeticEvaluatorTest, HandlesLongOperatorRuns) {
                              std::u16string(kRunLength - 1, u'-') + u"4+4-4"));
   EXPECT_EQ(Integer(-4), EvaluateArithmeticExpression(u"-4+4-4"));
   EXPECT_EQ(Integer(8), EvaluateArithmeticExpression(u"4 - -4"));
-  EXPECT_EQ(Integer(5), EvaluateArithmeticExpression(u"-+-5"));
 
   // Nesting constructs are depth-bounded instead.
   EXPECT_EQ(std::nullopt, EvaluateArithmeticExpression(

--- a/components/omnibox/browser/brave_search_provider.cc
+++ b/components/omnibox/browser/brave_search_provider.cc
@@ -7,6 +7,7 @@
 
 #include <vector>
 
+#include "base/feature_list.h"
 #include "base/logging.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/strings/utf_string_conversions.h"
@@ -72,9 +73,16 @@ BraveSearchProvider::~BraveSearchProvider() = default;
 
 void BraveSearchProvider::Start(const AutocompleteInput& input,
                                 bool minimal_changes) {
-  // Evaluated up front because `SearchProvider::Start()` consults
-  // `IsQueryPotentiallyPrivate()` while deciding whether to query suggest.
-  calculator_answer_ = MaybeEvaluateLocally(input);
+  // Everything else keys off `calculator_answer_`, so leaving it empty is all
+  // it takes to fall back to the upstream behaviour.
+  calculator_answer_.reset();
+#if BUILDFLAG(ENABLE_STRICT_QUERY_CHECK_FOR_SEARCH_SUGGESTIONS)
+  if (base::FeatureList::IsEnabled(omnibox::kBraveLocalCalculator)) {
+    // Evaluated up front because `SearchProvider::Start()` consults
+    // `IsQueryPotentiallyPrivate()` while deciding whether to query suggest.
+    calculator_answer_ = MaybeEvaluateLocally(input);
+  }
+#endif
 
   SearchProvider::Start(input, minimal_changes);
 }
@@ -100,9 +108,9 @@ void BraveSearchProvider::UpdateMatches() {
   SearchProvider::UpdateMatches();
 }
 
+#if BUILDFLAG(ENABLE_STRICT_QUERY_CHECK_FOR_SEARCH_SUGGESTIONS)
 std::optional<std::u16string> BraveSearchProvider::MaybeEvaluateLocally(
     const AutocompleteInput& input) const {
-#if BUILDFLAG(ENABLE_STRICT_QUERY_CHECK_FOR_SEARCH_SUGGESTIONS)
   if (input.IsZeroSuggest() || input.type() == metrics::OmniboxInputType::URL) {
     return std::nullopt;
   }
@@ -124,10 +132,8 @@ std::optional<std::u16string> BraveSearchProvider::MaybeEvaluateLocally(
   }
 
   return omnibox::EvaluateArithmeticExpression(input.text());
-#else
-  return std::nullopt;
-#endif
 }
+#endif
 
 void BraveSearchProvider::DoHistoryQuery(bool minimal_changes) {
   if (!client()->GetPrefs()->GetBoolean(omnibox::kHistorySuggestionsEnabled)) {

--- a/components/omnibox/browser/brave_search_provider.cc
+++ b/components/omnibox/browser/brave_search_provider.cc
@@ -5,16 +5,24 @@
 
 #include "brave/components/omnibox/browser/brave_search_provider.h"
 
+#include <vector>
+
 #include "base/logging.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
+#include "brave/components/omnibox/browser/arithmetic_evaluator.h"
 #include "brave/components/omnibox/browser/brave_omnibox_prefs.h"
+#include "brave/components/omnibox/browser/brave_search_suggestion_parser.h"
 #include "brave/components/omnibox/buildflags/buildflags.h"
+#include "components/omnibox/browser/autocomplete_input.h"
+#include "components/omnibox/browser/autocomplete_match_type.h"
 #include "components/omnibox/browser/autocomplete_provider.h"
 #include "components/omnibox/browser/autocomplete_provider_client.h"
 #include "components/omnibox/browser/omnibox_text_util.h"
 #include "components/omnibox/browser/search_provider.h"
+#include "components/omnibox/browser/search_suggestion_parser.h"
+#include "components/omnibox/common/omnibox_feature_configs.h"
 #include "components/prefs/pref_service.h"
 
 #if BUILDFLAG(ENABLE_STRICT_QUERY_CHECK_FOR_SEARCH_SUGGESTIONS)
@@ -56,7 +64,57 @@ bool IsQuerySafeToSearchSuggestions(const std::u16string& query) {
 
 }  // namespace
 
+BraveSearchProvider::BraveSearchProvider(AutocompleteProviderClient* client,
+                                         AutocompleteProviderListener* listener)
+    : SearchProvider(client, listener) {}
+
 BraveSearchProvider::~BraveSearchProvider() = default;
+
+void BraveSearchProvider::Start(const AutocompleteInput& input,
+                                bool minimal_changes) {
+  // Evaluated up front because `SearchProvider::Start()` consults
+  // `IsQueryPotentiallyPrivate()` while deciding whether to query suggest.
+  calculator_answer_ = MaybeEvaluateLocally(input);
+
+  SearchProvider::Start(input, minimal_changes);
+}
+
+void BraveSearchProvider::UpdateMatches() {
+  if (calculator_answer_) {
+    // Upstream calls this from several places for one input, so replace rather
+    // than append -- otherwise the answer would be listed once per call.
+    std::erase_if(default_results_.suggest_results, [](const auto& result) {
+      return result.type() == AutocompleteMatchType::CALCULATOR;
+    });
+    // Injected as a suggest result rather than a match so that the usual
+    // conversion (BaseSearchProvider::CreateSearchSuggestion) fills in the
+    // destination URL, search terms, classifications and dedup keys.
+    default_results_.suggest_results.push_back(
+        omnibox::MakeCalculatorSuggestResult(
+            /*expression=*/input_.text(), *calculator_answer_,
+            /*input_text=*/input_.text(), /*entity_info=*/{},
+            omnibox_feature_configs::CalcProvider::Get().score,
+            /*from_keyword=*/false));
+  }
+
+  SearchProvider::UpdateMatches();
+}
+
+std::optional<std::u16string> BraveSearchProvider::MaybeEvaluateLocally(
+    const AutocompleteInput& input) const {
+  if (input.IsZeroSuggest() || input.type() == metrics::OmniboxInputType::URL) {
+    return std::nullopt;
+  }
+
+  // In keyword mode the user picked an engine explicitly, and a keyword
+  // suggest request is still sent even for a private query -- its response
+  // would rebuild `matches_` and drop anything we added here.
+  if (input.in_keyword_mode()) {
+    return std::nullopt;
+  }
+
+  return omnibox::EvaluateArithmeticExpression(input.text());
+}
 
 void BraveSearchProvider::DoHistoryQuery(bool minimal_changes) {
   if (!client()->GetPrefs()->GetBoolean(omnibox::kHistorySuggestionsEnabled)) {
@@ -67,6 +125,13 @@ void BraveSearchProvider::DoHistoryQuery(bool minimal_changes) {
 }
 
 bool BraveSearchProvider::IsQueryPotentiallyPrivate() const {
+  // Answered locally in `UpdateMatches()`, so the operands never need to leave
+  // the browser. Deliberately ahead of everything else: when we can do the
+  // arithmetic ourselves there is no reason to ask anyone.
+  if (calculator_answer_) {
+    return true;
+  }
+
   if (SearchProvider::IsQueryPotentiallyPrivate()) {
     return true;
   }

--- a/components/omnibox/browser/brave_search_provider.cc
+++ b/components/omnibox/browser/brave_search_provider.cc
@@ -11,7 +11,6 @@
 #include "base/metrics/histogram_macros.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
-#include "brave/components/omnibox/browser/arithmetic_evaluator.h"
 #include "brave/components/omnibox/browser/brave_omnibox_prefs.h"
 #include "brave/components/omnibox/browser/brave_search_suggestion_parser.h"
 #include "brave/components/omnibox/buildflags/buildflags.h"
@@ -26,6 +25,7 @@
 #include "components/prefs/pref_service.h"
 
 #if BUILDFLAG(ENABLE_STRICT_QUERY_CHECK_FOR_SEARCH_SUGGESTIONS)
+#include "brave/components/omnibox/browser/arithmetic_evaluator.h"
 #include "brave/components/omnibox/browser/search_suggestions/query_check_utils.h"
 #endif
 
@@ -102,6 +102,7 @@ void BraveSearchProvider::UpdateMatches() {
 
 std::optional<std::u16string> BraveSearchProvider::MaybeEvaluateLocally(
     const AutocompleteInput& input) const {
+#if BUILDFLAG(ENABLE_STRICT_QUERY_CHECK_FOR_SEARCH_SUGGESTIONS)
   if (input.IsZeroSuggest() || input.type() == metrics::OmniboxInputType::URL) {
     return std::nullopt;
   }
@@ -113,7 +114,19 @@ std::optional<std::u16string> BraveSearchProvider::MaybeEvaluateLocally(
     return std::nullopt;
   }
 
+  // Only step in and provide local calculations for queries that would fail the
+  // `IsQueryPotentiallyPrivate` check due to having a long number in the query.
+  // If the query doesn't meet that criteria, we're safe to pass it along to the
+  // search suggestions API.
+  if (!search_suggestions::HasLongNumberInQuery(
+          base::UTF16ToUTF8(omnibox::SanitizeTextForPaste(input.text())))) {
+    return std::nullopt;
+  }
+
   return omnibox::EvaluateArithmeticExpression(input.text());
+#else
+  return std::nullopt;
+#endif
 }
 
 void BraveSearchProvider::DoHistoryQuery(bool minimal_changes) {

--- a/components/omnibox/browser/brave_search_provider.h
+++ b/components/omnibox/browser/brave_search_provider.h
@@ -6,16 +6,26 @@
 #ifndef BRAVE_COMPONENTS_OMNIBOX_BROWSER_BRAVE_SEARCH_PROVIDER_H_
 #define BRAVE_COMPONENTS_OMNIBOX_BROWSER_BRAVE_SEARCH_PROVIDER_H_
 
+#include <optional>
+#include <string>
+
 #include "base/auto_reset.h"
 #include "components/omnibox/browser/search_provider.h"
 
+class AutocompleteInput;
+class AutocompleteProviderClient;
+class AutocompleteProviderListener;
+
 class BraveSearchProvider : public SearchProvider {
  public:
-  using SearchProvider::SearchProvider;
+  BraveSearchProvider(AutocompleteProviderClient* client,
+                      AutocompleteProviderListener* listener);
   BraveSearchProvider(const BraveSearchProvider&) = delete;
   BraveSearchProvider& operator=(const BraveSearchProvider&) = delete;
 
+  void Start(const AutocompleteInput& input, bool minimal_changes) override;
   void DoHistoryQuery(bool minimal_changes) override;
+  void UpdateMatches() override;
   bool IsQueryPotentiallyPrivate() const override;
   BraveSearchProvider* AsBraveSearchProvider() override;
 
@@ -27,7 +37,16 @@ class BraveSearchProvider : public SearchProvider {
   ~BraveSearchProvider() override;
 
  private:
+  // Returns the answer when `input` is arithmetic we can evaluate exactly.
+  std::optional<std::u16string> MaybeEvaluateLocally(
+      const AutocompleteInput& input) const;
+
   bool input_is_pasted_from_clipboard_ = false;
+
+  // Set for the current input when we answered it ourselves. Computed in
+  // `Start()` because `IsQueryPotentiallyPrivate()` reads it from within
+  // `SearchProvider::Start()`.
+  std::optional<std::u16string> calculator_answer_;
 };
 
 #endif  // BRAVE_COMPONENTS_OMNIBOX_BROWSER_BRAVE_SEARCH_PROVIDER_H_

--- a/components/omnibox/browser/brave_search_provider.h
+++ b/components/omnibox/browser/brave_search_provider.h
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "base/auto_reset.h"
+#include "brave/components/omnibox/buildflags/buildflags.h"
 #include "components/omnibox/browser/search_provider.h"
 
 class AutocompleteInput;
@@ -37,9 +38,12 @@ class BraveSearchProvider : public SearchProvider {
   ~BraveSearchProvider() override;
 
  private:
-  // Returns the answer when `input` is arithmetic we can evaluate exactly.
+#if BUILDFLAG(ENABLE_STRICT_QUERY_CHECK_FOR_SEARCH_SUGGESTIONS)
+  // Returns the answer when `input` is arithmetic we can evaluate exactly, and
+  // the long-number check would withhold it from the suggest server.
   std::optional<std::u16string> MaybeEvaluateLocally(
       const AutocompleteInput& input) const;
+#endif
 
   bool input_is_pasted_from_clipboard_ = false;
 

--- a/components/omnibox/browser/brave_search_provider_unittest.cc
+++ b/components/omnibox/browser/brave_search_provider_unittest.cc
@@ -20,6 +20,7 @@
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/test/scoped_feature_list.h"
 #include "base/time/time.h"
 #include "brave/components/omnibox/browser/brave_omnibox_prefs.h"
 #include "brave/components/omnibox/buildflags/buildflags.h"
@@ -47,6 +48,7 @@
 #include "third_party/metrics_proto/omnibox_event.pb.h"
 
 #if BUILDFLAG(ENABLE_STRICT_QUERY_CHECK_FOR_SEARCH_SUGGESTIONS)
+#include "brave/components/omnibox/browser/arithmetic_evaluator.h"
 #include "brave/components/omnibox/browser/search_suggestions/query_check_utils.h"
 #endif
 
@@ -329,6 +331,20 @@ TEST_F(BraveSearchProviderTest, ArithmeticIsAnsweredLocally) {
   ASSERT_NO_FATAL_FAILURE(QueryForInput(u"12345678"));
   EXPECT_FALSE(sent_to_suggest("12345678"));
   EXPECT_FALSE(has_calculator_match());
+}
+
+// With the kill switch off, a withheld query gets no answer, as it did before
+// the local calculator existed.
+TEST_F(BraveSearchProviderTest, ArithmeticIsNotAnsweredWhenFeatureDisabled) {
+  base::test::ScopedFeatureList features;
+  features.InitAndDisableFeature(omnibox::kBraveLocalCalculator);
+
+  ASSERT_NO_FATAL_FAILURE(QueryForInput(u"9500+7804"));
+  EXPECT_FALSE(test_url_loader_factory_.IsPending(
+      base::StrCat({kSuggestionUrlHost, base::EscapePath("9500+7804")})));
+  EXPECT_FALSE(std::ranges::any_of(provider_->matches(), [](const auto& match) {
+    return match.type == AutocompleteMatchType::CALCULATOR;
+  }));
 }
 
 TEST_F(BraveSearchProviderTest, SearchSuggestionsSendTest) {

--- a/components/omnibox/browser/brave_search_provider_unittest.cc
+++ b/components/omnibox/browser/brave_search_provider_unittest.cc
@@ -33,6 +33,7 @@
 #include "components/history/core/browser/history_service.h"
 #include "components/omnibox/browser/autocomplete_input.h"
 #include "components/omnibox/browser/autocomplete_match.h"
+#include "components/omnibox/browser/autocomplete_match_type.h"
 #include "components/omnibox/browser/autocomplete_provider.h"
 #include "components/omnibox/browser/remote_suggestions_service.h"
 #include "components/omnibox/browser/search_provider.h"
@@ -290,6 +291,26 @@ TEST_F(BraveSearchProviderTest, DontSendClipboardTextToSuggest) {
       base::StrCat({kSuggestionUrlHost, "brave_private"})));
 }
 #endif
+
+// Arithmetic is answered locally, so the operands never reach the suggest
+// server. Unlike the checks below, this applies on every platform.
+TEST_F(BraveSearchProviderTest, ArithmeticIsAnsweredLocally) {
+  const auto has_calculator_match = [&]() {
+    return std::ranges::any_of(provider_->matches(), [](const auto& match) {
+      return match.type == AutocompleteMatchType::CALCULATOR;
+    });
+  };
+
+  ASSERT_NO_FATAL_FAILURE(QueryForInput(u"9500+7804"));
+  EXPECT_EQ(0, test_url_loader_factory_.NumPending());
+  EXPECT_TRUE(has_calculator_match());
+
+  // Expressions we can't answer exactly fall through to the suggest server
+  // instead of showing an approximation.
+  ASSERT_NO_FATAL_FAILURE(QueryForInput(u"10 / 3"));
+  EXPECT_EQ(1, test_url_loader_factory_.NumPending());
+  EXPECT_FALSE(has_calculator_match());
+}
 
 #if BUILDFLAG(ENABLE_STRICT_QUERY_CHECK_FOR_SEARCH_SUGGESTIONS)
 TEST_F(BraveSearchProviderTest, SearchSuggestionsSendTest) {

--- a/components/omnibox/browser/brave_search_provider_unittest.cc
+++ b/components/omnibox/browser/brave_search_provider_unittest.cc
@@ -292,8 +292,11 @@ TEST_F(BraveSearchProviderTest, DontSendClipboardTextToSuggest) {
 }
 #endif
 
-// Arithmetic is answered locally, so the operands never reach the suggest
-// server. Unlike the checks below, this applies on every platform.
+#if BUILDFLAG(ENABLE_STRICT_QUERY_CHECK_FOR_SEARCH_SUGGESTIONS)
+// Arithmetic is only answered locally when `IsQueryPotentiallyPrivate` returns
+// true when evaluating the query. This fallback behavior lets a calculation
+// happen versus just dropping the query. Everything else will be sent/processed
+// by the search suggestions server.
 TEST_F(BraveSearchProviderTest, ArithmeticIsAnsweredLocally) {
   const auto has_calculator_match = [&]() {
     return std::ranges::any_of(provider_->matches(), [](const auto& match) {
@@ -301,18 +304,33 @@ TEST_F(BraveSearchProviderTest, ArithmeticIsAnsweredLocally) {
     });
   };
 
+  const auto sent_to_suggest = [&](const std::string& input) {
+    return test_url_loader_factory_.IsPending(
+        base::StrCat({kSuggestionUrlHost, base::EscapePath(input)}));
+  };
+
+  // "95007804" is 8 digits, so the query is withheld and we answer it.
   ASSERT_NO_FATAL_FAILURE(QueryForInput(u"9500+7804"));
-  EXPECT_EQ(0, test_url_loader_factory_.NumPending());
+  EXPECT_FALSE(sent_to_suggest("9500+7804"));
   EXPECT_TRUE(has_calculator_match());
 
-  // Expressions we can't answer exactly fall through to the suggest server
-  // instead of showing an approximation.
-  ASSERT_NO_FATAL_FAILURE(QueryForInput(u"10 / 3"));
-  EXPECT_EQ(1, test_url_loader_factory_.NumPending());
+  // One digit shorter, so the server still answers it as it always has.
+  ASSERT_NO_FATAL_FAILURE(QueryForInput(u"9500+780"));
+  EXPECT_TRUE(sent_to_suggest("9500+780"));
+  EXPECT_FALSE(has_calculator_match());
+
+  // Withheld, but not something we can answer exactly: no calculator row
+  // rather than an approximate one.
+  ASSERT_NO_FATAL_FAILURE(QueryForInput(u"12345678 / 7"));
+  EXPECT_FALSE(sent_to_suggest("12345678 / 7"));
+  EXPECT_FALSE(has_calculator_match());
+
+  // Withheld and not arithmetic at all.
+  ASSERT_NO_FATAL_FAILURE(QueryForInput(u"12345678"));
+  EXPECT_FALSE(sent_to_suggest("12345678"));
   EXPECT_FALSE(has_calculator_match());
 }
 
-#if BUILDFLAG(ENABLE_STRICT_QUERY_CHECK_FOR_SEARCH_SUGGESTIONS)
 TEST_F(BraveSearchProviderTest, SearchSuggestionsSendTest) {
 #if BUILDFLAG(IS_MAC)
   // TODO(crbug.com/434660312): Re-enable on macOS 26 once issues with

--- a/components/omnibox/browser/brave_search_suggestion_parser.cc
+++ b/components/omnibox/browser/brave_search_suggestion_parser.cc
@@ -44,6 +44,37 @@ std::optional<std::u16string> GetAnswer(const base::DictValue& suggestion) {
 
 }  // namespace
 
+SearchSuggestionParser::SuggestResult MakeCalculatorSuggestResult(
+    const std::u16string& expression,
+    const std::u16string& answer,
+    const std::u16string& input_text,
+    EntityInfo entity_info,
+    int relevance,
+    bool from_keyword) {
+  std::u16string match_contents = answer;
+  if (ui::GetDeviceFormFactor() == ui::DEVICE_FORM_FACTOR_DESKTOP) {
+    // Desktop shows "<expression> = <answer>" on one line, as upstream does.
+    match_contents = l10n_util::GetStringFUTF16(
+        IDS_OMNIBOX_ONE_LINE_CALCULATOR_SUGGESTION_TEMPLATE, expression,
+        answer);
+  }
+
+  // The suggestion is the answer, so accepting the match searches the text the
+  // user typed. See BaseSearchProvider::CreateSearchSuggestion.
+  return SearchSuggestionParser::SuggestResult(
+      /*suggestion*/ answer, AutocompleteMatchType::CALCULATOR,
+      omnibox::TYPE_CALCULATOR,
+      /*subtypes*/ {}, match_contents,
+      /*match_contents_prefix*/ {},
+      // An annotation would become the match description, which restores the
+      // separator the desktop match cell suppresses for CALCULATOR -- the row
+      // would read "<answer> - <annotation>".
+      /*annotation*/ {}, std::move(entity_info),
+      /*deletion_url*/ {}, from_keyword, omnibox::NAV_INTENT_NONE, relevance,
+      /*relevance_from_server*/ false, /*should_prefetch*/ false,
+      /*should_prerender*/ false, base::CollapseWhitespace(input_text, false));
+}
+
 bool ParseSuggestResults(const base::ListValue& root_list,
                          const AutocompleteInput& input,
                          bool is_keyword_result,
@@ -136,9 +167,9 @@ bool ParseSuggestResults(const base::ListValue& root_list,
       suggest_type = omnibox::TYPE_ENTITY;
       match_type = AutocompleteMatchType::SEARCH_SUGGEST_ENTITY;
     } else if (GetVerticalType(suggestion_dict) == "calculator") {
-      // Verticals we don't handle stay plain query suggestions.
+      // Verticals we don't handle stay plain query suggestions. The match type
+      // is set by MakeCalculatorSuggestResult() below.
       suggest_type = omnibox::TYPE_CALCULATOR;
-      match_type = AutocompleteMatchType::CALCULATOR;
     }
 
     if (auto* name = suggestion_dict.FindString("name")) {
@@ -161,38 +192,23 @@ bool ParseSuggestResults(const base::ListValue& root_list,
       entity_info.set_annotation(*description);
     }
 
-    std::u16string suggestion_text;
-    std::u16string match_contents;
     if (suggest_type == omnibox::TYPE_CALCULATOR) {
       auto answer = GetAnswer(suggestion_dict);
       if (!answer || answer->empty()) {
         continue;
       }
-      // An annotation becomes the match description, which restores the
-      // separator the desktop match cell suppresses for CALCULATOR -- the row
-      // would read "<answer> - <description>".
-      annotation.clear();
-      // The suggestion is the answer, so accepting the match searches the text
-      // the user typed. See BaseSearchProvider::CreateSearchSuggestion.
-      suggestion_text = std::move(*answer);
-      match_contents = suggestion_text;
-      if (ui::GetDeviceFormFactor() == ui::DEVICE_FORM_FACTOR_DESKTOP) {
-        // Desktop shows "<expression> = <answer>" on one line, as upstream
-        // does.
-        const auto* expression = suggestion_dict.FindString("expression");
-        match_contents = l10n_util::GetStringFUTF16(
-            IDS_OMNIBOX_ONE_LINE_CALCULATOR_SUGGESTION_TEMPLATE,
-            base::UTF8ToUTF16(expression ? *expression : *search_query),
-            suggestion_text);
-      }
-    } else {
-      suggestion_text = base::UTF8ToUTF16(*search_query);
-      match_contents = suggestion_text;
+      const auto* expression = suggestion_dict.FindString("expression");
+      results->suggest_results.push_back(MakeCalculatorSuggestResult(
+          base::UTF8ToUTF16(expression ? *expression : *search_query), *answer,
+          input_text, std::move(entity_info), /*relevance*/ -1,
+          is_keyword_result));
+      continue;
     }
 
+    const std::u16string suggestion_text = base::UTF8ToUTF16(*search_query);
     auto result = SearchSuggestionParser::SuggestResult(
         suggestion_text, match_type, suggest_type,
-        /*subtypes*/ {}, match_contents,
+        /*subtypes*/ {}, /*match_contents*/ suggestion_text,
         /*match_contents_prefix*/ {},
         /*annotation*/ annotation, std::move(entity_info),
         /*deletion_url*/ {}, is_keyword_result, omnibox::NAV_INTENT_NONE,

--- a/components/omnibox/browser/brave_search_suggestion_parser.h
+++ b/components/omnibox/browser/brave_search_suggestion_parser.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_COMPONENTS_OMNIBOX_BROWSER_BRAVE_SEARCH_SUGGESTION_PARSER_H_
 #define BRAVE_COMPONENTS_OMNIBOX_BROWSER_BRAVE_SEARCH_SUGGESTION_PARSER_H_
 
+#include <string>
+
 #include "components/omnibox/browser/search_suggestion_parser.h"
 
 class AutocompleteInput;
@@ -16,6 +18,18 @@ bool ParseSuggestResults(const base::ListValue& root_list,
                          const AutocompleteInput& input,
                          bool is_keyword_result,
                          SearchSuggestionParser::Results* results);
+
+// Builds the suggestion for a calculator answer, in the shape
+// //components/omnibox renders a server-provided one. Shared by the Brave
+// Search calculator vertical and by answers BraveSearchProvider computes
+// locally, so the two stay presented identically.
+SearchSuggestionParser::SuggestResult MakeCalculatorSuggestResult(
+    const std::u16string& expression,
+    const std::u16string& answer,
+    const std::u16string& input_text,
+    EntityInfo entity_info,
+    int relevance,
+    bool from_keyword);
 
 }  // namespace omnibox
 

--- a/components/omnibox/browser/search_suggestions/query_check_utils.cc
+++ b/components/omnibox/browser/search_suggestions/query_check_utils.cc
@@ -82,25 +82,6 @@ bool HasEmailInQuery(const std::string& query) {
   return RE2::PartialMatch(query, *regex.get());
 }
 
-bool HasLongNumberInQuery(const std::string& query) {
-  std::string updated_query = query;
-  RE2::GlobalReplace(&updated_query, "[^A-Za-z0-9]", "");
-  RE2::GlobalReplace(&updated_query, "[A-Za-z]+", " ");
-
-  const std::vector<std::string_view> numbers = base::SplitStringPiece(
-      updated_query, " ", base::WhitespaceHandling::TRIM_WHITESPACE,
-      base::SplitResult::SPLIT_WANT_NONEMPTY);
-
-  constexpr int kMaxAllowedNumberLength = 7;
-  for (const auto& number : numbers) {
-    if (number.length() > kMaxAllowedNumberLength) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 bool HasValidWordCountInQuery(const std::string& query) {
   std::vector<std::string_view> words_in_query = base::SplitStringPiece(
       query, " ", base::WhitespaceHandling::TRIM_WHITESPACE,
@@ -269,6 +250,25 @@ bool IsPotentiallyLeakingUrlInformation(const std::string& query) {
 }  // namespace
 
 namespace search_suggestions {
+
+bool HasLongNumberInQuery(const std::string& query) {
+  std::string updated_query = query;
+  RE2::GlobalReplace(&updated_query, "[^A-Za-z0-9]", "");
+  RE2::GlobalReplace(&updated_query, "[A-Za-z]+", " ");
+
+  const std::vector<std::string_view> numbers = base::SplitStringPiece(
+      updated_query, " ", base::WhitespaceHandling::TRIM_WHITESPACE,
+      base::SplitResult::SPLIT_WANT_NONEMPTY);
+
+  constexpr int kMaxAllowedNumberLength = 7;
+  for (const auto& number : numbers) {
+    if (number.length() > kMaxAllowedNumberLength) {
+      return true;
+    }
+  }
+
+  return false;
+}
 
 bool IsSuspiciousQuery(const std::string& query) {
   if (!HasValidWordCountInQuery(query)) {

--- a/components/omnibox/browser/search_suggestions/query_check_utils.h
+++ b/components/omnibox/browser/search_suggestions/query_check_utils.h
@@ -13,6 +13,15 @@ namespace search_suggestions {
 bool IsSuspiciousQuery(const std::string& query);
 bool IsSafeQueryUrl(const std::string& query);
 
+// Returns true if `query` has more than 7 digits once non-alphanumerics are
+// removed. Intention here is to prevent PII (card numbers, phone numbers, etc)
+// from being sent via the search suggestions API.
+//
+// Called by `IsSuspiciousQuery` but needs to be public so we can provide local
+// calculations as a fallback when query is flagged as suspicious. For more
+// info, see `BraveSearchProvider::MaybeEvaluateLocally`.
+bool HasLongNumberInQuery(const std::string& query);
+
 }  // namespace search_suggestions
 
 #endif  // BRAVE_COMPONENTS_OMNIBOX_BROWSER_SEARCH_SUGGESTIONS_QUERY_CHECK_UTILS_H_

--- a/components/omnibox/browser/sources.gni
+++ b/components/omnibox/browser/sources.gni
@@ -8,6 +8,8 @@ import("//brave/components/commander/common/buildflags/buildflags.gni")
 import("//brave/components/omnibox/buildflags/buildflags.gni")
 
 brave_components_omnibox_browser_sources = [
+  "//brave/components/omnibox/browser/arithmetic_evaluator.cc",
+  "//brave/components/omnibox/browser/arithmetic_evaluator.h",
   "//brave/components/omnibox/browser/brave_bookmark_provider.cc",
   "//brave/components/omnibox/browser/brave_bookmark_provider.h",
   "//brave/components/omnibox/browser/brave_history_quick_provider.cc",
@@ -36,6 +38,7 @@ brave_components_omnibox_browser_sources = [
 
 brave_components_omnibox_browser_deps = [
   "//base",
+  "//base:i18n",
   "//brave/components/brave_search_conversion",
   "//brave/components/constants",
   "//brave/components/omnibox/buildflags",

--- a/components/omnibox/browser/sources.gni
+++ b/components/omnibox/browser/sources.gni
@@ -38,7 +38,6 @@ brave_components_omnibox_browser_deps = [
   "//base",
   "//brave/components/brave_search_conversion",
   "//brave/components/constants",
-  "//brave/components/omnibox/browser:arithmetic_evaluator",
   "//brave/components/omnibox/buildflags",
   "//brave/components/resources:strings",
   "//brave/components/vector_icons",
@@ -79,6 +78,8 @@ if (enable_commander) {
 }
 
 if (enable_strict_query_check_for_search_suggestions) {
-  brave_components_omnibox_browser_deps +=
-      [ "//brave/components/omnibox/browser/search_suggestions" ]
+  brave_components_omnibox_browser_deps += [
+    "//brave/components/omnibox/browser:arithmetic_evaluator",
+    "//brave/components/omnibox/browser/search_suggestions",
+  ]
 }

--- a/components/omnibox/browser/sources.gni
+++ b/components/omnibox/browser/sources.gni
@@ -8,8 +8,6 @@ import("//brave/components/commander/common/buildflags/buildflags.gni")
 import("//brave/components/omnibox/buildflags/buildflags.gni")
 
 brave_components_omnibox_browser_sources = [
-  "//brave/components/omnibox/browser/arithmetic_evaluator.cc",
-  "//brave/components/omnibox/browser/arithmetic_evaluator.h",
   "//brave/components/omnibox/browser/brave_bookmark_provider.cc",
   "//brave/components/omnibox/browser/brave_bookmark_provider.h",
   "//brave/components/omnibox/browser/brave_history_quick_provider.cc",
@@ -38,9 +36,9 @@ brave_components_omnibox_browser_sources = [
 
 brave_components_omnibox_browser_deps = [
   "//base",
-  "//base:i18n",
   "//brave/components/brave_search_conversion",
   "//brave/components/constants",
+  "//brave/components/omnibox/browser:arithmetic_evaluator",
   "//brave/components/omnibox/buildflags",
   "//brave/components/resources:strings",
   "//brave/components/vector_icons",

--- a/patches/components-omnibox-browser-search_provider.h.patch
+++ b/patches/components-omnibox-browser-search_provider.h.patch
@@ -1,0 +1,13 @@
+diff --git a/components/omnibox/browser/search_provider.h b/components/omnibox/browser/search_provider.h
+index 65822afe5114472da03fe62c3efd493e8ef9f2c8..7ae61c470d698ddeedd652edd886f544de2e8f32 100644
+--- a/components/omnibox/browser/search_provider.h
++++ b/components/omnibox/browser/search_provider.h
+@@ -213,7 +213,7 @@ class SearchProvider : public BaseSearchProvider,
+ 
+   // Updates |matches_| from the latest results; applies calculated relevances
+   // if suggested relevances cause undesirable behavior. Updates |done_|.
+-  void UpdateMatches();
++  virtual void UpdateMatches();
+ 
+   // Checks constraints that may be violated by suggested relevances and
+   // revises/rolls back the suggested relevance scores to make all constraints

--- a/rewrite/components/omnibox/browser/search_provider.h.yaml
+++ b/rewrite/components/omnibox/browser/search_provider.h.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Make `UpdateMatches` virtual.
+
+      `BraveSearchProvider` answers arithmetic expressions itself rather than
+      sending them to the suggest server. It overrides this to add the answer
+      to `default_results_`, so the upstream conversion to matches presents it
+      exactly as it would a server-provided calculator suggestion.
+    make_virtual:
+      class_name: SearchProvider
+      method_name: UpdateMatches


### PR DESCRIPTION
Privacy / security review: https://github.com/brave/reviews/issues/2343

Local processing which will prevent the omnibox input from being sent via Search Suggestions API when it looks like arithmetic. This prevents the extra call from being made but also fixes an issue that looks like truncation due to extra processing.

We are checking input for search suggestions and will attempt to block situations where PII might have unintentionally been pasted (ex: card number, date, etc). Logic that was put in place by https://github.com/brave/brave-core/pull/25243 basically.

Fixes https://github.com/brave/brave-browser/issues/54277