### PR TITLE
[iOS] Add variable blur to top edge when using bottom bar mode

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -329,6 +329,17 @@ extension BrowserViewController: TabManagerDelegate {
       coins: dappSupportedCoins
     )
     updateURLBarWalletButton()
+
+    if #available(iOS 26.0, *) {
+      if let topEdgeInteraction {
+        topEdgeView.removeInteraction(topEdgeInteraction)
+      }
+      let interaction = UIScrollEdgeElementContainerInteraction()
+      interaction.edge = .top
+      interaction.scrollView = selected?.webViewProxy?.scrollView
+      topEdgeView.addInteraction(interaction)
+      topEdgeInteraction = interaction
+    }
   }
 
   func tabManager(_ tabManager: TabManager, willAddTab tab: some TabState) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -106,6 +106,18 @@ public class BrowserViewController: UIViewController {
     return statusBarOverlay
   }()
 
+  // On 26 this is the `UIScrollEdgeElementContainerInteraction` assigned to the top of the web view
+  var topEdgeInteraction: (any UIInteraction)?
+  let topEdgeView: UIView = {
+    if #available(iOS 26, *) {
+      let view = UIVisualEffectView(effect: UIGlassEffect(style: .regular))
+      view.isUserInteractionEnabled = false
+      return view
+    } else {
+      return UIView()
+    }
+  }()
+
   private(set) var toolbar: BottomToolbarView?
   /// The fullscreen editing surface (URL input + favorites/search screens) shown while editing the
   /// URL. Builds and owns the favorites, search-results and search-loader instances.
@@ -675,7 +687,14 @@ public class BrowserViewController: UIViewController {
     super.viewSafeAreaInsetsDidChange()
 
     topTouchArea.isEnabled = view.safeAreaInsets.top > 0
-    statusBarOverlay.isHidden = view.safeAreaInsets.top.isZero
+    statusBarOverlay.isHidden = isStatusBarOverlayHidden
+  }
+
+  private var isStatusBarOverlayHidden: Bool {
+    if #unavailable(iOS 26.0) {
+      return view.safeAreaInsets.top.isZero
+    }
+    return isUsingBottomBar || view.safeAreaInsets.top.isZero
   }
 
   @available(iOS 26.0, *)
