### PR TITLE
[ads] Fix intermittent Brave Ads integration tests hang (uplift to 1.94.x)

### DIFF
--- a/components/brave_ads/core/internal/account/deposits/cash_deposit_test.cc
+++ b/components/brave_ads/core/internal/account/deposits/cash_deposit_test.cc
@@ -5,7 +5,6 @@
 
 #include "brave/components/brave_ads/core/internal/account/deposits/cash_deposit.h"
 
-#include "base/test/run_until.h"
 #include "base/test/test_future.h"
 #include "brave/components/brave_ads/core/internal/ad_units/test/ad_test_constants.h"
 #include "brave/components/brave_ads/core/internal/catalog/catalog_url_request_builder_util.h"
@@ -36,16 +35,11 @@ TEST_F(BraveAdsCashDepositIntegrationTest, GetValue) {
   CashDeposit deposit;
 
   // Act & Assert
-  ASSERT_TRUE(base::test::RunUntil([&] {
-    base::test::TestFuture<bool, double> test_future;
-    deposit.GetValue(test::kCreativeInstanceId, test_future.GetCallback());
-    const auto [success, value] = test_future.Take();
-    if (!success) {
-      return false;
-    }
-    EXPECT_DOUBLE_EQ(test::kValue, value);
-    return true;
-  }));
+  base::test::TestFuture<bool, double> test_future;
+  deposit.GetValue(test::kCreativeInstanceId, test_future.GetCallback());
+  const auto [success, value] = test_future.Take();
+  EXPECT_TRUE(success);
+  EXPECT_DOUBLE_EQ(test::kValue, value);
 }
 
 TEST_F(BraveAdsCashDepositIntegrationTest,

--- a/components/brave_ads/core/internal/common/test/test_base.cc
+++ b/components/brave_ads/core/internal/common/test/test_base.cc
@@ -373,9 +373,7 @@ void TestBase::FlushImmediateTasks() {
   // sequence, even for fire-and-forget calls with `base::DoNothing`. Those
   // replies arrive with a 0ms delay and must be flushed so that callers see
   // only genuinely scheduled tasks.
-  if (task_environment_.NextMainThreadPendingTaskDelay().is_zero()) {
-    task_environment_.FastForwardBy(base::TimeDelta());
-  }
+  task_environment_.FastForwardBy(base::TimeDelta());
 }
 
 }  // namespace brave_ads::test

--- a/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table_test.cc
+++ b/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table_test.cc
@@ -5,7 +5,6 @@
 
 #include "brave/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table.h"
 
-#include "base/test/run_until.h"
 #include "base/test/test_future.h"
 #include "brave/components/brave_ads/core/internal/catalog/catalog_url_request_builder_util.h"
 #include "brave/components/brave_ads/core/internal/common/test/mock_test_util.h"
@@ -36,17 +35,12 @@ TEST_F(BraveAdsConversionsDatabaseTableIntegrationTest,
   const database::table::CreativeSetConversions database_table;
 
   // Act & Assert
-  ASSERT_TRUE(base::test::RunUntil([&] {
-    base::test::TestFuture<bool, CreativeSetConversionList> test_future;
-    database_table.GetUnexpired(
-        test_future.GetCallback<bool, const CreativeSetConversionList&>());
-    const auto [success, creative_set_conversions] = test_future.Take();
-    if (!success || creative_set_conversions.empty()) {
-      return false;
-    }
-    EXPECT_THAT(creative_set_conversions, ::testing::SizeIs(2));
-    return true;
-  }));
+  base::test::TestFuture<bool, CreativeSetConversionList> test_future;
+  database_table.GetUnexpired(
+      test_future.GetCallback<bool, const CreativeSetConversionList&>());
+  const auto [success, creative_set_conversions] = test_future.Take();
+  EXPECT_TRUE(success);
+  EXPECT_THAT(creative_set_conversions, ::testing::SizeIs(2));
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table_test.cc
+++ b/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table_test.cc
@@ -5,7 +5,6 @@
 
 #include "brave/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table.h"
 
-#include "base/test/run_until.h"
 #include "base/test/test_future.h"
 #include "brave/components/brave_ads/core/internal/catalog/catalog_url_request_builder_util.h"
 #include "brave/components/brave_ads/core/internal/common/test/mock_test_util.h"
@@ -36,20 +35,15 @@ TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableIntegrationTest,
   const database::table::CreativeNotificationAds database_table;
 
   // Act & Assert
-  ASSERT_TRUE(base::test::RunUntil([&] {
-    base::test::TestFuture<bool, SegmentList, CreativeNotificationAdList>
-        test_future;
-    database_table.GetForSegments(
-        /*segments=*/{"technology & computing"},
-        test_future.GetCallback<bool, const SegmentList&,
-                                CreativeNotificationAdList>());
-    const auto [success, segments, creative_ads] = test_future.Take();
-    if (!success || creative_ads.empty()) {
-      return false;
-    }
-    EXPECT_THAT(creative_ads, ::testing::SizeIs(2));
-    return true;
-  }));
+  base::test::TestFuture<bool, SegmentList, CreativeNotificationAdList>
+      test_future;
+  database_table.GetForSegments(
+      /*segments=*/{"technology & computing"},
+      test_future
+          .GetCallback<bool, const SegmentList&, CreativeNotificationAdList>());
+  const auto [success, segments, creative_ads] = test_future.Take();
+  EXPECT_TRUE(success);
+  EXPECT_THAT(creative_ads, ::testing::SizeIs(2));
 }
 
 }  // namespace brave_ads


### PR DESCRIPTION
Uplift of #39172
Resolves https://github.com/brave/brave-browser/issues/58135

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.