### PR TITLE
Use SequentialUpdateChecker for components only

### DIFF
--- a/chromium_src/components/component_updater/component_updater_service.cc
+++ b/chromium_src/components/component_updater/component_updater_service.cc
@@ -8,8 +8,13 @@
 #include "base/notreached.h"
 #include "components/component_updater/component_installer.h"
 #include "components/component_updater/component_updater_service_internal.h"
+#include "components/update_client/update_client.h"
 
+// See the documentation of SequentialUpdateClientFactory for an explanation why
+// we use it here.
+#define UpdateClientFactory SequentialUpdateClientFactory
 #include <components/component_updater/component_updater_service.cc>
+#undef UpdateClientFactory
 
 namespace component_updater {
 

--- a/chromium_src/components/component_updater/component_updater_service.cc
+++ b/chromium_src/components/component_updater/component_updater_service.cc
@@ -8,13 +8,8 @@
 #include "base/notreached.h"
 #include "components/component_updater/component_installer.h"
 #include "components/component_updater/component_updater_service_internal.h"
-#include "components/update_client/update_client.h"
 
-// See the documentation of SequentialUpdateClientFactory for an explanation why
-// we use it here.
-#define UpdateClientFactory SequentialUpdateClientFactory
 #include <components/component_updater/component_updater_service.cc>
-#undef UpdateClientFactory
 
 namespace component_updater {
 

--- a/chromium_src/components/update_client/update_client.cc
+++ b/chromium_src/components/update_client/update_client.cc
@@ -5,13 +5,11 @@
 
 #include "components/update_client/update_client.h"
 
-#include "base/logging.h"
+#include "base/functional/bind.h"
+#include "base/memory/scoped_refptr.h"
+#include "components/update_client/update_checker.h"
 
-#define UpdateClientFactory UpdateClientFactory_ChromiumImpl
 #include <components/update_client/update_client.cc>
-#undef UpdateClientFactory
-
-#include "base/logging.h"
 
 namespace update_client {
 
@@ -19,9 +17,8 @@ bool CrxInstaller::IsBraveComponent() const {
   return false;
 }
 
-scoped_refptr<UpdateClient> UpdateClientFactory(
+scoped_refptr<UpdateClient> SequentialUpdateClientFactory(
     scoped_refptr<Configurator> config) {
-  VLOG(3) << "Brave UpdateClientFactory called";
   return base::MakeRefCounted<UpdateClientImpl>(
       config, base::MakeRefCounted<PingManager>(config),
       base::BindRepeating(&SequentialUpdateChecker::Create));

--- a/chromium_src/components/update_client/update_client.h
+++ b/chromium_src/components/update_client/update_client.h
@@ -10,13 +10,16 @@
   IsBraveComponent() const; \
   virtual bool Uninstall(__VA_ARGS__)
 
-#define UpdateClientFactory                                             \
-  UpdateClientFactory_ChromiumImpl(scoped_refptr<Configurator> config); \
-  scoped_refptr<UpdateClient> UpdateClientFactory
-
 #include <components/update_client/update_client.h>  // IWYU pragma: export
 
 #undef Uninstall
-#undef UpdateClientFactory
+
+namespace update_client {
+
+// Like `UpdateClientFactory`, but uses `SequentialUpdateChecker`.
+scoped_refptr<UpdateClient> SequentialUpdateClientFactory(
+    scoped_refptr<Configurator> config);
+
+}  // namespace update_client
 
 #endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_UPDATE_CLIENT_UPDATE_CLIENT_H_

--- a/patches/components-component_updater-component_updater_service.cc.patch
+++ b/patches/components-component_updater-component_updater_service.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/components/component_updater/component_updater_service.cc b/components/component_updater/component_updater_service.cc
+index b8210dce96d8013c9a8f8e06f9647b1c17b71ede..2a48dafb1f405521fa64f3e67b8eb02131ec59d1 100644
+--- a/components/component_updater/component_updater_service.cc
++++ b/components/component_updater/component_updater_service.cc
+@@ -573,7 +573,7 @@ std::unique_ptr<ComponentUpdateService> ComponentUpdateServiceFactory(
+     const std::string& brand) {
+   CHECK(config);
+   CHECK(scheduler);
+-  auto update_client = update_client::UpdateClientFactory(config);
++  auto update_client = update_client::SequentialUpdateClientFactory(config);
+   return std::make_unique<CrxUpdateService>(config, std::move(scheduler),
+                                             std::move(update_client), brand);
+ }

--- a/rewrite/components/component_updater/component_updater_service.cc.yaml
+++ b/rewrite/components/component_updater/component_updater_service.cc.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |-
+      Use SequentialUpdateClientFactory for component updates.
+
+      See the documentation of SequentialUpdateChecker for why it is needed
+      here. It is intentionally not used for extension or browser updates.
+    regex:
+      pattern: 'update_client::UpdateClientFactory(config)'
+      replace: 'update_client::SequentialUpdateClientFactory(config)'


### PR DESCRIPTION
It is only needed for component updates. Previously, it was also used for extension updates and, via Omaha 4, for browser updates. Restricting it to component updates limits the impact of bugs in SequentialUpdateChecker.

Resolves https://github.com/brave/brave-browser/issues/58414