@@ -931,6 +950,8 @@ public class BrowserViewController: UIViewController {
       searchContainer?.isUsingBottomBar = isUsingBottomBar
       bottomBarKeyboardBackground.isHidden = !isUsingBottomBar
       topToolbar.displayTabTraySwipeGestureRecognizer?.isEnabled = isUsingBottomBar
+      statusBarOverlay.isHidden = isStatusBarOverlayHidden
+      topEdgeView.isHidden = !isUsingBottomBar
       updateTabsBarVisibility()
       updateStatusBarOverlayColor()
       updateViewConstraints()
@@ -964,6 +985,10 @@ public class BrowserViewController: UIViewController {
     view.addSubview(footer)
     view.addSubview(statusBarOverlay)
     view.addSubview(header)
+
+    if #available(iOS 26.0, *) {
+      view.addSubview(topEdgeView)
+    }
 
     // For now we hide some elements so they are not visible
     header.isHidden = true
@@ -1316,9 +1341,25 @@ public class BrowserViewController: UIViewController {
 
   override public func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
-    statusBarOverlay.snp.remakeConstraints { make in
-      make.top.left.right.equalTo(self.view)
-      make.bottom.equalTo(view.safeArea.top)
+
+    if #available(iOS 26, *), isUsingBottomBar {
+      // UIScrollEdgeElementContainerInteraction does not work unless the view its added to contains
+      // a glass view hierarchy in it (UIGlassEffect/UIGlassContainerEffect). The top edge in bottom
+      // bar doesn't contain any real chrome in that spot so we create a temporary
+      // view which has no real visibility (non-zero width)
+      topEdgeView.frame = .init(
+        x: 0,
+        y: 0,
+        width: CGFloat.leastNormalMagnitude,
+        height: view.safeAreaInsets.top
+      )
+    } else {
+      statusBarOverlay.frame = .init(
+        x: 0,
+        y: 0,
+        width: view.bounds.width,
+        height: view.safeAreaInsets.top
+      )
     }
 
     toolbarVisibilityViewModel.transitionDistance =
@@ -2184,16 +2225,21 @@ public class BrowserViewController: UIViewController {
   }
 
   public override var preferredStatusBarStyle: UIStatusBarStyle {
-    if isUsingBottomBar, let tab = tabManager.selectedTab, let url = tab.visibleURL,
-      !url.isNewTabURL, !InternalURL.isValid(url: url),
-      let color = tab.sampledPageTopColor
-    {
-      return color.isLight ? .darkContent : .lightContent
+    if #unavailable(iOS 26.0) {
+      if isUsingBottomBar, let tab = tabManager.selectedTab, let url = tab.visibleURL,
+        !url.isNewTabURL, !InternalURL.isValid(url: url),
+        let color = tab.sampledPageTopColor
+      {
+        return color.isLight ? .darkContent : .lightContent
+      }
     }
     return super.preferredStatusBarStyle
   }
 
   func updateStatusBarOverlayColor() {
+    if #available(iOS 26.0, *) {
+      return
+    }
     defer { setNeedsStatusBarAppearanceUpdate() }
     guard isUsingBottomBar, let tab = tabManager.selectedTab, let url = tab.visibleURL,
       !url.isNewTabURL, !InternalURL.isValid(url: url),

--- a/ios/brave-ios/Sources/Web/Chromium/ChromiumTabState.swift
+++ b/ios/brave-ios/Sources/Web/Chromium/ChromiumTabState.swift
@@ -163,18 +163,20 @@ class ChromiumTabState: TabState, TabStateImpl {
     webViewObservations.append(
       contentsOf: keyValueObservations.map { observation in .init { observation.invalidate() } }
     )
-    if let webView = webView.internalWebView {
-      let sampledPageTopColorObservation =
-        StringKeyPathObserver<WKWebView, UIColor>(
-          object: webView,
-          keyPath: "_sampl\("edPageTopC")olor",
-          changeHandler: { [weak self] _ in
-            self?.webViewSampledPageTopColorDidChange()
-          }
+    if #unavailable(iOS 26.0) {
+      if let webView = webView.internalWebView {
+        let sampledPageTopColorObservation =
+          StringKeyPathObserver<WKWebView, UIColor>(
+            object: webView,
+            keyPath: "_sampl\("edPageTopC")olor",
+            changeHandler: { [weak self] _ in
+              self?.webViewSampledPageTopColorDidChange()
+            }
+          )
+        webViewObservations.append(
+          .init { sampledPageTopColorObservation.invalidate() }
         )
-      webViewObservations.append(
-        .init { sampledPageTopColorObservation.invalidate() }
-      )
+      }
     }
   }
 

--- a/ios/brave-ios/Sources/Web/TabObserver.swift
+++ b/ios/brave-ios/Sources/Web/TabObserver.swift
@@ -27,6 +27,7 @@ public protocol TabObserver: AnyObject {
   func tabDidChangeLoadProgress(_ tab: some TabState)
   func tabDidChangeVisibleSecurityState(_ tab: some TabState)
   func tabDidChangeBackForwardState(_ tab: some TabState)
+  @available(iOS, obsoleted: 26.0, message: "Page top color is not sampled on iOS 26+")
   func tabDidChangeSampledPageTopColor(_ tab: some TabState)
   func tabDidUpdateFaviconStatus(_ tab: some TabState)
   func tab(_ tab: some TabState, didUpdateFaviconURLCandidates candidates: [WebFaviconCandidate])

--- a/ios/brave-ios/Sources/Web/TabState.swift
+++ b/ios/brave-ios/Sources/Web/TabState.swift
@@ -261,6 +261,7 @@ public protocol TabState: AnyObject {
   /// Returns the PDF data for the current page if one is being displayed
   var dataForDisplayedPDF: Data? { get }
   /// Returns a colour that was sampled from the top of the page for UI purposes
+  @available(iOS, obsoleted: 26.0, message: "Page top color is not sampled on iOS 26+")
   var sampledPageTopColor: UIColor? { get }
   /// The scale applied to the WKWebView which can be used to apply custom zoom settings to a page
   var viewScale: CGFloat { get set }


### PR DESCRIPTION
This replaces the status bar overlay that usually appears in the top safe area with a variable blur. It also removes top page sampling usage in iOS 26+ as this is handled automatically by iOS when using obscured insets

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58418

### Test
iOS 26+:
- In bottom bar mode scroll down and verify webpage scrolls under the status bar instead of solid color clipping it
- In top bar mode verify no changes

iOS 18:
- No behavior changes