### PR TITLE
[ads] Fix condition-less matchers being silently dropped on load

### DIFF
--- a/components/brave_ads/core/internal/creatives/condition_matchers_database_table_util.cc
+++ b/components/brave_ads/core/internal/creatives/condition_matchers_database_table_util.cc
@@ -38,23 +38,26 @@ ConditionMatcherMap StringToConditionMatchers(const std::string& value) {
 
   ConditionMatcherMap condition_matchers;
   for (const auto& condition_matcher_as_string : condition_matchers_as_string) {
+    // `SPLIT_WANT_ALL` because a condition-less matcher's `[pref path
+    // operator]` value base64 encodes to an empty trailing segment, which
+    // `SPLIT_WANT_NONEMPTY` would silently drop.
     const std::vector<std::string> condition_matcher =
         base::SplitString(condition_matcher_as_string, "|",
-                          base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+                          base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
     if (condition_matcher.size() != 2) {
-      // Malfomed condition matcher.
+      // Malformed condition matcher.
       continue;
     }
 
     std::string pref_path;
     if (!base::Base64Decode(condition_matcher[0], &pref_path)) {
-      // Malfomed condition matcher.
+      // Malformed condition matcher.
       continue;
     }
 
     std::string condition;
     if (!base::Base64Decode(condition_matcher[1], &condition)) {
-      // Malfomed condition matcher.
+      // Malformed condition matcher.
       continue;
     }
 

--- a/components/brave_ads/core/internal/creatives/condition_matchers_database_table_util_unittest.cc
+++ b/components/brave_ads/core/internal/creatives/condition_matchers_database_table_util_unittest.cc
@@ -54,4 +54,21 @@ TEST(BraveAdsConditionMatchersDatabaseTableUtilTest,
   EXPECT_THAT(StringToConditionMatchers(R"(malformed)"), ::testing::IsEmpty());
 }
 
+TEST(BraveAdsConditionMatchersDatabaseTableUtilTest,
+     RoundTripConditionMatcherWithoutCondition) {
+  // Arrange
+  //
+  // Regression test: the "[pref path operator]" (does not exist) matcher
+  // has no condition, which base64 encodes to an empty trailing segment -
+  // confirm it survives the string round trip rather than being dropped as
+  // malformed.
+  const ConditionMatcherMap condition_matchers = {
+      {/*pref_path*/ "[!]:foo.bar", /*condition*/ ""}};
+
+  // Act & Assert
+  EXPECT_EQ(
+      condition_matchers,
+      StringToConditionMatchers(ConditionMatchersToString(condition_matchers)));
+}
+
 }  // namespace brave_ads::database::table


### PR DESCRIPTION
`StringToConditionMatchers` used `SPLIT_WANT_NONEMPTY`, so a condition-less matcher (the "[pref path operator]" `[!]:` matcher, see condition_matcher_util.h) base64-encodes to an empty trailing segment that gets silently dropped, malforming the matcher and excluding it from real ad-serving eligibility checks. Switches to `SPLIT_WANT_ALL` so the empty segment survives the split.

Part of https://github.com/brave/brave-browser/issues/17393

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
