### PR TITLE
[plaster] Initial `gn` edit support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ patches/**/*.patchinfo
 /third_party/node/mac_arm64/
 /third_party/node/win/
 /third_party/node/*.tar.gz
+/third_party/gn/
 /third_party/opengrep/bin/
 /third_party/wintun/
 /third_party/ast-grep-intermediate/

--- a/DEPS
+++ b/DEPS
@@ -3,9 +3,44 @@ use_relative_paths = True
 vars = {
   'download_prebuilt_sparkle': True,
   'checkout_dmg_tool': False,
+  # TODO(https://brave.dev/b/58378): Remove once `cr154` is merged.
+  'plaster_gn_version': 'git_revision:e0a6ab04a113b2dd039cab7c21c6f387e0d881ee',
 }
 
 deps = {
+  # TODO(https://brave.dev/b/58378): Remove this gn checkout once `cr154` is
+  # merged.
+  "third_party/gn/linux64": {
+    "packages": [
+      {
+        "package": "gn/gn/linux-${{arch}}",
+        "version": Var("plaster_gn_version"),
+      }
+    ],
+    "dep_type": "cipd",
+    "condition": 'host_os == "linux"',
+  },
+  "third_party/gn/mac": {
+    "packages": [
+      {
+        "package": "gn/gn/mac-${{arch}}",
+        "version": Var("plaster_gn_version"),
+      }
+    ],
+    "dep_type": "cipd",
+    "condition": 'host_os == "mac"',
+  },
+  "third_party/gn/win": {
+    "packages": [
+      {
+        "package": "gn/gn/windows-amd64",
+        "version": Var("plaster_gn_version"),
+      }
+    ],
+    "dep_type": "cipd",
+    "condition": 'host_os == "win"',
+  },
+
   "vendor/omaha": {
     "url": "https://github.com/brave/omaha.git@32383a4dc9c50a88e42be0e03e5b2f2ba7ad058b",
     "condition": "checkout_win",

--- a/docs/plaster.md
+++ b/docs/plaster.md
@@ -149,6 +149,8 @@ introduce more rewriters. These are the ones we have supported for now.
 | `add_to_public`                           | `cxx`     | AST   | Appends a member to a class `public:` section.        |
 | `add_enum_entries`                        | `cxx`     | AST   | Appends entries to the end of a C++ enum.             |
 | `set_feature_flag_default_state`          | `cxx`     | macro | Sets a `BASE_FEATURE`'s default state.                |
+| `add_deps`                                | `gn`      | gn    | Adds dependencies to a target in a build file.        |
+| `add_sources`                             | `gn`      | gn    | Adds source files to a target in a build file.        |
 | `set_blink_runtime_enabled_feature_state` | `js`      | AST   | Sets a Blink runtime feature's `base_feature_status`. |
 
 Use `plaster --help` to discover rewriters and read their full docs:

--- a/script/brave_license_helper.py
+++ b/script/brave_license_helper.py
@@ -187,6 +187,11 @@ def AddBraveCredits(root, prune_paths, special_cases, prune_dirs,
         # plaster .toml file location should be skipped.
         os.path.join('brave', 'rewrite', 'third_party'),
 
+        # TODO(https://brave.dev/b/58378): Remove once `cr154` is merged.
+        # This path is being used to deploy a `gn` binary that is newer than the
+        # one in `master` right now.
+        os.path.join('brave', 'third_party', 'gn'),
+
         # TODO(https://github.com/brave/brave-browser/issues/54804)
         # remove the following line once we start putting
         # WinTun binaries into the browser distribution on Windows.

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -23,6 +23,7 @@ import re
 import string
 import subprocess
 import sys
+import tempfile
 import textwrap
 from types import MappingProxyType
 from typing import Callable, ClassVar, Final
@@ -528,11 +529,17 @@ class RewriterNamespace:
 # The global namespace, available to all plaster extensions.
 _GLOBAL_NAMESPACE: Final = 'all'
 
+# The namespace for `gn` files.
+_GN_NAMESPACE: Final = 'gn'
+
 # Every namespace plaster knows. The single place to register a language.
 _NAMESPACES: Final = (
     RewriterNamespace(name=_GLOBAL_NAMESPACE,
                       ast_grep_language=None,
                       suffixes=frozenset()),
+    RewriterNamespace(name=_GN_NAMESPACE,
+                      ast_grep_language=None,
+                      suffixes=frozenset({'.gn', '.gni'})),
     RewriterNamespace(name='cxx',
                       ast_grep_language='cpp',
                       suffixes=frozenset({
@@ -2605,6 +2612,24 @@ _REGEX_MACRO_SCHEMA = {
     schema.Optional('re_flags'): [str],
 }
 
+# One declared input of a `gn_edit` op. `variadic` marks the input a plaster
+# may pass a list to (the values being added), which renders as gn's
+# space-separated value list; every other input takes a single string.
+_GN_EDIT_INPUT_SCHEMA = {
+    'name': _NON_EMPTY_STR,
+    'description': _NON_EMPTY_STR,
+    schema.Optional('variadic'): bool,
+}
+
+# A `gn edit` op: the two arguments `gn edit` takes, as templates over the op's
+# declared `inputs`.
+_GN_EDIT_SCHEMA = {
+    'description': _NON_EMPTY_STR,
+    'inputs': [_GN_EDIT_INPUT_SCHEMA],
+    'pattern': _NON_EMPTY_STR,
+    'command': _NON_EMPTY_STR,
+}
+
 # Top-level schema for rewriters.pyl.
 _REWRITERS_SCHEMA = schema.Schema({
     schema.Optional('ast.matcher'): {
@@ -2615,6 +2640,9 @@ _REWRITERS_SCHEMA = schema.Schema({
     },
     schema.Optional('regex_macro'): {
         schema.Optional(_OP_ID): _REGEX_MACRO_SCHEMA
+    },
+    schema.Optional('gn_edit'): {
+        schema.Optional(_OP_ID): _GN_EDIT_SCHEMA
     },
 })
 
@@ -2647,6 +2675,7 @@ class RewritersEval:
         self._matchers = data.get('ast.matcher', {})
         self._rewriters = data.get('ast.rewriter', {})
         self._regex_macros = data.get('regex_macro', {})
+        self._gn_edits = data.get('gn_edit', {})
         self._check_cross_references()
 
     @classmethod
@@ -2697,6 +2726,19 @@ class RewritersEval:
         except KeyError:
             raise RewritersSchemaError(
                 f'unknown regex macro op: {op_id!r}') from None
+
+    @property
+    def gn_edits(self) -> MappingProxyType[str, dict]:
+        """Read-only mapping of gn edit op id -> validated op spec."""
+        return MappingProxyType(self._gn_edits)
+
+    def gn_edit(self, op_id: str) -> dict:
+        """Return the gn edit spec for `op_id`, or raise if it is unknown."""
+        try:
+            return self._gn_edits[op_id]
+        except KeyError:
+            raise RewritersSchemaError(
+                f'unknown gn edit op: {op_id!r}') from None
 
     @classmethod
     def language_of(cls, op_id: str) -> str:
@@ -2749,6 +2791,15 @@ class RewritersEval:
                         f'parse with; only text ops (regex_macro) can live '
                         f'there')
 
+        # A gn edit op drives the `gn` binary to edit an upstream `gn` file.
+        for op_id in self._gn_edits:
+            namespace = op_id.split('.', 1)[0]
+            if namespace != _GN_NAMESPACE:
+                raise RewritersSchemaError(
+                    f'{self._source}: gn edit op {op_id!r} cannot be used in '
+                    f'the {namespace!r} namespace. They can only be used in '
+                    f'the {_GN_NAMESPACE!r} namespace.')
+
         # Every other rule is per-op, and each checker below documents the
         # one it enforces.
         for op_id, spec in self._matchers.items():
@@ -2757,6 +2808,8 @@ class RewritersEval:
             self._check_rewriter_interface(op_id, spec)
         for op_id, spec in self._regex_macros.items():
             self._check_regex_macro_interface(op_id, spec)
+        for op_id, spec in self._gn_edits.items():
+            self._check_gn_edit_interface(op_id, spec)
 
     def _check_matcher_captures(self, op_id: str, spec: dict) -> None:
         """Every metavariable a capture reads must be bound by the template."""
@@ -2868,6 +2921,34 @@ class RewritersEval:
         if unused:
             raise RewritersSchemaError(
                 f'{self._source}: regex macro {op_id!r} declares input(s) '
+                f'never used in its templates: {", ".join(unused)}')
+
+    def _check_gn_edit_interface(self, op_id: str, spec: dict) -> None:
+        """Checks a gn edit op's `pattern`/`command` and declared `inputs`.
+
+        `inputs` entry's `name` must be unique, and the set of names are exactly
+        the union of the `{placeholder}`s the templates use, so the op's
+        advertised interface matches what is passed to `gn edit`.
+        """
+        names = [entry['name'] for entry in spec['inputs']]
+        duplicates = sorted({name for name in names if names.count(name) > 1})
+        if duplicates:
+            raise RewritersSchemaError(
+                f'{self._source}: gn edit op {op_id!r} declares duplicate '
+                f'input name(s): {", ".join(duplicates)}')
+
+        declared = set(names)
+        used = _placeholders(spec['pattern']) | _placeholders(spec['command'])
+
+        undeclared = sorted(used - declared)
+        if undeclared:
+            raise RewritersSchemaError(
+                f'{self._source}: gn edit op {op_id!r} templates use '
+                f'undeclared input(s): {", ".join(undeclared)}')
+        unused = sorted(declared - used)
+        if unused:
+            raise RewritersSchemaError(
+                f'{self._source}: gn edit op {op_id!r} declares input(s) '
                 f'never used in its templates: {", ".join(unused)}')
 
 
@@ -3372,6 +3453,26 @@ class AstRewriter:
         return total
 
 
+def _check_declared_inputs(op_id: str, *, declared: frozenset[str],
+                           provided: frozenset[str]) -> None:
+    """Raise unless `provided` is exactly the inputs `op_id` declares.
+
+    Shared by the declarative backends, whose ops render templates over a
+    declared interface and so cannot render at all with an input missing, nor
+    silently ignore one that was never declared.
+    """
+    if provided == declared:
+        return
+    problems = []
+    missing = sorted(declared - provided)
+    if missing:
+        problems.append(f'missing input(s): {", ".join(missing)}')
+    unknown = sorted(provided - declared)
+    if unknown:
+        problems.append(f'unknown input(s): {", ".join(unknown)}')
+    raise ValueError(f'{op_id}: ' + '; '.join(problems))
+
+
 class RegexMacroEngine:
     """Applies named `regex_macro` ops (from `rewriters.pyl`) to file contents.
 
@@ -3400,16 +3501,9 @@ class RegexMacroEngine:
         """
         spec = self._rewriters.regex_macro(op_id)
         declared = frozenset(entry['name'] for entry in spec['inputs'])
-        provided = frozenset(inputs)
-        if provided != declared:
-            problems = []
-            missing = sorted(declared - provided)
-            if missing:
-                problems.append(f'missing input(s): {", ".join(missing)}')
-            unknown = sorted(provided - declared)
-            if unknown:
-                problems.append(f'unknown input(s): {", ".join(unknown)}')
-            raise ValueError(f'{op_id}: ' + '; '.join(problems))
+        _check_declared_inputs(op_id,
+                               declared=declared,
+                               provided=frozenset(inputs))
 
         re_pattern = spec.get('re_pattern')
         if re_pattern is not None:
@@ -3434,7 +3528,7 @@ class RegexMacro(Rewriter):
     substitution.
 
     Every `regex_macro` op gets a `RegexMacro` subclass generated automatically
-    from its `rewriters.pyl` spec (see `_regex_macro_rewriters`), carrying only
+    from its `rewriters.pyl` spec (see `_generated_rewriters`), carrying only
     the per-op `NAME` (the `substitutions:` key that selects it), `OP_ID`, and
     the `SUMMARY`/ `HELP` `plaster --help` renders.
 
@@ -3442,7 +3536,7 @@ class RegexMacro(Rewriter):
     applying it via `RegexMacroEngine` lives in this class.
     """
 
-    # Set on the generated subclass (see `_regex_macro_rewriters`): the
+    # Set on the generated subclass (see `_generated_rewriters`): the
     # `rewriters.pyl` op id this resolves to (e.g.
     # `cxx.set_feature_flag_default_state`).
     OP_ID: ClassVar[str] = ''
@@ -3496,16 +3590,304 @@ class RegexMacro(Rewriter):
         return cls({key: body[key] for key in keys})
 
 
-def _regex_macro_help(spec: dict) -> str:
-    """Full `plaster --help <macro>` text for one `regex_macro` spec.
+# TODO(https://brave.dev/b/58378): Remove once `cr154` is merged.
+def _gn_platform_dir() -> str:
+    """Host-OS token in gn's per-platform dir name under `third_party/gn`.
 
-    This function produces the markdown text used to show the help section for
-    a given regex macro.
+    Mirrors the CIPD subdirectories `brave/DEPS` provisions gn into.
+    """
+    if sys.platform == 'darwin':
+        return 'mac'
+    if sys.platform == 'win32':
+        return 'win'
+    return 'linux64'
+
+
+# TODO(https://brave.dev/b/58378): Remove once `cr154` is merged and the
+# upstream pin carries `gn edit`. At that point plaster should just call `gn`
+# off the PATH.
+_GN_EXE = '.exe' if sys.platform == 'win32' else ''
+GN_BIN = (Path(__file__).resolve().parents[2] / 'third_party' / 'gn' /
+          _gn_platform_dir() / f'gn{_GN_EXE}')
+
+
+class GnEditError(PlasterError):
+    """Raised when the gn binary fails to run an edit command."""
+
+
+def _quote_for_gn_command(value: str) -> str:
+    """Quote one value for the command string `gn edit` tokenises itself.
+
+    `gn edit` takes its subcommand and that subcommand's values as a single
+    argument, which it splits with `std::quoted`. A value carrying whitespace
+    or a quote therefore has to arrive already quoted and escaped the way
+    `std::quoted` expects, rather than relying on argv splitting.
+    """
+    if not value:
+        return '""'
+    if not any(character in value for character in ' \t\n"\\'):
+        return value
+    escaped = value.replace('\\', '\\\\').replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+@dataclass(frozen=True)
+class GnEditOutcome:
+    """What one `gn edit` invocation did to a build file."""
+
+    # The build file text after the edit.
+    contents: str
+
+    # True when gn rewrote the file. gn edits are idempotent, so a `False`
+    # here means the edit was a no-op: everything it would add is already
+    # present.
+    changed: bool
+
+
+class GnEditSandbox:
+    """A throwaway gn source root, so `gn edit` can act on plaster's text.
+
+    `gn edit` only edits build files *on disk*, and only inside a directory gn
+    recognises as a source root. So this lays out the smallest tree gn
+    accepts, hands it the contents, and reads the result back, leaving nothing
+    behind.
+
+    The contents are always written as the root `BUILD.gn`, which makes every
+    target addressable as `//:<name>` no matter where the real file lives.
+    Nothing is lost by dropping the real directory from the label, because
+    plaster already names the plaster file in every diagnostic it reports.
+    """
+
+    # A valid fake dotfile for `gn` to load, otherwise it segfaults.
+    _DOTFILE_CONTENTS: Final = 'buildconfig = "//build/BUILDCONFIG.gn"\n'
+
+    # The name gn expects of a build file.
+    _BUILD_FILE_NAME: Final = 'BUILD.gn'
+
+    def __init__(self, contents: str):
+        # The build file text as it arrived, kept to tell afterwards whether
+        # gn actually changed anything.
+        self._contents = contents
+
+        # The temporary source root, owned for the life of the `with` block.
+        # None outside it, since it only exists between enter and exit.
+        self._tempdir: tempfile.TemporaryDirectory | None = None
+
+        # Path of the build file inside that root, i.e. what gn edits and what
+        # the result is read back from. None until `__enter__` lays it out.
+        self._build_file: Path | None = None
+
+    def __enter__(self) -> GnEditSandbox:
+        self._tempdir = tempfile.TemporaryDirectory(prefix='plaster-gn-')
+        root = Path(self._tempdir.name)
+        (root / '.gn').write_text(self._DOTFILE_CONTENTS,
+                                  encoding='utf-8',
+                                  newline='\n')
+        self._build_file = root / self._BUILD_FILE_NAME
+        self._build_file.write_text(self._contents,
+                                    encoding='utf-8',
+                                    newline='\n')
+        return self
+
+    def __exit__(self, *exc_info) -> None:
+        assert self._tempdir is not None
+        self._tempdir.cleanup()
+        self._tempdir = None
+        self._build_file = None
+
+    def run(self, *, command: str, pattern: str) -> GnEditOutcome:
+        """Run `gn edit <command> <pattern>` and report what it did.
+
+        Raises `GnEditError` when gn refuses the edit, which covers both a
+        malformed command and a pattern matching no target, either way an error
+        in the plaster that named it.
+        """
+        assert self._build_file is not None
+        # TODO(https://brave.dev/b/58378): Drop this check once `cr154` is
+        # merged and `GN_BIN` becomes a plain `gn` off the PATH, which needs no
+        # provisioning of its own.
+        if not GN_BIN.exists():
+            raise GnEditError(
+                f'the gn binary is missing: {GN_BIN}. Run `gclient sync` to '
+                f'provision it')
+        root = self._build_file.parent
+        try:
+            terminal.run([GN_BIN, 'edit', command, pattern, f'--root={root}'])
+        except subprocess.CalledProcessError as e:
+            # gn reports the problem on stdout rather than stderr.
+            detail = ((e.stdout or '') + (e.stderr or '')).strip()
+            raise GnEditError(
+                f'gn edit failed ({e.returncode}): {detail}') from e
+
+        contents = self._build_file.read_text(encoding='utf-8')
+        return GnEditOutcome(contents=contents,
+                             changed=contents != self._contents)
+
+
+class GnEditEngine:
+    """Applies named `gn_edit` ops (from `rewriters.pyl`) to file contents.
+    """
+
+    def __init__(self, rewriters: RewritersEval, content: str):
+        # The loaded `rewriters.pyl`, which `run` reads an op's `pattern` and
+        # `command` templates out of.
+        self._rewriters = rewriters
+
+        # The file contents, replaced by each `run` with what gn wrote, so
+        # several ops applied in turn accumulate onto one another.
+        self._source = content
+
+    @property
+    def content(self) -> str:
+        """The current file contents, reflecting every applied edit."""
+        return self._source
+
+    def run(self, op_id: str, inputs: dict[str, str]) -> GnEditOutcome:
+        """Run one gn edit op, mutate content, and report what gn did.
+
+        `inputs` must supply exactly the op's declared `inputs`, no more and
+        no fewer. The spec's `pattern` and `command` are rendered with them
+        via `str.format` to form the two arguments `gn edit` takes.
+        """
+        spec = self._rewriters.gn_edit(op_id)
+        declared = frozenset(entry['name'] for entry in spec['inputs'])
+        _check_declared_inputs(op_id,
+                               declared=declared,
+                               provided=frozenset(inputs))
+        with GnEditSandbox(self._source) as sandbox:
+            outcome = sandbox.run(command=spec['command'].format(**inputs),
+                                  pattern=spec['pattern'].format(**inputs))
+        self._source = outcome.contents
+        return outcome
+
+
+class GnEditRewriter(Rewriter):
+    """Applies a named `gn_edit` op (declared in `rewriters.pyl`) as a
+    substitution.
+
+    Every `gn_edit` op gets a `GnEditRewriter` subclass generated
+    automatically from its `rewriters.pyl` spec (see `_generated_rewriters`),
+    exactly as `RegexMacro` does for regex macros, carrying only the per-op
+    `NAME` (the `substitutions:` key that selects it), `OP_ID`, and the
+    `SUMMARY`/`HELP` `plaster --help` renders.
+
+    Behaviour validating a body's keys against the op's declared `inputs`, and
+    applying it via `GnEditEngine`, lives in this class.
+    """
+
+    # Set on the generated subclass (see `_generated_rewriters`): the
+    # `rewriters.pyl` op id this resolves to (e.g. `gn.add_deps`).
+    OP_ID: ClassVar[str] = ''
+
+    def __init__(self, inputs: dict[str, str]):
+        self._inputs = inputs
+
+    @classmethod
+    def namespace(cls) -> str:
+        """The `<ns>.` prefix of the op (always `gn`)."""
+        return cls.OP_ID.split('.', 1)[0]
+
+    @classmethod
+    def validate_count(cls, count: int, description: str) -> None:
+        # gn reports whether it rewrote the build file, never how many places
+        # it touched, so there is no count for a `count:` to assert against.
+        if count != 1:
+            raise ValueError(
+                f'{cls.NAME} does not accept a count other than 1 '
+                f'(in "{description}"); gn reports whether the build file '
+                f'changed, not a number of matches')
+
+    def apply(
+        self,
+        contents: str,
+        *,
+        count: int,
+        description: str,
+        blank_for_parse: BlankForParseOptions = BlankForParseOptions()
+    ) -> tuple[str, list[str]]:
+        del count  # Rejected by `validate_count`; gn reports no match count.
+        del blank_for_parse  # gn parses build files itself; nothing to relax.
+        engine = GnEditEngine(RewritersEval.load(), contents)
+        try:
+            outcome = engine.run(self.OP_ID, self._inputs)
+        except GnEditError as e:
+            # A pattern that matches no target, or a command gn rejects, is a
+            # mistake in the plaster rather than a bug in the tool, so it is
+            # reported like any other substitution failure instead of
+            # aborting the run with a traceback.
+            return contents, [f'{e} (in "{description}")']
+        # An edit that changed nothing is the one failure gn itself does not
+        # report: the values are all present already, so the substitution has
+        # become redundant and should be removed from the plaster.
+        errors = [] if outcome.changed else [
+            f'{self.NAME} changed nothing (in "{description}"); the target '
+            f'already carries every value it would add'
+        ]
+        return engine.content, errors
+
+    @classmethod
+    def parse(cls, body: object, *, description: str) -> GnEditRewriter:
+        """Validate a `<op-name>:` body against the op's declared `inputs`.
+
+        A `variadic` input accepts a single string or a non-empty list of
+        them, and is rendered as gn's space-separated value list. Every other
+        input takes one non-empty string.
+        """
+        if not isinstance(body, dict):
+            raise ValueError(
+                f'"{cls.NAME}" must be a mapping (in "{description}")')
+        spec = RewritersEval.load().gn_edit(cls.OP_ID)
+        keys = frozenset(entry['name'] for entry in spec['inputs'])
+        variadic = frozenset(entry['name'] for entry in spec['inputs']
+                             if entry.get('variadic'))
+        unknown = sorted(set(body) - keys)
+        if unknown:
+            raise ValueError(
+                f'Unrecognised {cls.NAME} arg(s): '
+                f'{", ".join(repr(k) for k in unknown)} (in "{description}")')
+        missing = sorted(keys - set(body))
+        if missing:
+            raise ValueError(f'{cls.NAME} requires arg(s): '
+                             f'{", ".join(missing)} (in "{description}")')
+
+        inputs = {}
+        for key in sorted(keys):
+            value = body[key]
+            if key in variadic:
+                inputs[key] = ' '.join(
+                    _quote_for_gn_command(item)
+                    for item in cls._parse_values(key, value, description))
+            elif isinstance(value, str) and value:
+                inputs[key] = value
+            else:
+                raise ValueError(f'{cls.NAME} `{key}` must be a non-empty '
+                                 f'string (in "{description}")')
+        return cls(inputs)
+
+    @classmethod
+    def _parse_values(cls, key: str, value: object,
+                      description: str) -> list[str]:
+        """Normalise a variadic input to a non-empty list of strings."""
+        if isinstance(value, str) and value:
+            return [value]
+        if (isinstance(value, list) and value
+                and all(isinstance(item, str) and item for item in value)):
+            return list(value)
+        raise ValueError(f'{cls.NAME} `{key}` must be a non-empty string or a '
+                         f'non-empty list of them (in "{description}")')
+
+
+def _declared_op_help(spec: dict) -> str:
+    """Full `plaster --help <name>` text for one declarative op spec.
+
+    Shared by regex macros and gn edit ops since both document their interface
+    the same way, as `inputs` of `{name, description}`.
     """
     lines = spec['description'].rstrip('\n').splitlines()
     fields = ['Fields:', ''] + [
-        f"- `{entry['name']}` — {entry['description']}"
-        for entry in spec['inputs']
+        f"- `{entry['name']}` — {entry['description']}" +
+        (' May be a single value or a list of them.'
+         if entry.get('variadic') else '') for entry in spec['inputs']
     ]
     for index, line in enumerate(lines):
         if line.startswith('```'):
@@ -3513,14 +3895,18 @@ def _regex_macro_help(spec: dict) -> str:
     return '\n'.join(lines + [''] + fields)
 
 
-def _regex_macro_rewriters() -> list[type[RegexMacro]]:
-    """One auto-generated `RegexMacro` subclass per declared `regex_macro` op.
+def _generated_rewriters(base: type[Rewriter],
+                         specs: Mapping[str, dict]) -> list[type[Rewriter]]:
+    """One generated `base` subclass per declarative op in `specs`.
 
-    This function produces the entries `_REWRITERS` registers for all the
-    `regex_macro` ops declared in `rewriters.pyl`.
+    The two declarative backends expose their ops as `substitutions:` keys the
+    same way, so the class each one needs is built the same: the op's `NAME`
+    (the key that selects it) and `OP_ID`, plus the help `plaster --help`
+    renders. This function produces the entries `_REWRITERS` registers for
+    them.
     """
-    rewriters: list[type[RegexMacro]] = []
-    for op_id, spec in RewritersEval.load().regex_macros.items():
+    rewriters: list[type[Rewriter]] = []
+    for op_id, spec in specs.items():
         namespace, name = op_id.split('.', 1)
         first_paragraph = spec['description'].strip().split('\n\n', 1)[0]
         # `[Namespace][Name]Rewriter`, matching how the hand-written rewriters
@@ -3531,19 +3917,23 @@ def _regex_macro_rewriters() -> list[type[RegexMacro]]:
                               for word in name.split('_')) + 'Rewriter')
         rewriters.append(
             type(
-                class_name, (RegexMacro, ), {
+                class_name, (base, ), {
                     'NAME': name,
                     'OP_ID': op_id,
                     'SUMMARY': ' '.join(first_paragraph.split()),
-                    'HELP': _regex_macro_help(spec),
+                    'HELP': _declared_op_help(spec),
                 }))
     return rewriters
 
 
-# The global registry of all rewriters plaster knows about, including the
-# regex macros and the ast-based hand-written rewriters.
-_REWRITERS: Final = RewriterRegistry(*_DECLARED_REWRITERS,
-                                     *_regex_macro_rewriters())
+# The global registry of all rewriters plaster knows about: the hand-written
+# ones, plus the generated ones for each declarative backend.
+_REWRITERS: Final = RewriterRegistry(
+    *_DECLARED_REWRITERS,
+    *_generated_rewriters(RegexMacro,
+                          RewritersEval.load().regex_macros),
+    *_generated_rewriters(GnEditRewriter,
+                          RewritersEval.load().gn_edits))
 
 
 def get_plaster_files(filepaths: list[str] | None = None) -> list[PlasterFile]:

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -19,6 +19,7 @@ import time
 
 import plaster
 import repository
+import terminal
 
 from test.fake_chromium_repo import FakeChromiumRepo
 
@@ -4076,7 +4077,7 @@ class RegexMacroDispatchTest(unittest.TestCase):
     key (e.g. `set_feature_flag_default_state:`) to `RegexMacro`.
 
     Every `regex_macro` op declared in `rewriters.pyl` is handled by the same
-    `RegexMacro` class (see `_regex_macro_rewriters`), so these tests exercise
+    `RegexMacro` class (see `_generated_rewriters`), so these tests exercise
     that generic dispatch/validation path via the one macro currently shipped
     (`set_feature_flag_default_state`), rather than the macro's own regex --
     that is `ToggleBaseFeatureDefaultStateTest`'s job (renamed
@@ -4229,28 +4230,33 @@ class RegexMacroDispatchTest(unittest.TestCase):
         self.assertIn(substr, str(ctx.exception))
 
 
-class RegexMacroHelpTest(unittest.TestCase):
-    """Unit tests for `_regex_macro_help`, independent of the shipped macro.
+class DeclaredOpHelpTest(unittest.TestCase):
+    """Unit tests for `_declared_op_help`, independent of any shipped op.
+
+    The builder is shared by every backend whose rewriters are generated from
+    `rewriters.pyl` -- regex macros and gn edit ops -- so it is exercised on a
+    synthetic spec rather than through either of them.
     """
 
     @staticmethod
-    def _spec(description: str) -> dict:
-        return {
-            'description': description,
-            'inputs': [
-                {
-                    'name': 'foo',
-                    'description': 'The foo to use.'
-                },
-                {
-                    'name': 'bar',
-                    'description': 'The bar to use.'
-                },
-            ],
-        }
+    def _spec(description: str, *, variadic: str = '') -> dict:
+        inputs = [
+            {
+                'name': 'foo',
+                'description': 'The foo to use.'
+            },
+            {
+                'name': 'bar',
+                'description': 'The bar to use.'
+            },
+        ]
+        for entry in inputs:
+            if entry['name'] == variadic:
+                entry['variadic'] = True
+        return {'description': description, 'inputs': inputs}
 
     def test_fields_inserted_before_example_code_block(self):
-        help_text = plaster._regex_macro_help(
+        help_text = plaster._declared_op_help(
             self._spec('Does a thing.\n\n```cpp\ncode here\n```\n'))
         fields_index = help_text.index('Fields:')
         example_index = help_text.index('```cpp')
@@ -4259,15 +4265,30 @@ class RegexMacroHelpTest(unittest.TestCase):
         self.assertIn('- `bar` — The bar to use.', help_text)
 
     def test_fields_appended_when_no_code_block(self):
-        help_text = plaster._regex_macro_help(self._spec('Does a thing.'))
+        help_text = plaster._declared_op_help(self._spec('Does a thing.'))
         self.assertTrue(help_text.startswith('Does a thing.'))
         self.assertIn('Fields:', help_text)
         self.assertIn('- `foo` — The foo to use.', help_text)
         self.assertIn('- `bar` — The bar to use.', help_text)
 
     def test_field_order_matches_declared_inputs(self):
-        help_text = plaster._regex_macro_help(self._spec('Does a thing.'))
+        help_text = plaster._declared_op_help(self._spec('Does a thing.'))
         self.assertLess(help_text.index('`foo`'), help_text.index('`bar`'))
+
+    def test_a_variadic_input_says_a_list_is_accepted(self):
+        # A caller cannot tell from the name alone whether a field takes one
+        # value or many, so the help has to say so.
+        help_text = plaster._declared_op_help(
+            self._spec('Does a thing.', variadic='bar'))
+        self.assertIn(
+            '- `bar` — The bar to use. May be a single value or a '
+            'list of them.', help_text)
+
+    def test_a_non_variadic_input_makes_no_such_claim(self):
+        help_text = plaster._declared_op_help(
+            self._spec('Does a thing.', variadic='bar'))
+        self.assertIn('- `foo` — The foo to use.\n', help_text)
+        self.assertNotIn('- `foo` — The foo to use. May be', help_text)
 
 
 class RewriterNamespaceTest(unittest.TestCase):
@@ -7214,6 +7235,968 @@ class OverrideFeatureDefaultStateTest(unittest.TestCase):
                     'value': 'base::FEATURE_ENABLED_BY_DEFAULT',
                     'extra': 'x',
                 })
+
+
+class DeclaredInputsTest(unittest.TestCase):
+    """`_check_declared_inputs` guards both declarative backends.
+
+    An op renders templates over a declared interface, so it can neither
+    render with an input missing nor quietly ignore one it never declared.
+    """
+
+    def test_an_exact_match_passes(self):
+        plaster._check_declared_inputs('ns.op',
+                                       declared=frozenset({'a', 'b'}),
+                                       provided=frozenset({'a', 'b'}))
+
+    def test_no_inputs_at_all_passes(self):
+        plaster._check_declared_inputs('ns.op',
+                                       declared=frozenset(),
+                                       provided=frozenset())
+
+    def test_a_missing_input_is_named(self):
+        with self.assertRaises(ValueError) as cm:
+            plaster._check_declared_inputs('ns.op',
+                                           declared=frozenset({'a', 'b'}),
+                                           provided=frozenset({'a'}))
+        self.assertIn('ns.op', str(cm.exception))
+        self.assertIn('missing input(s): b', str(cm.exception))
+
+    def test_an_unknown_input_is_named(self):
+        with self.assertRaises(ValueError) as cm:
+            plaster._check_declared_inputs('ns.op',
+                                           declared=frozenset({'a'}),
+                                           provided=frozenset({'a', 'z'}))
+        self.assertIn('unknown input(s): z', str(cm.exception))
+
+    def test_both_problems_are_reported_together(self):
+        # One pass over the interface should surface everything wrong with it,
+        # rather than making the author fix it one round-trip at a time.
+        with self.assertRaises(ValueError) as cm:
+            plaster._check_declared_inputs('ns.op',
+                                           declared=frozenset({'a', 'b'}),
+                                           provided=frozenset({'a', 'z'}))
+        self.assertIn('missing input(s): b', str(cm.exception))
+        self.assertIn('unknown input(s): z', str(cm.exception))
+
+
+class GeneratedRewritersTest(unittest.TestCase):
+    """`_generated_rewriters` builds the classes for a declarative backend."""
+
+    @staticmethod
+    def _specs(op_id: str) -> dict:
+        return {
+            op_id: {
+                'description': 'Does a thing.\n\nMore detail here.',
+                'inputs': [{
+                    'name': 'foo',
+                    'description': 'The foo.'
+                }],
+            }
+        }
+
+    def _generate(self, op_id: str, base=None):
+        """The single rewriter generated for `op_id`."""
+        generated = plaster._generated_rewriters(
+            base or plaster.GnEditRewriter, self._specs(op_id))
+        self.assertEqual(len(generated), 1)
+        return generated[0]
+
+    def test_name_and_op_id_come_from_the_op(self):
+        generated = self._generate('gn.add_thing')
+        self.assertEqual(generated.NAME, 'add_thing')
+        self.assertEqual(generated.OP_ID, 'gn.add_thing')
+        self.assertTrue(issubclass(generated, plaster.GnEditRewriter))
+
+    def test_class_name_carries_the_namespace(self):
+        # Two ops sharing a NAME across namespaces must not collide on a
+        # class name either.
+        self.assertEqual(
+            self._generate('gn.add_thing').__name__, 'GnAddThingRewriter')
+
+    def test_summary_is_the_first_paragraph_on_one_line(self):
+        self.assertEqual(
+            self._generate('gn.add_thing').SUMMARY, 'Does a thing.')
+
+    def test_help_documents_the_inputs(self):
+        self.assertIn('- `foo` — The foo.',
+                      self._generate('gn.add_thing').HELP)
+
+    def test_the_base_class_is_honoured(self):
+        # The same generator serves both declarative backends.
+        generated = self._generate('cxx.do_thing', base=plaster.RegexMacro)
+        self.assertTrue(issubclass(generated, plaster.RegexMacro))
+        self.assertEqual(generated.__name__, 'CxxDoThingRewriter')
+
+    def test_no_specs_generates_nothing(self):
+        self.assertEqual(
+            plaster._generated_rewriters(plaster.GnEditRewriter, {}), [])
+
+
+class GnEditQuotingTest(unittest.TestCase):
+    """`_quote_for_gn_command` feeds gn's own `std::quoted` tokenizer.
+
+    `gn edit` takes a subcommand and its values as one argument and splits it
+    itself, so anything with whitespace or a quote has to arrive escaped the
+    way `std::quoted` expects.
+    """
+
+    def test_an_ordinary_label_is_left_alone(self):
+        # The overwhelmingly common case: quoting it would only add noise to
+        # the command plaster builds.
+        for value in ('//brave/foo', '//brave/foo:bar', 'a/b/c.cc', ':dep'):
+            self.assertEqual(plaster._quote_for_gn_command(value), value)
+
+    def test_a_value_with_a_space_is_quoted(self):
+        self.assertEqual(plaster._quote_for_gn_command('has space.cc'),
+                         '"has space.cc"')
+
+    def test_a_tab_or_newline_is_quoted(self):
+        self.assertEqual(plaster._quote_for_gn_command('a\tb'), '"a\tb"')
+        self.assertEqual(plaster._quote_for_gn_command('a\nb'), '"a\nb"')
+
+    def test_a_quote_is_escaped(self):
+        self.assertEqual(plaster._quote_for_gn_command('quote".cc'),
+                         '"quote\\".cc"')
+
+    def test_a_backslash_is_escaped(self):
+        # Escaped before the quote character, so the two do not interfere.
+        self.assertEqual(plaster._quote_for_gn_command('back\\slash.cc'),
+                         '"back\\\\slash.cc"')
+
+    def test_a_backslash_before_a_quote_survives_both_escapes(self):
+        self.assertEqual(plaster._quote_for_gn_command('a\\"b'), '"a\\\\\\"b"')
+
+    def test_an_empty_value_becomes_empty_quotes(self):
+        # Without quoting an empty value would vanish from the command and
+        # silently shift every later token.
+        self.assertEqual(plaster._quote_for_gn_command(''), '""')
+
+
+class GnEditSandboxTest(unittest.TestCase):
+    """`GnEditSandbox` bridges plaster's in-memory text and gn's on-disk edit.
+    """
+
+    _TARGET = 'source_set("foo") {\n  deps = [ "//b" ]\n}\n'
+
+    def test_the_dotfile_declares_a_buildconfig(self):
+        # gn's `DoSetupForEditing` does not validate the dotfile the way a
+        # full setup does: one declaring no `buildconfig` segfaults it rather
+        # than drawing an error, so this must never regress to an empty file.
+        self.assertIn('buildconfig', plaster.GnEditSandbox._DOTFILE_CONTENTS)
+
+    def test_the_root_is_laid_out_for_gn(self):
+        with plaster.GnEditSandbox(self._TARGET) as sandbox:
+            root = sandbox._build_file.parent
+            self.assertEqual(sandbox._build_file.name, 'BUILD.gn')
+            self.assertEqual(sandbox._build_file.read_text(), self._TARGET)
+            self.assertEqual((root / '.gn').read_text(),
+                             plaster.GnEditSandbox._DOTFILE_CONTENTS)
+
+    def test_every_file_is_written_with_unix_newlines(self):
+        # Plaster diffs the same bytes on every platform, so the sandbox must
+        # not let the host's line ending convention leak into anything it
+        # lays out. This asserts on the `newline` argument rather than on the
+        # bytes written, because an omitted one translates to `os.linesep` --
+        # which is already a newline everywhere but Windows, so the bytes
+        # alone would not catch the omission off Windows.
+        written = []
+        real_write_text = Path.write_text
+
+        def spy(self_path, data, **kwargs):
+            written.append((self_path.name, kwargs.get('newline')))
+            return real_write_text(self_path, data, **kwargs)
+
+        with mock.patch.object(Path, 'write_text', spy):
+            with plaster.GnEditSandbox('a = 1\nb = 2\n') as sandbox:
+                root = sandbox._build_file.parent
+                self.assertNotIn(b'\r\n', sandbox._build_file.read_bytes())
+                self.assertNotIn(b'\r\n', (root / '.gn').read_bytes())
+
+        self.assertCountEqual(written, [('.gn', '\n'), ('BUILD.gn', '\n')])
+
+    def test_the_root_is_removed_on_exit(self):
+        with plaster.GnEditSandbox(self._TARGET) as sandbox:
+            root = sandbox._build_file.parent
+            self.assertTrue(root.exists())
+        self.assertFalse(root.exists())
+
+    def test_the_root_is_removed_even_when_the_body_raises(self):
+        with self.assertRaises(RuntimeError):
+            with plaster.GnEditSandbox(self._TARGET) as sandbox:
+                root = sandbox._build_file.parent
+                raise RuntimeError('boom')
+        self.assertFalse(root.exists())
+
+    def test_an_edit_reports_the_new_contents_and_that_it_changed(self):
+        with plaster.GnEditSandbox(self._TARGET) as sandbox:
+            outcome = sandbox.run(command='add deps //brave/a',
+                                  pattern='//:foo')
+        self.assertTrue(outcome.changed)
+        self.assertIn('"//brave/a"', outcome.contents)
+
+    def test_a_redundant_edit_reports_no_change(self):
+        # gn edits are idempotent, which is what makes "unchanged" a usable
+        # signal that a substitution has become redundant.
+        with plaster.GnEditSandbox(self._TARGET) as sandbox:
+            outcome = sandbox.run(command='add deps //b', pattern='//:foo')
+        self.assertFalse(outcome.changed)
+        self.assertEqual(outcome.contents, self._TARGET)
+
+    def test_an_unmatched_pattern_raises(self):
+        with plaster.GnEditSandbox(self._TARGET) as sandbox:
+            with self.assertRaises(plaster.GnEditError) as cm:
+                sandbox.run(command='add deps //brave/a', pattern='//:nope')
+        self.assertIn('Target(s) not found', str(cm.exception))
+
+    def test_a_command_gn_rejects_raises(self):
+        with plaster.GnEditSandbox(self._TARGET) as sandbox:
+            with self.assertRaises(plaster.GnEditError) as cm:
+                sandbox.run(command='bogus deps //brave/a', pattern='//:foo')
+        self.assertIn('Unknown edit command', str(cm.exception))
+
+    def test_a_missing_binary_is_reported_as_a_gn_edit_error(self):
+        with mock.patch.object(plaster, 'GN_BIN',
+                               Path('/nonexistent/gn')) as _:
+            with plaster.GnEditSandbox(self._TARGET) as sandbox:
+                with self.assertRaises(plaster.GnEditError) as cm:
+                    sandbox.run(command='add deps //brave/a', pattern='//:foo')
+        self.assertIn('gn binary is missing', str(cm.exception))
+
+    def test_gni_contents_are_editable_under_the_build_file_name(self):
+        # A label only ever resolves to a `BUILD.gn`, so handing gn the text
+        # under that name is exactly what makes a `.gni` target addressable.
+        gni = ('template("t") {\n'
+               '  source_set("inner") {\n'
+               '    deps = []\n'
+               '  }\n'
+               '}\n')
+        with plaster.GnEditSandbox(gni) as sandbox:
+            outcome = sandbox.run(command='add deps //brave/a',
+                                  pattern='//:inner')
+        self.assertTrue(outcome.changed)
+        self.assertIn('"//brave/a"', outcome.contents)
+
+
+class GnEditEngineTest(unittest.TestCase):
+    """Behavioural tests for `GnEditEngine.run`, against synthetic specs."""
+
+    _OP_ID = 'gn.add_thing'
+
+    @classmethod
+    def _rewriters(cls, op: dict) -> plaster.RewritersEval:
+        """Build a `RewritersEval` from an op body, filling in the schema
+        boilerplate the test bodies below do not care about. `inputs` entries
+        may be a bare name or a full `{name, description, variadic}` dict.
+        """
+        op = dict(op)
+        op.setdefault('description', 'A gn edit op used for testing.')
+        op['inputs'] = [
+            entry if isinstance(entry, dict) else {
+                'name': entry,
+                'description': 'doc'
+            } for entry in op['inputs']
+        ]
+        return plaster.RewritersEval(repr({'gn_edit': {cls._OP_ID: op}}))
+
+    def _engine(self, op: dict, content: str) -> plaster.GnEditEngine:
+        return plaster.GnEditEngine(self._rewriters(op), content)
+
+    _SIMPLE_OP = {
+        'inputs': ['target', 'values'],
+        'pattern': '//:{target}',
+        'command': 'add deps {values}',
+    }
+
+    def test_pattern_and_command_are_rendered_with_inputs(self):
+        engine = self._engine(self._SIMPLE_OP,
+                              'source_set("foo") {\n  deps = []\n}\n')
+        outcome = engine.run(self._OP_ID, {
+            'target': 'foo',
+            'values': '//brave/a',
+        })
+        self.assertTrue(outcome.changed)
+        self.assertIn('"//brave/a"', engine.content)
+
+    def test_content_accumulates_across_runs(self):
+        # A composed rewriter may emit several operations, each building on
+        # what the last one wrote.
+        engine = self._engine(
+            {
+                'inputs': ['target', 'attribute', 'values'],
+                'pattern': '//:{target}',
+                'command': 'add {attribute} {values}',
+            }, 'source_set("foo") {\n}\n')
+        engine.run(self._OP_ID, {
+            'target': 'foo',
+            'attribute': 'deps',
+            'values': '//brave/a',
+        })
+        engine.run(self._OP_ID, {
+            'target': 'foo',
+            'attribute': 'sources',
+            'values': 'x.cc',
+        })
+        self.assertIn('"//brave/a"', engine.content)
+        self.assertIn('"x.cc"', engine.content)
+
+    def test_content_is_unchanged_after_a_redundant_run(self):
+        source = 'source_set("foo") {\n  deps = [ "//b" ]\n}\n'
+        engine = self._engine(self._SIMPLE_OP, source)
+        outcome = engine.run(self._OP_ID, {
+            'target': 'foo',
+            'values': '//b',
+        })
+        self.assertFalse(outcome.changed)
+        self.assertEqual(engine.content, source)
+
+    def test_a_missing_input_is_rejected_before_gn_runs(self):
+        engine = self._engine(self._SIMPLE_OP, 'source_set("foo") {\n}\n')
+        with self.assertRaises(ValueError) as cm:
+            engine.run(self._OP_ID, {'target': 'foo'})
+        self.assertIn('missing input(s): values', str(cm.exception))
+
+    def test_an_unknown_input_is_rejected_before_gn_runs(self):
+        engine = self._engine(self._SIMPLE_OP, 'source_set("foo") {\n}\n')
+        with self.assertRaises(ValueError) as cm:
+            engine.run(self._OP_ID, {
+                'target': 'foo',
+                'values': '//a',
+                'extra': 'x',
+            })
+        self.assertIn('unknown input(s): extra', str(cm.exception))
+
+    def test_an_unknown_op_id_raises(self):
+        engine = self._engine(self._SIMPLE_OP, 'source_set("foo") {\n}\n')
+        with self.assertRaises(plaster.RewritersSchemaError):
+            engine.run('gn.nope', {'target': 'foo', 'values': '//a'})
+
+
+class GnEditSchemaTest(unittest.TestCase):
+    """Schema and cross-reference validation for `gn_edit` ops."""
+
+    def setUp(self):
+        # load() memoises a process-wide instance; clear it so tests that
+        # exercise the singleton start from a clean slate.
+        plaster.RewritersEval._instance = None
+        self.addCleanup(setattr, plaster.RewritersEval, '_instance', None)
+
+    @staticmethod
+    def _input(name: str, description: str = 'doc') -> dict:
+        return {'name': name, 'description': description}
+
+    @classmethod
+    def _valid_spec(cls) -> dict:
+        """A minimal, schema-valid `gn_edit` spec as a Python dict."""
+        return {
+            'gn_edit': {
+                'gn.add_thing': {
+                    'description': 'Adds a thing.',
+                    'inputs': [
+                        cls._input('target'),
+                        dict(cls._input('values'), variadic=True),
+                    ],
+                    'pattern': '//:{target}',
+                    'command': 'add deps {values}',
+                },
+            },
+        }
+
+    def _eval_valid(self) -> plaster.RewritersEval:
+        return plaster.RewritersEval(repr(self._valid_spec()))
+
+    def _assert_invalid(self, mutate, expected_substr=None):
+        """Apply `mutate` to a valid spec and assert it fails validation."""
+        spec = self._valid_spec()
+        mutate(spec)
+        with self.assertRaises(plaster.RewritersSchemaError) as cm:
+            plaster.RewritersEval(repr(spec))
+        if expected_substr is not None:
+            self.assertIn(expected_substr, str(cm.exception))
+
+    # -- access -------------------------------------------------------------
+
+    def test_valid_spec_round_trips(self):
+        rewriters = self._eval_valid()
+        self.assertEqual(list(rewriters.gn_edits), ['gn.add_thing'])
+        spec = rewriters.gn_edit('gn.add_thing')
+        self.assertEqual(spec['pattern'], '//:{target}')
+        self.assertEqual(spec['command'], 'add deps {values}')
+        self.assertEqual(spec['description'], 'Adds a thing.')
+
+    def test_unknown_op_access_raises(self):
+        with self.assertRaises(plaster.RewritersSchemaError):
+            self._eval_valid().gn_edit('gn.nope')
+
+    def test_exposed_mapping_is_read_only(self):
+        with self.assertRaises(TypeError):
+            self._eval_valid().gn_edits['x'] = {}
+
+    def test_present_but_empty_is_valid(self):
+        rewriters = plaster.RewritersEval("{'gn_edit': {}}")
+        self.assertEqual(dict(rewriters.gn_edits), {})
+
+    def test_absent_is_valid(self):
+        rewriters = plaster.RewritersEval('{}')
+        self.assertEqual(dict(rewriters.gn_edits), {})
+
+    # -- shape --------------------------------------------------------------
+
+    def test_pattern_is_required(self):
+        self._assert_invalid(
+            lambda s: s['gn_edit']['gn.add_thing'].pop('pattern'))
+
+    def test_command_is_required(self):
+        self._assert_invalid(
+            lambda s: s['gn_edit']['gn.add_thing'].pop('command'))
+
+    def test_description_is_required(self):
+        self._assert_invalid(
+            lambda s: s['gn_edit']['gn.add_thing'].pop('description'))
+
+    def test_an_input_must_be_documented(self):
+        # An op is meant to be read and reused by someone other than its
+        # author, so a bare input name is not enough.
+        self._assert_invalid(
+            lambda s: s['gn_edit']['gn.add_thing'].update(inputs=[{
+                'name': 'target'
+            }, {
+                'name': 'values'
+            }]))
+
+    def test_variadic_must_be_a_bool(self):
+        self._assert_invalid(
+            lambda s: s['gn_edit']['gn.add_thing'].update(inputs=[
+                self._input('target'),
+                dict(self._input('values'), variadic='yes'),
+            ]))
+
+    def test_variadic_is_optional(self):
+        spec = self._valid_spec()
+        spec['gn_edit']['gn.add_thing']['inputs'] = [
+            self._input('target'),
+            self._input('values'),
+        ]
+        rewriters = plaster.RewritersEval(repr(spec))
+        self.assertEqual(list(rewriters.gn_edits), ['gn.add_thing'])
+
+    def test_an_unknown_field_is_rejected(self):
+        self._assert_invalid(
+            lambda s: s['gn_edit']['gn.add_thing'].update(extra='x'))
+
+    # -- cross references ---------------------------------------------------
+
+    def test_a_template_using_an_undeclared_input_is_rejected(self):
+        self._assert_invalid(
+            lambda s: s['gn_edit']['gn.add_thing'].update(
+                command='add deps {nope}'), 'undeclared input(s): nope')
+
+    def test_a_declared_input_no_template_uses_is_rejected(self):
+        # An advertised input that reaches neither template would silently do
+        # nothing when a plaster passed it.
+        self._assert_invalid(
+            lambda s: s['gn_edit']['gn.add_thing']['inputs'].append(
+                self._input('unused')), 'never used in its templates: unused')
+
+    def test_a_duplicate_input_name_is_rejected(self):
+        self._assert_invalid(
+            lambda s: s['gn_edit']['gn.add_thing']['inputs'].append(
+                self._input('target')), 'duplicate input name(s): target')
+
+    def test_an_input_used_only_by_pattern_is_enough(self):
+        # The two templates are checked as a union, not individually.
+        spec = self._valid_spec()
+        spec['gn_edit']['gn.add_thing']['command'] = 'remove deps'
+        spec['gn_edit']['gn.add_thing']['inputs'] = [self._input('target')]
+        rewriters = plaster.RewritersEval(repr(spec))
+        self.assertEqual(list(rewriters.gn_edits), ['gn.add_thing'])
+
+    def test_an_op_outside_the_gn_namespace_is_rejected(self):
+        # A gn edit op offered on, say, a C++ target would hand gn something
+        # it cannot parse.
+        def move_to_cxx(spec):
+            spec['gn_edit']['cxx.add_thing'] = spec['gn_edit'].pop(
+                'gn.add_thing')
+
+        self._assert_invalid(
+            move_to_cxx, "gn edit op 'cxx.add_thing' cannot be used in the "
+            "'cxx' namespace")
+
+    def test_an_unknown_namespace_is_rejected(self):
+
+        def move_to_nowhere(spec):
+            spec['gn_edit']['nope.add_thing'] = spec['gn_edit'].pop(
+                'gn.add_thing')
+
+        self._assert_invalid(move_to_nowhere)
+
+    # -- the shipped ops ----------------------------------------------------
+
+    def test_the_shipped_ops_validate(self):
+        # `load()` validates on construction, so this fails loudly if a
+        # shipped op ever drifts from its declared interface.
+        self.assertEqual(sorted(plaster.RewritersEval.load().gn_edits),
+                         ['gn.add_deps', 'gn.add_sources'])
+
+
+class GnEditRewriterTest(unittest.TestCase):
+    """`GnEditRewriter` validates a substitution body and drives the engine."""
+
+    @staticmethod
+    def _cls(name: str = 'add_deps'):
+        return plaster._REWRITERS.resolve(name, plaster._GN_NAMESPACE)
+
+    def _parse(self, body, name='add_deps', description='t'):
+        return self._cls(name).parse(body, description=description)
+
+    def _expect_parse_error(self, body, substr, name='add_deps'):
+        with self.assertRaises(ValueError) as cm:
+            self._parse(body, name=name)
+        self.assertIn(substr, str(cm.exception))
+
+    # -- registration -------------------------------------------------------
+
+    def test_registered_under_its_bare_name_in_the_gn_namespace(self):
+        for name, op_id in (('add_deps', 'gn.add_deps'), ('add_sources',
+                                                          'gn.add_sources')):
+            cls = self._cls(name)
+            self.assertTrue(issubclass(cls, plaster.GnEditRewriter))
+            self.assertEqual(cls.OP_ID, op_id)
+            self.assertEqual(cls.namespace(), 'gn')
+
+    def test_help_documents_every_input_including_variadicity(self):
+        help_text = self._cls().HELP
+        self.assertIn('- `target` — ', help_text)
+        self.assertIn('May be a single value or a list of them.', help_text)
+
+    # -- count --------------------------------------------------------------
+
+    def test_a_count_other_than_one_is_rejected(self):
+        # gn reports whether the file changed, never how many places it
+        # touched, so there is no number for a `count:` to assert against.
+        for count in (0, 2, 7):
+            with self.assertRaises(ValueError) as cm:
+                self._cls().validate_count(count, 't')
+            self.assertIn('does not accept a count other than 1',
+                          str(cm.exception))
+
+    def test_the_implicit_count_of_one_is_accepted(self):
+        self._cls().validate_count(1, 't')
+
+    # -- body validation ----------------------------------------------------
+
+    def test_a_non_mapping_body_is_rejected(self):
+        self._expect_parse_error(['not', 'a', 'mapping'], 'must be a mapping')
+
+    def test_a_missing_arg_is_rejected(self):
+        self._expect_parse_error({'target': 'foo'}, 'requires arg(s): deps')
+
+    def test_an_unknown_arg_is_rejected(self):
+        self._expect_parse_error({
+            'target': 'foo',
+            'deps': '//a',
+            'nope': 1
+        }, "Unrecognised add_deps arg(s): 'nope'")
+
+    def test_an_empty_scalar_input_is_rejected(self):
+        self._expect_parse_error({
+            'target': '',
+            'deps': '//a'
+        }, '`target` must be a non-empty string')
+
+    def test_a_non_string_scalar_input_is_rejected(self):
+        self._expect_parse_error({
+            'target': 7,
+            'deps': '//a'
+        }, '`target` must be a non-empty string')
+
+    def test_a_variadic_input_accepts_a_bare_string(self):
+        self._parse({'target': 'foo', 'deps': '//a'})
+
+    def test_a_variadic_input_accepts_a_list(self):
+        self._parse({'target': 'foo', 'deps': ['//a', '//b']})
+
+    def test_an_empty_variadic_list_is_rejected(self):
+        self._expect_parse_error({
+            'target': 'foo',
+            'deps': []
+        }, '`deps` must be a non-empty string or a non-empty list of them')
+
+    def test_a_variadic_list_of_non_strings_is_rejected(self):
+        self._expect_parse_error({
+            'target': 'foo',
+            'deps': [123]
+        }, '`deps` must be a non-empty string or a non-empty list of them')
+
+    def test_a_variadic_list_with_an_empty_entry_is_rejected(self):
+        self._expect_parse_error({
+            'target': 'foo',
+            'deps': ['//a', '']
+        }, '`deps` must be a non-empty string or a non-empty list of them')
+
+    # -- apply --------------------------------------------------------------
+
+    def test_apply_adds_the_values(self):
+        rewriter = self._parse({'target': 'foo', 'deps': ['//brave/a']})
+        result, errors = rewriter.apply(
+            'source_set("foo") {\n  deps = []\n}\n', count=1, description='d')
+        self.assertEqual(errors, [])
+        self.assertIn('"//brave/a"', result)
+
+    def test_apply_reports_an_edit_that_changed_nothing(self):
+        rewriter = self._parse({'target': 'foo', 'deps': '//b'})
+        source = 'source_set("foo") {\n  deps = [ "//b" ]\n}\n'
+        result, errors = rewriter.apply(source, count=1, description='d')
+        self.assertEqual(result, source)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('changed nothing', errors[0])
+        self.assertIn('(in "d")', errors[0])
+
+    def test_apply_reports_a_gn_failure_as_a_substitution_error(self):
+        # A pattern matching no target is a mistake in the plaster, so it is
+        # reported like any other substitution failure rather than aborting
+        # the run with a traceback.
+        rewriter = self._parse({'target': 'nope', 'deps': '//brave/a'})
+        source = 'source_set("foo") {\n}\n'
+        result, errors = rewriter.apply(source, count=1, description='d')
+        self.assertEqual(result, source)
+        self.assertEqual(len(errors), 1)
+        self.assertIn('Target(s) not found', errors[0])
+        self.assertIn('(in "d")', errors[0])
+
+    def test_apply_sends_every_value_in_one_gn_invocation(self):
+        # The values share one edit and one format pass, so they must not be
+        # spread over a call each.
+        calls = []
+        real_run = terminal.terminal.run
+
+        def spy(cmd, **kwargs):
+            calls.append([str(part) for part in cmd])
+            return real_run(cmd, **kwargs)
+
+        with mock.patch.object(terminal.terminal, 'run', side_effect=spy):
+            self._parse({
+                'target': 'foo',
+                'deps': ['//brave/a', '//brave/b'],
+            }).apply('source_set("foo") {\n  deps = []\n}\n',
+                     count=1,
+                     description='d')
+        self.assertEqual(len(calls), 1)
+        self.assertIn('add deps //brave/a //brave/b', calls[0])
+
+    def test_apply_quotes_a_value_needing_it(self):
+        calls = []
+        real_run = terminal.terminal.run
+
+        def spy(cmd, **kwargs):
+            calls.append([str(part) for part in cmd])
+            return real_run(cmd, **kwargs)
+
+        with mock.patch.object(terminal.terminal, 'run', side_effect=spy):
+            self._parse({
+                'target': 'foo',
+                'sources': 'has space.cc',
+            },
+                        name='add_sources').apply(
+                            'source_set("foo") {\n  sources = []\n}\n',
+                            count=1,
+                            description='d')
+        self.assertIn('add sources "has space.cc"', calls[0])
+
+    def test_add_sources_adds_to_sources(self):
+        rewriter = self._parse({
+            'target': 'foo',
+            'sources': ['b.cc', 'a.cc'],
+        },
+                               name='add_sources')
+        result, errors = rewriter.apply(
+            'source_set("foo") {\n  sources = [ "existing.cc" ]\n}\n',
+            count=1,
+            description='d')
+        self.assertEqual(errors, [])
+        for expected in ('"a.cc"', '"b.cc"', '"existing.cc"'):
+            self.assertIn(expected, result)
+
+
+class GnEditDispatchTest(unittest.TestCase):
+    """End-to-end tests for dispatching a `gn_edit:`-style substitution key.
+
+    These run a real plaster apply against a fake Chromium repo, so they
+    cover suffix-based namespace resolution, the real `gn` binary, and the
+    patch that comes out the other end.
+    """
+
+    def setUp(self):
+        self.fake_chromium_src = FakeChromiumRepo()
+        self.fake_chromium_src.setup()
+        self.addCleanup(self.fake_chromium_src.cleanup)
+
+    def _apply(self, name: str, source: str, yaml_body: str) -> str:
+        """Write `source`+plaster, apply, and return the rewritten source."""
+        src = Path('components/omnibox/browser') / name
+        self.fake_chromium_src.write_and_stage_file(
+            src, source, self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit(f'Add {name}',
+                                      self.fake_chromium_src.chromium)
+        plaster_path = plaster.PLASTER_FILES_PATH / (str(src) + '.yaml')
+        plaster_path.parent.mkdir(parents=True, exist_ok=True)
+        plaster_path.write_text(yaml_body)
+        plaster.PlasterFile(plaster_path).apply()
+        return (self.fake_chromium_src.chromium / src).read_text()
+
+    _SOURCE = ('source_set("browser") {\n'
+               '  sources = [ "browser.cc" ]\n'
+               '  deps = [ "//base" ]\n'
+               '}\n')
+
+    def test_add_deps_applies_to_a_build_gn_target(self):
+        result = self._apply(
+            'BUILD.gn', self._SOURCE, 'substitutions:\n'
+            '  - description: Depend on the Brave omnibox additions.\n'
+            '    add_deps:\n'
+            '      target: browser\n'
+            '      deps:\n'
+            '        - //brave/components/omnibox/browser\n'
+            '        - //brave/components/omnibox/common\n')
+        self.assertEqual(
+            result, 'source_set("browser") {\n'
+            '  sources = [ "browser.cc" ]\n'
+            '  deps = [\n'
+            '    "//base",\n'
+            '    "//brave/components/omnibox/browser",\n'
+            '    "//brave/components/omnibox/common",\n'
+            '  ]\n'
+            '}\n')
+
+    def test_add_sources_applies_to_a_build_gn_target(self):
+        result = self._apply(
+            'BUILD.gn', self._SOURCE, 'substitutions:\n'
+            '  - description: Build the Brave sources.\n'
+            '    add_sources:\n'
+            '      target: browser\n'
+            '      sources: //brave/components/omnibox/browser/extra.cc\n')
+        self.assertIn('"//brave/components/omnibox/browser/extra.cc"', result)
+
+    def test_several_substitutions_accumulate(self):
+        result = self._apply(
+            'BUILD.gn', self._SOURCE, 'substitutions:\n'
+            '  - description: Add the Brave deps.\n'
+            '    add_deps:\n'
+            '      target: browser\n'
+            '      deps: //brave/components/omnibox/browser\n'
+            '  - description: Add the Brave sources.\n'
+            '    add_sources:\n'
+            '      target: browser\n'
+            '      sources: //brave/x.cc\n')
+        self.assertIn('"//brave/components/omnibox/browser"', result)
+        self.assertIn('"//brave/x.cc"', result)
+
+    def test_applies_to_a_gni_target(self):
+        result = self._apply(
+            'sources.gni', 'template("t") {\n'
+            '  source_set("inner") {\n'
+            '    deps = []\n'
+            '  }\n'
+            '}\n', 'substitutions:\n'
+            '  - description: Depend on the Brave additions.\n'
+            '    add_deps:\n'
+            '      target: inner\n'
+            '      deps: //brave/a\n')
+        self.assertIn('"//brave/a"', result)
+
+    def test_only_the_named_target_is_edited(self):
+        result = self._apply(
+            'BUILD.gn', 'source_set("a") {\n'
+            '  deps = []\n'
+            '}\n'
+            'source_set("b") {\n'
+            '  deps = []\n'
+            '}\n', 'substitutions:\n'
+            '  - description: Only a.\n'
+            '    add_deps:\n'
+            '      target: a\n'
+            '      deps: //brave/a\n')
+        self.assertEqual(
+            result, 'source_set("a") {\n'
+            '  deps = [ "//brave/a" ]\n'
+            '}\n'
+            'source_set("b") {\n'
+            '  deps = []\n'
+            '}\n')
+
+    def test_upstream_formatting_is_otherwise_untouched(self):
+        # gn reserialises the whole file, so a plaster must not smuggle in
+        # unrelated reformatting alongside the edit it asked for.
+        source = ('# A leading comment.\n'
+                  'source_set("browser") {\n'
+                  '  # An inner comment.\n'
+                  '  deps = [ "//base" ]\n'
+                  '\n'
+                  '  if (is_android) {\n'
+                  '    deps += [ "//android" ]\n'
+                  '  }\n'
+                  '}\n')
+        result = self._apply(
+            'BUILD.gn', source, 'substitutions:\n'
+            '  - description: Add a Brave dep.\n'
+            '    add_deps:\n'
+            '      target: browser\n'
+            '      deps: //brave/a\n')
+        self.assertEqual(
+            result, '# A leading comment.\n'
+            'source_set("browser") {\n'
+            '  # An inner comment.\n'
+            '  deps = [\n'
+            '    "//base",\n'
+            '    "//brave/a",\n'
+            '  ]\n'
+            '\n'
+            '  if (is_android) {\n'
+            '    deps += [ "//android" ]\n'
+            '  }\n'
+            '}\n')
+
+    def test_a_redundant_substitution_fails_the_apply(self):
+        with self.assertRaises(plaster.PlasterApplyError) as cm:
+            self._apply(
+                'BUILD.gn', self._SOURCE, 'substitutions:\n'
+                '  - description: Already there.\n'
+                '    add_deps:\n'
+                '      target: browser\n'
+                '      deps: //base\n')
+        self.assertIn('changed nothing', str(cm.exception))
+
+    def test_an_unmatched_target_fails_the_apply(self):
+        with self.assertRaises(plaster.PlasterApplyError) as cm:
+            self._apply(
+                'BUILD.gn', self._SOURCE, 'substitutions:\n'
+                '  - description: No such target.\n'
+                '    add_deps:\n'
+                '      target: nope\n'
+                '      deps: //brave/a\n')
+        self.assertIn('Target(s) not found', str(cm.exception))
+
+    def test_a_count_is_rejected_for_a_gn_target(self):
+        with self.assertRaises(ValueError) as cm:
+            self._apply(
+                'BUILD.gn', self._SOURCE, 'substitutions:\n'
+                '  - description: Counting makes no sense here.\n'
+                '    count: 2\n'
+                '    add_deps:\n'
+                '      target: browser\n'
+                '      deps: //brave/a\n')
+        self.assertIn('does not accept a count other than 1',
+                      str(cm.exception))
+
+    def test_a_cxx_only_file_flag_is_rejected_for_a_gn_target(self):
+        with self.assertRaises(ValueError) as cm:
+            self._apply(
+                'BUILD.gn', self._SOURCE,
+                'blank_macros_for_ast_parsing: true\n'
+                'substitutions:\n'
+                '  - description: Add a Brave dep.\n'
+                '    add_deps:\n'
+                '      target: browser\n'
+                '      deps: //brave/a\n')
+        self.assertIn('only supported for C++ sources', str(cm.exception))
+
+    def test_a_gn_rewriter_is_unavailable_on_a_cxx_target(self):
+        with self.assertRaises(ValueError) as cm:
+            self._apply(
+                'browser.cc', 'int x = 1;\n', 'substitutions:\n'
+                '  - description: Wrong kind of source.\n'
+                '    add_deps:\n'
+                '      target: browser\n'
+                '      deps: //brave/a\n')
+        self.assertIn('not available for this source', str(cm.exception))
+
+    def test_the_regex_rewriter_is_still_available_on_a_gn_target(self):
+        # `regex` lives in the global namespace, so introducing a `gn`
+        # namespace must not have taken it away from build files.
+        result = self._apply(
+            'BUILD.gn', 'source_set("browser") {\n}\n', 'substitutions:\n'
+            '  - description: A plain regex on a build file.\n'
+            '    regex:\n'
+            "      pattern: 'source_set'\n"
+            "      replace: 'static_library'\n")
+        self.assertEqual(result, 'static_library("browser") {\n}\n')
+
+    def test_a_patch_is_generated_for_the_edit(self):
+        self._apply(
+            'BUILD.gn', self._SOURCE, 'substitutions:\n'
+            '  - description: Add a Brave dep.\n'
+            '    add_deps:\n'
+            '      target: browser\n'
+            '      deps: //brave/a\n')
+        patch = (self.fake_chromium_src.brave_patches /
+                 'components-omnibox-browser-BUILD.gn.patch')
+        self.assertTrue(patch.exists())
+        contents = patch.read_text()
+        self.assertIn('+    "//brave/a",', contents)
+
+
+class GnBinaryPathTest(unittest.TestCase):
+    """`_gn_platform_dir` mirrors the CIPD dirs `brave/DEPS` provisions."""
+
+    def _dir_for(self, platform: str) -> str:
+        with mock.patch.object(plaster.sys, 'platform', platform):
+            return plaster._gn_platform_dir()
+
+    def test_each_host_maps_to_its_cipd_subdirectory(self):
+        self.assertEqual(self._dir_for('linux'), 'linux64')
+        self.assertEqual(self._dir_for('darwin'), 'mac')
+        self.assertEqual(self._dir_for('win32'), 'win')
+
+    def test_an_unrecognised_host_falls_back_to_linux(self):
+        self.assertEqual(self._dir_for('freebsd13'), 'linux64')
+
+    def test_the_binary_sits_under_brave_third_party_gn(self):
+        # A different gn from the one Chromium pins under `buildtools/`, since
+        # `gn edit` is newer than the revision Chromium builds with.
+        self.assertEqual(plaster.GN_BIN.parent.parent.name, 'gn')
+        self.assertEqual(plaster.GN_BIN.parent.parent.parent.name,
+                         'third_party')
+        self.assertTrue(plaster.GN_BIN.name.startswith('gn'))
+
+
+class GnNamespaceTest(unittest.TestCase):
+    """The `gn` namespace claims build files and names no grammar."""
+
+    def test_an_ast_op_cannot_live_in_the_gn_namespace(self):
+        # `gn` is a second grammar-less namespace alongside `all`, so the rule
+        # that ast ops need a parseable namespace now has another way to be
+        # broken.
+        spec = {
+            'ast.matcher': {
+                'gn.find_thing': {
+                    'template': 'pattern: $X',
+                    'result': {
+                        'node': 'identifier'
+                    },
+                },
+            },
+        }
+        with self.assertRaises(plaster.RewritersSchemaError) as cm:
+            plaster.RewritersEval(repr(spec))
+        self.assertIn('names no grammar to parse with', str(cm.exception))
+
+    def test_build_gn_and_gni_targets_resolve_to_the_gn_namespace(self):
+        for name in ('BUILD.gn.yaml', 'sources.gni.yaml', 'build_webui.gni'
+                     '.yaml'):
+            self.assertEqual(
+                plaster._namespace_of_source(Path('rewrite/dir') / name), 'gn',
+                name)
+
+    def test_the_gn_namespace_names_no_grammar(self):
+        # gn does its own parsing, so there is no ast-grep language for it and
+        # an ast op may never be declared in this namespace.
+        namespace = plaster._NAMESPACE_BY_NAME[plaster._GN_NAMESPACE]
+        self.assertIsNone(namespace.ast_grep_language)
+
+    def test_a_gn_target_is_not_a_cxx_source(self):
+        self.assertFalse(plaster._is_cxx_source(Path('rewrite/BUILD.gn.yaml')))
+        self.assertFalse(
+            plaster._is_cxx_source(Path('rewrite/sources.gni.yaml')))
 
 
 if __name__ == '__main__':

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -3,10 +3,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 #
-# rewriters.pyl — ast-grep op specs for plaster. Data only: a Python literal
+# rewriters.pyl — rewriter op specs for plaster. Data only: a Python literal
 # (ast.literal_eval), so no imports, calls, or names.
 #
-# Three op categories, each keyed by an op id "<namespace>.<name>".
+# Four op categories, each keyed by an op id "<namespace>.<name>".
 #
 # The namespace says which sources an op may be used on. It is matched against
 # the namespace claiming a plaster's target suffix (`foo.cc.yaml` -> `.cc` ->
@@ -99,6 +99,27 @@
 #       than the macro inspecting what is there. The substitution's own
 #       `count:` is what tells the caller a match -- and so a change --
 #       actually happened.
+#
+#   "gn_edit" — an edit performed by `gn edit` itself. Where the categories
+#       above rewrite text, these hand the build file to gn, which parses it,
+#       edits its syntax tree and formats the result, so an op says what to
+#       change.
+#       description: Markdown documenting the op, rendered by
+#                `plaster --help <name>` like a `Rewriter`'s `HELP`.
+#       inputs:  the op's `{placeholder}`s, each documented as
+#                { name, description }, plus optional `variadic` for the one a
+#                plaster may pass a list to (the values being added), which is
+#                rendered as gn's space-separated, quoted value list.
+#       pattern: the label pattern argument, selecting the targets to edit.
+#                Plaster hands gn the build file as the root `BUILD.gn`, so a
+#                target is addressed as "//:{target}".
+#       command: the command argument, i.e. a `gn help edit` subcommand and its
+#                values.
+#       Both templates are `str.format`ed with the inputs, and between them
+#       they must name every declared input exactly once over -- the same
+#       interface check the regex macros get. gn edits are idempotent, so
+#       plaster treats "the file did not change" as the failure to report
+#       rather than a `count:`, which these ops reject.
 
 {
     "ast.matcher": {
@@ -728,6 +749,75 @@ substitutions:
             ],
             "re_pattern": "([ \\t]*)(BASE_FEATURE\\(\\s*{feature_name}\\s*,)([^;]*,)?(\\s*)[^;]*?(\\);)",
             "replace": "\\1// {feature_name} feature state is enforced via plaster rewrite.\\n\\1\\2\\3\\4{value}\\5",
+        },
+    },
+    "gn_edit": {
+        "gn.add_deps": {
+            "description": """\
+Adds dependencies to a target in a `BUILD.gn` or `.gni` file.
+
+The labels are added to the target's `deps`, which is created if the target has
+none.
+
+```yaml
+substitutions:
+  - description: Depend on the Brave omnibox additions.
+    add_deps:
+      target: browser
+      deps:
+        - //brave/components/omnibox/browser
+        - //brave/components/omnibox/common
+```
+
+```diff
+   deps = [
++    "//brave/components/omnibox/browser",
++    "//brave/components/omnibox/common",
+     "//build:branding_buildflags",
+```
+""",
+            "inputs": [
+                {
+                    "name": "target",
+                    "description": "The target to add the dependencies to, e.g. `browser` for `static_library(\"browser\")`.",
+                },
+                {
+                    "name": "deps",
+                    "description": "The dependency label(s) to add, e.g. `//brave/components/omnibox/browser`.",
+                    "variadic": True,
+                },
+            ],
+            "pattern": "//:{target}",
+            "command": "add deps {deps}",
+        },
+        "gn.add_sources": {
+            "description": """\
+Adds source files to a target in a `BUILD.gn` or `.gni` file.
+
+The paths are added to the target's `sources`, which is created if the target
+has none.
+
+```yaml
+substitutions:
+  - description: Build the Brave colour mixers into the target.
+    add_sources:
+      target: mixers
+      sources: //brave/ui/color/brave_color_mixer.cc
+```
+""",
+            "inputs": [
+                {
+                    "name": "target",
+                    "description": "The target to add the sources to, e.g. `mixers` for `component(\"mixers\")`.",
+                },
+                {
+                    "name": "sources",
+                    "description": "The source path(s) to add, relative to the build file or `//`-rooted.",
+                    "variadic": True,
+                },
+            ],
+            "pattern": "//:{target}",
+            "command": "add sources {sources}",
         },
     },
 }


### PR DESCRIPTION
This PR introduces the use of `gn edit` to `plaster`. For now only two
rewriters are added: `add_source`, and `add_deps`.

```yaml
substitutions:
  - description: Depend on the Brave omnibox additions.
    add_deps:
      target: browser
      deps:
        - //brave/components/omnibox/browser
        - //brave/components/omnibox/common
```

Bug: https://github.com/brave/brave-browser/issues/58378
