### PR TITLE
Fix caption button/title misalignment with vertical tabs + Mica titlebar

### DIFF
--- a/browser/ui/views/frame/BUILD.gn
+++ b/browser/ui/views/frame/BUILD.gn
@@ -157,6 +157,7 @@ source_set("browser_tests") {
       "//brave/browser/ui:brave_tab_prefs",
       "//chrome/browser/ui/tabs:features",
       "//chrome/browser/ui/views/frame",
+      "//chrome/browser/win:mica_titlebar",
     ]
   }
 }

--- a/browser/ui/views/frame/brave_browser_frame_view_win.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_win.cc
@@ -107,13 +107,31 @@ int BraveBrowserFrameViewWin::GetTopInset(bool restored) const {
 
     if (!ShouldBrowserCustomDrawTitlebar(GetBrowserView())) {
       // In case Mica enabled, we should extend top insets so that title bar can
-      // be visible.
-      return TopAreaHeight(restored) +
-             caption_button_container_->GetPreferredSize().height();
+      // be visible. Note that we don't use TitlebarMaximizedVisualHeight()
+      // in this case, because it returns too short height for title to be
+      // visible - it will make title overlapped with toolbar area.
+      return TitlebarHeight(false);
     }
   }
 
   return BrowserFrameViewWin::GetTopInset(restored);
