### PR TITLE
[Local AI] [WebSpeech] Update speech models component management

### DIFF
--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -129,6 +129,7 @@
 
 #if BUILDFLAG(ENABLE_LOCAL_AI)
 #include "brave/components/local_ai/core/local_models_updater.h"
+#include "brave/components/local_ai/core/on_device_speech_models_component_installer.h"
 #endif
 
 using brave_component_updater::BraveComponent;
@@ -277,6 +278,7 @@ void BraveBrowserProcessImpl::StartTearDown() {
   // Drop the local models registrar's pointers to CrxUpdateService and
   // local_state before either is destroyed.
   local_ai::ShutdownLocalModelsComponentRegistration();
+  local_ai::ShutdownOnDeviceSpeechModelsComponentRegistration();
 #endif
   // Reset BraveOriginPolicyManager to prevent dangling pointer to local_state_
   brave_origin::BraveOriginPolicyManager::GetInstance()->Shutdown();

--- a/browser/speech/on_device_speech_recognition_controller.cc
+++ b/browser/speech/on_device_speech_recognition_controller.cc
@@ -180,9 +180,7 @@ void OnDeviceSpeechRecognitionController::Start(
   // renderer just to discover the files are missing in OnOrtFilesRead.
   // Dropping the stream/responder pipes here surfaces to the engine as a
   // recognition failure, the same outcome as a failed load.
-  if (local_ai::OnDeviceSpeechModelsState::GetInstance()
-          ->GetModelDir()
-          .empty()) {
+  if (!local_ai::OnDeviceSpeechModelsState::GetInstance()->IsModelInstalled()) {
     return;
   }
 

--- a/chromium_src/chrome/browser/component_updater/registration.cc
+++ b/chromium_src/chrome/browser/component_updater/registration.cc
@@ -84,7 +84,8 @@ void RegisterBraveComponentsForUpdate() {
 #if BUILDFLAG(ENABLE_LOCAL_AI)
   local_ai::ManageLocalModelsComponentRegistration(
       cus, g_browser_process->local_state());
-  local_ai::RegisterOnDeviceSpeechModelsComponent(cus);
+  local_ai::ManageOnDeviceSpeechModelsComponentRegistration(
+      cus, g_browser_process->local_state());
 #endif
   RegisterQueryFilterComponent(cus);
 }

--- a/components/local_ai/core/BUILD.gn
+++ b/components/local_ai/core/BUILD.gn
@@ -86,12 +86,14 @@ source_set("unit_tests") {
   sources = [
     "local_models_updater_unittest.cc",
     "on_device_speech_models_component_installer_unittest.cc",
+    "on_device_speech_models_state_unittest.cc",
   ]
 
   deps = [
     ":core",
     "//base",
     "//base/test:test_support",
+    "//brave/components/brave_component_updater/browser:public",
     "//brave/components/brave_component_updater/browser:test_support",
     "//components/component_updater:test_support",
     "//components/history_embeddings/core",

--- a/components/local_ai/core/on_device_speech_models_component_installer.cc
+++ b/components/local_ai/core/on_device_speech_models_component_installer.cc
@@ -9,22 +9,31 @@
 #include <iterator>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "base/feature_list.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"
+#include "base/functional/callback.h"
+#include "base/functional/callback_helpers.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/scoped_refptr.h"
-#include "base/path_service.h"
+#include "base/no_destructor.h"
+#include "base/scoped_observation.h"
+#include "base/task/bind_post_task.h"
 #include "base/values.h"
 #include "base/version.h"
 #include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
 #include "brave/components/local_ai/core/features.h"
 #include "brave/components/local_ai/core/on_device_speech_models_state.h"
+#include "brave/components/local_ai/core/pref_names.h"
 #include "components/component_updater/component_installer.h"
-#include "components/component_updater/component_updater_paths.h"
 #include "components/component_updater/component_updater_service.h"
+#include "components/prefs/pref_change_registrar.h"
+#include "components/prefs/pref_service.h"
+#include "components/update_client/crx_update_item.h"
 #include "components/update_client/update_client.h"
 #include "components/update_client/update_client_errors.h"
 #include "crypto/sha2.h"
@@ -36,7 +45,6 @@ namespace {
 constexpr base::FilePath::CharType kComponentInstallDir[] =
     FILE_PATH_LITERAL("BraveOnDeviceSpeechModels");
 constexpr char kComponentName[] = "Brave On-Device Speech Models";
-constexpr char kComponentId[] = "nhkekccefdppopbldokibkoegppanbba";
 
 // SHA256 of the provisioned component's public key.
 constexpr uint8_t kPublicKeySHA256[32] = {
@@ -46,28 +54,239 @@ constexpr uint8_t kPublicKeySHA256[32] = {
 static_assert(std::size(kPublicKeySHA256) == crypto::kSHA256Length,
               "Wrong hash length");
 
-base::FilePath GetComponentDir() {
-  base::FilePath components_dir =
-      base::PathService::CheckedGet(component_updater::DIR_COMPONENT_USER);
-
-  return components_dir.Append(kComponentInstallDir);
+// Whether the component may be installed. The feature is fixed for the session
+// but `kBraveLocalAIEnabled` is managed by Brave Origin and can flip at any
+// time.
+bool IsComponentAllowed(const PrefService* local_state) {
+  return base::FeatureList::IsEnabled(kBraveOnDeviceSpeechRecognition) &&
+         (!local_state || local_state->GetBoolean(prefs::kBraveLocalAIEnabled));
 }
 
-void DeleteComponentDirectory() {
-  base::DeletePathRecursively(GetComponentDir());
-}
+// Owns the component registration for the whole session and follows the master
+// switch so it stays in sync with it. It is also the one place that decides
+// when an install request is over, and answers it with whether a model is
+// installed.
+//
+// Registering and removing the model both go through the one
+// `ComponentInstaller` this holds, which is what orders a removal against an
+// install rather than racing it on an unrelated sequence.
+class OnDeviceSpeechModelsComponentRegistrar
+    : public component_updater::ServiceObserver {
+ public:
+  static OnDeviceSpeechModelsComponentRegistrar* GetInstance() {
+    static base::NoDestructor<OnDeviceSpeechModelsComponentRegistrar> instance;
+    return instance.get();
+  }
+
+  OnDeviceSpeechModelsComponentRegistrar(
+      const OnDeviceSpeechModelsComponentRegistrar&) = delete;
+  OnDeviceSpeechModelsComponentRegistrar& operator=(
+      const OnDeviceSpeechModelsComponentRegistrar&) = delete;
+
+  // Once per process, or once per `Shutdown`.
+  void Start(component_updater::ComponentUpdateService* cus,
+             PrefService* local_state) {
+    CHECK(pref_change_registrar_.IsEmpty() && !cus_);
+    CHECK(local_state);
+    cus_ = cus;
+    pref_change_registrar_.Init(local_state);
+    pref_change_registrar_.Add(
+        prefs::kBraveLocalAIEnabled,
+        base::BindRepeating(&OnDeviceSpeechModelsComponentRegistrar::Sync,
+                            base::Unretained(this)));
+    Sync();
+  }
+
+  void Shutdown() {
+    pref_change_registrar_.Reset();
+    cus_ = nullptr;
+    installer_.reset();
+    registration_pending_ = false;
+    // No model can arrive once the update service has been let go of, so a
+    // request still waiting is over.
+    SettlePendingRequests();
+  }
+
+  // Registers the component, which also requests the download. Joins a
+  // registration already in flight instead of starting a second one.
+  void Register(base::OnceCallback<void(bool)> callback) {
+    // Answered from a task on every path, so an answer never lands inside the
+    // caller's own call.
+    callback = base::BindPostTaskToCurrentDefault(std::move(callback));
+
+    if (!cus_ || !IsComponentAllowed(pref_change_registrar_.prefs())) {
+      std::move(callback).Run(false);
+      return;
+    }
+
+    pending_callbacks_.push_back(std::move(callback));
+    if (registration_pending_) {
+      return;
+    }
+    registration_pending_ = true;
+    EnsureInstaller();
+    installer_->Register(
+        cus_,
+        base::BindOnce(&OnDeviceSpeechModelsComponentRegistrar::OnRegistered,
+                       base::Unretained(this)));
+  }
+
+ private:
+  friend base::NoDestructor<OnDeviceSpeechModelsComponentRegistrar>;
+
+  OnDeviceSpeechModelsComponentRegistrar() = default;
+  ~OnDeviceSpeechModelsComponentRegistrar() override = default;
+
+  void Sync() {
+    if (!IsComponentAllowed(pref_change_registrar_.prefs())) {
+      Unregister();
+      return;
+    }
+    Register(base::DoNothing());
+  }
+
+  void OnRegistered() {
+    registration_pending_ = false;
+    // `Shutdown` ran while this was in flight. Falling through would read the
+    // prefs it dropped as the master switch being off and remove the model.
+    if (!cus_) {
+      SettlePendingRequests();
+      return;
+    }
+    // The switch turned off while this was in flight, so the unregister it ran
+    // found nothing to remove. Nothing else will try again, so finish the
+    // removal here.
+    if (!IsComponentAllowed(pref_change_registrar_.prefs())) {
+      Unregister();
+      return;
+    }
+    // Registering already published whatever was on disk. Only the download is
+    // refused, which is what --disable-component-update forbids and what trips
+    // a DCHECK in BraveOnDemandUpdater.
+    if (brave_component_updater::BraveOnDemandUpdater::GetInstance()
+            ->is_component_update_disabled()) {
+      SettlePendingRequests();
+      return;
+    }
+    // Watched before the download is asked for, so an event it causes cannot
+    // be missed. A request made while one is already running starts nothing
+    // and is answered `UPDATE_IN_PROGRESS`, so how that download ended is
+    // only reported on `ServiceObserver::OnEvent`.
+    if (!cus_observation_.IsObserving()) {
+      cus_observation_.Observe(cus_);
+    }
+    brave_component_updater::BraveOnDemandUpdater::GetInstance()
+        ->EnsureInstalled(
+            kOnDeviceSpeechModelsComponentId,
+            base::BindOnce(
+                &OnDeviceSpeechModelsComponentRegistrar::OnEnsureInstalled,
+                base::Unretained(this)));
+  }
+
+  void OnEnsureInstalled(update_client::Error error) {
+    // `UPDATE_IN_PROGRESS` leaves the request waiting on
+    // `ServiceObserver::OnEvent`. Every other answer ends it, including `NONE`
+    // for an update that never started because a copy was already installed.
+    if (error == update_client::Error::UPDATE_IN_PROGRESS) {
+      return;
+    }
+    SettlePendingRequests();
+  }
+
+  // component_updater::ServiceObserver:
+  // Only ever watched for a request waiting on a download, and every drain
+  // stops watching, so there is always one waiting here.
+  void OnEvent(const update_client::CrxUpdateItem& item) override {
+    if (item.id != kOnDeviceSpeechModelsComponentId) {
+      return;
+    }
+    // The first state an update cannot leave settles what is waiting. Which
+    // state it is says nothing on its own, because `kUpdated` and `kUpToDate`
+    // can both leave no model behind.
+    if (item.state == update_client::ComponentState::kUpdated ||
+        item.state == update_client::ComponentState::kUpToDate ||
+        item.state == update_client::ComponentState::kUpdateError) {
+      SettlePendingRequests();
+    }
+  }
+
+  void Unregister() {
+    // Only remove the files ourselves when the service did not (it uninstalls
+    // what it had registered) and no registration in flight may still install
+    // them.
+    const bool was_registered =
+        cus_ && cus_->UnregisterComponent(kOnDeviceSpeechModelsComponentId);
+    // Published before the files go, so nothing acts on a model whose files
+    // are on their way out.
+    OnDeviceSpeechModelsState::GetInstance()->SetInstallDir(base::FilePath());
+    if (!was_registered && !registration_pending_) {
+      EnsureInstaller();
+      installer_->Uninstall();
+    }
+    // A registration still in flight reads the switch again when it lands,
+    // which is what lets a switch turned off and back on finish the install it
+    // started. With none in flight, nothing else will answer what is waiting.
+    if (!registration_pending_) {
+      SettlePendingRequests();
+    }
+  }
+
+  // Answers every request waiting on this registration, and stops watching the
+  // update service, which is only ever watched for them.
+  void SettlePendingRequests() {
+    cus_observation_.Reset();
+    if (pending_callbacks_.empty()) {
+      return;
+    }
+    const bool success =
+        OnDeviceSpeechModelsState::GetInstance()->IsModelInstalled();
+    std::vector<base::OnceCallback<void(bool)>> callbacks;
+    callbacks.swap(pending_callbacks_);
+    for (auto& callback : callbacks) {
+      std::move(callback).Run(success);
+    }
+  }
+
+  void EnsureInstaller() {
+    if (!installer_) {
+      installer_ = base::MakeRefCounted<component_updater::ComponentInstaller>(
+          std::make_unique<OnDeviceSpeechModelsComponentInstallerPolicy>(
+              pref_change_registrar_.prefs()));
+    }
+  }
+
+  // Held from `Start` until `Shutdown`, which is also what tells an in-flight
+  // registration that it landed too late to be finished.
+  raw_ptr<component_updater::ComponentUpdateService> cus_ = nullptr;
+  base::ScopedObservation<component_updater::ComponentUpdateService,
+                          component_updater::ServiceObserver>
+      cus_observation_{this};
+  PrefChangeRegistrar pref_change_registrar_;
+  // True from `Register` until `OnRegistered`. The component is absent from
+  // the update service for that whole window, so a second `Register` would
+  // register it twice and an `Unregister` would find nothing to unregister.
+  bool registration_pending_ = false;
+  // Answered together, because everyone who asked while one registration was
+  // in flight is waiting on that same registration.
+  std::vector<base::OnceCallback<void(bool)>> pending_callbacks_;
+  // Reused: registration and uninstall share the installer's task runner, so a
+  // per-registration instance would let an uninstall delete what the next
+  // registration installed.
+  scoped_refptr<component_updater::ComponentInstaller> installer_;
+};
 
 }  // namespace
 
 OnDeviceSpeechModelsComponentInstallerPolicy::
-    OnDeviceSpeechModelsComponentInstallerPolicy() = default;
+    OnDeviceSpeechModelsComponentInstallerPolicy(PrefService* local_state)
+    : local_state_(local_state) {}
 OnDeviceSpeechModelsComponentInstallerPolicy::
     ~OnDeviceSpeechModelsComponentInstallerPolicy() = default;
 
 bool OnDeviceSpeechModelsComponentInstallerPolicy::VerifyInstallation(
     const base::DictValue& manifest,
     const base::FilePath& install_dir) const {
-  return true;
+  return base::DirectoryExists(install_dir.AppendASCII(kModelDirName));
 }
 
 bool OnDeviceSpeechModelsComponentInstallerPolicy::
@@ -96,6 +315,11 @@ void OnDeviceSpeechModelsComponentInstallerPolicy::ComponentReady(
   if (install_dir.empty()) {
     return;
   }
+  // Unregistration is deferred behind an in-flight update, so this still fires
+  // for a download that started before the switch turned off.
+  if (!IsComponentAllowed(local_state_)) {
+    return;
+  }
   OnDeviceSpeechModelsState::GetInstance()->SetInstallDir(install_dir);
 }
 
@@ -122,20 +346,21 @@ bool OnDeviceSpeechModelsComponentInstallerPolicy::IsBraveComponent() const {
   return true;
 }
 
-void RegisterOnDeviceSpeechModelsComponent(
-    component_updater::ComponentUpdateService* cus) {
-  if (!base::FeatureList::IsEnabled(kBraveOnDeviceSpeechRecognition) || !cus) {
-    DeleteComponentDirectory();
-    return;
-  }
+void ManageOnDeviceSpeechModelsComponentRegistration(
+    component_updater::ComponentUpdateService* cus,
+    PrefService* local_state) {
+  OnDeviceSpeechModelsComponentRegistrar::GetInstance()->Start(cus,
+                                                               local_state);
+}
 
-  auto installer = base::MakeRefCounted<component_updater::ComponentInstaller>(
-      std::make_unique<OnDeviceSpeechModelsComponentInstallerPolicy>());
-  installer->Register(
-      cus, base::BindOnce([]() {
-        brave_component_updater::BraveOnDemandUpdater::GetInstance()
-            ->EnsureInstalled(kComponentId);
-      }));
+void ShutdownOnDeviceSpeechModelsComponentRegistration() {
+  OnDeviceSpeechModelsComponentRegistrar::GetInstance()->Shutdown();
+}
+
+void MaybeRegisterOnDeviceSpeechModelsComponent(
+    base::OnceCallback<void(bool)> callback) {
+  OnDeviceSpeechModelsComponentRegistrar::GetInstance()->Register(
+      std::move(callback));
 }
 
 }  // namespace local_ai

--- a/components/local_ai/core/on_device_speech_models_component_installer.h
+++ b/components/local_ai/core/on_device_speech_models_component_installer.h
@@ -11,9 +11,14 @@
 #include <vector>
 
 #include "base/files/file_path.h"
+#include "base/functional/callback.h"
+#include "base/memory/raw_ptr.h"
 #include "base/values.h"
 #include "components/component_updater/component_installer.h"
+#include "components/component_updater/component_updater_service.h"
 #include "components/update_client/update_client.h"
+
+class PrefService;
 
 namespace base {
 class Version;
@@ -25,12 +30,20 @@ class ComponentUpdateService;
 
 namespace local_ai {
 
+// Component id of Brave's on-device speech recognition model, derived from the
+// public key it is signed with.
+inline constexpr char kOnDeviceSpeechModelsComponentId[] =
+    "nhkekccefdppopbldokibkoegppanbba";
+
 // Component Updater policy for Brave's on-device speech recognition model.
 // Exposed for testing - follows upstream Chromium pattern.
 class OnDeviceSpeechModelsComponentInstallerPolicy
     : public component_updater::ComponentInstallerPolicy {
  public:
-  OnDeviceSpeechModelsComponentInstallerPolicy();
+  // `local_state` gates `ComponentReady` on the `kBraveLocalAIEnabled` master
+  // switch, which can turn off while an update is already in flight.
+  explicit OnDeviceSpeechModelsComponentInstallerPolicy(
+      PrefService* local_state);
   ~OnDeviceSpeechModelsComponentInstallerPolicy() override;
 
   OnDeviceSpeechModelsComponentInstallerPolicy(
@@ -55,12 +68,41 @@ class OnDeviceSpeechModelsComponentInstallerPolicy
   std::string GetName() const override;
   update_client::InstallerAttributes GetInstallerAttributes() const override;
   bool IsBraveComponent() const override;
+
+ private:
+  raw_ptr<PrefService> local_state_ = nullptr;
 };
 
-// Registers the on-device speech models component when the feature is enabled,
-// otherwise removes any previously installed copy. No-op if `cus` is null.
-void RegisterOnDeviceSpeechModelsComponent(
-    component_updater::ComponentUpdateService* cus);
+// Called once, while components are registered at startup. Sets up the
+// registrar, which from then on follows the `kBraveLocalAIEnabled` master
+// switch and the feature for the rest of the session, registering the
+// component or taking the model back off disk to match.
+//
+// Brave Origin manages the switch and verifies the purchase asynchronously, so
+// its value can land after components are registered, which is why the switch
+// is followed rather than read once.
+//
+// `local_state` is required. `cus` may be null, which leaves the registrar
+// with nothing to register against and every request refused. Calling this
+// again without `ShutdownOnDeviceSpeechModelsComponentRegistration` first
+// CHECK-fails.
+void ManageOnDeviceSpeechModelsComponentRegistration(
+    component_updater::ComponentUpdateService* cus,
+    PrefService* local_state);
+
+// Drops the references taken by
+// `ManageOnDeviceSpeechModelsComponentRegistration`. Must run before `cus` and
+// `local_state` are destroyed.
+void ShutdownOnDeviceSpeechModelsComponentRegistration();
+
+// Registers the component, publishing a copy already on disk and asking the
+// updater to download one that is not. Safe to call repeatedly. `callback`
+// runs once, asynchronously, with whether a model ended up installed, even
+// when nothing is registered, which is the case while the feature or the
+// master switch is off, or before
+// `ManageOnDeviceSpeechModelsComponentRegistration` has run.
+void MaybeRegisterOnDeviceSpeechModelsComponent(
+    base::OnceCallback<void(bool)> callback);
 
 }  // namespace local_ai
 

--- a/components/local_ai/core/on_device_speech_models_component_installer_unittest.cc
+++ b/components/local_ai/core/on_device_speech_models_component_installer_unittest.cc
@@ -6,23 +6,36 @@
 #include "brave/components/local_ai/core/on_device_speech_models_component_installer.h"
 
 #include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/memory/raw_ptr.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"
 #include "base/test/run_until.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/scoped_path_override.h"
 #include "base/test/task_environment.h"
+#include "base/test/test_future.h"
 #include "base/threading/thread_restrictions.h"
 #include "base/values.h"
 #include "base/version.h"
+#include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
 #include "brave/components/brave_component_updater/browser/mock_on_demand_updater.h"
 #include "brave/components/local_ai/core/features.h"
 #include "brave/components/local_ai/core/on_device_speech_models_state.h"
+#include "brave/components/local_ai/core/pref_names.h"
 #include "components/component_updater/component_updater_paths.h"
+#include "components/component_updater/component_updater_service.h"
 #include "components/component_updater/mock_component_updater_service.h"
+#include "components/prefs/testing_pref_service.h"
+#include "components/update_client/crx_update_item.h"
+#include "components/update_client/update_client.h"
+#include "components/update_client/update_client_errors.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -32,10 +45,6 @@ namespace {
 
 constexpr base::FilePath::CharType kComponentInstallDir[] =
     FILE_PATH_LITERAL("BraveOnDeviceSpeechModels");
-constexpr char kComponentId[] = "nhkekccefdppopbldokibkoegppanbba";
-// Model subdirectory within the install dir. Kept in sync with the
-// `kModelDir` constant in on_device_speech_models_state.cc.
-constexpr char kModelDir[] = "nemotron-speech-streaming-en-0.6b-int4-onnx";
 
 }  // namespace
 
@@ -50,6 +59,20 @@ class OnDeviceSpeechModelsComponentInstallerUnitTest : public testing::Test {
 
   void SetUp() override {
     cus_ = std::make_unique<component_updater::MockComponentUpdateService>();
+    // The registrar watches the update service for the whole session, so hold
+    // on to what it registered and let a test drive events through it.
+    EXPECT_CALL(*cus_, AddObserver(testing::_))
+        .Times(testing::AnyNumber())
+        .WillRepeatedly([this](component_updater::ServiceObserver* observer) {
+          cus_observer_ = observer;
+        });
+    EXPECT_CALL(*cus_, RemoveObserver(testing::_))
+        .Times(testing::AnyNumber())
+        .WillRepeatedly([this](component_updater::ServiceObserver* observer) {
+          cus_observer_ = nullptr;
+        });
+    local_state_ = std::make_unique<TestingPrefServiceSimple>();
+    prefs::RegisterLocalStatePrefs(local_state_->registry());
     auto component_dir =
         base::PathService::CheckedGet(component_updater::DIR_COMPONENT_USER);
     install_dir_ = component_dir.Append(kComponentInstallDir);
@@ -57,7 +80,52 @@ class OnDeviceSpeechModelsComponentInstallerUnitTest : public testing::Test {
 
   void TearDown() override {
     // Clear singleton state to avoid polluting other test suites.
+    ShutdownOnDeviceSpeechModelsComponentRegistration();
     OnDeviceSpeechModelsState::GetInstance()->SetInstallDir(base::FilePath());
+  }
+
+  // Drives the registrar to where a request will park on the update service,
+  // registered with a download already running. Download requests are answered
+  // the way the update service answers them while one is already running,
+  // which starts nothing and leaves the request waiting on
+  // `ServiceObserver::OnEvent`. One registration and one download for the
+  // registrar itself, plus one for each request the test makes after it,
+  // because each waits for the registration before it to land.
+  void StartWithADownloadRunning(int requests) {
+    EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+        .Times(requests + 1)
+        .WillRepeatedly(testing::Return(true));
+    EXPECT_CALL(on_demand_updater_,
+                EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+        .Times(requests + 1)
+        .WillRepeatedly([this](const std::string& id,
+                               component_updater::Callback callback) {
+          ++download_count_;
+          std::move(callback).Run(update_client::Error::UPDATE_IN_PROGRESS);
+        });
+    ManageOnDeviceSpeechModelsComponentRegistration(cus_.get(),
+                                                    local_state_.get());
+    ASSERT_TRUE(WaitForDownloadRequests(1));
+  }
+
+  // A download is asked for once a registration lands, so this is how a test
+  // waits for one registration to be over before asking for another. Each
+  // request then starts a registration of its own rather than joining one.
+  bool WaitForDownloadRequests(int count) {
+    return base::test::RunUntil([&]() { return download_count_ == count; });
+  }
+
+  std::string ComponentId() {
+    return std::string(kOnDeviceSpeechModelsComponentId);
+  }
+
+  // Delivered the way the update service delivers it, to whoever it
+  // registered.
+  void SendEvent(update_client::ComponentState state, const std::string& id) {
+    update_client::CrxUpdateItem item;
+    item.state = state;
+    item.id = id;
+    cus_observer_->OnEvent(item);
   }
 
   bool PathExists(const base::FilePath& file_path) {
@@ -73,8 +141,38 @@ class OnDeviceSpeechModelsComponentInstallerUnitTest : public testing::Test {
  protected:
   brave_component_updater::MockOnDemandUpdater on_demand_updater_;
   std::unique_ptr<component_updater::MockComponentUpdateService> cus_;
+  std::unique_ptr<TestingPrefServiceSimple> local_state_;
   base::test::TaskEnvironment task_environment_;
   base::FilePath install_dir_;
+  raw_ptr<component_updater::ServiceObserver> cus_observer_ = nullptr;
+  int download_count_ = 0;
+
+  // Drives `ManageOnDeviceSpeechModelsComponentRegistration` against a model
+  // that is installed and on disk, and asserts it registers nothing,
+  // downloads nothing, and takes the model away.
+  void ExpectNoRegistrationAndDeletedCopy() {
+    CreateDirectory(install_dir_);
+    ASSERT_TRUE(PathExists(install_dir_));
+    auto* state = OnDeviceSpeechModelsState::GetInstance();
+    state->SetInstallDir(install_dir_);
+    ASSERT_TRUE(state->IsModelInstalled());
+
+    EXPECT_CALL(*cus_, RegisterComponent(testing::_)).Times(0);
+    EXPECT_CALL(on_demand_updater_,
+                EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+        .Times(0);
+    // Nothing was registered, so the files are ours to remove.
+    EXPECT_CALL(*cus_, UnregisterComponent(kOnDeviceSpeechModelsComponentId))
+        .Times(1)
+        .WillOnce(testing::Return(false));
+    ManageOnDeviceSpeechModelsComponentRegistration(cus_.get(),
+                                                    local_state_.get());
+    // Reported gone before the files are, so nothing acts on a model whose
+    // files are on their way out.
+    EXPECT_FALSE(state->IsModelInstalled());
+    ASSERT_TRUE(
+        base::test::RunUntil([&]() { return !PathExists(install_dir_); }));
+  }
 
  private:
   base::ScopedPathOverride scoped_path_override_{
@@ -82,77 +180,709 @@ class OnDeviceSpeechModelsComponentInstallerUnitTest : public testing::Test {
   base::test::ScopedFeatureList feature_list_;
 };
 
-// Tests that the component is registered and an on-demand install requested
-// when the feature is enabled.
-TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest, Register) {
-  base::RunLoop run_loop;
-  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
-      .Times(1)
-      .WillOnce(testing::Return(true));
-  EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
-      .Times(1)
-      .WillOnce([quit = run_loop.QuitClosure()]() { quit.Run(); });
-  RegisterOnDeviceSpeechModelsComponent(cus_.get());
-  run_loop.Run();
+// `OnDeviceSpeechModelsComponentInstallerPolicy`, which the component
+// updater calls into. `ComponentReady` reports an install landing, either
+// at registration for a copy already on disk or once a download completes,
+// and publishing it is what makes the model count as installed.
+
+// Tests that a component is only a usable install once the model
+// subdirectory is there. Verifying the directory rather than the file list is
+// deliberate: the file list changes with every model, and a stale one would
+// fail silently as "the model never installs".
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest, VerifyInstallation) {
+  base::ScopedAllowBlockingForTesting allow_blocking;
+  OnDeviceSpeechModelsComponentInstallerPolicy policy(local_state_.get());
+  ASSERT_TRUE(CreateDirectory(install_dir_));
+
+  // A mis-packaged component should not report as installed.
+  EXPECT_FALSE(policy.VerifyInstallation(base::DictValue(), install_dir_));
+
+  ASSERT_TRUE(CreateDirectory(install_dir_.AppendASCII(kModelDirName)));
+  EXPECT_TRUE(policy.VerifyInstallation(base::DictValue(), install_dir_));
 }
 
-// Tests that ComponentReady sets up the install directory and model dir.
+// Tests that a component arriving publishes the install dir and the model dir
+// derived from it.
 TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest, ComponentReady) {
-  OnDeviceSpeechModelsComponentInstallerPolicy policy;
+  OnDeviceSpeechModelsComponentInstallerPolicy policy(local_state_.get());
+
   policy.ComponentReady(base::Version("1.0.0"), install_dir_,
                         base::DictValue());
 
   auto* state = OnDeviceSpeechModelsState::GetInstance();
   EXPECT_EQ(state->GetInstallDir(), install_dir_);
-  EXPECT_EQ(state->GetModelDir(), install_dir_.AppendASCII(kModelDir));
+  EXPECT_EQ(state->GetModelDir(), install_dir_.AppendASCII(kModelDirName));
 }
 
-// Tests that an empty install dir clears the model dir.
-TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest, EmptyInstallDirClears) {
+// Tests the early return for an empty dir.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest,
+       ComponentReady_EmptyDirDoesNotRemove) {
   auto* state = OnDeviceSpeechModelsState::GetInstance();
   state->SetInstallDir(install_dir_);
-  ASSERT_FALSE(state->GetModelDir().empty());
+  ASSERT_TRUE(state->IsModelInstalled());
 
-  state->SetInstallDir(base::FilePath());
-  EXPECT_TRUE(state->GetInstallDir().empty());
-  EXPECT_TRUE(state->GetModelDir().empty());
+  OnDeviceSpeechModelsComponentInstallerPolicy policy(local_state_.get());
+  policy.ComponentReady(base::Version("1.0.0"), base::FilePath(),
+                        base::DictValue());
+
+  EXPECT_EQ(install_dir_, state->GetInstallDir());
+  EXPECT_TRUE(state->IsModelInstalled());
 }
 
-// Tests that the component directory is deleted when the feature is disabled.
-TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest, DeleteComponent) {
-  CreateDirectory(install_dir_);
-  EXPECT_TRUE(PathExists(install_dir_));
-
+// Tests that a download already in flight when the feature goes off does not
+// land as an install.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest,
+       ComponentReady_NoInstallWhenFeatureDisabled) {
   base::test::ScopedFeatureList feature_list;
   feature_list.InitAndDisableFeature(kBraveOnDeviceSpeechRecognition);
+
+  OnDeviceSpeechModelsComponentInstallerPolicy policy(local_state_.get());
+  policy.ComponentReady(base::Version("1.0.0"), install_dir_,
+                        base::DictValue());
+
+  EXPECT_FALSE(OnDeviceSpeechModelsState::GetInstance()->IsModelInstalled());
+}
+
+// Tests the same for the master switch. Unregistering cannot cancel a download
+// already in flight, so this is the last place to refuse it.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest,
+       ComponentReady_NoInstallWhenLocalAIDisabled) {
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+
+  OnDeviceSpeechModelsComponentInstallerPolicy policy(local_state_.get());
+  policy.ComponentReady(base::Version("1.0.0"), install_dir_,
+                        base::DictValue());
+
+  EXPECT_FALSE(OnDeviceSpeechModelsState::GetInstance()->IsModelInstalled());
+}
+
+// `ManageOnDeviceSpeechModelsComponentRegistration`, which we call while
+// components are registered at startup and again whenever the master
+// switch changes. Removing the model is only ever done from here.
+
+// Tests that the allowed branch reaches
+// `MaybeRegisterOnDeviceSpeechModelsComponent`, so the component is registered
+// and the download requested.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest,
+       ManageOnDeviceSpeechModelsComponentRegistration_Registers) {
+  base::RunLoop run_loop;
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+      .Times(1)
+      .WillOnce([quit = run_loop.QuitClosure()]() { quit.Run(); });
+
+  ManageOnDeviceSpeechModelsComponentRegistration(cus_.get(),
+                                                  local_state_.get());
+  run_loop.Run();
+}
+
+// Tests that `ManageOnDeviceSpeechModelsComponentRegistration` removes the
+// model when Brave's own feature flag is off, one of the two conditions
+// `IsComponentAllowed` requires.
+TEST_F(
+    OnDeviceSpeechModelsComponentInstallerUnitTest,
+    ManageOnDeviceSpeechModelsComponentRegistration_RemovesWhenFeatureDisabled) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndDisableFeature(kBraveOnDeviceSpeechRecognition);
+
+  ExpectNoRegistrationAndDeletedCopy();
+}
+
+// Tests that `ManageOnDeviceSpeechModelsComponentRegistration` removes the
+// model when the Local AI master switch is off, the other condition
+// `IsComponentAllowed` requires. Brave Origin manages this one, so it can turn
+// off long after startup.
+TEST_F(
+    OnDeviceSpeechModelsComponentInstallerUnitTest,
+    ManageOnDeviceSpeechModelsComponentRegistration_RemovesWhenLocalAIDisabled) {
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+  ExpectNoRegistrationAndDeletedCopy();
+}
+
+// Tests that the model is removed even where the component updater may not be
+// used. Removing it is not an update, and --disable-component-update says
+// nothing about whether the user still wants an on-device model.
+TEST_F(
+    OnDeviceSpeechModelsComponentInstallerUnitTest,
+    ManageOnDeviceSpeechModelsComponentRegistration_RemovesEvenWhenComponentUpdateDisabled) {
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitAndDisableFeature(kBraveOnDeviceSpeechRecognition);
+  brave_component_updater::BraveOnDemandUpdater::GetInstance()
+      ->RegisterOnDemandUpdater(/*is_component_update_disabled=*/true,
+                                &on_demand_updater_);
+
+  ExpectNoRegistrationAndDeletedCopy();
+}
+
+// Tests that the pref is followed for the rest of the session rather than read
+// once, so a model already registered and downloaded is taken away when the
+// switch turns off later. Brave Origin resolves it asynchronously, so it can
+// land well after components are registered.
+TEST_F(
+    OnDeviceSpeechModelsComponentInstallerUnitTest,
+    ManageOnDeviceSpeechModelsComponentRegistration_RemovesWhenLocalAIPrefChanges) {
+  ASSERT_TRUE(CreateDirectory(install_dir_));
+  auto* state = OnDeviceSpeechModelsState::GetInstance();
+  state->SetInstallDir(install_dir_);
+  ASSERT_TRUE(state->IsModelInstalled());
+
+  base::RunLoop run_loop;
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+      .Times(1)
+      .WillOnce([quit = run_loop.QuitClosure()]() { quit.Run(); });
+  ManageOnDeviceSpeechModelsComponentRegistration(cus_.get(),
+                                                  local_state_.get());
+  // Wait for the registration to reach the service, so this is the settled
+  // case and not the in-flight one
+  // `ManageOnDeviceSpeechModelsComponentRegistration_TogglingWhileRegistrationPending`
+  // covers.
+  run_loop.Run();
+
+  // The component was registered, so the update service owns removing the
+  // files through `ComponentInstaller::Uninstall`. All we do is stop reporting
+  // the model as installed.
+  EXPECT_CALL(*cus_, UnregisterComponent(kOnDeviceSpeechModelsComponentId))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+
+  EXPECT_FALSE(state->IsModelInstalled());
+
+  // Shutting down drops the references the registrar holds, which is what
+  // keeps them from dangling once the browser process tears down. The switch
+  // is not followed after that.
+  testing::Mock::VerifyAndClearExpectations(cus_.get());
+  ShutdownOnDeviceSpeechModelsComponentRegistration();
+  state->SetInstallDir(install_dir_);
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, true);
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+  EXPECT_TRUE(state->IsModelInstalled());
+}
+
+// The other direction, and the one a first run takes: the switch is off while
+// components are registered, so nothing is registered and whatever was on disk
+// goes, and it turns on once Brave Origin has verified the purchase.
+TEST_F(
+    OnDeviceSpeechModelsComponentInstallerUnitTest,
+    ManageOnDeviceSpeechModelsComponentRegistration_RegistersWhenLocalAIPrefTurnsOn) {
+  ASSERT_TRUE(CreateDirectory(install_dir_));
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+
   EXPECT_CALL(*cus_, RegisterComponent(testing::_)).Times(0);
-  EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
       .Times(0);
-  RegisterOnDeviceSpeechModelsComponent(cus_.get());
+  EXPECT_CALL(*cus_, UnregisterComponent(kOnDeviceSpeechModelsComponentId))
+      .Times(1)
+      .WillOnce(testing::Return(false));
+  ManageOnDeviceSpeechModelsComponentRegistration(cus_.get(),
+                                                  local_state_.get());
   ASSERT_TRUE(
       base::test::RunUntil([&]() { return !PathExists(install_dir_); }));
-  EXPECT_FALSE(PathExists(install_dir_));
+  testing::Mock::VerifyAndClearExpectations(cus_.get());
+  testing::Mock::VerifyAndClearExpectations(&on_demand_updater_);
+
+  base::RunLoop run_loop;
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+      .Times(1)
+      .WillOnce([quit = run_loop.QuitClosure()]() { quit.Run(); });
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, true);
+  run_loop.Run();
 }
 
-// Tests that the component is not registered when the feature is disabled.
+// Toggling the switch while a registration is in flight must not start a
+// second one. The component is absent from the update service for that whole
+// window, so a second registration would replace the first and the removal the
+// off-transition ran would take the files the on-transition is installing.
+TEST_F(
+    OnDeviceSpeechModelsComponentInstallerUnitTest,
+    ManageOnDeviceSpeechModelsComponentRegistration_TogglingWhileRegistrationPending) {
+  ASSERT_TRUE(CreateDirectory(install_dir_));
+  base::RunLoop run_loop;
+  // Nothing is registered for the whole toggle, because the registration
+  // reaches the service only once `ComponentInstaller` has read the manifest.
+  EXPECT_CALL(*cus_, UnregisterComponent(kOnDeviceSpeechModelsComponentId))
+      .WillRepeatedly(testing::Return(false));
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+      .Times(1)
+      .WillOnce([quit = run_loop.QuitClosure()]() { quit.Run(); });
+
+  ManageOnDeviceSpeechModelsComponentRegistration(cus_.get(),
+                                                  local_state_.get());
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, true);
+  run_loop.Run();
+  EXPECT_TRUE(PathExists(install_dir_));
+
+  // Turning the switch off removes the files on the installer's own task
+  // runner, which a second registration would have been queued ahead of. So
+  // seeing them go is what makes the single `RegisterComponent` expectation
+  // proof that no second registration was started, rather than that none had
+  // landed yet.
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+  ASSERT_TRUE(
+      base::test::RunUntil([&]() { return !PathExists(install_dir_); }));
+}
+
+// Registration and uninstall share the installer's task runner, so a fresh
+// instance per registration would let a queued uninstall run afterwards and
+// delete what the next registration installed.
 TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest,
-       NoRegisterWhenFeatureDisabled) {
+       ManageOnDeviceSpeechModelsComponentRegistration_ReusesInstaller) {
+  std::vector<scoped_refptr<update_client::CrxInstaller>> installers;
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .WillRepeatedly(
+          [&installers](
+              const component_updater::ComponentRegistration& registration) {
+            installers.push_back(registration.installer);
+            return true;
+          });
+  EXPECT_CALL(*cus_, UnregisterComponent(kOnDeviceSpeechModelsComponentId))
+      .WillRepeatedly(testing::Return(true));
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+      .Times(testing::AnyNumber());
+
+  ManageOnDeviceSpeechModelsComponentRegistration(cus_.get(),
+                                                  local_state_.get());
+  ASSERT_TRUE(base::test::RunUntil([&]() { return installers.size() == 1u; }));
+
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, true);
+  ASSERT_TRUE(base::test::RunUntil([&]() { return installers.size() == 2u; }));
+
+  EXPECT_EQ(installers[0], installers[1]);
+}
+
+// `MaybeRegisterOnDeviceSpeechModelsComponent`, for every condition it
+// weighs. It asks the same registrar, so each of these runs it after
+// `ManageOnDeviceSpeechModelsComponentRegistration` has handed over the update
+// service and the local state. Every request is answered, so a test waits for
+// the answer rather than for the absence of one. A model arriving is published
+// as the install dir on top of that.
+
+// Feature off: nothing registered. Also the row that pins the two things
+// every other row relies on, that the answer arrives from a task, and that
+// refusing leaves a model already installed alone.
+TEST_F(
+    OnDeviceSpeechModelsComponentInstallerUnitTest,
+    MaybeRegisterOnDeviceSpeechModelsComponent_NoRegisterWhenFeatureDisabled) {
   base::test::ScopedFeatureList feature_list;
   feature_list.InitAndDisableFeature(kBraveOnDeviceSpeechRecognition);
 
   EXPECT_CALL(*cus_, RegisterComponent(testing::_)).Times(0);
-  EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
       .Times(0);
-  RegisterOnDeviceSpeechModelsComponent(cus_.get());
+  EXPECT_CALL(*cus_, UnregisterComponent(kOnDeviceSpeechModelsComponentId))
+      .Times(1)
+      .WillOnce(testing::Return(false));
+  ManageOnDeviceSpeechModelsComponentRegistration(cus_.get(),
+                                                  local_state_.get());
+
+  auto* state = OnDeviceSpeechModelsState::GetInstance();
+  state->SetInstallDir(install_dir_);
+  ASSERT_TRUE(state->IsModelInstalled());
+
+  base::test::TestFuture<bool> future;
+  MaybeRegisterOnDeviceSpeechModelsComponent(future.GetCallback());
+  EXPECT_FALSE(future.IsReady());
+
+  EXPECT_FALSE(future.Get());
+  EXPECT_TRUE(state->IsModelInstalled());
 }
 
-// Tests that the component is not registered when ComponentUpdateService is
-// null.
-TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest,
-       NoRegisterWhenCUSIsNull) {
-  EXPECT_CALL(on_demand_updater_, EnsureInstalled(kComponentId, testing::_))
+// Master switch off: nothing registered.
+TEST_F(
+    OnDeviceSpeechModelsComponentInstallerUnitTest,
+    MaybeRegisterOnDeviceSpeechModelsComponent_NoRegisterWhenLocalAIDisabled) {
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_)).Times(0);
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
       .Times(0);
-  RegisterOnDeviceSpeechModelsComponent(nullptr);
+  EXPECT_CALL(*cus_, UnregisterComponent(kOnDeviceSpeechModelsComponentId))
+      .Times(1)
+      .WillOnce(testing::Return(false));
+  ManageOnDeviceSpeechModelsComponentRegistration(cus_.get(),
+                                                  local_state_.get());
+
+  base::test::TestFuture<bool> future;
+  MaybeRegisterOnDeviceSpeechModelsComponent(future.GetCallback());
+  EXPECT_FALSE(future.Get());
+}
+
+// Asked before `ManageOnDeviceSpeechModelsComponentRegistration` has run, so
+// the registrar has nothing to register with yet: refused rather than left
+// waiting for the session to hand it one.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest,
+       MaybeRegisterOnDeviceSpeechModelsComponent_NoRegisterBeforeStart) {
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_)).Times(0);
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+      .Times(0);
+
+  base::test::TestFuture<bool> future;
+  MaybeRegisterOnDeviceSpeechModelsComponent(future.GetCallback());
+  EXPECT_FALSE(future.Get());
+}
+
+// No update service to register with: nothing registered.
+TEST_F(
+    OnDeviceSpeechModelsComponentInstallerUnitTest,
+    MaybeRegisterOnDeviceSpeechModelsComponent_NoRegisterWhenNoUpdateService) {
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_)).Times(0);
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+      .Times(0);
+  ManageOnDeviceSpeechModelsComponentRegistration(nullptr, local_state_.get());
+
+  base::test::TestFuture<bool> future;
+  MaybeRegisterOnDeviceSpeechModelsComponent(future.GetCallback());
+  EXPECT_FALSE(future.Get());
+}
+
+// Asking once that registration has settled: registered again, which is
+// harmless because the update service replaces the registration it already
+// had, and the download requested. `ComponentReady` publishes the install dir
+// before the request is answered, which is what makes it a success.
+TEST_F(
+    OnDeviceSpeechModelsComponentInstallerUnitTest,
+    MaybeRegisterOnDeviceSpeechModelsComponent_RegistersAndRequestsDownload) {
+  base::RunLoop run_loop;
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+      .Times(1)
+      .WillOnce([quit = run_loop.QuitClosure()]() { quit.Run(); });
+  ManageOnDeviceSpeechModelsComponentRegistration(cus_.get(),
+                                                  local_state_.get());
+  run_loop.Run();
+  testing::Mock::VerifyAndClearExpectations(cus_.get());
+  testing::Mock::VerifyAndClearExpectations(&on_demand_updater_);
+
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+      .Times(1)
+      .WillOnce([this](const std::string& id,
+                       component_updater::Callback callback) {
+        OnDeviceSpeechModelsState::GetInstance()->SetInstallDir(install_dir_);
+        std::move(callback).Run(update_client::Error::NONE);
+      });
+
+  base::test::TestFuture<bool> future;
+  MaybeRegisterOnDeviceSpeechModelsComponent(future.GetCallback());
+  EXPECT_TRUE(future.Get());
+  EXPECT_TRUE(OnDeviceSpeechModelsState::GetInstance()->IsModelInstalled());
+}
+
+// Two requests made before a registration lands wait on that one registration
+// and are answered together, rather than each starting one of its own.
+TEST_F(
+    OnDeviceSpeechModelsComponentInstallerUnitTest,
+    MaybeRegisterOnDeviceSpeechModelsComponent_RequestsWaitingAreAnsweredTogether) {
+  // One registration and one download for both requests, not one of each per
+  // request: they join what `ManageOnDeviceSpeechModelsComponentRegistration`
+  // already started.
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+      .Times(1)
+      .WillOnce([this](const std::string& id,
+                       component_updater::Callback callback) {
+        OnDeviceSpeechModelsState::GetInstance()->SetInstallDir(install_dir_);
+        std::move(callback).Run(update_client::Error::NONE);
+      });
+  ManageOnDeviceSpeechModelsComponentRegistration(cus_.get(),
+                                                  local_state_.get());
+
+  base::test::TestFuture<bool> first;
+  base::test::TestFuture<bool> second;
+  MaybeRegisterOnDeviceSpeechModelsComponent(first.GetCallback());
+  MaybeRegisterOnDeviceSpeechModelsComponent(second.GetCallback());
+
+  EXPECT_TRUE(first.Get());
+  EXPECT_TRUE(second.Get());
+}
+
+// Component updates turned off: still registered, because registering is what
+// publishes a copy already on disk, but the download is refused. Asking for it
+// is what that switch forbids, and what trips a DCHECK in BraveOnDemandUpdater.
+TEST_F(
+    OnDeviceSpeechModelsComponentInstallerUnitTest,
+    MaybeRegisterOnDeviceSpeechModelsComponent_RegistersWithoutDownloadWhenComponentUpdateDisabled) {
+  brave_component_updater::BraveOnDemandUpdater::GetInstance()
+      ->RegisterOnDemandUpdater(/*is_component_update_disabled=*/true,
+                                &on_demand_updater_);
+
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+      .Times(0);
+  // The update service is watched to hear how a download went, so asking for
+  // none leaves nothing to hear.
+  EXPECT_CALL(*cus_, AddObserver(testing::_)).Times(0);
+  ManageOnDeviceSpeechModelsComponentRegistration(cus_.get(),
+                                                  local_state_.get());
+
+  base::test::TestFuture<bool> future;
+  MaybeRegisterOnDeviceSpeechModelsComponent(future.GetCallback());
+  EXPECT_FALSE(future.Get());
+}
+
+// Switch turned off while the registration was in flight: registered, then
+// taken back out here, and the files removed here too. Both unregisters find
+// nothing, because the component only reaches the update service once the
+// registration lands, so the removal is ours to finish.
+TEST_F(
+    OnDeviceSpeechModelsComponentInstallerUnitTest,
+    MaybeRegisterOnDeviceSpeechModelsComponent_UnregistersWhenSwitchedOffDuringRegistration) {
+  ASSERT_TRUE(CreateDirectory(install_dir_));
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+      .Times(0);
+  // Twice: the pref change finds a registration pending and leaves the files
+  // alone, then the abandoned registration cleans up.
+  EXPECT_CALL(*cus_, UnregisterComponent(kOnDeviceSpeechModelsComponentId))
+      .Times(2)
+      .WillRepeatedly(testing::Return(false));
+  ManageOnDeviceSpeechModelsComponentRegistration(cus_.get(),
+                                                  local_state_.get());
+
+  base::test::TestFuture<bool> future;
+  MaybeRegisterOnDeviceSpeechModelsComponent(future.GetCallback());
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+
+  EXPECT_FALSE(future.Get());
+  ASSERT_TRUE(
+      base::test::RunUntil([&]() { return !PathExists(install_dir_); }));
+}
+
+// Switch turned off and back on while a registration was pending: finished by
+// the registration that lands, which succeeds. Reporting a failure when it
+// turned off would fail an install the on transition then completes.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest,
+       MaybeRegisterOnDeviceSpeechModelsComponent_TogglingWhileWaiting) {
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  EXPECT_CALL(*cus_, UnregisterComponent(kOnDeviceSpeechModelsComponentId))
+      .Times(1)
+      .WillOnce(testing::Return(false));
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+      .Times(1)
+      .WillOnce([this](const std::string& id,
+                       component_updater::Callback callback) {
+        OnDeviceSpeechModelsState::GetInstance()->SetInstallDir(install_dir_);
+        std::move(callback).Run(update_client::Error::NONE);
+      });
+  ManageOnDeviceSpeechModelsComponentRegistration(cus_.get(),
+                                                  local_state_.get());
+
+  base::test::TestFuture<bool> future;
+  MaybeRegisterOnDeviceSpeechModelsComponent(future.GetCallback());
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, true);
+
+  EXPECT_TRUE(future.Get());
+  EXPECT_TRUE(OnDeviceSpeechModelsState::GetInstance()->IsModelInstalled());
+}
+
+// Shutting down while a registration is in flight leaves the model where it
+// is, and answers the request with it. Letting go of the update service is not
+// what takes a model away, so a request waiting on one already here is not a
+// failure either.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest,
+       MaybeRegisterOnDeviceSpeechModelsComponent_ShutdownDuringRegistration) {
+  auto* state = OnDeviceSpeechModelsState::GetInstance();
+  state->SetInstallDir(install_dir_);
+  ASSERT_TRUE(state->IsModelInstalled());
+
+  base::test::TestFuture<void> registered;
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce([callback = registered.GetCallback()]() mutable {
+        std::move(callback).Run();
+        return true;
+      });
+  EXPECT_CALL(*cus_, UnregisterComponent(kOnDeviceSpeechModelsComponentId))
+      .Times(0);
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+      .Times(0);
+  ManageOnDeviceSpeechModelsComponentRegistration(cus_.get(),
+                                                  local_state_.get());
+
+  base::test::TestFuture<bool> future;
+  MaybeRegisterOnDeviceSpeechModelsComponent(future.GetCallback());
+  ShutdownOnDeviceSpeechModelsComponentRegistration();
+
+  EXPECT_TRUE(future.Get());
+  // The registration still lands, on the installer the shutdown let go of.
+  EXPECT_TRUE(registered.Wait());
+  EXPECT_TRUE(state->IsModelInstalled());
+}
+
+// The update service, which reports how a download that was already running
+// ended. A request made then starts nothing, so this is the one outcome its
+// own answer cannot carry.
+
+// Tests that every state an update cannot leave settles a request waiting on
+// it, and that nothing else does. Which state it is says nothing on its own: a
+// failed download, an update that landed without publishing, and a server with
+// nothing to offer all leave the request without a model.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest,
+       TerminalStateSettlesARequestWaitingOnTheUpdate) {
+  // One request per terminal state below, each parking on a download of its
+  // own.
+  StartWithADownloadRunning(/*requests=*/3);
+
+  int downloads = 1;
+  for (auto update_state : {update_client::ComponentState::kUpdateError,
+                            update_client::ComponentState::kUpdated,
+                            update_client::ComponentState::kUpToDate}) {
+    SCOPED_TRACE(testing::Message()
+                 << "update state: " << static_cast<int>(update_state));
+    base::test::TestFuture<bool> future;
+    MaybeRegisterOnDeviceSpeechModelsComponent(future.GetCallback());
+    ASSERT_TRUE(WaitForDownloadRequests(++downloads));
+
+    // Another component reaching a terminal state is not ours to settle, and
+    // ours is not there yet while it is still on its way. Settling stops
+    // watching the update service before it answers anything, so still
+    // watching is what says neither of these settled the request. The answer
+    // itself arrives from a task, so it has not landed here either way.
+    SendEvent(update_client::ComponentState::kUpdateError,
+              "abcdefghijklmnopabcdefghijklmnop");
+    SendEvent(update_client::ComponentState::kDownloading, ComponentId());
+    EXPECT_NE(nullptr, cus_observer_);
+
+    SendEvent(update_state, ComponentId());
+    EXPECT_FALSE(future.Get());
+  }
+}
+
+// Tests the same state settling a request as a success once the download it
+// waited on published a model. What the state is never decides that on its own.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest,
+       TerminalStateSettlesARequestWithTheModelThatArrived) {
+  StartWithADownloadRunning(/*requests=*/1);
+
+  base::test::TestFuture<bool> future;
+  MaybeRegisterOnDeviceSpeechModelsComponent(future.GetCallback());
+  ASSERT_TRUE(WaitForDownloadRequests(2));
+
+  // What `ComponentReady` publishes when the download lands, which the update
+  // service reports as over right after.
+  OnDeviceSpeechModelsState::GetInstance()->SetInstallDir(install_dir_);
+  SendEvent(update_client::ComponentState::kUpdated, ComponentId());
+
+  EXPECT_TRUE(future.Get());
+}
+
+// Tests that turning the master switch off answers a request that was waiting
+// on a download, and stops watching the update service for it. Nothing else
+// would answer it, because the model it waited for is being taken away, and
+// how that download ends is no longer anyone's news.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest,
+       SwitchingOffSettlesARequestWaitingOnADownload) {
+  // The component was registered, so the update service owns removing the
+  // files and this test never touches disk.
+  EXPECT_CALL(*cus_, UnregisterComponent(kOnDeviceSpeechModelsComponentId))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  StartWithADownloadRunning(/*requests=*/1);
+
+  base::test::TestFuture<bool> future;
+  MaybeRegisterOnDeviceSpeechModelsComponent(future.GetCallback());
+  ASSERT_TRUE(WaitForDownloadRequests(2));
+  ASSERT_NE(nullptr, cus_observer_);
+
+  local_state_->SetBoolean(prefs::kBraveLocalAIEnabled, false);
+
+  EXPECT_FALSE(future.Get());
+  EXPECT_EQ(nullptr, cus_observer_);
+}
+
+// Tests that shutting down settles a request that was waiting on a download,
+// and stops watching the update service. Nothing unregisters here, because
+// letting go of the update service is not what takes a model away, and a watch
+// left on it would outlive the service it points at.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest,
+       ShutdownSettlesARequestWaitingOnADownload) {
+  EXPECT_CALL(*cus_, UnregisterComponent(kOnDeviceSpeechModelsComponentId))
+      .Times(0);
+  StartWithADownloadRunning(/*requests=*/1);
+
+  base::test::TestFuture<bool> future;
+  MaybeRegisterOnDeviceSpeechModelsComponent(future.GetCallback());
+  ASSERT_TRUE(WaitForDownloadRequests(2));
+  ASSERT_NE(nullptr, cus_observer_);
+
+  ShutdownOnDeviceSpeechModelsComponentRegistration();
+
+  EXPECT_FALSE(future.Get());
+  EXPECT_EQ(nullptr, cus_observer_);
+}
+
+// Tests that a download that failed settles the request, and answers it
+// without a model. The download was started for this request, so its own
+// answer is what carries the failure. The update service reports the failure
+// too, but by then there is nothing left waiting to hear it.
+TEST_F(OnDeviceSpeechModelsComponentInstallerUnitTest,
+       DownloadFailureSettlesTheRequest) {
+  EXPECT_CALL(*cus_, RegisterComponent(testing::_))
+      .Times(2)
+      .WillRepeatedly(testing::Return(true));
+  EXPECT_CALL(on_demand_updater_,
+              EnsureInstalled(kOnDeviceSpeechModelsComponentId, testing::_))
+      .Times(2)
+      .WillRepeatedly(
+          [this](const std::string& id, component_updater::Callback callback) {
+            ++download_count_;
+            std::move(callback).Run(update_client::Error::UPDATE_CHECK_ERROR);
+          });
+  ManageOnDeviceSpeechModelsComponentRegistration(cus_.get(),
+                                                  local_state_.get());
+  ASSERT_TRUE(WaitForDownloadRequests(1));
+
+  base::test::TestFuture<bool> future;
+  MaybeRegisterOnDeviceSpeechModelsComponent(future.GetCallback());
+
+  EXPECT_FALSE(future.Get());
+  EXPECT_FALSE(OnDeviceSpeechModelsState::GetInstance()->IsModelInstalled());
+  // Watched only for a request waiting on a download, so nothing is left
+  // watching once none is.
+  EXPECT_EQ(nullptr, cus_observer_);
 }
 
 }  // namespace local_ai

