### PR TITLE
[plaster] `//chrome/browser/browsing_data` 🩹🩹

### DIFF
--- a/chromium_src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.cc
+++ b/chromium_src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.cc
@@ -7,6 +7,4 @@
 
 #include "brave/browser/browsing_data/brave_browsing_data_remover_delegate.h"
 
-#define ChromeBrowsingDataRemoverDelegate BraveBrowsingDataRemoverDelegate
 #include <chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.cc>
-#undef ChromeBrowsingDataRemoverDelegate

--- a/chromium_src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.h
+++ b/chromium_src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.h
@@ -6,9 +6,7 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_BROWSING_DATA_CHROME_BROWSING_DATA_REMOVER_DELEGATE_FACTORY_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_BROWSING_DATA_CHROME_BROWSING_DATA_REMOVER_DELEGATE_FACTORY_H_
 
-#define ChromeBrowsingDataRemoverDelegate BraveBrowsingDataRemoverDelegate
 #include <chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.h>  // IWYU pragma: export
-#undef ChromeBrowsingDataRemoverDelegate
 
 #include "brave/browser/browsing_data/brave_browsing_data_remover_delegate.h"
 

--- a/chromium_src/chrome/browser/browsing_data/counters/site_settings_counter.cc
+++ b/chromium_src/chrome/browser/browsing_data/counters/site_settings_counter.cc
@@ -41,11 +41,4 @@ void ProcessBraveTypes(Iterator&& iterate_content_settings_list,
 
 }  // namespace
 
-#define ReportResult(...)                                      \
-  ProcessBraveTypes(iterate_content_settings_list, map_.get(), \
-                    empty_host_pattern);                       \
-  ReportResult(__VA_ARGS__);
-
 #include <chrome/browser/browsing_data/counters/site_settings_counter.cc>
-
-#undef ReportResult

--- a/patches/chrome-browser-browsing_data-chrome_browsing_data_remover_delegate_factory.cc.patch
+++ b/patches/chrome-browser-browsing_data-chrome_browsing_data_remover_delegate_factory.cc.patch
@@ -1,0 +1,23 @@
+diff --git a/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.cc b/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.cc
+index 80cfa7e5302878f0cc5a7df1d854ced9889ffcb6..8222a1e52f70c0c47ea021630029d20afa814235 100644
+--- a/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.cc
++++ b/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.cc
+@@ -44,9 +44,9 @@ ChromeBrowsingDataRemoverDelegateFactory::GetInstance() {
+ }
+ 
+ // static
+-ChromeBrowsingDataRemoverDelegate*
++BraveBrowsingDataRemoverDelegate*
+ ChromeBrowsingDataRemoverDelegateFactory::GetForProfile(Profile* profile) {
+-  return static_cast<ChromeBrowsingDataRemoverDelegate*>(
++  return static_cast<BraveBrowsingDataRemoverDelegate*>(
+       GetInstance()->GetServiceForBrowserContext(profile, true));
+ }
+ 
+@@ -99,5 +99,5 @@ ChromeBrowsingDataRemoverDelegateFactory::BuildServiceInstanceForBrowserContext(
+   // For guest profiles the browsing data is in the OTR profile.
+   Profile* profile = static_cast<Profile*>(context);
+   DCHECK(!profile->IsGuestSession() || profile->IsOffTheRecord());
+-  return std::make_unique<ChromeBrowsingDataRemoverDelegate>(context);
++  return std::make_unique<BraveBrowsingDataRemoverDelegate>(context);
+ }

--- a/patches/chrome-browser-browsing_data-chrome_browsing_data_remover_delegate_factory.h.patch
+++ b/patches/chrome-browser-browsing_data-chrome_browsing_data_remover_delegate_factory.h.patch
@@ -1,0 +1,22 @@
+diff --git a/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.h b/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.h
+index 74819905270c55c2e61a034766b86d9b74d44063..62e749cb0c5a40f5accd1fed9dc851f7ad9c0c0f 100644
+--- a/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.h
++++ b/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.h
+@@ -12,7 +12,7 @@ template <typename T>
+ class NoDestructor;
+ }
+ 
+-class ChromeBrowsingDataRemoverDelegate;
++class BraveBrowsingDataRemoverDelegate;
+ class Profile;
+ 
+ class ChromeBrowsingDataRemoverDelegateFactory
+@@ -22,7 +22,7 @@ class ChromeBrowsingDataRemoverDelegateFactory
+   static ChromeBrowsingDataRemoverDelegateFactory* GetInstance();
+ 
+   // Returns the ChromeBrowsingDataRemoverDelegate associated with |profile|.
+-  static ChromeBrowsingDataRemoverDelegate* GetForProfile(Profile* profile);
++  static BraveBrowsingDataRemoverDelegate* GetForProfile(Profile* profile);
+ 
+   ChromeBrowsingDataRemoverDelegateFactory(
+       const ChromeBrowsingDataRemoverDelegateFactory&) = delete;

--- a/patches/chrome-browser-browsing_data-counters-site_settings_counter.cc.patch
+++ b/patches/chrome-browser-browsing_data-counters-site_settings_counter.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/browsing_data/counters/site_settings_counter.cc b/chrome/browser/browsing_data/counters/site_settings_counter.cc
+index 4fad4d847a0c95cf8c6417db88ccd115dc449e2f..0d670410aa780314a4ee70b4423739663228bee4 100644
+--- a/chrome/browser/browsing_data/counters/site_settings_counter.cc
++++ b/chrome/browser/browsing_data/counters/site_settings_counter.cc
+@@ -125,5 +125,7 @@ void SiteSettingsCounter::Count() {
+     }
+   }
+ 
++  ProcessBraveTypes(iterate_content_settings_list, map_.get(),
++                    empty_host_pattern);
+   ReportResult(hosts.size() + empty_host_pattern);
+ }

--- a/rewrite/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.cc.yaml
+++ b/rewrite/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.cc.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description:
+      'Have the factory build and return BraveBrowsingDataRemoverDelegate.'
+    rename_class:
+      class_name: ChromeBrowsingDataRemoverDelegate
+      rename: BraveBrowsingDataRemoverDelegate

--- a/rewrite/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.h.yaml
+++ b/rewrite/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate_factory.h.yaml
@@ -1,0 +1,11 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description:
+      'Have the factory build and return BraveBrowsingDataRemoverDelegate.'
+    rename_class:
+      class_name: ChromeBrowsingDataRemoverDelegate
+      rename: BraveBrowsingDataRemoverDelegate

--- a/rewrite/chrome/browser/browsing_data/counters/site_settings_counter.cc.yaml
+++ b/rewrite/chrome/browser/browsing_data/counters/site_settings_counter.cc.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Recount Brave content settings types before Count() reports the total.
+
+      HostContentSettingsMap folds BRAVE_COOKIES into COOKIES and does not
+      enumerate the Shields-only types on its own, so ProcessBraveTypes must
+      run before the upstream total is reported.
+    regex:
+      re_pattern: '(ReportResult\(hosts\.size\(\) \+ empty_host_pattern\);)'
+      replace: |-
+        ProcessBraveTypes(iterate_content_settings_list, map_.get(),
+                            empty_host_pattern);
+          \1


### PR DESCRIPTION
This is a strict plaster migration for this path.

Bug: https://github.com/brave/brave-browser/issues/45050