+}
+
+int BraveBrowserFrameViewWin::TopAreaHeight(bool restored) const {
+  auto* browser = GetBrowserView()->browser();
+  if (auto* vtc = VerticalTabController::FromBrowser(browser);
+      vtc->ShouldShowBraveVerticalTabs()) {
+    if (vtc->ShouldShowWindowTitleForVerticalTabs() &&
+        !ShouldBrowserCustomDrawTitlebar(GetBrowserView())) {
+      // In case Mica enabled, we should extend top insets so that caption
+      // button is as tall as top area. Note that we don't use
+      // TitlebarMaximizedVisualHeight() in this case, because it returns too
+      // short height for title to be visible - it will make title overlapped
+      // with toolbar area.
+      return TitlebarHeight(false);
+    }
+  }
+  return BrowserFrameViewWin::TopAreaHeight(restored);
 }
 
 int BraveBrowserFrameViewWin::NonClientHitTest(const gfx::Point& point) {

--- a/browser/ui/views/frame/brave_browser_frame_view_win.h
+++ b/browser/ui/views/frame/brave_browser_frame_view_win.h
@@ -37,6 +37,7 @@ class BraveBrowserFrameViewWin : public BrowserFrameViewWin,
   // BraveBrowserFrameViewWin overrides:
   void OnPaint(gfx::Canvas* canvas) override;
   int GetTopInset(bool restored) const override;
+  int TopAreaHeight(bool restored) const override;
   int NonClientHitTest(const gfx::Point& point) override;
   bool ShouldShowWindowTitle(TitlebarType type) const override;
   void LayoutCaptionButtons() override;

--- a/browser/ui/views/frame/brave_browser_frame_view_win_browsertest.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_win_browsertest.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
@@ -10,6 +11,7 @@
 #include "chrome/browser/ui/views/frame/browser_frame_view_win.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/top_container_view.h"
+#include "chrome/browser/win/mica_titlebar.h"
 #include "chrome/browser/win/titlebar_config.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "components/prefs/pref_service.h"
@@ -171,6 +173,119 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserFrameViewWinVerticalTabsLayoutTest,
 
 INSTANTIATE_TEST_SUITE_P(,
                          BraveBrowserFrameViewWinVerticalTabsLayoutTest,
+                         testing::Bool(),
+                         [](const testing::TestParamInfo<bool>& info) {
+                           return info.param ? "WithTitle" : "WithoutTitle";
+                         });
+
+// Parameterized fixture: bool param = show window title in vertical tab mode.
+// Forces the (upstream-abandoned, no longer toggleable via chrome://flags)
+// Mica titlebar feature on, to exercise the vertical-tabs + Mica code paths
+// that the tests above skip. Whether this actually activates Mica still also
+// depends on OS state outside this test's control (Windows 11 22H2+, the
+// profile's theme, and the "accent color on title bars" setting), so on
+// machines/CI where those conditions aren't met this skips rather than
+// asserting anything.
+//
+// Regression coverage for
+// https://github.com/brave/brave-browser/issues/54721.
+class BraveBrowserFrameViewWinMicaVerticalTabsLayoutTest
+    : public BraveBrowserFrameViewWinTest,
+      public testing::WithParamInterface<bool> {
+ public:
+  BraveBrowserFrameViewWinMicaVerticalTabsLayoutTest() {
+    scoped_feature_list_.InitAndEnableFeature(kWindows11MicaTitlebar);
+  }
+
+ private:
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
+
+// Verifies that when Mica is actually active, the caption button container is
+// aligned exactly the same way as in the non-Mica case above (see
+// BraveBrowserFrameViewWinVerticalTabsLayoutTest): top at window-top +
+// WindowTopY(), and bottom aligned with the toolbar row top (with title) or
+// content area top (without title). Before the fix, GetTopInset() reserved
+// space using the container's independently computed GetPreferredSize()
+// (brave/brave-browser#54721) or, in an intermediate attempt, its live
+// height() queried before any layout had happened -- both drifted from the
+// height LayoutCaptionButtons() actually set, causing the container to render
+// clipped/shifted.
+IN_PROC_BROWSER_TEST_P(BraveBrowserFrameViewWinMicaVerticalTabsLayoutTest,
+                       CaptionButtonContainerAlignedWithTopContainerAndBorder) {
+  auto* frame = win_frame_view();
+  ASSERT_TRUE(frame) << "Expected BrowserFrameViewWin; wrong frame type";
+
+  if (ShouldBrowserCustomDrawTitlebar(browser_view())) {
+    GTEST_SKIP() << "Mica titlebar isn't actually active on this machine "
+                    "(needs Windows 11 22H2+, default System theme, and no "
+                    "\"accent color on title bars\"); can't exercise the "
+                    "Mica code path here.";
+  }
+
+  ASSERT_FALSE(browser_view()->GetWidget()->IsMaximized())
+      << "Test requires a restored (non-maximized) window";
+
+  const bool show_title = GetParam();
+  auto* prefs = browser()->GetProfile()->GetPrefs();
+  prefs->SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
+  prefs->SetBoolean(brave_tabs::kVerticalTabsShowTitleOnWindow, show_title);
+  browser_view()->InvalidateLayout();
+  RunScheduledLayouts();
+
+  const auto* container = frame->caption_button_container_for_testing();
+  ASSERT_TRUE(container);
+
+  const gfx::Rect container_screen = container->GetBoundsInScreen();
+  const gfx::Rect window_screen = frame->GetWidget()->GetWindowBoundsInScreen();
+
+  const char* mode = show_title ? "Mica, vertical tabs with title"
+                                : "Mica, vertical tabs without title";
+
+  // 1. Container top must be at window top + WindowTopY().
+  EXPECT_EQ(container_screen.y(), window_screen.y() + frame->WindowTopY())
+      << "Caption button container top (" << container_screen.y()
+      << ") must be window top (" << window_screen.y() << ") + WindowTopY ("
+      << frame->WindowTopY() << ") in " << mode;
+
+  // 2. Container bottom alignment depends on whether the window title is
+  //    shown:
+  //    - With title: aligns with top_container top (toolbar row top).
+  //    - Without title: GetTopInset() is 0 while restored (see GetTopInset()),
+  //      so the container itself provides no reserved space; only check it
+  //      isn't clipped by (i.e. doesn't extend past) the content area top.
+  const gfx::Rect top_container_screen =
+      browser_view()->top_container()->GetBoundsInScreen();
+
+  if (show_title) {
+    EXPECT_EQ(container_screen.bottom(), top_container_screen.y())
+        << "Caption button container bottom (" << container_screen.bottom()
+        << ") must equal top_container top (" << top_container_screen.y()
+        << ") in " << mode;
+
+    // TopAreaHeight() is what BrowserDesktopWindowTreeHostWin::
+    // GetDwmFrameInsetsInPixels() reads (via the now-virtual TopAreaHeight())
+    // to decide how far down to extend the Mica glass material -- i.e. how
+    // tall a band the OS actually composites its native caption/buttons
+    // into. It must match GetTopInset() (the Views-side reserved space),
+    // or the native caption ends up squeezed into a shorter band than the
+    // toolbar is offset by, rendering the caption buttons undersized even
+    // though the Views-side layout above looks correct.
+    EXPECT_EQ(frame->TopAreaHeight(/*restored=*/false),
+              frame->GetTopInset(/*restored=*/false))
+        << "TopAreaHeight() (drives the Mica glass/native caption height) "
+           "must match GetTopInset() (the Views-reserved space) in "
+        << mode;
+  } else {
+    EXPECT_LE(container_screen.bottom(), top_container_screen.bottom())
+        << "Caption button container bottom (" << container_screen.bottom()
+        << ") must not exceed top_container bottom ("
+        << top_container_screen.bottom() << ") in " << mode;
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(,
+                         BraveBrowserFrameViewWinMicaVerticalTabsLayoutTest,
                          testing::Bool(),
                          [](const testing::TestParamInfo<bool>& info) {
                            return info.param ? "WithTitle" : "WithoutTitle";

--- a/chromium_src/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_win.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_desktop_window_tree_host_win.cc
@@ -11,8 +11,16 @@
 #include "base/feature_list.h"
 #include "base/win/windows_types.h"
 #include "brave/browser/ui/brave_ui_features.h"
+#include "brave/browser/ui/tabs/public/vertical_tab_controller.h"
+#include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
+#include "chrome/browser/ui/views/frame/browser_frame_view.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/frame/browser_widget.h"
 #include "skia/ext/skia_utils_win.h"
+#include "ui/display/win/screen_win.h"
+#include "ui/gfx/geometry/insets.h"
+#include "ui/gfx/geometry/point.h"
 
 #define BrowserDesktopWindowTreeHostWin \
   BrowserDesktopWindowTreeHostWin_ChromiumImpl

--- a/patches/chrome-browser-ui-views-frame-browser_frame_view_win.h.patch
+++ b/patches/chrome-browser-ui-views-frame-browser_frame_view_win.h.patch
@@ -1,7 +1,16 @@
 diff --git a/chrome/browser/ui/views/frame/browser_frame_view_win.h b/chrome/browser/ui/views/frame/browser_frame_view_win.h
-index 0d3be37f68c7c1defba82902b197b71fa3128f3b..32c4cf9f3b039097303bfe1f0918d559074cbc2a 100644
+index 0d3be37f68c7c1defba82902b197b71fa3128f3b..2e3ae6ddda8ee322a8621e3a166a34b5edca5316 100644
 --- a/chrome/browser/ui/views/frame/browser_frame_view_win.h
 +++ b/chrome/browser/ui/views/frame/browser_frame_view_win.h
+@@ -79,7 +79,7 @@ class BrowserFrameViewWin : public BrowserFrameView, public TabIconViewModel {
+   // additional draggable area that's considered part of the window frame rather
+   // than the tabstrip. If |restored| is true, this is calculated as if the
+   // window was restored, regardless of its current state.
+-  int TopAreaHeight(bool restored) const;
++  virtual int TopAreaHeight(bool restored) const;
+ 
+   const BrowserCaptionButtonContainer* caption_button_container_for_testing()
+       const {
 @@ -101,6 +101,7 @@ class BrowserFrameViewWin : public BrowserFrameView, public TabIconViewModel {
                                    float new_device_scale_factor) override;
  

--- a/rewrite/chrome/browser/ui/views/frame/browser_frame_view_win.h.yaml
+++ b/rewrite/chrome/browser/ui/views/frame/browser_frame_view_win.h.yaml
@@ -23,3 +23,8 @@ substitutions:
     add_friend:
       class_name: BrowserFrameViewWin
       friend_type: class BraveBrowserFrameViewWin
+
+  - description: 'Make TopAreaHeight virtual'
+    make_virtual:
+      class_name: BrowserFrameViewWin
+      method_name: TopAreaHeight


### PR DESCRIPTION
When vertical tabs and "Show Title Bar" are enabled together with Windows 11's Mica titlebar active, the reserved top-inset height (BraveBrowserFrameViewWin::GetTopInset()) didn't return the proper height which makes the title bar is too short.

TopAreaHeight() should also return proper height
so that system drawn caption buton can be
sized correctly. Without it, caption button's height will be too short.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/54721

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
