### PR TITLE
Move v1 endpoint constants under v1::endpoints namespace

### DIFF
--- a/components/brave_vpn/browser/api/brave_vpn_api_helper.cc
+++ b/components/brave_vpn/browser/api/brave_vpn_api_helper.cc
@@ -24,6 +24,13 @@
 
 namespace brave_vpn {
 
+using v1::endpoints::kSupportTicketEmailKey;
+using v1::endpoints::kSupportTicketPartnerClientIdKey;
+using v1::endpoints::kSupportTicketPaymentValidationMethodKey;
+using v1::endpoints::kSupportTicketSubjectKey;
+using v1::endpoints::kSupportTicketSubscriberCredential;
+using v1::endpoints::kSupportTicketSupportTicketKey;
+
 std::unique_ptr<Hostname> PickBestHostname(
     const std::vector<Hostname>& hostnames) {
   std::vector<Hostname> filtered_hostnames;

--- a/components/brave_vpn/browser/api/brave_vpn_api_helper_unittest.cc
+++ b/components/brave_vpn/browser/api/brave_vpn_api_helper_unittest.cc
@@ -12,6 +12,13 @@
 
 namespace brave_vpn {
 
+using v1::endpoints::kSupportTicketEmailKey;
+using v1::endpoints::kSupportTicketPartnerClientIdKey;
+using v1::endpoints::kSupportTicketPaymentValidationMethodKey;
+using v1::endpoints::kSupportTicketSubjectKey;
+using v1::endpoints::kSupportTicketSubscriberCredential;
+using v1::endpoints::kSupportTicketSupportTicketKey;
+
 TEST(BraveVPNAPIHelperTest, TicketInfoTest) {
   base::DictValue ticket_value = GetValueWithTicketInfos(
       "brave-vpn@brave.com", "It's cool feature", "Love the Brave VPN!",

--- a/components/brave_vpn/browser/api/brave_vpn_api_request.cc
+++ b/components/brave_vpn/browser/api/brave_vpn_api_request.cc
@@ -57,6 +57,16 @@ std::string CreateJSONRequestBody(base::ValueView node) {
 
 namespace brave_vpn {
 
+using v1::endpoints::kCreateSubscriberCredentialV12;
+using v1::endpoints::kCreateSupportTicket;
+using v1::endpoints::kCredential;
+using v1::endpoints::kHostnameForRegionNew;
+using v1::endpoints::kProfileCredential;
+using v1::endpoints::kServerRegionsWithCities;
+using v1::endpoints::kTimezonesForRegions;
+using v1::endpoints::kVerifyPurchaseToken;
+using v1::endpoints::kVpnHost;
+
 BraveVpnAPIRequest::BraveVpnAPIRequest(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory)
     : api_request_helper_(GetNetworkTrafficAnnotationTag(),

--- a/components/brave_vpn/browser/connection/brave_vpn_region_data_helper.cc
+++ b/components/brave_vpn/browser/connection/brave_vpn_region_data_helper.cc
@@ -22,6 +22,19 @@
 #include "third_party/icu/source/i18n/unicode/timezone.h"
 
 namespace brave_vpn {
+
+using v1::endpoints::kRegionCitiesKey;
+using v1::endpoints::kRegionContinentKey;
+using v1::endpoints::kRegionCountryIsoCodeKey;
+using v1::endpoints::kRegionCountryKey;
+using v1::endpoints::kRegionLatitudeKey;
+using v1::endpoints::kRegionLongitudeKey;
+using v1::endpoints::kRegionNameKey;
+using v1::endpoints::kRegionNamePrettyKey;
+using v1::endpoints::kRegionPrecisionKey;
+using v1::endpoints::kRegionServerCountKey;
+using v1::endpoints::kRegionSmartRoutingProxyStateKey;
+
 mojom::RegionPtr GetRegionPtrWithNameFromRegionList(
     const std::string& name,
     const std::vector<mojom::RegionPtr>& region_list) {

--- a/components/brave_vpn/browser/connection/brave_vpn_region_data_manager.cc
+++ b/components/brave_vpn/browser/connection/brave_vpn_region_data_manager.cc
@@ -24,6 +24,9 @@
 #include "components/prefs/pref_service.h"
 
 namespace brave_vpn {
+
+using v1::endpoints::kRegionCountryIsoCodeKey;
+
 BraveVPNRegionDataManager::BraveVPNRegionDataManager(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     PrefService* local_prefs)

--- a/components/brave_vpn/browser/connection/ikev2/mac/ikev2_connection_api_impl_mac.mm
+++ b/components/brave_vpn/browser/connection/ikev2/mac/ikev2_connection_api_impl_mac.mm
@@ -28,6 +28,8 @@
 // https://github.com/GuardianFirewall/GuardianConnect
 namespace brave_vpn {
 
+using v1::endpoints::kServerStatus;
+
 namespace {
 
 const NSString* kBraveVPNKey = @"BraveVPNKey";

--- a/components/brave_vpn/common/brave_vpn_constants.h
+++ b/components/brave_vpn/common/brave_vpn_constants.h
@@ -21,6 +21,10 @@ inline constexpr char kManageUrlDev[] =
 inline constexpr char kFeedbackUrl[] = "https://support.brave.app/";
 inline constexpr char kAboutUrl[] = "https://brave.com/firewall-vpn/";
 
+// TODO(https://github.com/brave/brave-browser/issues/54596)
+// Remove everything under v1::endpoints namespace, as this is now deprecated
+// and only used in BraveVPN V1 code.
+namespace v1::endpoints {
 inline constexpr char kRegionNameKey[] = "name";
 inline constexpr char kRegionNamePrettyKey[] = "name-pretty";
 inline constexpr char kRegionCountryKey[] = "country";
@@ -58,6 +62,8 @@ inline constexpr char kVerifyPurchaseToken[] = "api/v1.1/verify-purchase-token";
 inline constexpr char kCreateSubscriberCredentialV12[] =
     "api/v1.2/subscriber-credential/create";
 inline constexpr char kServerStatus[] = "api/v1.3/server-status";
+}  // namespace v1::endpoints
+
 inline constexpr int kP3AIntervalHours = 24;
 
 inline constexpr char kSubscriberCredentialKey[] = "credential";


### PR DESCRIPTION
Moved Guardian wire constants (region keys, support-ticket keys, host/ path constants) in `brave_vpn_constants.h` under `v1::endpoints`, marked for removal once BraveVPN V1 is retired. Updated all v1 consumers to reference them via the new namespace: one source of truth instead of duplicating values in v2's `endpoint_constants.h`.

Resolves https://github.com/brave/brave-browser/issues/54600

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
