### PR TITLE
[History Embeddings] Keep the relaunch prompt across history reloads

### DIFF
--- a/browser/history_embeddings/BUILD.gn
+++ b/browser/history_embeddings/BUILD.gn
@@ -7,6 +7,23 @@ import("//brave/components/local_ai/buildflags/buildflags.gni")
 
 assert(enable_local_ai)
 
+# Holds the setting the embedding services were built with, so the
+# brave://history toggle can prompt for a relaunch once it diverges. Separate
+# from ":history_embeddings" because //chrome/browser/passage_embeddings reads
+# it, and that is what ":history_embeddings" is built on top of.
+source_set("status") {
+  public = [ "brave_history_embeddings_status.h" ]
+  sources = [ "brave_history_embeddings_status.cc" ]
+
+  public_deps = [ "//base" ]
+
+  deps = [
+    "//chrome/browser:browser_public_dependencies",
+    "//chrome/browser/history_embeddings",
+    "//chrome/browser/profiles:profile",
+  ]
+}
+
 # Resolves open-tab URLs to URLIDs via HistoryService and ranks them with
 # HistoryEmbeddingsSearch. Shared by the tab_search WebUI page handler and the
 # AI Chat `tabSearch` markdown directive.
@@ -34,16 +51,25 @@ source_set("open_tab_search") {
 
 source_set("unit_tests") {
   testonly = true
-  sources = [ "brave_passage_embeddings_service_controller_unittest.cc" ]
+  sources = [
+    "brave_history_embeddings_status_unittest.cc",
+    "brave_passage_embeddings_service_controller_unittest.cc",
+  ]
 
   deps = [
     ":history_embeddings",
+    ":status",
     "//base",
     "//base/test:test_support",
     "//brave/components/local_ai/core",
+    "//chrome/browser/prefs",
+    "//chrome/test:test_support",
+    "//components/history_embeddings/core",
     "//components/optimization_guide/core",
     "//components/optimization_guide/proto:optimization_guide_proto",
     "//components/passage_embeddings/core",
+    "//components/prefs",
+    "//components/sync_preferences:test_support",
     "//content/test:test_support",
     "//testing/gtest",
   ]

--- a/browser/history_embeddings/README.md
+++ b/browser/history_embeddings/README.md
@@ -50,6 +50,14 @@ toggle off ⇒ neither service is built ⇒ no embedder. (Its other upstream gat
 `kPassageEmbedder`/`kPermissionsAIv4`, are disabled in Brave.) Applied at
 service creation, so changes take effect on restart.
 
+Because of that, the gate reads the setting through
+[`BraveHistoryEmbeddingsStatus`](brave_history_embeddings_status.h), which
+captures it as profile user data at profile setup — so the value the services
+were built with is available for the rest of the session. The side bar shows its
+"Relaunch" button while `NeedsRestart()` holds, reading it from `loadTimeData`
+(injected by `BraveHistoryUI`) on load and from the `OnEnabledChanged` Mojo push
+afterwards, so reloading brave://history does not clear the prompt.
+
 ## Model delivery + `EmbedderMetadataUpdated`
 
 `SchedulingEmbedder` waits for `EmbedderMetadataUpdated` before it dispatches
@@ -71,6 +79,12 @@ stored history rather than mix vector spaces. The file is generated in
 [`brave/leo-local-models`](https://github.com/brave/leo-local-models).
 
 ## Key Files
+
+- **`brave_history_embeddings_status.{h,cc}`** — Profile user data holding the
+  Semantic History Search setting the embedding services were built with. The
+  passage embedder gate reads through it, so `NeedsRestart()` answers whether
+  the brave://history toggle is waiting on a relaunch (see "Enabling / the
+  brave://history toggle" above).
 
 - **`brave_passage_embeddings_service_controller.{h,cc}`** — Singleton subclass
   of `PassageEmbeddingsServiceController`. Provides `LitertServiceLauncher`,
@@ -124,6 +138,10 @@ utility through the standard `LoadModels` mojo call.
   `PassageEmbedderImpl::BuildExecutionTask` (via a
   `BRAVE_PASSAGE_EMBEDDER_IMPL_BUILD_EXECUTION_TASK` macro), so the sandboxed
   utility runs EmbeddingGemma on LiteRT instead of upstream's TFLite executor.
+
+- **`browser/ui/webui/history/brave_history_ui.{h,cc}`** — brave://history's
+  WebUI controller. Injects `braveHistoryEmbeddingsNeedsRestart` into the data
+  source and owns the Mojo page handler backing the toggle.
 
 - **`chromium_src/chrome/browser/page_content_annotations/`** — Factory
   overrides for `PageContentAnnotationsService`, `PageContentExtractionService`,

--- a/browser/history_embeddings/brave_history_embeddings_status.cc
+++ b/browser/history_embeddings/brave_history_embeddings_status.cc
@@ -1,0 +1,54 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/history_embeddings/brave_history_embeddings_status.h"
+
+#include <memory>
+
+#include "chrome/browser/history_embeddings/history_embeddings_utils.h"
+#include "chrome/browser/profiles/profile.h"
+
+namespace history_embeddings {
+
+namespace {
+
+constexpr char kBraveHistoryEmbeddingsStatusKey[] =
+    "brave_history_embeddings_status";
+
+}  // namespace
+
+BraveHistoryEmbeddingsStatus::BraveHistoryEmbeddingsStatus(Profile* profile,
+                                                           bool enabled)
+    : profile_(profile), enabled_(enabled) {}
+
+// static
+void BraveHistoryEmbeddingsStatus::CreateForProfile(Profile* profile) {
+  if (profile->GetUserData(kBraveHistoryEmbeddingsStatusKey)) {
+    return;
+  }
+  // Object cleanup is handled by SupportsUserData
+  profile->SetUserData(
+      kBraveHistoryEmbeddingsStatusKey,
+      std::make_unique<BraveHistoryEmbeddingsStatus>(
+          profile, IsHistoryEmbeddingsEnabledForProfile(profile)));
+}
+
+// static
+BraveHistoryEmbeddingsStatus* BraveHistoryEmbeddingsStatus::GetForProfile(
+    Profile* profile) {
+  CreateForProfile(profile);
+  return static_cast<BraveHistoryEmbeddingsStatus*>(
+      profile->GetUserData(kBraveHistoryEmbeddingsStatusKey));
+}
+
+bool BraveHistoryEmbeddingsStatus::IsEnabled() const {
+  return enabled_;
+}
+
+bool BraveHistoryEmbeddingsStatus::NeedsRestart() const {
+  return IsHistoryEmbeddingsEnabledForProfile(profile_) != enabled_;
+}
+
+}  // namespace history_embeddings

--- a/browser/history_embeddings/brave_history_embeddings_status.h
+++ b/browser/history_embeddings/brave_history_embeddings_status.h
@@ -1,0 +1,45 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_HISTORY_EMBEDDINGS_BRAVE_HISTORY_EMBEDDINGS_STATUS_H_
+#define BRAVE_BROWSER_HISTORY_EMBEDDINGS_BRAVE_HISTORY_EMBEDDINGS_STATUS_H_
+
+#include "base/memory/raw_ptr.h"
+#include "base/supports_user_data.h"
+
+class Profile;
+
+namespace history_embeddings {
+
+// The Semantic History Search setting a profile's embedding services run with.
+// The services are built at most once per session, so the setting is captured
+// at profile setup and then held: a later change has no effect until the
+// browser relaunches.
+class BraveHistoryEmbeddingsStatus : public base::SupportsUserData::Data {
+ public:
+  BraveHistoryEmbeddingsStatus(Profile* profile, bool enabled);
+
+  // Captures the setting at profile setup, before anything gated on it is
+  // built. Later calls are no-ops.
+  static void CreateForProfile(Profile* profile);
+
+  // Never null. Profiles that skip profile setup, such as those built directly
+  // in tests, capture the setting here instead.
+  static BraveHistoryEmbeddingsStatus* GetForProfile(Profile* profile);
+
+  // The setting the embedding services were built with.
+  bool IsEnabled() const;
+
+  // Whether the setting has changed since, so it is waiting on a relaunch.
+  bool NeedsRestart() const;
+
+ private:
+  const raw_ptr<Profile> profile_;
+  const bool enabled_;
+};
+
+}  // namespace history_embeddings
+
+#endif  // BRAVE_BROWSER_HISTORY_EMBEDDINGS_BRAVE_HISTORY_EMBEDDINGS_STATUS_H_

--- a/browser/history_embeddings/brave_history_embeddings_status_unittest.cc
+++ b/browser/history_embeddings/brave_history_embeddings_status_unittest.cc
@@ -1,0 +1,99 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/history_embeddings/brave_history_embeddings_status.h"
+
+#include <memory>
+#include <utility>
+
+#include "base/test/scoped_feature_list.h"
+#include "brave/components/local_ai/core/pref_names.h"
+#include "chrome/browser/prefs/browser_prefs.h"
+#include "chrome/test/base/testing_profile.h"
+#include "components/history_embeddings/core/history_embeddings_features.h"
+#include "components/prefs/pref_service.h"
+#include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "content/public/test/browser_task_environment.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace history_embeddings {
+
+// The setting is captured at profile setup, so each test picks the value the
+// embedding services would have been built with before building `profile_`.
+// `feature_list_` is a member so the feature is already on by then — otherwise
+// the status would read off for two reasons at once.
+class BraveHistoryEmbeddingsStatusTest : public testing::Test {
+ protected:
+  void BuildProfileWithSetting(bool enabled) {
+    auto prefs =
+        std::make_unique<sync_preferences::TestingPrefServiceSyncable>();
+    RegisterUserProfilePrefs(prefs->registry());
+    prefs->SetBoolean(local_ai::prefs::kBraveHistoryEmbeddingsEnabled, enabled);
+
+    TestingProfile::Builder builder;
+    builder.SetPrefService(std::move(prefs));
+    profile_ = builder.Build();
+
+    // Stands in for BraveProfileManager::InitProfileUserPrefs(), which
+    // TestingProfile skips without a TestingProfileManager.
+    BraveHistoryEmbeddingsStatus::CreateForProfile(profile_.get());
+  }
+
+  void SetSemanticHistorySearchEnabled(bool enabled) {
+    profile_->GetPrefs()->SetBoolean(
+        local_ai::prefs::kBraveHistoryEmbeddingsEnabled, enabled);
+  }
+
+  BraveHistoryEmbeddingsStatus* status() {
+    return BraveHistoryEmbeddingsStatus::GetForProfile(profile_.get());
+  }
+
+  base::test::ScopedFeatureList feature_list_{kHistoryEmbeddings};
+  content::BrowserTaskEnvironment task_environment_;
+  std::unique_ptr<TestingProfile> profile_;
+};
+
+TEST_F(BraveHistoryEmbeddingsStatusTest, NoRestartWhileTheSettingIsUnchanged) {
+  BuildProfileWithSetting(false);
+
+  EXPECT_FALSE(status()->IsEnabled());
+  EXPECT_FALSE(status()->NeedsRestart());
+
+  BuildProfileWithSetting(true);
+
+  EXPECT_TRUE(status()->IsEnabled());
+  EXPECT_FALSE(status()->NeedsRestart());
+}
+
+TEST_F(BraveHistoryEmbeddingsStatusTest, RestartOnceTheSettingIsTurnedOn) {
+  BuildProfileWithSetting(false);
+
+  SetSemanticHistorySearchEnabled(true);
+
+  // The services are still running with the setting they were built with.
+  EXPECT_FALSE(status()->IsEnabled());
+  EXPECT_TRUE(status()->NeedsRestart());
+}
+
+TEST_F(BraveHistoryEmbeddingsStatusTest, RestartOnceTheSettingIsTurnedOff) {
+  BuildProfileWithSetting(true);
+
+  SetSemanticHistorySearchEnabled(false);
+
+  EXPECT_TRUE(status()->IsEnabled());
+  EXPECT_TRUE(status()->NeedsRestart());
+}
+
+TEST_F(BraveHistoryEmbeddingsStatusTest, RestartClearsWhenTheSettingReverts) {
+  BuildProfileWithSetting(false);
+  SetSemanticHistorySearchEnabled(true);
+  ASSERT_TRUE(status()->NeedsRestart());
+
+  SetSemanticHistorySearchEnabled(false);
+
+  EXPECT_FALSE(status()->NeedsRestart());
+}
+
+}  // namespace history_embeddings

--- a/browser/passage_embeddings/BUILD.gn
+++ b/browser/passage_embeddings/BUILD.gn
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/local_ai/buildflags/buildflags.gni")
+
+assert(enable_local_ai)
+
+source_set("chromium_impl") {
+  sources = [ "passage_embedder_model_observer_factory.cc" ]
+
+  deps = [ "//brave/browser/history_embeddings:status" ]
+}

--- a/browser/passage_embeddings/passage_embedder_model_observer_factory.cc
+++ b/browser/passage_embeddings/passage_embedder_model_observer_factory.cc
@@ -1,0 +1,14 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/history_embeddings/brave_history_embeddings_status.h"
+
+class Profile;
+
+bool BraveIsHistoryEmbeddingsEnabled(Profile* profile) {
+  return history_embeddings::BraveHistoryEmbeddingsStatus::GetForProfile(
+             profile)
+      ->IsEnabled();
+}

--- a/browser/profiles/brave_profile_manager.cc
+++ b/browser/profiles/brave_profile_manager.cc
@@ -25,6 +25,7 @@
 #include "brave/components/constants/brave_constants.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/content_settings/core/browser/brave_content_settings_pref_provider.h"
+#include "brave/components/local_ai/buildflags/buildflags.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
 #include "brave/components/request_otr/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
@@ -54,6 +55,10 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_REWARDS)
 #include "brave/browser/brave_rewards/rewards_service_factory.h"
+#endif
+
+#if BUILDFLAG(ENABLE_LOCAL_AI)
+#include "brave/browser/history_embeddings/brave_history_embeddings_status.h"
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
@@ -176,6 +181,12 @@ void BraveProfileManager::InitProfileUserPrefs(Profile* profile) {
   brave::SetDefaultSearchVersion(profile, profile->IsNewProfile());
   brave::SetDefaultThirdPartyCookieBlockValue(profile);
   perf::MaybeEnableBraveFeaturesPrefsForPerfTesting(profile);
+
+#if BUILDFLAG(ENABLE_LOCAL_AI)
+  // Capture the Semantic History Search setting before the embedding services
+  // are built on it.
+  history_embeddings::BraveHistoryEmbeddingsStatus::CreateForProfile(profile);
+#endif
 }
 
 void BraveProfileManager::DoFinalInitForServices(Profile* profile,

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -409,6 +409,8 @@ if (enable_email_aliases) {
 if (enable_local_ai) {
   brave_chrome_browser_deps += [
     "//brave/browser/history_embeddings",
+    "//brave/browser/history_embeddings:status",
+    "//brave/browser/passage_embeddings:chromium_impl",
     "//brave/browser/speech",
     "//brave/browser/ui/webui/local_ai",
     "//brave/components/local_ai/core",

--- a/browser/ui/webui/history/BUILD.gn
+++ b/browser/ui/webui/history/BUILD.gn
@@ -30,7 +30,6 @@ source_set("history") {
     "//chrome/browser/profiles:profile",
     "//chrome/browser/ui/webui/page_not_available_for_guest",
     "//chrome/common:constants",
-    "//components/prefs",
     "//content/public/common",
   ]
 
@@ -40,7 +39,12 @@ source_set("history") {
       "brave_history_embeddings_page_handler.h",
     ]
 
-    deps += [ "//brave/components/local_ai/core" ]
+    deps += [
+      "//brave/browser/history_embeddings:status",
+      "//brave/components/local_ai/core",
+      "//chrome/browser/history_embeddings",
+      "//components/prefs",
+    ]
   }
 }
 

--- a/browser/ui/webui/history/brave_history_embeddings.mojom
+++ b/browser/ui/webui/history/brave_history_embeddings.mojom
@@ -26,5 +26,7 @@ interface PageHandler {
 // Notifications from the browser back to all chrome://history pages so any
 // UI consuming the enabled state can react without a page reload.
 interface Page {
-  OnEnabledChanged(bool enabled);
+  // `needs_restart` is true while `enabled` differs from the value the
+  // embedding services were built with, so it only applies after a relaunch.
+  OnEnabledChanged(bool enabled, bool needs_restart);
 };

--- a/browser/ui/webui/history/brave_history_embeddings_page_handler.cc
+++ b/browser/ui/webui/history/brave_history_embeddings_page_handler.cc
@@ -6,20 +6,23 @@
 #include "brave/browser/ui/webui/history/brave_history_embeddings_page_handler.h"
 
 #include "base/functional/bind.h"
+#include "brave/browser/history_embeddings/brave_history_embeddings_status.h"
 #include "brave/components/local_ai/core/pref_names.h"
+#include "chrome/browser/history_embeddings/history_embeddings_utils.h"
+#include "chrome/browser/profiles/profile.h"
 #include "components/prefs/pref_service.h"
 
 BraveHistoryEmbeddingsPageHandler::BraveHistoryEmbeddingsPageHandler(
     mojo::PendingReceiver<brave_history_embeddings::mojom::PageHandler>
         receiver,
     mojo::PendingRemote<brave_history_embeddings::mojom::Page> page,
-    PrefService* prefs,
+    Profile* profile,
     PrefService* local_state)
     : receiver_(this, std::move(receiver)),
       page_(std::move(page)),
-      prefs_(prefs),
+      profile_(profile),
       local_state_(local_state) {
-  pref_change_registrar_.Init(prefs_);
+  pref_change_registrar_.Init(profile_->GetPrefs());
   pref_change_registrar_.Add(
       local_ai::prefs::kBraveHistoryEmbeddingsEnabled,
       base::BindRepeating(&BraveHistoryEmbeddingsPageHandler::OnPrefChanged,
@@ -39,16 +42,15 @@ BraveHistoryEmbeddingsPageHandler::~BraveHistoryEmbeddingsPageHandler() =
     default;
 
 void BraveHistoryEmbeddingsPageHandler::SetEnabled(bool enabled) {
-  prefs_->SetBoolean(local_ai::prefs::kBraveHistoryEmbeddingsEnabled, enabled);
+  profile_->GetPrefs()->SetBoolean(
+      local_ai::prefs::kBraveHistoryEmbeddingsEnabled, enabled);
 }
 
 void BraveHistoryEmbeddingsPageHandler::OnPrefChanged() {
-  // History embeddings is only effectively enabled when both the master
-  // "Local AI" switch (Brave Origin) and the per-profile history embeddings
-  // toggle are on.
-  const bool local_ai_enabled =
-      local_state_->GetBoolean(local_ai::prefs::kBraveLocalAIEnabled);
-  const bool profile_enabled =
-      prefs_->GetBoolean(local_ai::prefs::kBraveHistoryEmbeddingsEnabled);
-  page_->OnEnabledChanged(local_ai_enabled && profile_enabled);
+  // Same helper the WebUI data source reads `enableHistoryEmbeddings` from, so
+  // the pushed value matches what the rest of the page sees.
+  page_->OnEnabledChanged(
+      history_embeddings::IsHistoryEmbeddingsEnabledForProfile(profile_),
+      history_embeddings::BraveHistoryEmbeddingsStatus::GetForProfile(profile_)
+          ->NeedsRestart());
 }

--- a/browser/ui/webui/history/brave_history_embeddings_page_handler.h
+++ b/browser/ui/webui/history/brave_history_embeddings_page_handler.h
@@ -15,6 +15,7 @@
 #include "mojo/public/cpp/bindings/remote.h"
 
 class PrefService;
+class Profile;
 
 class BraveHistoryEmbeddingsPageHandler
     : public brave_history_embeddings::mojom::PageHandler {
@@ -23,7 +24,7 @@ class BraveHistoryEmbeddingsPageHandler
       mojo::PendingReceiver<brave_history_embeddings::mojom::PageHandler>
           receiver,
       mojo::PendingRemote<brave_history_embeddings::mojom::Page> page,
-      PrefService* prefs,
+      Profile* profile,
       PrefService* local_state);
 
   BraveHistoryEmbeddingsPageHandler(const BraveHistoryEmbeddingsPageHandler&) =
@@ -41,8 +42,8 @@ class BraveHistoryEmbeddingsPageHandler
 
   mojo::Receiver<brave_history_embeddings::mojom::PageHandler> receiver_;
   mojo::Remote<brave_history_embeddings::mojom::Page> page_;
-  raw_ptr<PrefService> prefs_;
-  raw_ptr<PrefService> local_state_;
+  const raw_ptr<Profile> profile_;
+  const raw_ptr<PrefService> local_state_;
   PrefChangeRegistrar pref_change_registrar_;
   PrefChangeRegistrar local_state_change_registrar_;
 };

--- a/browser/ui/webui/history/brave_history_ui.cc
+++ b/browser/ui/webui/history/brave_history_ui.cc
@@ -7,11 +7,15 @@
 
 #include <utility>
 
+#include "base/values.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/webui/page_not_available_for_guest/page_not_available_for_guest_ui.h"
+#include "chrome/common/webui_url_constants.h"
+#include "content/public/browser/web_ui_data_source.h"
 
 #if BUILDFLAG(ENABLE_LOCAL_AI)
+#include "brave/browser/history_embeddings/brave_history_embeddings_status.h"
 #include "brave/browser/ui/webui/history/brave_history_embeddings_page_handler.h"
 #endif
 
@@ -26,7 +30,23 @@ BraveHistoryUIConfig::CreateWebUIController(content::WebUI* web_ui,
   return std::make_unique<BraveHistoryUI>(web_ui);
 }
 
-BraveHistoryUI::BraveHistoryUI(content::WebUI* web_ui) : HistoryUI(web_ui) {}
+BraveHistoryUI::BraveHistoryUI(content::WebUI* web_ui) : HistoryUI(web_ui) {
+  Profile* profile = Profile::FromWebUI(web_ui);
+
+  // The Semantic History Search toggle only takes effect on relaunch, so a
+  // change made in an earlier page load is still pending.
+  bool needs_restart = false;
+#if BUILDFLAG(ENABLE_LOCAL_AI)
+  needs_restart =
+      history_embeddings::BraveHistoryEmbeddingsStatus::GetForProfile(profile)
+          ->NeedsRestart();
+#endif  // BUILDFLAG(ENABLE_LOCAL_AI)
+
+  base::DictValue update;
+  update.Set("braveHistoryEmbeddingsNeedsRestart", needs_restart);
+  content::WebUIDataSource::Update(profile, chrome::kChromeUIHistoryHost,
+                                   std::move(update));
+}
 
 BraveHistoryUI::~BraveHistoryUI() = default;
 
@@ -43,8 +63,7 @@ void BraveHistoryUI::CreateInterfacePageHandler(
     mojo::PendingReceiver<brave_history_embeddings::mojom::PageHandler>
         receiver) {
   page_handler_ = std::make_unique<BraveHistoryEmbeddingsPageHandler>(
-      std::move(receiver), std::move(page),
-      Profile::FromWebUI(web_ui())->GetPrefs(),
+      std::move(receiver), std::move(page), Profile::FromWebUI(web_ui()),
       g_browser_process->local_state());
 }
 #endif

--- a/chromium_src/chrome/browser/passage_embeddings/passage_embedder_model_observer_factory.cc
+++ b/chromium_src/chrome/browser/passage_embeddings/passage_embedder_model_observer_factory.cc
@@ -9,17 +9,26 @@
 // keeps the on-device AI embedder from being created when the toggle is off.
 // Applied at service creation, so a toggle change takes effect on restart.
 
+#include "brave/components/local_ai/buildflags/buildflags.h"
 #include "chrome/browser/history_embeddings/history_embeddings_utils.h"
 #include "chrome/browser/profiles/profile.h"
 #include "content/public/browser/browser_context.h"
+
+// Implemented in //brave/browser/passage_embeddings:chromium_impl. Returns the
+// setting the profile's embedding services were built with.
+bool BraveIsHistoryEmbeddingsEnabled(Profile* profile);
 
 namespace history_embeddings {
 
 // Per-profile overload the macro below routes the upstream no-arg call to,
 // using the `context` in scope at the call site.
 bool IsHistoryEmbeddingsFeatureEnabled(content::BrowserContext* context) {
-  return IsHistoryEmbeddingsEnabledForProfile(
-      Profile::FromBrowserContext(context));
+  Profile* profile = Profile::FromBrowserContext(context);
+#if BUILDFLAG(ENABLE_LOCAL_AI)
+  return BraveIsHistoryEmbeddingsEnabled(profile);
+#else
+  return IsHistoryEmbeddingsEnabledForProfile(profile);
+#endif  // BUILDFLAG(ENABLE_LOCAL_AI)
 }
 
 }  // namespace history_embeddings

--- a/chromium_src/chrome/browser/resources/history/app.ts
+++ b/chromium_src/chrome/browser/resources/history/app.ts
@@ -14,28 +14,36 @@ import {
   getBraveHistoryEmbeddingsBrowserProxy,
 } from './brave_history_embeddings_browser_proxy.js'
 
-// Subscribe directly to the Mojo `onEnabledChanged` notification so the
-// chrome://history UI reacts even when the side bar isn't rendered. Update
+// Refresh loadTimeData so any code reading `enableHistoryEmbeddings` or
+// `braveHistoryEmbeddingsNeedsRestart` inline picks up the new values, update
 // each history-app's reactive `enableHistoryEmbeddings_` accessor (Lit
-// re-renders the app shell), refresh loadTimeData so any code that reads
-// `enableHistoryEmbeddings` inline picks up the new value, and force a
-// re-render of the toolbar/list whose `compute*_` methods cache the value.
+// re-renders the app shell), and force a re-render of the toolbar/list whose
+// `compute*_` methods cache the value.
+function onHistoryEmbeddingsEnabledChanged(
+    enabled: boolean, needsRestart: boolean) {
+  loadTimeData.overrideValues({
+    enableHistoryEmbeddings: enabled,
+    braveHistoryEmbeddingsNeedsRestart: needsRestart,
+  })
+  for (const app of document.querySelectorAll('history-app')) {
+    ;(app as unknown as {enableHistoryEmbeddings_: boolean})
+        .enableHistoryEmbeddings_ = enabled
+  }
+  const root = document.querySelector('history-app')?.shadowRoot
+  if (!root) {
+    return
+  }
+  for (const el of root.querySelectorAll(
+           'history-side-bar, history-toolbar, history-list')) {
+    ;(el as unknown as {requestUpdate?: () => void}).requestUpdate?.()
+  }
+}
+
+// Subscribe directly to the Mojo notification so the brave://history UI reacts
+// even when the side bar isn't rendered.
 getBraveHistoryEmbeddingsBrowserProxy()
-    .callbackRouter.onEnabledChanged.addListener((enabled: boolean) => {
-      loadTimeData.overrideValues({enableHistoryEmbeddings: enabled})
-      for (const app of document.querySelectorAll('history-app')) {
-        ;(app as unknown as {enableHistoryEmbeddings_: boolean})
-            .enableHistoryEmbeddings_ = enabled
-      }
-      const root = document.querySelector('history-app')?.shadowRoot
-      if (!root) {
-        return
-      }
-      for (const el of root.querySelectorAll(
-               'history-side-bar, history-toolbar, history-list')) {
-        ;(el as unknown as {requestUpdate?: () => void}).requestUpdate?.()
-      }
-    })
+    .callbackRouter.onEnabledChanged.addListener(
+        onHistoryEmbeddingsEnabledChanged)
 // </if>
 
 injectStyle(HistoryAppElement, css`

--- a/chromium_src/chrome/browser/resources/history/side_bar.ts
+++ b/chromium_src/chrome/browser/resources/history/side_bar.ts
@@ -21,11 +21,6 @@ import {
 } from './brave_history_embeddings_browser_proxy.js'
 // </if>
 
-// Toggle value at startup, before any change. Services are gated at creation
-// time, so a change only takes effect after a relaunch.
-const braveHistoryEmbeddingsStartupEnabled =
-    loadTimeData.getBoolean('enableHistoryEmbeddings')
-
 injectStyle(HistorySideBarElementChromium, css`
   .cr-nav-menu-item {
     min-height: 20px !important;
@@ -103,21 +98,22 @@ class HistorySideBarElement extends HistorySideBarElementChromium {
       loadTimeData.getBoolean('isHistoryEmbeddingsFeatureEnabled')
   override accessor braveHistoryEmbeddingsEnabled: boolean =
       loadTimeData.getBoolean('enableHistoryEmbeddings')
-  // True once the toggle differs from its startup value, so the change is
-  // pending a relaunch. Flipping back to the original value clears it.
-  override accessor braveHistoryEmbeddingsNeedsRestart: boolean = false
+  // True while the toggle differs from the value the embedding services were
+  // built with. Tracked in the browser and injected by BraveHistoryUI so it
+  // outlives a page reload.
+  override accessor braveHistoryEmbeddingsNeedsRestart: boolean =
+      loadTimeData.getBoolean('braveHistoryEmbeddingsNeedsRestart')
 
-  // Re-read the toggle state from loadTimeData on every render cycle. The
-  // single Mojo subscription in app.ts updates loadTimeData and then calls
-  // requestUpdate() on this element, the toolbar, and the list — keeping all
-  // consumers on the same refresh mechanism.
+  // Re-read the toggle state and the relaunch flag from loadTimeData on every
+  // render cycle. The single Mojo subscription in app.ts updates loadTimeData
+  // and then calls requestUpdate() on this element, the toolbar, and the list
+  // — keeping all consumers on the same refresh mechanism.
   override willUpdate(changedProperties: PropertyValues<this>) {
     super.willUpdate(changedProperties)
     this.braveHistoryEmbeddingsEnabled =
         loadTimeData.getBoolean('enableHistoryEmbeddings')
     this.braveHistoryEmbeddingsNeedsRestart =
-        this.braveHistoryEmbeddingsEnabled !==
-        braveHistoryEmbeddingsStartupEnabled
+        loadTimeData.getBoolean('braveHistoryEmbeddingsNeedsRestart')
   }
 
   // <if expr="enable_local_ai">


### PR DESCRIPTION
- Resolves https://github.com/brave/brave-browser/issues/58415

The side bar compared the Semantic History Search toggle against a snapshot
taken when the page script loaded, so reloading brave://history re-read the
baseline from the already-changed pref and hid the Relaunch button while the
change was still pending.

`BraveHistoryEmbeddingsStatus` captures the setting at profile setup and holds
it as profile user data, so it is the value the embedding services are built
with; the passage embedder gate reads through it. The side bar gets the
comparison from `loadTimeData` on load and from the `OnEnabledChanged` Mojo
push afterwards, so it lasts the browser session.

## Test plan

1. Enable `brave://flags/#brave-history-embeddings` and relaunch
2. Navigate to brave://history
3. Toggle "Semantic History Search" on — the Relaunch button appears
4. Refresh the page — the Relaunch button is still there
5. Toggle it back off — the Relaunch button goes away
6. Repeat from step 3 with the toggle starting on