--- a/components/local_ai/core/on_device_speech_models_state.cc
+++ b/components/local_ai/core/on_device_speech_models_state.cc
@@ -11,11 +11,6 @@
 
 namespace local_ai {
 
-namespace {
-// Subdirectory within the component install dir that holds the model files.
-constexpr char kModelDir[] = "nemotron-speech-streaming-en-0.6b-int4-onnx";
-}  // namespace
-
 // static
 OnDeviceSpeechModelsState* OnDeviceSpeechModelsState::GetInstance() {
   static base::NoDestructor<OnDeviceSpeechModelsState> instance;
@@ -25,6 +20,17 @@ OnDeviceSpeechModelsState* OnDeviceSpeechModelsState::GetInstance() {
 OnDeviceSpeechModelsState::OnDeviceSpeechModelsState() = default;
 OnDeviceSpeechModelsState::~OnDeviceSpeechModelsState() = default;
 
+void OnDeviceSpeechModelsState::AddObserver(Observer* observer) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  observers_.AddObserver(observer);
+  observer->OnSpeechModelDirChanged(model_dir_);
+}
+
+void OnDeviceSpeechModelsState::RemoveObserver(Observer* observer) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  observers_.RemoveObserver(observer);
+}
+
 void OnDeviceSpeechModelsState::SetInstallDir(
     const base::FilePath& install_dir) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
@@ -32,16 +38,24 @@ void OnDeviceSpeechModelsState::SetInstallDir(
     return;
   }
   install_dir_ = install_dir;
-  if (install_dir.empty()) {
-    model_dir_ = base::FilePath();
-    return;
-  }
-  model_dir_ = install_dir_.AppendASCII(kModelDir);
+  model_dir_ = install_dir_.empty() ? base::FilePath()
+                                    : install_dir_.AppendASCII(kModelDirName);
+  NotifyModelDirChanged();
+}
+
+void OnDeviceSpeechModelsState::NotifyModelDirChanged() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  observers_.Notify(&Observer::OnSpeechModelDirChanged, model_dir_);
 }
 
 const base::FilePath& OnDeviceSpeechModelsState::GetInstallDir() const {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   return install_dir_;
+}
+
+bool OnDeviceSpeechModelsState::IsModelInstalled() const {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  return !model_dir_.empty();
 }
 
 const base::FilePath& OnDeviceSpeechModelsState::GetModelDir() const {

--- a/components/local_ai/core/on_device_speech_models_state.h
+++ b/components/local_ai/core/on_device_speech_models_state.h
@@ -6,28 +6,52 @@
 #ifndef BRAVE_COMPONENTS_LOCAL_AI_CORE_ON_DEVICE_SPEECH_MODELS_STATE_H_
 #define BRAVE_COMPONENTS_LOCAL_AI_CORE_ON_DEVICE_SPEECH_MODELS_STATE_H_
 
+#include <string_view>
+
 #include "base/files/file_path.h"
 #include "base/no_destructor.h"
+#include "base/observer_list.h"
+#include "base/observer_list_types.h"
 #include "base/sequence_checker.h"
 
 namespace local_ai {
 
+// Subdirectory of the install dir holding the model files. Shared so that the
+// installer policy verifies the directory this class hands out.
+inline constexpr std::string_view kModelDirName =
+    "nemotron-speech-streaming-en-0.6b-int4-onnx";
+
 // Singleton holding the install directory of Brave's on-device speech
-// recognition model. The component installer populates it on
-// `ComponentReady`.
+// recognition model. The component installer populates it on `ComponentReady`.
 class OnDeviceSpeechModelsState {
  public:
+  // Notified when the model directory changes, which covers a model arriving,
+  // a model being removed, and a component update moving it to a new version.
+  class Observer : public base::CheckedObserver {
+   public:
+    // `model_dir` is empty when no model is installed.
+    virtual void OnSpeechModelDirChanged(const base::FilePath& model_dir) = 0;
+  };
+
   static OnDeviceSpeechModelsState* GetInstance();
 
   OnDeviceSpeechModelsState(const OnDeviceSpeechModelsState&) = delete;
   OnDeviceSpeechModelsState& operator=(const OnDeviceSpeechModelsState&) =
       delete;
 
-  // Sets the install directory (the model directory itself). An empty path
-  // clears the state.
+  // Fires `OnSpeechModelDirChanged` immediately with the current directory.
+  void AddObserver(Observer* observer);
+  void RemoveObserver(Observer* observer);
+
+  // Sets the component install directory, which `GetModelDir()` is derived
+  // from. An empty path clears the state.
   void SetInstallDir(const base::FilePath& install_dir);
 
   const base::FilePath& GetInstallDir() const;
+
+  // Whether there is a model to use, which is the same as the last directory
+  // published to `OnSpeechModelDirChanged` not being empty.
+  bool IsModelInstalled() const;
 
   // Returns the model subdirectory within the install dir, or an empty path
   // when no component is installed.
@@ -38,8 +62,12 @@ class OnDeviceSpeechModelsState {
   OnDeviceSpeechModelsState();
   ~OnDeviceSpeechModelsState();
 
+  void NotifyModelDirChanged();
+
   base::FilePath install_dir_;
   base::FilePath model_dir_;
+
+  base::ObserverList<Observer> observers_;
 
   SEQUENCE_CHECKER(sequence_checker_);
 };

--- a/components/local_ai/core/on_device_speech_models_state_unittest.cc
+++ b/components/local_ai/core/on_device_speech_models_state_unittest.cc
@@ -1,0 +1,106 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/local_ai/core/on_device_speech_models_state.h"
+
+#include "base/files/file_path.h"
+#include "base/scoped_observation.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace local_ai {
+
+namespace {
+
+class MockObserver : public OnDeviceSpeechModelsState::Observer {
+ public:
+  MOCK_METHOD(void,
+              OnSpeechModelDirChanged,
+              (const base::FilePath& model_dir),
+              (override));
+};
+
+}  // namespace
+
+class OnDeviceSpeechModelsStateUnitTest : public testing::Test {
+ public:
+  void TearDown() override {
+    // The state is a process-wide singleton, so clear it rather than leaking
+    // it into the next test in this binary.
+    state()->SetInstallDir(base::FilePath());
+  }
+
+ protected:
+  OnDeviceSpeechModelsState* state() {
+    return OnDeviceSpeechModelsState::GetInstance();
+  }
+
+  // No test here touches the filesystem, so this never has to exist.
+  const base::FilePath install_dir_{FILE_PATH_LITERAL("/brave/speech/models")};
+};
+
+// Tests that the model dir and what `IsModelInstalled` reports both follow the
+// install dir, in and out.
+TEST_F(OnDeviceSpeechModelsStateUnitTest, IsModelInstalledFollowsInstallDir) {
+  EXPECT_FALSE(state()->IsModelInstalled());
+  EXPECT_TRUE(state()->GetModelDir().empty());
+
+  state()->SetInstallDir(install_dir_);
+  EXPECT_TRUE(state()->IsModelInstalled());
+  EXPECT_EQ(install_dir_, state()->GetInstallDir());
+  EXPECT_EQ(install_dir_.AppendASCII(kModelDirName), state()->GetModelDir());
+
+  state()->SetInstallDir(base::FilePath());
+  EXPECT_FALSE(state()->IsModelInstalled());
+  EXPECT_TRUE(state()->GetInstallDir().empty());
+  EXPECT_TRUE(state()->GetModelDir().empty());
+}
+
+// Tests that a consumer can follow the model by observing alone, without
+// asking. Every move matters: an update lands on a new version directory and
+// deletes the old one, and removal takes the model away entirely, so a
+// consumer holding anything derived from the last directory has to redo it.
+TEST_F(OnDeviceSpeechModelsStateUnitTest, ObservesEveryModelDirChange) {
+  const base::FilePath v1{FILE_PATH_LITERAL("/brave/speech/models/1.0")};
+  const base::FilePath v2{FILE_PATH_LITERAL("/brave/speech/models/2.0")};
+
+  // Strict, so a directory published twice for an update that landed on the
+  // same one is a failure rather than an extra call nobody looks at.
+  testing::StrictMock<MockObserver> observer;
+  base::ScopedObservation<OnDeviceSpeechModelsState,
+                          OnDeviceSpeechModelsState::Observer>
+      observation{&observer};
+  {
+    // Subscribing with nothing installed, the install, the update, the removal.
+    testing::InSequence seq;
+    EXPECT_CALL(observer, OnSpeechModelDirChanged(base::FilePath()));
+    EXPECT_CALL(observer,
+                OnSpeechModelDirChanged(v1.AppendASCII(kModelDirName)));
+    EXPECT_CALL(observer,
+                OnSpeechModelDirChanged(v2.AppendASCII(kModelDirName)));
+    EXPECT_CALL(observer, OnSpeechModelDirChanged(base::FilePath()));
+  }
+  observation.Observe(state());
+
+  state()->SetInstallDir(v1);
+
+  // A consumer created after the component arrived hears about it too, rather
+  // than reporting that it is waiting for something already here.
+  testing::StrictMock<MockObserver> late_observer;
+  EXPECT_CALL(late_observer,
+              OnSpeechModelDirChanged(v1.AppendASCII(kModelDirName)));
+  state()->AddObserver(&late_observer);
+  state()->RemoveObserver(&late_observer);
+
+  // An update landing on the same directory changed nothing.
+  state()->SetInstallDir(v1);
+
+  state()->SetInstallDir(v2);
+  EXPECT_EQ(v2.AppendASCII(kModelDirName), state()->GetModelDir());
+
+  state()->SetInstallDir(base::FilePath());
+}
+
+}  // namespace local_ai


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58426

1. Add an observer for model install state so we can observe changes later in WebSpeech code stack
2. Observe Local AI master switch, unregister and remove component whenever the switch is off
3. Test updates