### PR TITLE
[AI Chat] Do not cache credential for OHTTP relay requests (uplift to 1.95.x)

### DIFF
--- a/components/ai_chat/core/browser/ai_chat_credential_manager.h
+++ b/components/ai_chat/core/browser/ai_chat_credential_manager.h
@@ -54,7 +54,7 @@ class AIChatCredentialManager {
       base::OnceCallback<void(std::optional<CredentialCacheEntry> credential)>
           callback);
 
-  void PutCredentialInCache(CredentialCacheEntry credential);
+  virtual void PutCredentialInCache(CredentialCacheEntry credential);
 
 #if BUILDFLAG(IS_ANDROID)
   void CreateOrderFromReceipt(

--- a/components/ai_chat/core/browser/ai_chat_service_share_conversation_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_service_share_conversation_unittest.cc
@@ -55,6 +55,7 @@ class MockAIChatCredentialManager : public AIChatCredentialManager {
               GetPremiumStatus,
               (mojom::Service::GetPremiumStatusCallback callback),
               (override));
+  MOCK_METHOD(void, PutCredentialInCache, (CredentialCacheEntry), (override));
 };
 
 // Returns a fixed share result without any network access, so tests can

--- a/components/ai_chat/core/browser/ai_chat_service_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_service_unittest.cc
@@ -88,6 +88,7 @@ class MockAIChatCredentialManager : public AIChatCredentialManager {
               GetPremiumStatus,
               (mojom::Service::GetPremiumStatusCallback callback),
               (override));
+  MOCK_METHOD(void, PutCredentialInCache, (CredentialCacheEntry), (override));
 };
 
 class MockServiceClient : public mojom::ServiceObserver {

--- a/components/ai_chat/core/browser/associated_content_manager_unittest.cc
+++ b/components/ai_chat/core/browser/associated_content_manager_unittest.cc
@@ -49,6 +49,7 @@ class MockAIChatCredentialManager : public AIChatCredentialManager {
     std::move(callback).Run(mojom::PremiumStatus::Inactive,
                             mojom::PremiumInfo::New());
   }
+  MOCK_METHOD(void, PutCredentialInCache, (CredentialCacheEntry), (override));
 };
 
 }  // namespace

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -91,6 +91,7 @@ class MockAIChatCredentialManager : public AIChatCredentialManager {
               GetPremiumStatus,
               (mojom::Service::GetPremiumStatusCallback callback),
               (override));
+  MOCK_METHOD(void, PutCredentialInCache, (CredentialCacheEntry), (override));
 };
 
 // TODO(https://github.com/brave/brave-browser/issues/55381): Use

--- a/components/ai_chat/core/browser/engine/conversation_api_client_unittest.cc
+++ b/components/ai_chat/core/browser/engine/conversation_api_client_unittest.cc
@@ -237,6 +237,7 @@ class MockAIChatCredentialManager : public AIChatCredentialManager {
               FetchPremiumCredential,
               (base::OnceCallback<void(std::optional<CredentialCacheEntry>)>),
               (override));
+  MOCK_METHOD(void, PutCredentialInCache, (CredentialCacheEntry), (override));
 };
 
 // Create a version of the ConversationAPIClient that contains our mocks

