### PR TITLE
[plaster] Override `gn` version in `package.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ patches/**/*.patchinfo
 /third_party/node/mac_arm64/
 /third_party/node/win/
 /third_party/node/*.tar.gz
-/third_party/gn/
 /third_party/opengrep/bin/
 /third_party/wintun/
 /third_party/ast-grep-intermediate/

--- a/DEPS
+++ b/DEPS
@@ -3,44 +3,9 @@ use_relative_paths = True
 vars = {
   'download_prebuilt_sparkle': True,
   'checkout_dmg_tool': False,
-  # TODO(https://brave.dev/b/58378): Remove once `cr154` is merged.
-  'plaster_gn_version': 'git_revision:e0a6ab04a113b2dd039cab7c21c6f387e0d881ee',
 }
 
 deps = {
-  # TODO(https://brave.dev/b/58378): Remove this gn checkout once `cr154` is
-  # merged.
-  "third_party/gn/linux64": {
-    "packages": [
-      {
-        "package": "gn/gn/linux-${{arch}}",
-        "version": Var("plaster_gn_version"),
-      }
-    ],
-    "dep_type": "cipd",
-    "condition": 'host_os == "linux"',
-  },
-  "third_party/gn/mac": {
-    "packages": [
-      {
-        "package": "gn/gn/mac-${{arch}}",
-        "version": Var("plaster_gn_version"),
-      }
-    ],
-    "dep_type": "cipd",
-    "condition": 'host_os == "mac"',
-  },
-  "third_party/gn/win": {
-    "packages": [
-      {
-        "package": "gn/gn/windows-amd64",
-        "version": Var("plaster_gn_version"),
-      }
-    ],
-    "dep_type": "cipd",
-    "condition": 'host_os == "win"',
-  },
-
   "vendor/omaha": {
     "url": "https://github.com/brave/omaha.git@32383a4dc9c50a88e42be0e03e5b2f2ba7ad058b",
     "condition": "checkout_win",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
         "custom_vars": {
           "checkout_clang_coverage_tools": true,
           "checkout_clangd": true,
-          "download_reclient": true
+          "download_reclient": true,
+          "gn_version": "git_revision:c7ffaf80713afbe5a4f4d95a605c0a98084374de"
         }
       },
       "depot_tools": {

--- a/script/brave_license_helper.py
+++ b/script/brave_license_helper.py
@@ -187,11 +187,6 @@ def AddBraveCredits(root, prune_paths, special_cases, prune_dirs,
         # plaster .toml file location should be skipped.
         os.path.join('brave', 'rewrite', 'third_party'),
 
-        # TODO(https://brave.dev/b/58378): Remove once `cr154` is merged.
-        # This path is being used to deploy a `gn` binary that is newer than the
-        # one in `master` right now.
-        os.path.join('brave', 'third_party', 'gn'),
-
         # TODO(https://github.com/brave/brave-browser/issues/54804)
         # remove the following line once we start putting
         # WinTun binaries into the browser distribution on Windows.

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -3590,25 +3590,14 @@ class RegexMacro(Rewriter):
         return cls({key: body[key] for key in keys})
 
 
-# TODO(https://brave.dev/b/58378): Remove once `cr154` is merged.
-def _gn_platform_dir() -> str:
-    """Host-OS token in gn's per-platform dir name under `third_party/gn`.
+# TODO(https://brave.dev/b/58378): `gn edit` needs a newer gn than the one in
+# the current tag, so so package.json is overriding it, but the override must be
+# removed once cr154 is merged.
+GN_BIN = 'gn'
 
-    Mirrors the CIPD subdirectories `brave/DEPS` provisions gn into.
-    """
-    if sys.platform == 'darwin':
-        return 'mac'
-    if sys.platform == 'win32':
-        return 'win'
-    return 'linux64'
-
-
-# TODO(https://brave.dev/b/58378): Remove once `cr154` is merged and the
-# upstream pin carries `gn edit`. At that point plaster should just call `gn`
-# off the PATH.
-_GN_EXE = '.exe' if sys.platform == 'win32' else ''
-GN_BIN = (Path(__file__).resolve().parents[2] / 'third_party' / 'gn' /
-          _gn_platform_dir() / f'gn{_GN_EXE}')
+# The path `gn` is run at, to make sure the depot_tools shim resolves to the
+# correct `gn`.
+_BRAVE_CORE_DIR = Path(__file__).resolve().parents[2]
 
 
 class GnEditError(PlasterError):
@@ -3703,21 +3692,17 @@ class GnEditSandbox:
         in the plaster that named it.
         """
         assert self._build_file is not None
-        # TODO(https://brave.dev/b/58378): Drop this check once `cr154` is
-        # merged and `GN_BIN` becomes a plain `gn` off the PATH, which needs no
-        # provisioning of its own.
-        if not GN_BIN.exists():
-            raise GnEditError(
-                f'the gn binary is missing: {GN_BIN}. Run `gclient sync` to '
-                f'provision it')
         root = self._build_file.parent
         try:
-            terminal.run([GN_BIN, 'edit', command, pattern, f'--root={root}'])
+            terminal.run([GN_BIN, 'edit', command, pattern, f'--root={root}'],
+                         cwd=_BRAVE_CORE_DIR)
         except subprocess.CalledProcessError as e:
             # gn reports the problem on stdout rather than stderr.
             detail = ((e.stdout or '') + (e.stderr or '')).strip()
             raise GnEditError(
                 f'gn edit failed ({e.returncode}): {detail}') from e
+        except (FileNotFoundError, RuntimeError) as e:
+            raise GnEditError('the gn binary is missing') from e
 
         contents = self._build_file.read_text(encoding='utf-8')
         return GnEditOutcome(contents=contents,

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -7456,8 +7456,7 @@ class GnEditSandboxTest(unittest.TestCase):
         self.assertIn('Unknown edit command', str(cm.exception))
 
     def test_a_missing_binary_is_reported_as_a_gn_edit_error(self):
-        with mock.patch.object(plaster, 'GN_BIN',
-                               Path('/nonexistent/gn')) as _:
+        with mock.patch.object(plaster, 'GN_BIN', '/nonexistent/gn') as _:
             with plaster.GnEditSandbox(self._TARGET) as sandbox:
                 with self.assertRaises(plaster.GnEditError) as cm:
                     sandbox.run(command='add deps //brave/a', pattern='//:foo')
@@ -8136,27 +8135,10 @@ class GnEditDispatchTest(unittest.TestCase):
 
 
 class GnBinaryPathTest(unittest.TestCase):
-    """`_gn_platform_dir` mirrors the CIPD dirs `brave/DEPS` provisions."""
+    """`GN_BIN` names the depot_tools shim, resolved off PATH."""
 
-    def _dir_for(self, platform: str) -> str:
-        with mock.patch.object(plaster.sys, 'platform', platform):
-            return plaster._gn_platform_dir()
-
-    def test_each_host_maps_to_its_cipd_subdirectory(self):
-        self.assertEqual(self._dir_for('linux'), 'linux64')
-        self.assertEqual(self._dir_for('darwin'), 'mac')
-        self.assertEqual(self._dir_for('win32'), 'win')
-
-    def test_an_unrecognised_host_falls_back_to_linux(self):
-        self.assertEqual(self._dir_for('freebsd13'), 'linux64')
-
-    def test_the_binary_sits_under_brave_third_party_gn(self):
-        # A different gn from the one Chromium pins under `buildtools/`, since
-        # `gn edit` is newer than the revision Chromium builds with.
-        self.assertEqual(plaster.GN_BIN.parent.parent.name, 'gn')
-        self.assertEqual(plaster.GN_BIN.parent.parent.parent.name,
-                         'third_party')
-        self.assertTrue(plaster.GN_BIN.name.startswith('gn'))
+    def test_gn_bin_is_the_bare_shim_name(self):
+        self.assertEqual(plaster.GN_BIN, 'gn')
 
 
 class GnNamespaceTest(unittest.TestCase):


### PR DESCRIPTION
This change drops the unncessary `gn` download being done to
`third_party`, and rather just overrides the `gn` revision to the one
being used in 154 at the moment.

Bug: https://github.com/brave/brave-browser/issues/58378
