### PR TITLE
[ads] Improve verbose log clarity for failed ad-serving requests

### DIFF
--- a/components/brave_ads/core/internal/account/user_rewards/user_rewards.cc
+++ b/components/brave_ads/core/internal/account/user_rewards/user_rewards.cc
@@ -82,8 +82,12 @@ void UserRewards::OnDidRefillConfirmationTokens() {
   BLOG(1, "Successfully refilled confirmation tokens");
 }
 
-void UserRewards::OnFailedToRefillConfirmationTokens() {
-  BLOG(0, "Failed to refill confirmation tokens");
+void UserRewards::OnFailedToRefillConfirmationTokens(bool will_retry) {
+  if (will_retry) {
+    BLOG(1, "Failed to refill confirmation tokens, will retry");
+  } else {
+    BLOG(0, "Failed to refill confirmation tokens, giving up");
+  }
 }
 
 void UserRewards::OnWillRetryRefillingConfirmationTokens(base::Time retry_at) {

--- a/components/brave_ads/core/internal/account/user_rewards/user_rewards.h
+++ b/components/brave_ads/core/internal/account/user_rewards/user_rewards.h
@@ -58,7 +58,7 @@ class UserRewards final : public AdsClientNotifierObserver,
   // RefillConfirmationTokensDelegate:
   void OnWillRefillConfirmationTokens(size_t count) override;
   void OnDidRefillConfirmationTokens() override;
-  void OnFailedToRefillConfirmationTokens() override;
+  void OnFailedToRefillConfirmationTokens(bool will_retry) override;
   void OnWillRetryRefillingConfirmationTokens(base::Time retry_at) override;
   void OnDidRetryRefillingConfirmationTokens() override;
   void OnCaptchaRequiredToRefillConfirmationTokens(

--- a/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.cc
+++ b/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.cc
@@ -41,6 +41,16 @@ namespace brave_ads {
 
 namespace {
 constexpr base::TimeDelta kRetryAfter = base::Seconds(15);
+
+// A failure that will retry isn't an error yet, it's just a transient setback
+// on the way to success or eventual, real failure.
+void BlogFailure(const std::string& message, bool should_retry) {
+  if (should_retry) {
+    BLOG(1, message << ", will retry");
+  } else {
+    BLOG(0, message << ", giving up");
+  }
+}
 }  // namespace
 
 RefillConfirmationTokens::RefillConfirmationTokens() = default;
@@ -140,7 +150,7 @@ void RefillConfirmationTokens::RequestSignedTokensCallback(
       HandleRequestSignedTokensUrlResponse(mojom_url_response);
   if (!url_response_result.has_value()) {
     const auto& error = url_response_result.error();
-    BLOG(0, error.message);
+    BlogFailure(error.message, error.should_retry);
     if (error.should_retry) {
       return FailedToRefillAndRetry();
     }
@@ -217,7 +227,7 @@ void RefillConfirmationTokens::GetSignedTokensCallback(
       HandleGetSignedTokensUrlResponse(mojom_url_response);
   if (!url_response_result.has_value()) {
     const auto& error = url_response_result.error();
-    BLOG(0, error.message);
+    BlogFailure(error.message, error.should_retry);
     if (error.should_retry) {
       return FailedToRefillAndRetry();
     }
@@ -306,7 +316,7 @@ void RefillConfirmationTokens::SuccessfullyRefilled() {
 }
 
 void RefillConfirmationTokens::FailedToRefillAndRetry() {
-  NotifyFailedToRefillConfirmationTokens();
+  NotifyFailedToRefillConfirmationTokens(/*will_retry=*/true);
 
   Retry();
 }
@@ -314,7 +324,7 @@ void RefillConfirmationTokens::FailedToRefillAndRetry() {
 void RefillConfirmationTokens::FailedToRefill() {
   Reset();
 
-  NotifyFailedToRefillConfirmationTokens();
+  NotifyFailedToRefillConfirmationTokens(/*will_retry=*/false);
 }
 
 void RefillConfirmationTokens::Retry() {
@@ -376,9 +386,10 @@ void RefillConfirmationTokens::NotifyDidRefillConfirmationTokens() const {
   }
 }
 
-void RefillConfirmationTokens::NotifyFailedToRefillConfirmationTokens() const {
+void RefillConfirmationTokens::NotifyFailedToRefillConfirmationTokens(
+    bool will_retry) const {
   if (delegate_) {
-    delegate_->OnFailedToRefillConfirmationTokens();
+    delegate_->OnFailedToRefillConfirmationTokens(will_retry);
   }
 }
 

--- a/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.h
+++ b/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.h
@@ -76,7 +76,7 @@ class RefillConfirmationTokens final {
   void NotifyCaptchaRequiredToRefillConfirmationTokens(
       const std::string& captcha_id) const;
   void NotifyDidRefillConfirmationTokens() const;
-  void NotifyFailedToRefillConfirmationTokens() const;
+  void NotifyFailedToRefillConfirmationTokens(bool will_retry) const;
   void NotifyWillRetryRefillingConfirmationTokens(base::Time retry_at) const;
   void NotifyDidRetryRefillingConfirmationTokens() const;
 

--- a/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens_delegate.h
+++ b/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens_delegate.h
@@ -22,8 +22,9 @@ class RefillConfirmationTokensDelegate {
   // tokens.
   virtual void OnDidRefillConfirmationTokens() {}
 
-  // Invoked to tell the delegate we failed to refill the confirmation tokens.
-  virtual void OnFailedToRefillConfirmationTokens() {}
+  // Invoked to tell the delegate we failed to refill the confirmation
+  // tokens; `will_retry` says whether a further attempt will follow.
+  virtual void OnFailedToRefillConfirmationTokens(bool will_retry) {}
 
   // Invoked to tell the delegate that we will retry refilling the confirmation
   // tokens at `retry_at`.

--- a/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/test/refill_confirmation_tokens_delegate_mock.h
+++ b/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/test/refill_confirmation_tokens_delegate_mock.h
@@ -28,7 +28,7 @@ class RefillConfirmationTokensDelegateMock
 
   MOCK_METHOD(void, OnWillRefillConfirmationTokens, (size_t));
   MOCK_METHOD(void, OnDidRefillConfirmationTokens, ());
-  MOCK_METHOD(void, OnFailedToRefillConfirmationTokens, ());
+  MOCK_METHOD(void, OnFailedToRefillConfirmationTokens, (bool));
   MOCK_METHOD(void, OnWillRetryRefillingConfirmationTokens, (base::Time));
   MOCK_METHOD(void, OnDidRetryRefillingConfirmationTokens, ());
 

--- a/components/brave_ads/core/internal/common/url/url_response_string_util.cc
+++ b/components/brave_ads/core/internal/common/url/url_response_string_util.cc
@@ -11,6 +11,7 @@
 #include "base/containers/flat_map.h"
 #include "base/strings/string_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
+#include "net/base/net_errors.h"
 #include "net/http/http_status_code.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
 
@@ -38,16 +39,19 @@ std::string HeadersToString(
 
 std::string UrlResponseToString(
     const mojom::UrlResponseInfo& mojom_url_response) {
-  std::string_view http_reason_phrase =
+  // A negative code is a net:: error (the request never got a real HTTP
+  // response at all), so it has no HTTP reason phrase; describe it with its
+  // net:: error name instead of leaving it blank.
+  const std::string reason_phrase =
       mojom_url_response.code >= 0
-          ? net::GetHttpReasonPhrase(
-                static_cast<net::HttpStatusCode>(mojom_url_response.code))
-          : "";
+          ? std::string(net::GetHttpReasonPhrase(
+                static_cast<net::HttpStatusCode>(mojom_url_response.code)))
+          : net::ErrorToString(mojom_url_response.code);
 
   return absl::StrFormat(
       "URL Response:\n  URL: %s\n  Response Code: %d %s\n  Response: %s",
-      mojom_url_response.url.spec(), mojom_url_response.code,
-      http_reason_phrase, mojom_url_response.body);
+      mojom_url_response.url.spec(), mojom_url_response.code, reason_phrase,
+      mojom_url_response.body);
 }
 
 std::string UrlResponseHeadersToString(

--- a/components/brave_ads/core/internal/common/url/url_response_string_util_unittest.cc
+++ b/components/brave_ads/core/internal/common/url/url_response_string_util_unittest.cc
@@ -1,0 +1,50 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/core/internal/common/url/url_response_string_util.h"
+
+#include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+// npm run test -- brave_unit_tests --filter=BraveAds*
+
+namespace brave_ads {
+
+TEST(BraveAdsUrlResponseStringUtilTest,
+     UrlResponseToStringIncludesHttpReasonPhrase) {
+  // Arrange
+  mojom::UrlResponseInfo mojom_url_response;
+  mojom_url_response.url = GURL("https://brave.com");
+  mojom_url_response.code = 404;
+  mojom_url_response.body = "Not found";
+
+  // Act & Assert
+  EXPECT_EQ(
+      "URL Response:\n"
+      "  URL: https://brave.com/\n"
+      "  Response Code: 404 Not Found\n"
+      "  Response: Not found",
+      UrlResponseToString(mojom_url_response));
+}
+
+TEST(BraveAdsUrlResponseStringUtilTest,
+     UrlResponseToStringIncludesNetErrorNameForNegativeCode) {
+  // Arrange
+  mojom::UrlResponseInfo mojom_url_response;
+  mojom_url_response.url = GURL("https://brave.com");
+  mojom_url_response.code = -100;  // net::ERR_CONNECTION_CLOSED.
+  mojom_url_response.body = "";
+
+  // Act & Assert
+  EXPECT_EQ(
+      "URL Response:\n"
+      "  URL: https://brave.com/\n"
+      "  Response Code: -100 net::ERR_CONNECTION_CLOSED\n"
+      "  Response: ",
+      UrlResponseToString(mojom_url_response));
+}
+
+}  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler.cc
@@ -94,7 +94,7 @@ void NewTabPageAdEventHandler::GetAdEventsCallback(
     bool success,
     const AdEventList& ad_events) {
   if (!success) {
-    BLOG(1, "New tab page ad: Failed to get ad events");
+    BLOG(0, "New tab page ad: Failed to get ad events");
     return FailedToFireEvent(ad.placement_id, ad.creative_instance_id,
                              mojom_ad_event_type, std::move(callback));
   }

--- a/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler.cc
@@ -114,7 +114,7 @@ void SearchResultAdEventHandler::MaybeFireServedEventCallback(
     bool success,
     const AdEventList& ad_events) {
   if (!success) {
-    BLOG(1, "Search result ad: Failed to get ad events");
+    BLOG(0, "Search result ad: Failed to get ad events");
     return FailedToFireEvent(ad,
                              mojom::SearchResultAdEventType::kServedImpression,
                              std::move(callback));
@@ -184,7 +184,7 @@ void SearchResultAdEventHandler::MaybeFireEventCallback(
     bool success,
     const AdEventList& ad_events) const {
   if (!success) {
-    BLOG(1, "Search result ad: Failed to get ad events");
+    BLOG(0, "Search result ad: Failed to get ad events");
     return FailedToFireEvent(ad, mojom_ad_event_type, std::move(callback));
   }
 

--- a/components/brave_ads/core/test/BUILD.gn
+++ b/components/brave_ads/core/test/BUILD.gn
@@ -372,6 +372,7 @@ source_set("brave_ads_unit_tests") {
     "//brave/components/brave_ads/core/internal/common/url/request_builder/host/hosts/non_anonymous_url_host_unittest.cc",
     "//brave/components/brave_ads/core/internal/common/url/request_builder/host/hosts/static_url_host_unittest.cc",
     "//brave/components/brave_ads/core/internal/common/url/request_builder/host/url_host_util_unittest.cc",
+    "//brave/components/brave_ads/core/internal/common/url/url_response_string_util_unittest.cc",
     "//brave/components/brave_ads/core/internal/common/url/url_util_internal_unittest.cc",
     "//brave/components/brave_ads/core/internal/common/url/url_util_unittest.cc",
     "//brave/components/brave_ads/core/internal/creatives/campaigns_database_table_unittest.cc",


### PR DESCRIPTION
Describes negative net:: error codes (a request that never got a
real HTTP response) with the error name instead of a blank reason
phrase, distinguishes "will retry" from "giving up" when a
confirmation token refill fails, and raises "Failed to get ad
events" from an info to an error log level, since these are all
genuine failures rather than routine noise.

Part of https://github.com/brave/brave-browser/issues/17393

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
