### PR TITLE
[History] Show the not-available page for guest sessions

### DIFF
--- a/browser/ui/webui/history/BUILD.gn
+++ b/browser/ui/webui/history/BUILD.gn
@@ -28,6 +28,7 @@ source_set("history") {
     "//base",
     "//brave/components/local_ai/buildflags",
     "//chrome/browser/profiles:profile",
+    "//chrome/browser/ui/webui/page_not_available_for_guest",
     "//chrome/common:constants",
     "//components/prefs",
     "//content/public/common",

--- a/browser/ui/webui/history/brave_history_ui.cc
+++ b/browser/ui/webui/history/brave_history_ui.cc
@@ -5,12 +5,26 @@
 
 #include "brave/browser/ui/webui/history/brave_history_ui.h"
 
+#include <utility>
+
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/webui/page_not_available_for_guest/page_not_available_for_guest_ui.h"
 
 #if BUILDFLAG(ENABLE_LOCAL_AI)
 #include "brave/browser/ui/webui/history/brave_history_embeddings_page_handler.h"
 #endif
+
+// Matches HistoryUIConfig::CreateWebUIController, which this config replaces.
+std::unique_ptr<content::WebUIController>
+BraveHistoryUIConfig::CreateWebUIController(content::WebUI* web_ui,
+                                            const GURL& url) {
+  if (Profile::FromWebUI(web_ui)->IsGuestSession()) {
+    return std::make_unique<PageNotAvailableForGuestUI>(
+        web_ui, chrome::kChromeUIHistoryHost);
+  }
+  return std::make_unique<BraveHistoryUI>(web_ui);
+}
 
 BraveHistoryUI::BraveHistoryUI(content::WebUI* web_ui) : HistoryUI(web_ui) {}
 

--- a/browser/ui/webui/history/brave_history_ui.h
+++ b/browser/ui/webui/history/brave_history_ui.h
@@ -30,6 +30,11 @@ class BraveHistoryUIConfig
   BraveHistoryUIConfig()
       : DefaultWebUIConfig(content::kChromeUIScheme,
                            chrome::kChromeUIHistoryHost) {}
+
+  // content::WebUIConfig:
+  std::unique_ptr<content::WebUIController> CreateWebUIController(
+      content::WebUI* web_ui,
+      const GURL& url) override;
 };
 
 // Brave subclass of the chrome://history WebUI controller. When local AI is


### PR DESCRIPTION
- Resolves https://github.com/brave/brave-browser/issues/58419

https://github.com/brave/brave-core/pull/36624 replaced upstream's `HistoryUIConfig` with
`BraveHistoryUIConfig` and dropped its guest-session branch, so
brave://history builds the real controller in a Guest window.
`BrowsingHistoryHandler` then dereferences the `DeviceInfoSyncService`, which
guest profiles never get (`ProfileSelection::kNone`), crashing on the first
completed history query.

## Test plan

1. Launch a Guest window
2. Navigate to brave://history
3. The "not available in Guest mode" page is shown instead of a crash

Also verify a normal window still opens brave://history as usual.
