### PR TITLE
[iOS] Extend NTP backgrounds under the status bar in bottom bar mode

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -1376,6 +1376,13 @@ public class BrowserViewController: UIViewController {
 
     if #available(iOS 26.0, *) {
       updateWebViewObscuredInsets()
+      activeNewTabPageViewController?.additionalSafeAreaInsets = UIEdgeInsets(
+        top: pageOverlayLayoutGuide.layoutFrame.minY - view.safeAreaInsets.top,
+        left: 0,
+        bottom: view.bounds.height - pageOverlayLayoutGuide.layoutFrame.maxY
+          - view.safeAreaInsets.bottom,
+        right: 0
+      )
     }
   }
 
@@ -1690,12 +1697,17 @@ public class BrowserViewController: UIViewController {
       activeNewTabPageViewController = ntpController
 
       addChild(ntpController)
-      let subview = isUsingBottomBar ? header : statusBarOverlay
-      view.insertSubview(ntpController.view, belowSubview: subview)
+      view.insertSubview(ntpController.view, belowSubview: footer)
       ntpController.didMove(toParent: self)
 
-      ntpController.view.snp.makeConstraints {
-        $0.edges.equalTo(pageOverlayLayoutGuide)
+      if #available(iOS 26, *) {
+        ntpController.view.snp.makeConstraints {
+          $0.edges.equalTo(self.view)
+        }
+      } else {
+        ntpController.view.snp.makeConstraints {
+          $0.edges.equalTo(pageOverlayLayoutGuide)
+        }
       }
       ntpController.view.layoutIfNeeded()
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ScreenshotHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ScreenshotHelper.swift
@@ -28,7 +28,10 @@ class ScreenshotHelper {
 
     if url.isNewTabURL {
       if let homePanel = tabManager?.selectedTab?.newTabPageViewController {
-        let screenshot = homePanel.view.screenshot(quality: UIConstants.activeScreenshotQuality)
+        let screenshot = homePanel.view.screenshot(
+          offset: .init(x: 0, y: -homePanel.view.safeAreaInsets.top),
+          quality: UIConstants.activeScreenshotQuality
+        )
         tab.browserData?.setScreenshot(screenshot)
       } else {
         tab.browserData?.setScreenshot(nil)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageFlowLayout.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageFlowLayout.swift
@@ -43,7 +43,9 @@ class NewTabPageFlowLayout: UICollectionViewFlowLayout {
         at: IndexPath(item: 0, section: braveNewsSection)
       )
     {
-      let diff = collectionView.frame.height - attribute.frame.minY
+      let diff =
+        collectionView.frame.height - collectionView.adjustedContentInset.top
+        - collectionView.adjustedContentInset.bottom - attribute.frame.minY
       gapLength = diff - gapPadding
 
       // Obtain the total height of the Brave News section to calculate any extra height to be added
@@ -53,11 +55,12 @@ class NewTabPageFlowLayout: UICollectionViewFlowLayout {
       if let lastItemAttribute = super.layoutAttributesForItem(
         at: IndexPath(item: numberOfItems - 1, section: braveNewsSection)
       ) {
-        if lastItemAttribute.frame.maxY - attribute.frame.minY < collectionView.bounds.height
-          - gapPadding
-        {
+        let visibleHeight =
+          collectionView.bounds.height - collectionView.adjustedContentInset.top
+          - collectionView.adjustedContentInset.bottom
+        if lastItemAttribute.frame.maxY - attribute.frame.minY < visibleHeight - gapPadding {
           extraHeight =
-            (collectionView.bounds.height - gapPadding)
+            (visibleHeight - gapPadding)
             - (lastItemAttribute.frame.maxY - attribute.frame.minY)
         }
       }
@@ -164,19 +167,22 @@ class NewTabPageFlowLayout: UICollectionViewFlowLayout {
     withScrollingVelocity velocity: CGPoint
   ) -> CGPoint {
     guard let section = braveNewsSection,
-      collectionView?.numberOfItems(inSection: section) != 0,
+      let collectionView,
+      collectionView.numberOfItems(inSection: section) != 0,
       let item = layoutAttributesForItem(at: IndexPath(item: 0, section: section))
     else {
       return proposedContentOffset
     }
     var offset = proposedContentOffset
+    let contentY = offset.y + collectionView.adjustedContentInset.top
     let flicked = abs(velocity.y) > 0.3
-    if (offset.y > item.frame.minY / 2 && offset.y < item.frame.minY)
-      || (flicked && velocity.y > 0 && offset.y < item.frame.minY)
+    if (contentY > item.frame.minY / 2 && contentY < item.frame.minY)
+      || (flicked && velocity.y > 0 && contentY < item.frame.minY)
     {
-      offset.y = item.frame.minY - 56  // FIXME: Use size of header + padding
-    } else if offset.y < item.frame.minY {
-      offset.y = 0
+      // FIXME: Use size of header + padding
+      offset.y = item.frame.minY - collectionView.adjustedContentInset.top - 56
+    } else if contentY < item.frame.minY {
+      offset.y = -collectionView.adjustedContentInset.top
     }
     return offset
   }
@@ -223,7 +229,9 @@ class NewTabPageFlowLayout: UICollectionViewFlowLayout {
     // smooth scrolling.
     let currentElementY = originalAttributes.frame.minY
     let isScrolling = collectionView.isDragging || collectionView.isDecelerating
-    let isSizingElementAboveTopEdge = originalAttributes.frame.minY < collectionView.contentOffset.y
+    let isSizingElementAboveTopEdge =
+      originalAttributes.frame.minY
+      < collectionView.contentOffset.y + collectionView.adjustedContentInset.top
 
     if isScrolling && isSizingElementAboveTopEdge {
       let isSameRowAsLastSizedElement = lastSizedElementMinY == currentElementY

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
@@ -650,8 +650,11 @@ class NewTabPageViewController: UIViewController {
         collectionView.deleteItems(at: [IndexPath(item: 0, section: section)])
       }
 
-      // scroll to offset .zero to preserve padding above section
-      collectionView.setContentOffset(.zero, animated: true)
+      // scroll to the top to preserve padding above section
+      collectionView.setContentOffset(
+        .init(x: 0, y: -collectionView.adjustedContentInset.top),
+        animated: true
+      )
       backgroundButtonsView.setNeedsLayout()
       collectionView.verticalScrollIndicatorInsets = .zero
       UIView.animate(withDuration: 0.25) {
@@ -764,7 +767,7 @@ class NewTabPageViewController: UIViewController {
           self.feedOverlayView.loaderView.isHidden = true
         }
       )
-      if collectionView.contentOffset.y == collectionView.contentInset.top {
+      if collectionView.contentOffset.y == -collectionView.adjustedContentInset.top {
         collectionView.reloadData()
         collectionView.layoutIfNeeded()
         let cells = collectionView.indexPathsForVisibleItems
@@ -811,7 +814,7 @@ class NewTabPageViewController: UIViewController {
         _completeLoading()
       }
     case (_, .loading):
-      if collectionView.contentOffset.y == collectionView.contentInset.top
+      if collectionView.contentOffset.y == -collectionView.adjustedContentInset.top
         || collectionView.numberOfItems(inSection: section) == 0
       {
         feedOverlayView.loaderView.isHidden = false
@@ -831,7 +834,7 @@ class NewTabPageViewController: UIViewController {
 
   @objc private func checkForUpdatedFeed() {
     if !isBraveNewsVisible || Preferences.BraveNews.isShowingOptIn.value { return }
-    if collectionView.contentOffset.y == collectionView.contentInset.top {
+    if collectionView.contentOffset.y == -collectionView.adjustedContentInset.top {
       // Reload contents if the user is not currently scrolled into the feed
       loadFeedContents()
     } else {
@@ -1051,14 +1054,21 @@ extension NewTabPageViewController {
     if collectionView.numberOfItems(inSection: newsSection) > 0 {
       // Hide the buttons as Brave News feeds appear
       backgroundButtonsView.alpha =
-        1.0 - max(0.0, min(1.0, (scrollView.contentOffset.y - scrollView.contentInset.top) / 16))
+        1.0
+        - max(
+          0.0,
+          min(1.0, (scrollView.contentOffset.y + scrollView.adjustedContentInset.top) / 16)
+        )
       // Show the header as Brave News feeds appear
       // Offset of where Brave News starts
       let todayStart =
         collectionView.frame.height - feedOverlayView.headerView.bounds.height - 32 - 16
+        - scrollView.adjustedContentInset.top - scrollView.adjustedContentInset.bottom
       // Offset of where the header should begin becoming visible
-      let alphaInStart = collectionView.frame.height / 2.0
-      let value = scrollView.contentOffset.y
+      let alphaInStart =
+        (collectionView.frame.height - scrollView.adjustedContentInset.top
+          - scrollView.adjustedContentInset.bottom) / 2.0
+      let value = scrollView.contentOffset.y + scrollView.adjustedContentInset.top
       let alpha = max(0.0, min(1.0, (value - alphaInStart) / (todayStart - alphaInStart)))
       feedOverlayView.headerView.alpha = alpha
 
@@ -1066,7 +1076,7 @@ extension NewTabPageViewController {
         && !feedOverlayView.newContentAvailableButton.isLoading
       {
         let velocity = scrollView.panGestureRecognizer.velocity(in: scrollView).y
-        if velocity > 0 && collectionView.contentOffset.y < todayStart {
+        if velocity > 0 && value < todayStart {
           // Scrolling up
           self.feedOverlayView.hideNewContentAvailableButton()
         } else if velocity < 0 {
@@ -1100,9 +1110,15 @@ extension NewTabPageViewController {
       return
     }
     // Offset of where Brave News starts
-    let todayStart =
-      collectionView.frame.height - feedOverlayView.headerView.bounds.height - 32 - 16
-    collectionView.contentOffset.y = todayStart
+    guard let section = layout.braveNewsSection,
+      collectionView.numberOfItems(inSection: section) != 0,
+      let item = layout.layoutAttributesForItem(at: IndexPath(item: 0, section: section))
+    else {
+      return
+    }
+    // FIXME: Use size of header + padding
+    collectionView.contentOffset.y =
+      item.frame.minY - collectionView.adjustedContentInset.top - 56
   }
 
   // MARK: - P3A


### PR DESCRIPTION
Similar to web pages extending under the status bar in iOS 26, this also allows the backgrounds on the NTP to extend to the edges of the screen

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58450

### Test

On iOS 26:
- Verify that NTP backgrounds extend under the status bar now
- Verify scrolling to Brave News still lands correctly at the right spot
- Verify tapping "Brave News" in the browser menu scrolls to brave news correctly

On iOS 18:
- Verify no changes
