### PR TITLE
Render sidebar news images immediately

### DIFF
--- a/components/brave_news/browser/resources/shared/Context.tsx
+++ b/components/brave_news/browser/resources/shared/Context.tsx
@@ -85,6 +85,10 @@ interface BraveNewsContextProviderProps {
   // subtree. Used by surfaces like the sidebar, where articles must always open
   // in the main browser tab regardless of the configured preference.
   openArticlesInNewTab?: boolean
+  // Set by surfaces where the feed is on screen as soon as it mounts (e.g. the
+  // sidebar). The NTP defers images until the first scroll because its feed
+  // starts below the fold, but that scroll never comes on these surfaces.
+  renderImagesImmediately?: boolean
 }
 
 export function BraveNewsContextProvider(props: BraveNewsContextProviderProps) {
@@ -108,7 +112,8 @@ export function BraveNewsContextProvider(props: BraveNewsContextProviderProps) {
   const [channels, setChannels] = useState<Channels>({})
   const [publishers, setPublishers] = useState<Publishers>({})
   const [suggestedPublisherIds, setSuggestedPublisherIds] = useState<string[]>([])
-  const [shouldRenderImages, setShouldRenderImages] = useState(false)
+  const [hasScrolled, setHasScrolled] = useState(false)
+  const shouldRenderImages = props.renderImagesImmediately || hasScrolled
 
   // Get the default locale on load.
   useEffect(() => {
@@ -139,10 +144,11 @@ export function BraveNewsContextProvider(props: BraveNewsContextProviderProps) {
   }, [])
 
   React.useEffect(() => {
-    const handleScroll = () => setShouldRenderImages(true)
+    if (props.renderImagesImmediately) return
+    const handleScroll = () => setHasScrolled(true)
     document.addEventListener('scroll', handleScroll, { once: true })
     return () => document.removeEventListener('scroll', handleScroll)
-  }, [])
+  }, [props.renderImagesImmediately])
 
   const sortedPublishers = useMemo(() =>
     Object.values(publishers)

--- a/components/brave_news/browser/resources/sidebar.stories.tsx
+++ b/components/brave_news/browser/resources/sidebar.stories.tsx
@@ -17,7 +17,7 @@ export default {
 
 export const Default = () => (
   <div style={{ background: '#000' }}>
-    <BraveNewsContextProvider openArticlesInNewTab={false}>
+    <BraveNewsContextProvider openArticlesInNewTab={false} renderImagesImmediately>
       <Sidebar />
     </BraveNewsContextProvider>
   </div>

--- a/components/brave_news/browser/resources/sidebar.tsx
+++ b/components/brave_news/browser/resources/sidebar.tsx
@@ -90,7 +90,7 @@ if (root) {
 
   createRoot(root).render(
     <StyledComponentsProvider>
-      <BraveNewsContextProvider openArticlesInNewTab={false}>
+      <BraveNewsContextProvider openArticlesInNewTab={false} renderImagesImmediately>
         <Sidebar />
       </BraveNewsContextProvider>
     </StyledComponentsProvider>


### PR DESCRIPTION
Article image previews in the Brave News sidebar stayed blank on load, until the user scrolled the feed by even a single pixel.

`BraveNewsContextProvider` withholds every article image's `src` until the first `document` scroll event, via `shouldRenderImages`. That gate comes from #31516 (`[perf] Load brave news images on demand`) and is correct for the new tab page, where the feed starts below the fold: deferring image loads until the user scrolls down to the feed avoids fetching images that are never seen. The sidebar reuses the same provider, but its feed is on screen as soon as it mounts, so that scroll never happens and the images are left without a `src`.

## Changes

- Add an optional `renderImagesImmediately` prop to `BraveNewsContextProvider`, following the same per-surface override pattern already used for `openArticlesInNewTab`. When set, `shouldRenderImages` is true from the start and the scroll listener isn't attached.
- Enable it for the sidebar, and for its Storybook story so the story matches the real wiring.

New tab page behavior is unchanged: the prop defaults to undefined, so the scroll gate still applies there. Images below the sidebar's visible area are still deferred by the native `loading='lazy'` attribute on `SmallImage`/`LargeImage`, so this doesn't load the whole feed eagerly.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58411

## Result


https://github.com/user-attachments/assets/4b2c1cc9-0488-4fff-9129-c259615114ac


## Test plan

1. Open Brave News in the sidebar and don't scroll: image previews load on their own.
2. Scroll down the sidebar feed: images for cards further down load as they come into view.
3. Open Brave News on the new tab page: images still load once the feed is scrolled into view, as before.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

