### PR TITLE
Crash Report: PSST

### DIFF
--- a/browser/psst/BUILD.gn
+++ b/browser/psst/BUILD.gn
@@ -92,6 +92,7 @@ source_set("browser_tests") {
     "//brave/components/psst/buildflags",
     "//brave/components/psst/core/browser",
     "//brave/components/psst/core/common",
+    "//chrome/browser/ui/views/infobars",
     "//chrome/test:test_support",
     "//components/component_updater:test_support",
     "//components/infobars/content",

--- a/browser/psst/psst_infobar_delegate.cc
+++ b/browser/psst/psst_infobar_delegate.cc
@@ -40,6 +40,7 @@ bool PsstInfoBarDelegate::Accept() {
     std::move(on_accept_callback_).Run(true);
   }
 
+  // Returns true to allow the infobar to be removed automatically
   return true;
 }
 
@@ -48,6 +49,7 @@ bool PsstInfoBarDelegate::Cancel() {
     std::move(on_accept_callback_).Run(false);
   }
 
+  // Returns true to allow the infobar to be removed automatically
   return true;
 }
 

--- a/browser/psst/psst_infobar_delegate.cc
+++ b/browser/psst/psst_infobar_delegate.cc
@@ -40,7 +40,6 @@ bool PsstInfoBarDelegate::Accept() {
     std::move(on_accept_callback_).Run(true);
   }
 
-  // Returns true to allow the infobar to be removed automatically
   return true;
 }
 
@@ -49,7 +48,6 @@ bool PsstInfoBarDelegate::Cancel() {
     std::move(on_accept_callback_).Run(false);
   }
 
-  // Returns true to allow the infobar to be removed automatically
   return true;
 }
 

--- a/browser/psst/psst_infobar_delegate.h
+++ b/browser/psst/psst_infobar_delegate.h
@@ -24,8 +24,14 @@ class PsstInfoBarDelegate : public ConfirmInfoBarDelegate {
                      AcceptCallback on_accept_callback);
 
   // ConfirmInfoBarDelegate overrides:
+
+  // Handles infobar acceptance. The return value determines the upstream
+  // behavior; return `true` if the infobar should be removed automatically.
   bool Accept() override;
+  // Handles infobar cancellation. The return value determines upstream
+  // behavior: return `true` if the infobar should be removed automatically.
   bool Cancel() override;
+  // Handles infobar closing.
   void InfoBarDismissed() override;
 
   void DisableCallback();

