### PR TITLE
Fix YouTube PiP session resume type

### DIFF
--- a/android/java/org/chromium/chrome/browser/media/BraveYouTubePictureInPictureController.java
+++ b/android/java/org/chromium/chrome/browser/media/BraveYouTubePictureInPictureController.java
@@ -252,7 +252,10 @@ public class BraveYouTubePictureInPictureController {
         if (webContents != null) {
             final MediaSession mediaSession = getMediaSession(webContents);
             if (mediaSession != null) {
-                mediaSession.resume(SuspendType.SYSTEM);
+                // Must be UI, not SYSTEM: MediaSessionImpl::OnResumeInternal drops a SYSTEM
+                // resume unless the preceding suspend was also SYSTEM, and the pause this
+                // undoes comes from the page (YouTube pauses itself while entering fullscreen).
+                mediaSession.resume(SuspendType.UI);
             }
         }
         return true;

--- a/android/junit/src/org/chromium/chrome/browser/media/BraveYouTubePictureInPictureControllerTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/media/BraveYouTubePictureInPictureControllerTest.java
@@ -409,7 +409,9 @@ public class BraveYouTubePictureInPictureControllerTest {
     public void onEnterPictureInPictureMode_resumesSessionWebContents() {
         // The entry resume must target the session's own WebContents: after a screen-lock
         // re-entry the foreground tab can differ from the session tab, and resuming the
-        // foreground tab would start unrelated media while the PiP video stays paused.
+        // foreground tab would start unrelated media while the PiP video stays paused. It must
+        // also be a UI resume: the pause it undoes was issued by the page or by the system's
+        // sleep handling, and a SYSTEM resume is dropped unless the last suspend was SYSTEM too.
         BraveYouTubePictureInPictureController controller =
                 spy(new BraveYouTubePictureInPictureController(mBraveActivity));
         doReturn(mMediaSession).when(controller).getMediaSession(any());
@@ -417,7 +419,7 @@ public class BraveYouTubePictureInPictureControllerTest {
 
         assertTrue(controller.onEnterPictureInPictureMode());
 
-        verify(mMediaSession).resume(SuspendType.SYSTEM);
+        verify(mMediaSession).resume(SuspendType.UI);
         verify(mBraveActivity, never()).getCurrentWebContents();
     }
 


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/58181

This PR fixes a rebase regression that caused YT video pausing when triggering PiP from omnibox icon.

Both entry points (from omnibox icon and manually moving activity in background from fullscreen) converge on `BraveYouTubePictureInPictureController.onSessionRequested()`, which arms `mResumeMediaSessionOnPipEntry`. 

The toolbar path needs a resume because the injected fullscreen script drives YouTube's player into fullscreen and YouTube pauses the video itself during that transition (the original code comment: "sometimes when switching to fullscreen mode a video might be paused automatically from the backend if the buffer was not ready"). The player-fullscreen path never pauses, so its resume is a no-op and it looked fine.

That compensating resume stopped working in the `cr151` rebase. Upstream CL `5e7d3e1916e8b` parameterized `MediaSessionAndroid::Resume`, which until then hardcoded `SuspendType::kUI`. Brave's rebase commit `99d5dc15112 `mechanically rewrote `mediaSession.resume()` into `mediaSession.resume(SuspendType.SYSTEM)`, silently flipping the semantics:

In `content/browser/media/session/media_session_impl.cc:1004`

```c++
if (suspend_type == SuspendType::kSystem && suspend_type_ != suspend_type)
  return;
```

A `SYSTEM` resume is dropped unless the last suspend was also `SYSTEM`. YouTube's pause is page-initiated, so `suspend_type_` never matches and the resume silently does nothing and the video stays paused in the PiP window. 

The fix change resume type into `SuspendType.UI`, restoring the behavior before the rebase, with a comment explaining why `SYSTEM` is wrong.

Updated also `onEnterPictureInPictureMode_resumesSessionWebContents` in `BraveYouTubePictureInPictureControllerTest.java` to assert `resume(SuspendType.UI)`, so the mechanical rewrite can't recur unnoticed.

## Demo


https://github.com/user-attachments/assets/4e2726aa-7833-48fa-92ea-b867590ed0bf



<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
