### PR TITLE
Disable some flaky upstream tests

### DIFF
--- a/test/filters/browser_tests-windows.filter
+++ b/test/filters/browser_tests-windows.filter
@@ -153,9 +153,6 @@
 # https://github.com/brave/brave-browser/issues/55112
 -AutofillProgressDialogViewsBrowserTest.CloseBrowserWhileDialogShowing/3
 
-# Known upstream flake: 11.9% flake rate over 30 days per LUCI Analysis.
--IframeInfoMultiSourcePageContextFetcherBrowserTest.TakesScreenshot_AddsIframeInfoToAPC
-
 # Tests below this point have not been diagnosed or had issues created yet.
 -All/PDFPluginDisabledTest.*
 -AllowCurrentProfile_DifferentUserSignedInDefaultProfile/ExistingWinBrowserProfilesSigninUtilTest.*

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -2459,6 +2459,15 @@
 -PKIMetadataComponentChromeRootStoreMtcMetadataTest.EndToEnd/1
 -PKIMetadataComponentChromeRootStoreMtcMetadataTest.Revocation/1
 
+# Known upstream flake: 10.5% flake rate for TakesScreenshot_AddsIframeInfoToAPC
+# (127k+ verdicts) and 12.3% for the _IframeHasNoBorderAndLowOpacity variant
+# (91k+ verdicts) over 30 days per LUCI Analysis. Filtered on all platforms
+# because the upstream flake rate is not platform specific. No Brave
+# chromium_src overrides or patches touch the page context fetcher or the APC
+# iframe info path. https://github.com/brave/brave-browser/issues/58217
+-IframeInfoMultiSourcePageContextFetcherBrowserTest.TakesScreenshot_AddsIframeInfoToAPC
+-IframeInfoMultiSourcePageContextFetcherBrowserTest.TakesScreenshot_AddsIframeInfoToAPC_IframeHasNoBorderAndLowOpacity
+
 # Tests below this point have not been diagnosed or had issues created yet.
 -All/DeclarativeNetRequestBrowserTest.RendererCacheCleared/*
 -All/FromGWSNavigationAndKeepAliveRequestBrowserTest.TwoDifferentCategoryRequestAndTwoDifferentCategoryNavigationsFromSRP/*


### PR DESCRIPTION
- Resolves https://github.com/brave/brave-browser/issues/58217
- Resolves https://github.com/brave/brave-browser/issues/58134

```
❯ python3 script/check-upstream-flake.py IframeInfoMultiSourcePageContextFetcherBrowserTest.TakesScreenshot_AddsIframeInfoToAPC
Searching for 'IframeInfoMultiSourcePageContextFetcherBrowserTest.TakesScreenshot_AddsIframeInfoToAPC' in Chromium LUCI Analysis...
Found 3 matching test ID(s).
Fetching stats for: ://chrome/test\:android_browsertests!gtest::IframeInfoMultiSourcePageContextFetcherBrowserTest#TakesScreenshot_AddsIframeInfoToAPC
  No stats data, trying verdict query...
Fetching stats for: ://chrome/test\:browser_tests!gtest::IframeInfoMultiSourcePageContextFetcherBrowserTest#TakesScreenshot_AddsIframeInfoToAPC
Fetching stats for: ://chrome/test\:browser_tests!gtest::IframeInfoMultiSourcePageContextFetcherBrowserTest#TakesScreenshot_AddsIframeInfoToAPC_IframeHasNoBorderAndLowOpacity
# Upstream Flake Check: IframeInfoMultiSourcePageContextFetcherBrowserTest.TakesScreenshot_AddsIframeInfoToAPC

Lookback period: 30 days
Source: Chromium LUCI Analysis (analysis.api.luci.app)

## Test: `://chrome/test\:android_browsertests!gtest::IframeInfoMultiSourcePageContextFetcherBrowserTest#TakesScreenshot_AddsIframeInfoToAPC`

### Verdict: INSUFFICIENT DATA

**Recommendation:** Cannot determine -- no data found for this test ID in the lookback period.

### Statistics

- Meaningful verdicts (pass+fail+flaky): 0
- Passed: 0
- Failed: 0
- Flaky: 0
- Flake rate: 0.0%

## Test: `://chrome/test\:browser_tests!gtest::IframeInfoMultiSourcePageContextFetcherBrowserTest#TakesScreenshot_AddsIframeInfoToAPC`

### Verdict: KNOWN UPSTREAM FLAKE

**Recommendation:** Safe to filter -- this test has a confirmed flakiness pattern in Chromium upstream.

### Statistics

- Meaningful verdicts (pass+fail+flaky): 127212
- Passed: 113829
- Failed: 3512
- Flaky: 9871
- Execution errors: 345
- Flake rate: 10.5%

### Daily Breakdown

| Date | Total | Pass | Fail | Flaky | Rate |
|------|-------|------|------|-------|------|
| 2026-07-27 | 3532 | 3209 | 71 | 242 | 9% |
| 2026-07-28 | 5867 | 5322 | 141 | 388 | 9% |
| 2026-07-29 | 5469 | 4986 | 119 | 346 | 9% |
| 2026-07-30 | 5101 | 4652 | 120 | 318 | 9% |
| 2026-07-31 | 4787 | 4353 | 110 | 305 | 9% |
| 2026-08-01 | 1696 | 1525 | 45 | 125 | 10% |
| 2026-08-02 | 1370 | 1232 | 20 | 113 | 10% |
| 2026-08-03 | 4362 | 3949 | 115 | 282 | 9% |
| 2026-08-04 | 4998 | 4517 | 123 | 341 | 9% |
| 2026-08-05 | 5050 | 4573 | 122 | 344 | 9% |
| 2026-08-06 | 5421 | 4790 | 156 | 462 | 11% |
| 2026-08-07 | 5147 | 4475 | 163 | 490 | 13% |
| 2026-08-08 | 1559 | 1379 | 26 | 154 | 12% |
| 2026-08-09 | 423 | 372 | 11 | 38 | 12% |
| 2026-08-10 | 5091 | 4473 | 151 | 454 | 12% |
| 2026-08-11 | 5499 | 4872 | 144 | 470 | 11% |
| 2026-08-12 | 5559 | 4898 | 163 | 482 | 12% |
| 2026-08-13 | 5705 | 5007 | 190 | 482 | 12% |
| 2026-08-14 | 5321 | 4664 | 189 | 455 | 12% |
| 2026-08-15 | 1820 | 1664 | 47 | 104 | 8% |
| 2026-08-16 | 1510 | 1388 | 24 | 95 | 8% |
| 2026-08-17 | 5069 | 4485 | 174 | 393 | 11% |
| 2026-08-18 | 5584 | 4938 | 181 | 451 | 11% |
| 2026-08-19 | 5669 | 5030 | 155 | 473 | 11% |
| 2026-08-20 | 5139 | 4585 | 137 | 405 | 11% |
| 2026-08-21 | 4974 | 4425 | 140 | 401 | 11% |
| 2026-08-22 | 1834 | 1618 | 48 | 164 | 12% |
| 2026-08-23 | 1065 | 967 | 32 | 66 | 9% |
| 2026-08-24 | 5157 | 4552 | 160 | 432 | 12% |
| 2026-08-25 | 5702 | 5102 | 153 | 431 | 10% |
| 2026-08-26 | 2077 | 1827 | 82 | 165 | 12% |

## Test: `://chrome/test\:browser_tests!gtest::IframeInfoMultiSourcePageContextFetcherBrowserTest#TakesScreenshot_AddsIframeInfoToAPC_IframeHasNoBorderAndLowOpacity`

### Verdict: KNOWN UPSTREAM FLAKE

**Recommendation:** Safe to filter -- this test has a confirmed flakiness pattern in Chromium upstream.

### Statistics

- Meaningful verdicts (pass+fail+flaky): 91342
- Passed: 80124
- Failed: 3237
- Flaky: 7981
- Execution errors: 239
- Flake rate: 12.3%

### Daily Breakdown

| Date | Total | Pass | Fail | Flaky | Rate |
|------|-------|------|------|-------|------|
| 2026-07-31 | 6 | 5 | 0 | 1 | 17% |
| 2026-08-04 | 1160 | 1034 | 29 | 94 | 11% |
| 2026-08-05 | 5057 | 4496 | 169 | 381 | 11% |
| 2026-08-06 | 5419 | 4756 | 177 | 467 | 12% |
| 2026-08-07 | 5151 | 4452 | 191 | 489 | 13% |
| 2026-08-08 | 1565 | 1362 | 21 | 180 | 13% |
| 2026-08-09 | 423 | 363 | 19 | 36 | 13% |
| 2026-08-10 | 5097 | 4448 | 178 | 458 | 13% |
| 2026-08-11 | 5498 | 4802 | 162 | 525 | 13% |
| 2026-08-12 | 5555 | 4860 | 191 | 491 | 12% |
| 2026-08-13 | 5704 | 4983 | 207 | 499 | 12% |
| 2026-08-14 | 5322 | 4630 | 194 | 480 | 13% |
| 2026-08-15 | 1820 | 1634 | 40 | 145 | 10% |
| 2026-08-16 | 1513 | 1371 | 25 | 116 | 9% |
| 2026-08-17 | 5066 | 4450 | 193 | 408 | 12% |
| 2026-08-18 | 5582 | 4891 | 192 | 484 | 12% |
| 2026-08-19 | 5676 | 4955 | 194 | 512 | 12% |
| 2026-08-20 | 5135 | 4477 | 202 | 443 | 13% |
| 2026-08-21 | 4988 | 4399 | 190 | 385 | 12% |
| 2026-08-22 | 1831 | 1576 | 67 | 187 | 14% |
| 2026-08-23 | 1066 | 937 | 39 | 88 | 12% |
| 2026-08-24 | 5159 | 4497 | 217 | 429 | 13% |
| 2026-08-25 | 5705 | 4922 | 261 | 509 | 14% |
| 2026-08-26 | 2083 | 1824 | 79 | 174 | 12% |
```