### PR TITLE
[iOS] Ignore obscured insets when taking tab snapshots

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ScreenshotHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ScreenshotHelper.swift
@@ -37,7 +37,8 @@ class ScreenshotHelper {
       if !tab.canTakeSnapshot {
         return
       }
-      tab.takeSnapshot(rect: .null) { [weak tab] image in
+      let inset = tab.webViewProxy?.obscuredInsets ?? .zero
+      tab.takeSnapshot(rect: tab.view.bounds.inset(by: inset)) { [weak tab] image in
         guard let tab else { return }
         if let image = image {
           tab.browserData?.setScreenshot(image)


### PR DESCRIPTION
This adds an inset when taking snapshots of tabs based on the obscured insets so the displayed snapshot in the tab grid does not show the empty space at the top

Follow-up of https://github.com/brave/brave-core/pull/39169