--- a/components/ai_chat/core/browser/engine/oblivious_http_api_client.cc
+++ b/components/ai_chat/core/browser/engine/oblivious_http_api_client.cc
@@ -363,11 +363,6 @@ void ObliviousHttpAPIClient::OnInnerResponse(
   // Erase the InnerClient from the ownership list now that the request is done.
   inner_clients_.erase(request.it);
 
-  // 401 outer response indicates an invalid credential; do not cache it.
-  if (outer_response_code != net::HTTP_UNAUTHORIZED && credential.has_value()) {
-    credential_manager_->PutCredentialInCache(std::move(*credential));
-  }
-
   bool is_outer_response_code_bad =
       outer_response_code < 200 || outer_response_code >= 300;
 

--- a/components/ai_chat/core/browser/engine/oblivious_http_api_client_unittest.cc
+++ b/components/ai_chat/core/browser/engine/oblivious_http_api_client_unittest.cc
@@ -13,6 +13,7 @@
 
 #include "base/functional/callback_helpers.h"
 #include "base/json/json_reader.h"
+#include "base/memory/raw_ptr.h"
 #include "base/run_loop.h"
 #include "base/test/bind.h"
 #include "base/test/task_environment.h"
@@ -57,6 +58,7 @@ class MockAIChatCredentialManager : public AIChatCredentialManager {
               FetchPremiumCredential,
               (base::OnceCallback<void(std::optional<CredentialCacheEntry>)>),
               (override));
+  MOCK_METHOD(void, PutCredentialInCache, (CredentialCacheEntry), (override));
 };
 
 class MockObliviousHttpConfigManager : public ObliviousHttpConfigManager {
@@ -76,6 +78,7 @@ class ObliviousHttpAPIClientUnitTest : public testing::Test,
  protected:
   void SetUp() override {
     prefs::RegisterProfilePrefs(prefs_.registry());
+    prefs::RegisterLocalStatePrefs(prefs_.registry());
 
     credential_manager_ = std::make_unique<MockAIChatCredentialManager>(
         base::NullCallback(), &prefs_);
@@ -92,10 +95,10 @@ class ObliviousHttpAPIClientUnitTest : public testing::Test,
 
     auto config_manager =
         std::make_unique<MockObliviousHttpConfigManager>(&prefs_);
-    EXPECT_CALL(*config_manager, RequestKeyConfig(_, _))
-        .Times(testing::AtLeast(1))
-        .WillRepeatedly([](const std::string&,
-                           ObliviousHttpConfigManager::KeyConfigCallback cb) {
+    config_manager_ = config_manager.get();
+    ON_CALL(*config_manager_, RequestKeyConfig(_, _))
+        .WillByDefault([](const std::string&,
+                          ObliviousHttpConfigManager::KeyConfigCallback cb) {
           std::move(cb).Run(ObliviousHttpConfigManager::KeyConfigResult{
               /*key_config=*/"test-key-config-bytes",
               /*endpoint_url=*/GURL("https://endpoint.test/inner"),
@@ -103,6 +106,8 @@ class ObliviousHttpAPIClientUnitTest : public testing::Test,
         });
     client_->SetConfigManagerForTesting(std::move(config_manager));
   }
+
+  void TearDown() override { config_manager_ = nullptr; }
 
   void EmitRawChunk(const std::string& raw) {
     ASSERT_TRUE(chunk_client_.is_bound());
@@ -179,6 +184,7 @@ class ObliviousHttpAPIClientUnitTest : public testing::Test,
   TestingPrefServiceSimple prefs_;
   std::unique_ptr<MockAIChatCredentialManager> credential_manager_;
   std::unique_ptr<ObliviousHttpAPIClient> client_;
+  raw_ptr<MockObliviousHttpConfigManager> config_manager_ = nullptr;
   std::unique_ptr<base::RunLoop> run_loop_;
   EngineConsumer::GenerationResult result_ =
       base::unexpected(mojom::APIError::None);
@@ -402,6 +408,72 @@ TEST_F(ObliviousHttpAPIClientUnitTest, PerformRequest_UsesUpstreamModelName) {
   const std::string* model = parsed->GetDict().FindString("model");
   ASSERT_TRUE(model);
   EXPECT_EQ(kTestUpstreamModelName, *model);
+}
+
+TEST_F(ObliviousHttpAPIClientUnitTest,
+       PerformRequest_Success_DoesNotPutCredentialInCache) {
+  ON_CALL(*credential_manager_, FetchPremiumCredential(_))
+      .WillByDefault(
+          [&](base::OnceCallback<void(std::optional<CredentialCacheEntry>)>
+                  cb) {
+            std::move(cb).Run(CredentialCacheEntry{
+                "valid-token", base::Time::Now() + base::Hours(1)});
+          });
+
+  EXPECT_CALL(*credential_manager_, PutCredentialInCache(_)).Times(0);
+
+  PerformRequest();
+  CompleteWithInnerResponse(net::HTTP_OK, kNonStreamingResponseBody);
+  run_loop_->Run();
+
+  ASSERT_TRUE(result_.has_value());
+}
+
+TEST_F(ObliviousHttpAPIClientUnitTest,
+       PerformRequest_OuterUnauthorized_DoesNotPutCredentialInCache) {
+  ON_CALL(*credential_manager_, FetchPremiumCredential(_))
+      .WillByDefault(
+          [&](base::OnceCallback<void(std::optional<CredentialCacheEntry>)>
+                  cb) {
+            std::move(cb).Run(CredentialCacheEntry{
+                "invalid-token", base::Time::Now() + base::Hours(1)});
+          });
+
+  EXPECT_CALL(*credential_manager_, PutCredentialInCache(_)).Times(0);
+
+  PerformRequest();
+  completion_client_->OnCompleted(
+      network::mojom::ObliviousHttpCompletionResult::NewOuterResponseErrorCode(
+          net::HTTP_UNAUTHORIZED));
+  completion_client_.FlushForTesting();
+  run_loop_->Run();
+
+  ASSERT_FALSE(result_.has_value());
+}
+
+TEST_F(ObliviousHttpAPIClientUnitTest,
+       PerformRequest_FailedKeyConfigFetch_PutsCredentialInCache) {
+  ON_CALL(*credential_manager_, FetchPremiumCredential(_))
+      .WillByDefault(
+          [&](base::OnceCallback<void(std::optional<CredentialCacheEntry>)>
+                  cb) {
+            std::move(cb).Run(CredentialCacheEntry{
+                "valid-token", base::Time::Now() + base::Hours(1)});
+          });
+
+  EXPECT_CALL(*config_manager_, RequestKeyConfig(_, _))
+      .WillOnce([](const std::string&,
+                   ObliviousHttpConfigManager::KeyConfigCallback cb) {
+        std::move(cb).Run(std::nullopt);
+      });
+
+  EXPECT_CALL(*credential_manager_, PutCredentialInCache(_)).Times(1);
+
+  PerformRequest();
+  run_loop_->Run();
+
+  ASSERT_FALSE(result_.has_value());
+  EXPECT_EQ(mojom::APIError::ConnectionIssue, result_.error());
 }
 
 }  // namespace ai_chat


### PR DESCRIPTION
Uplift of #39401
Resolves https://github.com/brave/brave-browser/issues/58427

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.