--- a/browser/psst/psst_tab_web_contents_observer_browsertest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_browsertest.cc
@@ -1060,14 +1060,8 @@ IN_PROC_BROWSER_TEST_F(
   ASSERT_NO_FATAL_FAILURE(NavigateAndClickOnPsstLocationBarIcon(
       url, ui::EF_LEFT_MOUSE_BUTTON, &dialog_wc, &infobar_observer));
   ASSERT_TRUE(dialog_wc);
-  auto infobar =
-      std::ranges::find_if(manager->infobars(), [](infobars::InfoBar* infobar) {
-        return infobar->GetIdentifier() ==
-               infobars::InfoBarDelegate::BRAVE_PSST_INFOBAR_DELEGATE;
-      });
-  // Infobar must be closed right after left mouse button omnibar icon's click,
-  // just before consent dialog opening
-  ASSERT_FALSE(infobar != manager->infobars().end());
+  // Ensure the infobar is dismissed when the omnibar icon is left-clicked.
+  infobar_observer.WaitForInfobarRemoved();
 
   const std::vector<std::string> perform_uids = {"1", "2"};
   ASSERT_TRUE(AcceptModalDialog(

--- a/browser/psst/psst_tab_web_contents_observer_browsertest.cc
+++ b/browser/psst/psst_tab_web_contents_observer_browsertest.cc
@@ -33,6 +33,8 @@
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/toolbar_button_provider.h"
+#include "chrome/browser/ui/views/infobars/confirm_infobar.h"
+#include "chrome/browser/ui/views/infobars/infobar_view.h"
 #include "chrome/browser/ui/views/location_bar/icon_label_bubble_view.h"
 #include "chrome/browser/ui/views/page_action/test_support/page_action_test_support.h"
 #include "chrome/test/base/chrome_test_utils.h"
@@ -646,10 +648,12 @@ class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
   // and waits for the menu to appear, or opens the consent dialog and waits
   // for it to appear. For a left-click, the opened consent dialog's WebContents
   // is returned via `dialog_wc_out` when provided.
+  // Passing `infobar_observer` makes it wait for infobar appearing
   void NavigateAndClickOnPsstLocationBarIcon(
       const GURL& url,
       ui::EventFlags event_flags,
-      content::WebContents** dialog_wc_out = nullptr) {
+      content::WebContents** dialog_wc_out = nullptr,
+      InfobarObserver* infobar_observer = nullptr) {
     ASSERT_TRUE(event_flags == ui::EF_RIGHT_MOUSE_BUTTON ||
                 event_flags == ui::EF_LEFT_MOUSE_BUTTON);
 
@@ -658,6 +662,9 @@ class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
     ASSERT_TRUE(action);
 
     ASSERT_NO_FATAL_FAILURE(NavigateAndWaitForPsstIconVisible(url));
+    if (infobar_observer) {
+      infobar_observer->WaitForInfobarAdded();
+    }
 
     IconLabelBubbleView* const psst_view = GetPsstPageActionView();
     ASSERT_TRUE(psst_view);
@@ -721,6 +728,31 @@ class PsstTabWebContentsObserverBrowserTest : public PlatformBrowserTest {
         [dialog_ui]() { return dialog_ui->psst_consent_handler_ != nullptr; }));
   }
 
+  // Clicks the OK button to accept `infobar` and continue the flow, so that
+  // ConfirmInfoBar::OkButtonPressed() closes the infobar as it would in
+  // production.
+  void ClickInfobarOkButton(infobars::InfoBar* infobar) {
+    views::test::ButtonTestApi(
+        static_cast<ConfirmInfoBar*>(infobar)->ok_button_for_testing())
+        .NotifyClick(ui::MouseEvent(ui::EventType::kMousePressed, gfx::Point(),
+                                    gfx::Point(), base::TimeTicks(),
+                                    ui::EF_LEFT_MOUSE_BUTTON,
+                                    ui::EF_LEFT_MOUSE_BUTTON));
+  }
+
+  // Clicks the close ("x") button on `infobar`, so that
+  // InfoBarView::CloseButtonPressed() calls delegate()->InfoBarDismissed() and
+  // removes the infobar as it would in production.
+  void ClickInfobarCloseButton(infobars::InfoBar* infobar) {
+    views::test::ButtonTestApi(
+        views::Button::AsButton(
+            static_cast<InfoBarView*>(infobar)->close_button()))
+        .NotifyClick(ui::MouseEvent(ui::EventType::kMousePressed, gfx::Point(),
+                                    gfx::Point(), base::TimeTicks(),
+                                    ui::EF_LEFT_MOUSE_BUTTON,
+                                    ui::EF_LEFT_MOUSE_BUTTON));
+  }
+
  protected:
   raw_ptr<Profile> profile_;
   raw_ptr<PsstSettingsService> psst_settings_service_ = nullptr;
@@ -774,8 +806,8 @@ IN_PROC_BROWSER_TEST_F(PsstTabWebContentsObserverBrowserTest,
   EXPECT_EQ(confirm_delegate->GetIdentifier(),
             infobars::InfoBarDelegate::BRAVE_PSST_INFOBAR_DELEGATE);
 
-  // Accept the infobar to continue the flow
-  confirm_delegate->Accept();
+  ClickInfobarOkButton(*infobar);
+  ASSERT_TRUE(infobar_observer.WaitForInfobarRemoved());
 
   auto* dialog_wc = WaitForAndGetDialogWebContents(new_web_contents_observer);
   ASSERT_TRUE(dialog_wc);
@@ -826,14 +858,14 @@ IN_PROC_BROWSER_TEST_F(PsstTabWebContentsObserverBrowserTest,
   EXPECT_EQ(confirm_delegate->GetIdentifier(),
             infobars::InfoBarDelegate::BRAVE_PSST_INFOBAR_DELEGATE);
   // Dismissing the infobar disables PSST, which in turn removes the infobar.
-  confirm_delegate->InfoBarDismissed();
+  ClickInfobarCloseButton(psst_infobar);
   ASSERT_TRUE(infobar_observer.WaitForInfobarRemoved());
   EXPECT_FALSE(GetPsstInfobar(manager));
 
   // Wait for console message only from user script
   ASSERT_TRUE(console_observer.Wait());
   EXPECT_TRUE(console_observer.CheckMessages());
-  EXPECT_FALSE(GetPrefs()->GetBoolean(prefs::kPsstEnabled));
+  EXPECT_TRUE(GetPrefs()->GetBoolean(prefs::kPsstEnabled));
 }
 
 IN_PROC_BROWSER_TEST_F(PsstTabWebContentsObserverBrowserTest,
@@ -876,7 +908,7 @@ IN_PROC_BROWSER_TEST_F(PsstTabWebContentsObserverBrowserTest,
   EXPECT_EQ(confirm_delegate->GetIdentifier(),
             infobars::InfoBarDelegate::BRAVE_PSST_INFOBAR_DELEGATE);
 
-  confirm_delegate->Accept();
+  ClickInfobarOkButton(*infobar);
 
   auto* dialog_wc = WaitForAndGetDialogWebContents(new_web_contents_observer);
   ASSERT_TRUE(dialog_wc);
@@ -993,9 +1025,9 @@ IN_PROC_BROWSER_TEST_F(PsstTabWebContentsObserverBrowserTest,
 }
 
 // After navigating to the initial page and left-clicking the PSST location bar
-// icon, accepting the consent dialog runs both scripts across all task pages,
-// applies the PSST settings, and navigates the tab back to the initial page
-// where tuning started.
+// icon, hiding the opened infobar, accepting the consent dialog runs both
+// scripts across all task pages, applies the PSST settings, and navigates the
+// tab back to the initial page where tuning started.
 IN_PROC_BROWSER_TEST_F(
     PsstTabWebContentsObserverBrowserTest,
     LocationBarIconLeftClickAppliesSettingsAndReturnsToPage) {
@@ -1003,6 +1035,8 @@ IN_PROC_BROWSER_TEST_F(
   ASSERT_TRUE(GetPrefs()->GetBoolean(prefs::kPsstEnabled));
 
   const GURL url = GetEmbeddedTestServer().GetURL("a.test", "/a_test_0.html");
+  infobars::ContentInfoBarManager* manager =
+      infobars::ContentInfoBarManager::FromWebContents(web_contents());
 
   // Observe both scripts running across the initial page and each task page.
   PsstWebContentsConsoleObserver console_observer(
@@ -1020,10 +1054,20 @@ IN_PROC_BROWSER_TEST_F(
        base::StrCat({kPolicyScriptLogPrefix,
                      CreateTestUtf16URL(https_server_, "/a_test_2.html")})});
 
+  InfobarObserver infobar_observer(
+      manager, infobars::InfoBarDelegate::BRAVE_PSST_INFOBAR_DELEGATE);
   content::WebContents* dialog_wc = nullptr;
   ASSERT_NO_FATAL_FAILURE(NavigateAndClickOnPsstLocationBarIcon(
-      url, ui::EF_LEFT_MOUSE_BUTTON, &dialog_wc));
+      url, ui::EF_LEFT_MOUSE_BUTTON, &dialog_wc, &infobar_observer));
   ASSERT_TRUE(dialog_wc);
+  auto infobar =
+      std::ranges::find_if(manager->infobars(), [](infobars::InfoBar* infobar) {
+        return infobar->GetIdentifier() ==
+               infobars::InfoBarDelegate::BRAVE_PSST_INFOBAR_DELEGATE;
+      });
+  // Infobar must be closed right after left mouse button omnibar icon's click,
+  // just before consent dialog opening
+  ASSERT_FALSE(infobar != manager->infobars().end());
 
   const std::vector<std::string> perform_uids = {"1", "2"};
   ASSERT_TRUE(AcceptModalDialog(

--- a/browser/psst/psst_ui_delegate_impl.cc
+++ b/browser/psst/psst_ui_delegate_impl.cc
@@ -175,6 +175,9 @@ void PsstUiDelegateImpl::OnUserAcceptedInfobar(const bool is_accepted) {
                        weak_ptr_factory_.GetWeakPtr()));
 
     ui_presenter_->ShowConsentDialog();
+  } else {
+    // TODO(https://github.com/brave/brave-browser/issues/58449): Handle infobar
+    // dismissal (e.g. close button, tab/navigation away).
   }
 }
 

--- a/browser/psst/psst_ui_delegate_impl.cc
+++ b/browser/psst/psst_ui_delegate_impl.cc
@@ -175,9 +175,6 @@ void PsstUiDelegateImpl::OnUserAcceptedInfobar(const bool is_accepted) {
                        weak_ptr_factory_.GetWeakPtr()));
 
     ui_presenter_->ShowConsentDialog();
-  } else {
-    // Disable PSST if user declined the infobar
-    psst_settings_service_->SetPsstEnabled(false);
   }
 }
 

--- a/browser/psst/psst_ui_desktop_presenter.cc
+++ b/browser/psst/psst_ui_desktop_presenter.cc
@@ -216,8 +216,6 @@ void PsstUiDesktopPresenter::ShowConsentDialog() {
     return;
   }
 
-  HideInfoBar();
-
   if (psst_action_controller_) {
     psst_action_controller_->SetShowBadge(false);
   }
@@ -242,6 +240,11 @@ bool PsstUiDesktopPresenter::IsDialogShown() const {
 }
 
 void PsstUiDesktopPresenter::OnShowConsentDialogSelected() {
+  // Close the infobar if it is present. This is necessary because when the user
+  // clicks the omnibar icon, the PSST infobar may still be visible with no way
+  // to dismiss it.
+  HideInfoBar();
+
   ShowConsentDialog();
 }
 

--- a/browser/psst/psst_ui_desktop_presenter.h
+++ b/browser/psst/psst_ui_desktop_presenter.h
@@ -76,9 +76,14 @@ class PsstUiDesktopPresenter
   bool IsDialogShown() const override;
 
  private:
-  // page_actions::PsstActionController::Delegate:
+  // page_actions::PsstActionController::Delegate overrides:
+
+  // Handles the left mouse button click on the omnibar.
   void OnShowConsentDialogSelected() override;
+  // Handles the omnibar menu item that stops running Psst for a specific
+  // website
   void OnDontShowThisSiteSelected() override;
+  // Handles the omnibar menu item that disables Psst
   void OnDisablePrivacySettingsTuningSelected() override;
 
   base::WeakPtr<content::WebContents> web_contents_;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58187

- Fixes a crash on accepting the PSST infobar: PsstUiDesktopPresenter called HideInfoBar() itself when opening the consent dialog, racing with upstream's own infobar removal on close.



<!-- obsidian -->
Manual tests | Video
-- | --
|**Infobar `Review Suggestions` button clicked scenario**<br/>1. Check Brave Feature flag is `Enabled`<br/>2. Check Brave Origin is `Enabled`<br/>3. Sign in and navigate to `x.com`<br/>4. Page loaded<br/>5. Psst Omnibar Icon appears<br/>6. Psst InfoBar appears<br/>7. Click `Review Suggestions` button<br/>8. Make sure that that Infobar dismissed<br/>9. Make sure that OmniBar Icon is visible<br/>10. Make sure that Consent Dialog Appeared<br/>11. There is no UAF crash  | <video src="https://github.com/user-attachments/assets/39efa75e-00d2-4ea4-a7cd-abf2b73108bb" /> |
|**Infobar close button clicked scenario**<br/>1. Check Brave Feature flag is `Enabled`<br/>2. Check Brave Origin is `Enabled`<br/>3. Sign in and navigate to `x.com`<br/>4. Page loaded<br/>5. Psst Omnibar Icon appears<br/>6. Psst InfoBar appears<br/>7. Click close button<br/>8. Make sure that that Infobar dismissed<br/>9. Make sure that OmniBar Icon is visible<br/>11.Make sure there is no any UAF crash|<video src="https://github.com/user-attachments/assets/05e6f319-98f6-4f74-8947-1c08aea43d4d" />|










<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
