### PR TITLE
[Desktop] Custom profile image `manageProfile` integration

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -180,6 +180,9 @@
       <!-- Brave App Management strings -->
       <part file="brave_app_management.grdp" />
 
+      <!-- Custom profile image strings -->
+      <part file="custom_profile_image_strings.grdp" />
+
       <!--Add new items to the appropriate sections below -->
 
       <!-- Profile menu -->

--- a/app/custom_profile_image_strings.grdp
+++ b/app/custom_profile_image_strings.grdp
@@ -1,30 +1,30 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <grit-part>
-  <message name="IDS_CUSTOM_PROFILE_IMAGE_TITLE" desc="Heading for the Settings custom profile image section." formatter_data="webui=BraveSettings">
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_TITLE" desc="Heading for the custom profile image section." formatter_data="webui=CustomProfileImage">
     Custom profile image
   </message>
-  <message name="IDS_CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION" desc="Label for the empty custom profile image upload button." formatter_data="webui=BraveSettings">
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION" desc="Label for the empty custom profile image upload button." formatter_data="webui=CustomProfileImage">
     Upload custom image
   </message>
-  <message name="IDS_CUSTOM_PROFILE_IMAGE_REPLACE_ACTION" desc="Label for the custom profile image replace button." formatter_data="webui=BraveSettings">
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_REPLACE_ACTION" desc="Label for the custom profile image replace button." formatter_data="webui=CustomProfileImage">
     Replace
   </message>
-  <message name="IDS_CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP" desc="Tooltip and accessibility label for the custom profile image replace button." formatter_data="webui=BraveSettings">
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP" desc="Tooltip and accessibility label for the custom profile image replace button." formatter_data="webui=CustomProfileImage">
     Replace custom profile image
   </message>
-  <message name="IDS_CUSTOM_PROFILE_IMAGE_REMOVE_ACTION" desc="Label for the custom profile image remove button." formatter_data="webui=BraveSettings">
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_REMOVE_ACTION" desc="Label for the custom profile image remove button." formatter_data="webui=CustomProfileImage">
     Remove
   </message>
-  <message name="IDS_CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL" desc="Accessibility label for a selected custom profile image preview." formatter_data="webui=BraveSettings">
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL" desc="Accessibility label for a selected custom profile image preview." formatter_data="webui=CustomProfileImage">
     Custom profile image preview, selected
   </message>
-  <message name="IDS_CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP" desc="Tooltip and accessibility label for the custom profile image upload control." formatter_data="webui=BraveSettings">
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP" desc="Tooltip and accessibility label for the custom profile image upload control." formatter_data="webui=CustomProfileImage">
     Upload a custom profile image
   </message>
-  <message name="IDS_CUSTOM_PROFILE_IMAGE_REMOVE_TOOLTIP" desc="Tooltip and accessibility label for the custom profile image remove button." formatter_data="webui=BraveSettings">
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_REMOVE_TOOLTIP" desc="Tooltip and accessibility label for the custom profile image remove button." formatter_data="webui=CustomProfileImage">
     Remove custom profile image
   </message>
-  <message name="IDS_CUSTOM_PROFILE_IMAGE_INVALID_IMAGE" desc="Error shown when a selected custom profile image cannot be used." formatter_data="webui=BraveSettings">
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_INVALID_IMAGE" desc="Error shown when a selected custom profile image cannot be used." formatter_data="webui=CustomProfileImage">
     Brave can't use this file. Choose another image and try again.
   </message>
 </grit-part>

--- a/app/custom_profile_image_strings.grdp
+++ b/app/custom_profile_image_strings.grdp
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<grit-part>
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_TITLE" desc="Heading for the Settings custom profile image section." formatter_data="webui=BraveSettings">
+    Custom profile image
+  </message>
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION" desc="Label for the empty custom profile image upload button." formatter_data="webui=BraveSettings">
+    Upload custom image
+  </message>
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_REPLACE_ACTION" desc="Label for the custom profile image replace button." formatter_data="webui=BraveSettings">
+    Replace
+  </message>
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_REMOVE_ACTION" desc="Label for the custom profile image remove button." formatter_data="webui=BraveSettings">
+    Remove
+  </message>
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL" desc="Accessibility label for a selected custom profile image preview. PREVIEW_LABEL is the preview label." formatter_data="webui=BraveSettings">
+    <ph name="PREVIEW_LABEL">$1<ex>Custom profile image preview</ex></ph>, selected
+  </message>
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_PREVIEW_LABEL" desc="Accessibility label for the custom profile image preview." formatter_data="webui=BraveSettings">
+    Custom profile image preview
+  </message>
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP" desc="Tooltip and accessibility label for the custom profile image upload control." formatter_data="webui=BraveSettings">
+    Upload a custom profile image
+  </message>
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_REMOVE_TOOLTIP" desc="Tooltip and accessibility label for the custom profile image remove button." formatter_data="webui=BraveSettings">
+    Remove custom profile image
+  </message>
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_INVALID_IMAGE" desc="Error shown when a selected custom profile image cannot be used." formatter_data="webui=BraveSettings">
+    Brave can't use this file. Choose another image and try again.
+  </message>
+</grit-part>

--- a/app/custom_profile_image_strings.grdp
+++ b/app/custom_profile_image_strings.grdp
@@ -9,14 +9,14 @@
   <message name="IDS_CUSTOM_PROFILE_IMAGE_REPLACE_ACTION" desc="Label for the custom profile image replace button." formatter_data="webui=BraveSettings">
     Replace
   </message>
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP" desc="Tooltip and accessibility label for the custom profile image replace button." formatter_data="webui=BraveSettings">
+    Replace custom profile image
+  </message>
   <message name="IDS_CUSTOM_PROFILE_IMAGE_REMOVE_ACTION" desc="Label for the custom profile image remove button." formatter_data="webui=BraveSettings">
     Remove
   </message>
-  <message name="IDS_CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL" desc="Accessibility label for a selected custom profile image preview. PREVIEW_LABEL is the preview label." formatter_data="webui=BraveSettings">
-    <ph name="PREVIEW_LABEL">$1<ex>Custom profile image preview</ex></ph>, selected
-  </message>
-  <message name="IDS_CUSTOM_PROFILE_IMAGE_PREVIEW_LABEL" desc="Accessibility label for the custom profile image preview." formatter_data="webui=BraveSettings">
-    Custom profile image preview
+  <message name="IDS_CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL" desc="Accessibility label for a selected custom profile image preview." formatter_data="webui=BraveSettings">
+    Custom profile image preview, selected
   </message>
   <message name="IDS_CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP" desc="Tooltip and accessibility label for the custom profile image upload control." formatter_data="webui=BraveSettings">
     Upload a custom profile image

--- a/browser/resources/settings/BUILD.gn
+++ b/browser/resources/settings/BUILD.gn
@@ -23,6 +23,7 @@ import("//brave/components/tor/buildflags/buildflags.gni")
 import("//brave/components/traffic_control/buildflags/buildflags.gni")
 import("//brave/components/web_discovery/buildflags/buildflags.gni")
 import("//brave/resources/brave_grit.gni")
+import("//brave/ui/webui/custom_profile_image_config.gni")
 import("//chrome/common/features.gni")
 import("//extensions/buildflags/buildflags.gni")
 import("//tools/grit/preprocess_if_expr.gni")
@@ -109,6 +110,7 @@ preprocess_if_expr("preprocess") {
     "enable_brave_vpn_wireguard=$enable_brave_vpn_wireguard",
     "enable_brave_wallet=$enable_brave_wallet",
     "enable_containers=$enable_containers",
+    "enable_custom_profile_image=$enable_brave_custom_profile_image_webui",
     "enable_email_aliases=$enable_email_aliases",
     "enable_extensions=$enable_extensions",
     "enable_local_ai=$enable_local_ai",

--- a/browser/resources/settings/br/settings_manage_profile.ts
+++ b/browser/resources/settings/br/settings_manage_profile.ts
@@ -7,7 +7,16 @@ import {
   RegisterPolymerTemplateModifications,
   RegisterStyleOverride,
 } from 'chrome://resources/brave/polymer_overriding.js'
-import { html } from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js'
+import {html as polymerHtml} from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js'
+
+// <if expr="enable_custom_profile_image">
+import 'chrome://resources/brave/custom_profile_image_row.js'
+
+import {html, render} from 'chrome://resources/lit/v3_0/lit.rollup.js'
+
+import {BraveSettingsStrings} from '../brave_generated_resources_webui_strings.js'
+import {loadTimeData} from '../i18n_setup.js'
+// </if>
 
 // Brave avatar assets are organized in 7-color groups per style under
 // `app/theme/default_100_percent/common/avatars`. Chromium's default 6-column
@@ -17,7 +26,7 @@ const kManageProfilePickerColumns = '7'
 
 RegisterStyleOverride(
   'settings-manage-profile',
-  html`
+  polymerHtml`
     <style include="settings-shared">
       .content {
         --cr-section-indent-width: 20px;
@@ -31,26 +40,127 @@ RegisterStyleOverride(
         --icon-grid-gap: 22px !important;
         --icon-size: 66px !important;
       }
+
+      .custom-profile-image-section .content {
+        --icon-grid-gap: 22px;
+        --icon-size: 66px;
+      }
     </style>
   `,
 )
 
-RegisterPolymerTemplateModifications({
-  'settings-manage-profile': (templateContent) => {
-    const themeColorPicker = templateContent.querySelector(
-      'cr-theme-color-picker',
-    )
-    if (!themeColorPicker) {
-      throw new Error('[Settings] Missing Manage Profile theme color picker')
-    }
-    themeColorPicker.setAttribute('columns', kManageProfilePickerColumns)
+// <if expr="enable_custom_profile_image">
+const kCustomProfileImageRowId = 'customProfileImageRow'
 
-    const profileAvatarSelector = templateContent.querySelector(
-      'cr-profile-avatar-selector',
+function createCustomProfileImageSection(): DocumentFragment {
+  const previewLabel = loadTimeData.getString(
+    BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_PREVIEW_LABEL,
+  )
+  const selectedPreviewLabel = loadTimeData.getStringF(
+    BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL,
+    previewLabel,
+  )
+
+  const section = document.createDocumentFragment()
+  render(
+    html`
+      <div
+        class="cr-row manage-profile-section custom-profile-image-section"
+      >
+        <h1 class="cr-title-text">
+          ${loadTimeData.getString(
+            BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_TITLE,
+          )}
+        </h1>
+        <div class="content">
+          <br-custom-profile-image-row
+            id=${kCustomProfileImageRowId}
+            state="empty"
+            hide-title
+            title-label=${loadTimeData.getString(
+              BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION,
+            )}
+            replace-label=${loadTimeData.getString(
+              BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_REPLACE_ACTION,
+            )}
+            remove-label=${loadTimeData.getString(
+              BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_REMOVE_ACTION,
+            )}
+            selected-preview-label=${selectedPreviewLabel}
+            preview-label=${previewLabel}
+            upload-tooltip=${loadTimeData.getString(
+              BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP,
+            )}
+            remove-tooltip=${loadTimeData.getString(
+              BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_REMOVE_TOOLTIP,
+            )}
+            invalid-image-label=${loadTimeData.getString(
+              BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_INVALID_IMAGE,
+            )}
+          ></br-custom-profile-image-row>
+        </div>
+      </div>
+    `,
+    section,
+  )
+  return section
+}
+// </if>
+
+function customizeManageProfileTemplate(templateContent: DocumentFragment) {
+  const themeColorPicker = templateContent.querySelector(
+    'cr-theme-color-picker',
+  )
+  if (!themeColorPicker) {
+    throw new Error('[Settings] Missing Manage Profile theme color picker')
+  }
+  themeColorPicker.setAttribute('columns', kManageProfilePickerColumns)
+
+  const profileAvatarSelector = templateContent.querySelector(
+    'cr-profile-avatar-selector',
+  )
+  if (!profileAvatarSelector) {
+    throw new Error('[Settings] Missing Manage Profile avatar selector')
+  }
+  profileAvatarSelector.setAttribute('columns', kManageProfilePickerColumns)
+
+  // <if expr="enable_custom_profile_image">
+  if (!loadTimeData.getBoolean('customProfileImageEnabled')) {
+    return
+  }
+
+  if (templateContent.querySelector(`#${kCustomProfileImageRowId}`)) {
+    return
+  }
+
+  const themeColorSection = themeColorPicker.closest(
+    '.manage-profile-section',
+  )
+  if (!themeColorSection) {
+    throw new Error(
+      '[Settings] Missing Manage Profile theme color picker section',
     )
-    if (!profileAvatarSelector) {
-      throw new Error('[Settings] Missing Manage Profile avatar selector')
-    }
-    profileAvatarSelector.setAttribute('columns', kManageProfilePickerColumns)
-  },
+  }
+
+  const profileAvatarSection = profileAvatarSelector.closest(
+    '.manage-profile-section',
+  )
+  if (!profileAvatarSection) {
+    throw new Error('[Settings] Missing Manage Profile avatar section')
+  }
+
+  const sectionParent = profileAvatarSection.parentElement
+  if (!sectionParent || themeColorSection.parentElement !== sectionParent) {
+    throw new Error('[Settings] Manage Profile sections changed structure')
+  }
+
+  sectionParent.insertBefore(
+    createCustomProfileImageSection(),
+    profileAvatarSection,
+  )
+  // </if>
+}
+
+RegisterPolymerTemplateModifications({
+  'settings-manage-profile': customizeManageProfileTemplate,
 })

--- a/browser/resources/settings/br/settings_manage_profile.ts
+++ b/browser/resources/settings/br/settings_manage_profile.ts
@@ -6,13 +6,12 @@
 import {
   RegisterPolymerTemplateModifications,
   RegisterStyleOverride,
+  html as braveHtml,
 } from 'chrome://resources/brave/polymer_overriding.js'
 import {html as polymerHtml} from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js'
 
 // <if expr="enable_custom_profile_image">
 import 'chrome://resources/brave/custom_profile_image_row.js'
-
-import {html, render} from 'chrome://resources/lit/v3_0/lit.rollup.js'
 
 import {CustomProfileImageStrings} from '../brave_generated_resources_webui_strings.js'
 import {loadTimeData} from '../i18n_setup.js'
@@ -50,31 +49,19 @@ RegisterStyleOverride(
 )
 
 // <if expr="enable_custom_profile_image">
-const kCustomProfileImageRowId = 'customProfileImageRow'
-
-function createCustomProfileImageSection(): DocumentFragment {
-  const section = document.createDocumentFragment()
-  render(
-    html`
-      <div
-        class="cr-row manage-profile-section custom-profile-image-section"
-      >
-        <h1 class="cr-title-text">
-          ${loadTimeData.getString(
-            CustomProfileImageStrings.CUSTOM_PROFILE_IMAGE_TITLE,
-          )}
-        </h1>
-        <div class="content">
-          <br-custom-profile-image-row
-            id=${kCustomProfileImageRowId}
-            hide-title
-          ></br-custom-profile-image-row>
-        </div>
+function createCustomProfileImageSection() {
+  return braveHtml`
+    <div class="cr-row manage-profile-section custom-profile-image-section">
+      <h1 class="cr-title-text">
+        ${loadTimeData.getString(
+          CustomProfileImageStrings.CUSTOM_PROFILE_IMAGE_TITLE,
+        )}
+      </h1>
+      <div class="content">
+        <br-custom-profile-image-row hide-title></br-custom-profile-image-row>
       </div>
-    `,
-    section,
-  )
-  return section
+    </div>
+  `
 }
 // </if>
 

--- a/browser/resources/settings/br/settings_manage_profile.ts
+++ b/browser/resources/settings/br/settings_manage_profile.ts
@@ -14,7 +14,7 @@ import 'chrome://resources/brave/custom_profile_image_row.js'
 
 import {html, render} from 'chrome://resources/lit/v3_0/lit.rollup.js'
 
-import {BraveSettingsStrings} from '../brave_generated_resources_webui_strings.js'
+import {CustomProfileImageStrings} from '../brave_generated_resources_webui_strings.js'
 import {loadTimeData} from '../i18n_setup.js'
 // </if>
 
@@ -61,37 +61,13 @@ function createCustomProfileImageSection(): DocumentFragment {
       >
         <h1 class="cr-title-text">
           ${loadTimeData.getString(
-            BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_TITLE,
+            CustomProfileImageStrings.CUSTOM_PROFILE_IMAGE_TITLE,
           )}
         </h1>
         <div class="content">
           <br-custom-profile-image-row
             id=${kCustomProfileImageRowId}
             hide-title
-            title-label=${loadTimeData.getString(
-              BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION,
-            )}
-            replace-label=${loadTimeData.getString(
-              BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_REPLACE_ACTION,
-            )}
-            replace-tooltip=${loadTimeData.getString(
-              BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP,
-            )}
-            remove-label=${loadTimeData.getString(
-              BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_REMOVE_ACTION,
-            )}
-            selected-preview-label=${loadTimeData.getString(
-              BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL,
-            )}
-            upload-tooltip=${loadTimeData.getString(
-              BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP,
-            )}
-            remove-tooltip=${loadTimeData.getString(
-              BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_REMOVE_TOOLTIP,
-            )}
-            invalid-image-label=${loadTimeData.getString(
-              BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_INVALID_IMAGE,
-            )}
           ></br-custom-profile-image-row>
         </div>
       </div>

--- a/browser/resources/settings/br/settings_manage_profile.ts
+++ b/browser/resources/settings/br/settings_manage_profile.ts
@@ -67,7 +67,6 @@ function createCustomProfileImageSection(): DocumentFragment {
         <div class="content">
           <br-custom-profile-image-row
             id=${kCustomProfileImageRowId}
-            state="empty"
             hide-title
             title-label=${loadTimeData.getString(
               BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION,

--- a/browser/resources/settings/br/settings_manage_profile.ts
+++ b/browser/resources/settings/br/settings_manage_profile.ts
@@ -146,11 +146,11 @@ function customizeManageProfileTemplate(templateContent: DocumentFragment) {
   }
 
   const sectionParent = profileAvatarSection.parentElement
-  if (!sectionParent || themeColorSection.parentElement !== sectionParent) {
+  if (themeColorSection.parentElement !== sectionParent) {
     throw new Error('[Settings] Manage Profile sections changed structure')
   }
 
-  sectionParent.insertBefore(
+  sectionParent!.insertBefore(
     createCustomProfileImageSection(),
     profileAvatarSection,
   )

--- a/browser/resources/settings/br/settings_manage_profile.ts
+++ b/browser/resources/settings/br/settings_manage_profile.ts
@@ -87,10 +87,6 @@ function customizeManageProfileTemplate(templateContent: DocumentFragment) {
     return
   }
 
-  if (templateContent.querySelector(`#${kCustomProfileImageRowId}`)) {
-    return
-  }
-
   const themeColorSection = themeColorPicker.closest(
     '.manage-profile-section',
   )

--- a/browser/resources/settings/br/settings_manage_profile.ts
+++ b/browser/resources/settings/br/settings_manage_profile.ts
@@ -53,14 +53,6 @@ RegisterStyleOverride(
 const kCustomProfileImageRowId = 'customProfileImageRow'
 
 function createCustomProfileImageSection(): DocumentFragment {
-  const previewLabel = loadTimeData.getString(
-    BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_PREVIEW_LABEL,
-  )
-  const selectedPreviewLabel = loadTimeData.getStringF(
-    BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL,
-    previewLabel,
-  )
-
   const section = document.createDocumentFragment()
   render(
     html`
@@ -83,11 +75,15 @@ function createCustomProfileImageSection(): DocumentFragment {
             replace-label=${loadTimeData.getString(
               BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_REPLACE_ACTION,
             )}
+            replace-tooltip=${loadTimeData.getString(
+              BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP,
+            )}
             remove-label=${loadTimeData.getString(
               BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_REMOVE_ACTION,
             )}
-            selected-preview-label=${selectedPreviewLabel}
-            preview-label=${previewLabel}
+            selected-preview-label=${loadTimeData.getString(
+              BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL,
+            )}
             upload-tooltip=${loadTimeData.getString(
               BraveSettingsStrings.CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP,
             )}

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -71,6 +71,7 @@ source_set("ui") {
   ]
 
   deps = [
+    ":custom_profile_image_buildflags",
     "//brave/brave_domains",
     "//brave/browser/brave_adaptive_captcha",
     "//brave/browser/brave_origin",
@@ -113,6 +114,10 @@ source_set("ui") {
     "//chrome/browser/ui/toolbar",
     "//media",
   ]
+
+  if (enable_brave_custom_profile_image_webui) {
+    deps += [ "//brave/browser/ui/webui/custom_profile_image" ]
+  }
 
   if (is_mac) {
     deps += [ "//chrome/browser:global_keyboard_shortcuts_mac" ]

--- a/browser/ui/webui/settings/BUILD.gn
+++ b/browser/ui/webui/settings/BUILD.gn
@@ -6,6 +6,7 @@
 import("//brave/components/brave_ads/buildflags/buildflags.gni")
 import("//brave/components/brave_wallet/common/buildflags/buildflags.gni")
 import("//brave/components/email_aliases/buildflags/buildflags.gni")
+import("//brave/ui/webui/custom_profile_image_config.gni")
 
 source_set("unit_tests") {
   if (!is_android) {
@@ -76,11 +77,17 @@ source_set("browser_tests") {
     ]
 
     deps = [
+      "//brave/browser/ui:custom_profile_image_buildflags",
       "//chrome/browser/ui/",
       "//chrome/browser/ui/webui/settings",
       "//chrome/test:test_support",
       "//chrome/test:test_support_ui",
     ]
+
+    if (enable_brave_custom_profile_image_webui) {
+      deps += [ "//brave/browser/ui/webui/custom_profile_image" ]
+      data_deps = [ "//chrome:browser_tests_pak" ]
+    }
 
     if (enable_email_aliases) {
       sources += [ "email_aliases_link_browsertest.cc" ]

--- a/browser/ui/webui/settings/brave_manage_profile_browsertest.cc
+++ b/browser/ui/webui/settings/brave_manage_profile_browsertest.cc
@@ -7,6 +7,13 @@
 
 #if !BUILDFLAG(IS_CHROMEOS)
 
+#include "base/test/scoped_feature_list.h"
+#include "brave/browser/ui/custom_profile_image_buildflags.h"
+#if BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
+#include "brave/browser/ui/webui/custom_profile_image/features.h"
+#include "chrome/common/webui_url_constants.h"
+#include "chrome/test/base/web_ui_mocha_browser_test.h"
+#endif  // BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/common/chrome_isolated_world_ids.h"
@@ -126,6 +133,49 @@ IN_PROC_BROWSER_TEST_F(BraveManageProfileBrowserTest,
 
   ASSERT_EQ("ready", WaitForManageProfilePickerLayout(web_contents));
 }
+
+#if BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
+
+class BraveManageProfileWebUITest : public WebUIMochaBrowserTest {
+ protected:
+  explicit BraveManageProfileWebUITest(bool feature_enabled) {
+    scoped_feature_list_.InitWithFeatureState(
+        custom_profile_image::features::kBraveCustomProfileImage,
+        feature_enabled);
+    set_test_loader_host(chrome::kChromeUISettingsHost);
+  }
+
+ private:
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
+
+class BraveManageProfileFeatureDisabledWebUITest
+    : public BraveManageProfileWebUITest {
+ public:
+  BraveManageProfileFeatureDisabledWebUITest()
+      : BraveManageProfileWebUITest(false) {}
+};
+
+class BraveManageProfileFeatureEnabledWebUITest
+    : public BraveManageProfileWebUITest {
+ public:
+  BraveManageProfileFeatureEnabledWebUITest()
+      : BraveManageProfileWebUITest(true) {}
+};
+
+IN_PROC_BROWSER_TEST_F(BraveManageProfileFeatureDisabledWebUITest,
+                       DoesNotRenderCustomProfileImageRow) {
+  RunTest("settings/people_page_manage_profile_test.js",
+          "runMochaSuite('BraveManageProfileFeatureDisabledTests')");
+}
+
+IN_PROC_BROWSER_TEST_F(BraveManageProfileFeatureEnabledWebUITest,
+                       RendersAndUsesCustomProfileImageRow) {
+  RunTest("settings/people_page_manage_profile_test.js",
+          "runMochaSuite('BraveManageProfileFeatureEnabledTests')");
+}
+
+#endif  // BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
 
 }  // namespace
 

--- a/browser/ui/webui/settings/brave_manage_profile_browsertest.cc
+++ b/browser/ui/webui/settings/brave_manage_profile_browsertest.cc
@@ -7,13 +7,7 @@
 
 #if !BUILDFLAG(IS_CHROMEOS)
 
-#include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/custom_profile_image_buildflags.h"
-#if BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
-#include "brave/browser/ui/webui/custom_profile_image/features.h"
-#include "chrome/common/webui_url_constants.h"
-#include "chrome/test/base/web_ui_mocha_browser_test.h"
-#endif  // BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/common/chrome_isolated_world_ids.h"
@@ -23,6 +17,13 @@
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
 #include "url/gurl.h"
+
+#if BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
+#include "base/test/scoped_feature_list.h"
+#include "brave/browser/ui/webui/custom_profile_image/features.h"
+#include "chrome/common/webui_url_constants.h"
+#include "chrome/test/base/web_ui_mocha_browser_test.h"
+#endif  // BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
 
 namespace {
 

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -11,9 +11,6 @@
 #include "base/strings/utf_string_conversions.h"
 #include "brave/browser/shell_integrations/buildflags/buildflags.h"
 #include "brave/browser/ui/custom_profile_image_buildflags.h"
-#if BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
-#include "brave/browser/ui/webui/custom_profile_image/features.h"
-#endif  // BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
 #include "brave/browser/ui/webui/brave_settings_ui.h"
 #include "brave/browser/ui/webui/settings/brave_privacy_handler.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
@@ -60,6 +57,10 @@
 #include "extensions/common/extension_urls.h"
 #include "net/base/features.h"
 #include "ui/base/l10n/l10n_util.h"
+
+#if BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
+#include "brave/browser/ui/webui/custom_profile_image/features.h"
+#endif  // BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/browser/model_validator.h"

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -5,10 +5,15 @@
 
 #include "brave/browser/ui/webui/settings/brave_settings_localized_strings_provider.h"
 
+#include "base/feature_list.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/browser/shell_integrations/buildflags/buildflags.h"
+#include "brave/browser/ui/custom_profile_image_buildflags.h"
+#if BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
+#include "brave/browser/ui/webui/custom_profile_image/features.h"
+#endif  // BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
 #include "brave/browser/ui/webui/brave_settings_ui.h"
 #include "brave/browser/ui/webui/settings/brave_privacy_handler.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
@@ -1497,6 +1502,12 @@ void BraveAddLocalizedStrings(content::WebUIDataSource* html_source,
       l10n_util::GetStringUTF16(
           IDS_SETTINGS_COOKIES_LOCAL_STORAGE_SIZE_ON_DISK_LABEL));
   html_source->AddLocalizedStrings(webui::kBraveSettingsStrings);
+#if BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
+  html_source->AddBoolean(
+      "customProfileImageEnabled",
+      base::FeatureList::IsEnabled(
+          custom_profile_image::features::kBraveCustomProfileImage));
+#endif  // BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
 
   // We add strings regardless of the FeatureFlag state to prevent crash
 

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -1503,6 +1503,7 @@ void BraveAddLocalizedStrings(content::WebUIDataSource* html_source,
       l10n_util::GetStringUTF16(
           IDS_SETTINGS_COOKIES_LOCAL_STORAGE_SIZE_ON_DISK_LABEL));
   html_source->AddLocalizedStrings(webui::kBraveSettingsStrings);
+  html_source->AddLocalizedStrings(webui::kCustomProfileImageStrings);
 
   html_source->AddBoolean(
       "customProfileImageEnabled",

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -1502,12 +1502,16 @@ void BraveAddLocalizedStrings(content::WebUIDataSource* html_source,
       l10n_util::GetStringUTF16(
           IDS_SETTINGS_COOKIES_LOCAL_STORAGE_SIZE_ON_DISK_LABEL));
   html_source->AddLocalizedStrings(webui::kBraveSettingsStrings);
-#if BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
+
   html_source->AddBoolean(
       "customProfileImageEnabled",
+#if BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
       base::FeatureList::IsEnabled(
-          custom_profile_image::features::kBraveCustomProfileImage));
+          custom_profile_image::features::kBraveCustomProfileImage)
+#else
+      false
 #endif  // BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
+);
 
   // We add strings regardless of the FeatureFlag state to prevent crash
 

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -1512,7 +1512,7 @@ void BraveAddLocalizedStrings(content::WebUIDataSource* html_source,
 #else
       false
 #endif  // BUILDFLAG(ENABLE_CUSTOM_PROFILE_IMAGE)
-);
+  );
 
   // We add strings regardless of the FeatureFlag state to prevent crash
 

--- a/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
+++ b/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
@@ -1,15 +1,7 @@
-// Copyright 2016 The Chromium Authors
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 // Copyright (c) 2026 The Brave Authors. All rights reserved.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
-
-// <if expr="is_win or is_macosx or is_linux">
-// Load Brave's Settings overrides before the upstream test imports lazy_load.js,
-// which defines replaceable Chromium custom elements.
 import {
   loadTimeData,
   Router,

--- a/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
+++ b/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
@@ -260,39 +260,6 @@ function braveManageProfileFeatureEnabledTests() {
     assertEquals('7', themePicker.getAttribute('columns'))
     assertEquals('7', avatarSelector.getAttribute('columns'))
 
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION'),
-      row.titleLabel,
-    )
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REPLACE_ACTION'),
-      row.replaceLabel,
-    )
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP'),
-      row.replaceTooltip,
-    )
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REMOVE_ACTION'),
-      row.removeLabel,
-    )
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL'),
-      row.selectedPreviewLabel,
-    )
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP'),
-      row.uploadTooltip,
-    )
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REMOVE_TOOLTIP'),
-      row.removeTooltip,
-    )
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_INVALID_IMAGE'),
-      row.invalidImageLabel,
-    )
-
     const title = getRequiredElement<HTMLElement>(
       customSection!,
       '.cr-title-text',
@@ -310,16 +277,22 @@ function braveManageProfileFeatureEnabledTests() {
     )
     assertEquals('title', rowContainer.getAttribute('aria-labelledby'))
     const rowTitle = getRequiredElement<HTMLElement>(row.shadowRoot, '#title')
-    assertEquals(row.titleLabel, rowTitle.textContent.trim())
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION'),
+      rowTitle.textContent.trim(),
+    )
     assertEquals('none', getComputedStyle(rowTitle).display)
     const preview = getRequiredElement<HTMLElement>(row.shadowRoot, '#preview')
     assertEquals('LEO-BUTTON', preview.tagName)
     assertEquals('plain-faint', preview.getAttribute('kind'))
     assertEquals('jumbo', preview.getAttribute('size'))
     assertTrue(preview.hasAttribute('fab'))
-    assertEquals(row.uploadTooltip, preview.getAttribute('title'))
     assertEquals(
-      row.uploadTooltip,
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP'),
+      preview.getAttribute('title'),
+    )
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP'),
       getRequiredElement<HTMLElement>(preview, '#previewLabel').textContent,
     )
     const plusIcon = getRequiredElement<HTMLElement>(
@@ -336,7 +309,18 @@ function braveManageProfileFeatureEnabledTests() {
     assertEquals('LEO-BUTTON', uploadButton.tagName)
     assertEquals('filled', uploadButton.getAttribute('kind'))
     assertEquals('small', uploadButton.getAttribute('size'))
-    assertEquals(row.titleLabel, uploadButton.textContent.trim())
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION'),
+      uploadButton.textContent.trim(),
+    )
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP'),
+      uploadButton.getAttribute('title'),
+    )
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP'),
+      uploadButton.getAttribute('aria-label'),
+    )
     assertEquals(
       'image/*',
       getRequiredElement<HTMLInputElement>(row.shadowRoot, '#fileInput').accept,
@@ -369,7 +353,10 @@ function braveManageProfileFeatureEnabledTests() {
     assertEquals('saved-active', row.state)
     assertEquals(createdUrls[0], getPreviewUrl(row))
     const preview = getRequiredElement<HTMLElement>(row.shadowRoot, '#preview')
-    assertEquals(row.selectedPreviewLabel, preview.getAttribute('aria-label'))
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL'),
+      preview.getAttribute('aria-label'),
+    )
     const selectedIndicator = getRequiredElement<HTMLElement>(
       row.shadowRoot,
       '#selectedIndicator',
@@ -384,9 +371,18 @@ function braveManageProfileFeatureEnabledTests() {
     assertEquals('LEO-BUTTON', replaceButton.tagName)
     assertEquals('filled', replaceButton.getAttribute('kind'))
     assertEquals('small', replaceButton.getAttribute('size'))
-    assertEquals(row.replaceLabel, replaceButton.textContent.trim())
-    assertEquals(row.replaceTooltip, replaceButton.getAttribute('title'))
-    assertEquals(row.replaceTooltip, replaceButton.getAttribute('aria-label'))
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REPLACE_ACTION'),
+      replaceButton.textContent.trim(),
+    )
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP'),
+      replaceButton.getAttribute('title'),
+    )
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP'),
+      replaceButton.getAttribute('aria-label'),
+    )
     const removeButton = getRequiredElement<HTMLElement>(
       row.shadowRoot,
       '#removeButton',
@@ -394,6 +390,18 @@ function braveManageProfileFeatureEnabledTests() {
     assertEquals('LEO-BUTTON', removeButton.tagName)
     assertEquals('outline', removeButton.getAttribute('kind'))
     assertEquals('small', removeButton.getAttribute('size'))
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REMOVE_ACTION'),
+      removeButton.textContent.trim(),
+    )
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REMOVE_TOOLTIP'),
+      removeButton.getAttribute('title'),
+    )
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REMOVE_TOOLTIP'),
+      removeButton.getAttribute('aria-label'),
+    )
     assertDeepEquals([], revokedUrls)
   })
 
@@ -444,7 +452,7 @@ function braveManageProfileFeatureEnabledTests() {
     assertDeepEquals([], createdUrls)
     assertDeepEquals([], revokedUrls)
     assertEquals(
-      row.invalidImageLabel,
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_INVALID_IMAGE'),
       getRequiredElement(row.shadowRoot, '#fileError').textContent,
     )
   })
@@ -463,7 +471,7 @@ function braveManageProfileFeatureEnabledTests() {
     assertEquals('saved-active', row.state)
     assertEquals(firstPreviewUrl, getPreviewUrl(row))
     assertEquals(
-      row.invalidImageLabel,
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_INVALID_IMAGE'),
       getRequiredElement(row.shadowRoot, '#fileError').textContent,
     )
     assertDeepEquals([createdUrls[1]], revokedUrls)

--- a/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
+++ b/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
@@ -304,6 +304,14 @@ function braveManageProfileFeatureEnabledTests() {
 
     assertEquals('empty', row.state)
     assertTrue(row.hideTitle)
+    const rowContainer = getRequiredElement<HTMLElement>(
+      row.shadowRoot,
+      '#row',
+    )
+    assertEquals('title', rowContainer.getAttribute('aria-labelledby'))
+    const rowTitle = getRequiredElement<HTMLElement>(row.shadowRoot, '#title')
+    assertEquals(row.titleLabel, rowTitle.textContent.trim())
+    assertEquals('none', getComputedStyle(rowTitle).display)
     const preview = getRequiredElement<HTMLElement>(row.shadowRoot, '#preview')
     assertEquals('LEO-BUTTON', preview.tagName)
     assertEquals('plain-faint', preview.getAttribute('kind'))

--- a/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
+++ b/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
@@ -269,18 +269,15 @@ function braveManageProfileFeatureEnabledTests() {
       row.replaceLabel,
     )
     assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP'),
+      row.replaceTooltip,
+    )
+    assertEquals(
       loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REMOVE_ACTION'),
       row.removeLabel,
     )
     assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_PREVIEW_LABEL'),
-      row.previewLabel,
-    )
-    assertEquals(
-      loadTimeData.getStringF(
-        'CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL',
-        row.previewLabel,
-      ),
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL'),
       row.selectedPreviewLabel,
     )
     assertEquals(
@@ -366,7 +363,8 @@ function braveManageProfileFeatureEnabledTests() {
     )
     assertEquals('CR-BUTTON', replaceButton.tagName)
     assertEquals(row.replaceLabel, replaceButton.textContent.trim())
-    assertEquals(row.replaceLabel, replaceButton.getAttribute('aria-label'))
+    assertEquals(row.replaceTooltip, replaceButton.getAttribute('title'))
+    assertEquals(row.replaceTooltip, replaceButton.getAttribute('aria-label'))
     assertEquals(
       'CR-BUTTON',
       getRequiredElement<HTMLElement>(row.shadowRoot, '#removeButton').tagName,

--- a/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
+++ b/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
@@ -233,11 +233,10 @@ function braveManageProfileFeatureEnabledTests() {
     HTMLImageElement.prototype.decode = originalDecode
   })
 
-  test('RendersLocalizedRowBetweenPickers', async function() {
+  test('RendersEmptyRowBetweenPickers', async function() {
     assertTrue(loadTimeData.getBoolean('customProfileImageEnabled'))
 
-    const row = getCustomProfileImageRow(manageProfile)
-    assertTrue(!!row)
+    const row = getRequiredCustomProfileImageRow(manageProfile)
     await row.updateComplete
 
     const themePicker = getRequiredElement(
@@ -255,76 +254,21 @@ function braveManageProfileFeatureEnabledTests() {
     const customSection = row.closest('.manage-profile-section')
     const avatarSection = avatarSelector.closest('.manage-profile-section')
 
-    assertEquals(sections.indexOf(themeSection!), sections.indexOf(customSection!) - 1)
-    assertEquals(sections.indexOf(customSection!), sections.indexOf(avatarSection!) - 1)
+    assertEquals(
+      sections.indexOf(themeSection!),
+      sections.indexOf(customSection!) - 1,
+    )
+    assertEquals(
+      sections.indexOf(customSection!),
+      sections.indexOf(avatarSection!) - 1,
+    )
     assertEquals('7', themePicker.getAttribute('columns'))
     assertEquals('7', avatarSelector.getAttribute('columns'))
 
-    const title = getRequiredElement<HTMLElement>(
-      customSection!,
-      '.cr-title-text',
-    )
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_TITLE'),
-      title.textContent.trim(),
-    )
-
-    assertEquals('empty', row.state)
-    assertTrue(row.hideTitle)
-    const rowContainer = getRequiredElement<HTMLElement>(
-      row.shadowRoot,
-      '#row',
-    )
-    assertEquals('title', rowContainer.getAttribute('aria-labelledby'))
-    const rowTitle = getRequiredElement<HTMLElement>(row.shadowRoot, '#title')
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION'),
-      rowTitle.textContent.trim(),
-    )
-    assertEquals('none', getComputedStyle(rowTitle).display)
-    const preview = getRequiredElement<HTMLElement>(row.shadowRoot, '#preview')
-    assertEquals('LEO-BUTTON', preview.tagName)
-    assertEquals('plain-faint', preview.getAttribute('kind'))
-    assertEquals('jumbo', preview.getAttribute('size'))
-    assertTrue(preview.hasAttribute('fab'))
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP'),
-      preview.getAttribute('title'),
-    )
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP'),
-      getRequiredElement<HTMLElement>(preview, '#previewLabel').textContent,
-    )
-    const plusIcon = getRequiredElement<HTMLElement>(
-      preview,
-      '#plusIcon',
-    )
-    assertEquals('LEO-ICON', plusIcon.tagName)
-    assertEquals('plus-add', plusIcon.getAttribute('name'))
-
-    const uploadButton = getRequiredElement<HTMLElement>(
-      row.shadowRoot,
-      '#uploadButton',
-    )
-    assertEquals('LEO-BUTTON', uploadButton.tagName)
-    assertEquals('filled', uploadButton.getAttribute('kind'))
-    assertEquals('small', uploadButton.getAttribute('size'))
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION'),
-      uploadButton.textContent.trim(),
-    )
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP'),
-      uploadButton.getAttribute('title'),
-    )
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP'),
-      uploadButton.getAttribute('aria-label'),
-    )
-    assertEquals(
-      'image/*',
-      getRequiredElement<HTMLInputElement>(row.shadowRoot, '#fileInput').accept,
-    )
+    getRequiredElement(row.shadowRoot, '#preview')
+    getRequiredElement(row.shadowRoot, '#uploadButton')
+    getRequiredElement(row.shadowRoot, '#fileInput')
+    assertEquals(null, row.shadowRoot.querySelector('#previewImage'))
     assertEquals(null, row.shadowRoot.querySelector('#removeButton'))
   })
 
@@ -350,81 +294,23 @@ function braveManageProfileFeatureEnabledTests() {
     selectFile(row, 'first.png')
     await settleRow(row)
 
-    assertEquals('saved-active', row.state)
     assertEquals(createdUrls[0], getPreviewUrl(row))
-    const preview = getRequiredElement<HTMLElement>(row.shadowRoot, '#preview')
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL'),
-      preview.getAttribute('aria-label'),
-    )
-    const selectedIndicator = getRequiredElement<HTMLElement>(
-      row.shadowRoot,
-      '#selectedIndicator',
-    )
-    assertEquals('LEO-ICON', selectedIndicator.tagName)
-    assertEquals('check-normal', selectedIndicator.getAttribute('name'))
-
-    const replaceButton = getRequiredElement<HTMLElement>(
-      row.shadowRoot,
-      '#uploadButton',
-    )
-    assertEquals('LEO-BUTTON', replaceButton.tagName)
-    assertEquals('filled', replaceButton.getAttribute('kind'))
-    assertEquals('small', replaceButton.getAttribute('size'))
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REPLACE_ACTION'),
-      replaceButton.textContent.trim(),
-    )
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP'),
-      replaceButton.getAttribute('title'),
-    )
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP'),
-      replaceButton.getAttribute('aria-label'),
-    )
-    const removeButton = getRequiredElement<HTMLElement>(
-      row.shadowRoot,
-      '#removeButton',
-    )
-    assertEquals('LEO-BUTTON', removeButton.tagName)
-    assertEquals('outline', removeButton.getAttribute('kind'))
-    assertEquals('small', removeButton.getAttribute('size'))
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REMOVE_ACTION'),
-      removeButton.textContent.trim(),
-    )
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REMOVE_TOOLTIP'),
-      removeButton.getAttribute('title'),
-    )
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REMOVE_TOOLTIP'),
-      removeButton.getAttribute('aria-label'),
-    )
+    getRequiredElement(row.shadowRoot, '#preview')
+    getRequiredElement(row.shadowRoot, '#selectedIndicator')
+    getRequiredElement(row.shadowRoot, '#uploadButton')
+    getRequiredElement(row.shadowRoot, '#removeButton')
     assertDeepEquals([], revokedUrls)
-  })
-
-  test('UsesConfiguredActionSpacing', async function() {
-    const row = getRequiredCustomProfileImageRow(manageProfile)
-    selectFile(row, 'first.png')
-    await settleRow(row)
-
-    const actions = getRequiredElement<HTMLElement>(row.shadowRoot, '#actions')
-    assertEquals('12px', getComputedStyle(actions).gap)
   })
 
   test('ReplacesImageAndChangesPreviewUrl', async function() {
     const row = getRequiredCustomProfileImageRow(manageProfile)
     selectFile(row, 'first.png')
     await settleRow(row)
-    const firstPreviewUrl = getPreviewUrl(row)
 
     selectFile(row, 'second.png')
     await settleRow(row)
 
     assertEquals(createdUrls[1], getPreviewUrl(row))
-    assertFalse(firstPreviewUrl === getPreviewUrl(row))
     assertDeepEquals([createdUrls[0]], revokedUrls)
   })
 
@@ -436,9 +322,9 @@ function braveManageProfileFeatureEnabledTests() {
     getRequiredElement<HTMLElement>(row.shadowRoot, '#removeButton').click()
     await settleRow(row)
 
-    assertEquals('empty', row.state)
     assertEquals(null, getPreviewUrl(row))
     assertEquals(null, row.shadowRoot.querySelector('#removeButton'))
+    getRequiredElement(row.shadowRoot, '#uploadButton')
     assertDeepEquals([createdUrls[0]], revokedUrls)
   })
 
@@ -447,14 +333,11 @@ function braveManageProfileFeatureEnabledTests() {
     selectFile(row, 'not-an-image.txt', 'text/plain')
     await settleRow(row)
 
-    assertEquals('empty', row.state)
     assertEquals(null, getPreviewUrl(row))
+    assertEquals(null, row.shadowRoot.querySelector('#removeButton'))
     assertDeepEquals([], createdUrls)
     assertDeepEquals([], revokedUrls)
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_INVALID_IMAGE'),
-      getRequiredElement(row.shadowRoot, '#fileError').textContent,
-    )
+    getRequiredElement(row.shadowRoot, '#fileError')
   })
 
   test('RejectsCorruptImageAndPreservesPreview', async function() {
@@ -468,12 +351,8 @@ function braveManageProfileFeatureEnabledTests() {
     selectFile(row, 'corrupt.png')
     await settleRow(row)
 
-    assertEquals('saved-active', row.state)
     assertEquals(firstPreviewUrl, getPreviewUrl(row))
-    assertEquals(
-      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_INVALID_IMAGE'),
-      getRequiredElement(row.shadowRoot, '#fileError').textContent,
-    )
+    getRequiredElement(row.shadowRoot, '#fileError')
     assertDeepEquals([createdUrls[1]], revokedUrls)
   })
 
@@ -487,7 +366,6 @@ function braveManageProfileFeatureEnabledTests() {
 
     decodeResolvers[1]!.resolve()
     await settleRow(row)
-    assertEquals('saved-active', row.state)
     assertEquals(createdUrls[1], getPreviewUrl(row))
 
     decodeResolvers[0]!.resolve()
@@ -507,12 +385,12 @@ function braveManageProfileFeatureEnabledTests() {
 
     getRequiredElement<HTMLElement>(row.shadowRoot, '#removeButton').click()
     await settleRow(row)
-    assertEquals('empty', row.state)
+    assertEquals(null, getPreviewUrl(row))
+    assertEquals(null, row.shadowRoot.querySelector('#removeButton'))
     assertDeepEquals([createdUrls[0]], revokedUrls)
 
     decodeResolvers[0]!.resolve()
     await settleRow(row)
-    assertEquals('empty', row.state)
     assertEquals(null, getPreviewUrl(row))
     assertDeepEquals(createdUrls, revokedUrls)
   })
@@ -527,7 +405,6 @@ function braveManageProfileFeatureEnabledTests() {
     decodeResolvers[0]!.resolve()
     await settleRow(row)
 
-    assertEquals('empty', row.state)
     assertEquals(null, getPreviewUrl(row))
     assertDeepEquals([createdUrls[0]], revokedUrls)
   })
@@ -540,7 +417,6 @@ function braveManageProfileFeatureEnabledTests() {
     manageProfile.remove()
     await settleRow(row)
 
-    assertEquals('empty', row.state)
     assertEquals(null, getPreviewUrl(row))
     assertDeepEquals([createdUrls[0]], revokedUrls)
   })
@@ -557,8 +433,8 @@ function braveManageProfileFeatureEnabledTests() {
 
     const recreatedRow = getRequiredCustomProfileImageRow(manageProfile)
     await recreatedRow.updateComplete
-    assertEquals('empty', recreatedRow.state)
     assertEquals(null, getPreviewUrl(recreatedRow))
+    assertEquals(null, recreatedRow.shadowRoot.querySelector('#removeButton'))
     assertDeepEquals([createdUrls[0]], revokedUrls)
   })
 
@@ -582,7 +458,6 @@ function braveManageProfileFeatureEnabledTests() {
 
     const args = await browserProxy.whenCalled('setProfileIconToDefaultAvatar')
     assertEquals(1, args[0])
-    assertEquals('saved-active', row.state)
     assertEquals(customPreviewUrl, getPreviewUrl(row))
   })
 }

--- a/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
+++ b/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
@@ -305,16 +305,29 @@ function braveManageProfileFeatureEnabledTests() {
     assertEquals('empty', row.state)
     assertTrue(row.hideTitle)
     const preview = getRequiredElement<HTMLElement>(row.shadowRoot, '#preview')
-    assertEquals('CR-ICON-BUTTON', preview.tagName)
-    assertEquals('cr:add', preview.getAttribute('iron-icon'))
+    assertEquals('LEO-BUTTON', preview.tagName)
+    assertEquals('plain-faint', preview.getAttribute('kind'))
+    assertEquals('jumbo', preview.getAttribute('size'))
+    assertTrue(preview.hasAttribute('fab'))
     assertEquals(row.uploadTooltip, preview.getAttribute('title'))
-    assertEquals(row.uploadTooltip, preview.getAttribute('aria-label'))
+    assertEquals(
+      row.uploadTooltip,
+      getRequiredElement<HTMLElement>(preview, '#previewLabel').textContent,
+    )
+    const plusIcon = getRequiredElement<HTMLElement>(
+      preview,
+      '#plusIcon',
+    )
+    assertEquals('LEO-ICON', plusIcon.tagName)
+    assertEquals('plus-add', plusIcon.getAttribute('name'))
 
     const uploadButton = getRequiredElement<HTMLElement>(
       row.shadowRoot,
       '#uploadButton',
     )
-    assertEquals('CR-BUTTON', uploadButton.tagName)
+    assertEquals('LEO-BUTTON', uploadButton.tagName)
+    assertEquals('filled', uploadButton.getAttribute('kind'))
+    assertEquals('small', uploadButton.getAttribute('size'))
     assertEquals(row.titleLabel, uploadButton.textContent.trim())
     assertEquals(
       'image/*',
@@ -349,26 +362,30 @@ function braveManageProfileFeatureEnabledTests() {
     assertEquals(createdUrls[0], getPreviewUrl(row))
     const preview = getRequiredElement<HTMLElement>(row.shadowRoot, '#preview')
     assertEquals(row.selectedPreviewLabel, preview.getAttribute('aria-label'))
-    assertEquals(
-      'CR-ICON',
-      getRequiredElement<HTMLElement>(
-        row.shadowRoot,
-        '#selectedIndicator',
-      ).tagName,
+    const selectedIndicator = getRequiredElement<HTMLElement>(
+      row.shadowRoot,
+      '#selectedIndicator',
     )
+    assertEquals('LEO-ICON', selectedIndicator.tagName)
+    assertEquals('check-normal', selectedIndicator.getAttribute('name'))
 
     const replaceButton = getRequiredElement<HTMLElement>(
       row.shadowRoot,
       '#uploadButton',
     )
-    assertEquals('CR-BUTTON', replaceButton.tagName)
+    assertEquals('LEO-BUTTON', replaceButton.tagName)
+    assertEquals('filled', replaceButton.getAttribute('kind'))
+    assertEquals('small', replaceButton.getAttribute('size'))
     assertEquals(row.replaceLabel, replaceButton.textContent.trim())
     assertEquals(row.replaceTooltip, replaceButton.getAttribute('title'))
     assertEquals(row.replaceTooltip, replaceButton.getAttribute('aria-label'))
-    assertEquals(
-      'CR-BUTTON',
-      getRequiredElement<HTMLElement>(row.shadowRoot, '#removeButton').tagName,
+    const removeButton = getRequiredElement<HTMLElement>(
+      row.shadowRoot,
+      '#removeButton',
     )
+    assertEquals('LEO-BUTTON', removeButton.tagName)
+    assertEquals('outline', removeButton.getAttribute('kind'))
+    assertEquals('small', removeButton.getAttribute('size'))
     assertDeepEquals([], revokedUrls)
   })
 
@@ -378,7 +395,7 @@ function braveManageProfileFeatureEnabledTests() {
     await settleRow(row)
 
     const actions = getRequiredElement<HTMLElement>(row.shadowRoot, '#actions')
-    assertEquals('10px', getComputedStyle(actions).gap)
+    assertEquals('12px', getComputedStyle(actions).gap)
   })
 
   test('ReplacesImageAndChangesPreviewUrl', async function() {

--- a/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
+++ b/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
@@ -1,0 +1,578 @@
+// Copyright 2016 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// <if expr="is_win or is_macosx or is_linux">
+// Load Brave's Settings overrides before the upstream test imports lazy_load.js,
+// which defines replaceable Chromium custom elements.
+import {
+  loadTimeData,
+  Router,
+  routes,
+  StatusAction,
+} from 'chrome://settings/settings.js'
+// </if>
+
+import './people_page_manage_profile_test-chromium.js'
+
+// <if expr="is_win or is_macosx or is_linux">
+
+import {webUIListenerCallback} from 'chrome://resources/js/cr.js'
+import {PromiseResolver} from 'chrome://resources/js/promise_resolver.js'
+import type {BrCustomProfileImageRowElement} from 'chrome://resources/brave/custom_profile_image_row.js'
+import type {
+  ManageProfileBrowserProxy,
+  SettingsManageProfileElement,
+} from 'chrome://settings/lazy_load.js'
+import {
+  ManageProfileBrowserProxyImpl,
+  ProfileShortcutStatus,
+} from 'chrome://settings/lazy_load.js'
+import {
+  assertDeepEquals,
+  assertEquals,
+  assertFalse,
+  assertTrue,
+} from 'chrome://webui-test/chai_assert.js'
+import {microtasksFinished} from 'chrome://webui-test/test_util.js'
+import {TestBrowserProxy} from 'chrome://webui-test/test_browser_proxy.js'
+
+class BraveTestManageProfileBrowserProxy extends TestBrowserProxy implements
+    ManageProfileBrowserProxy {
+  constructor() {
+    super([
+      'getAvailableIcons',
+      'setProfileIconToGaiaAvatar',
+      'setProfileIconToDefaultAvatar',
+      'setProfileName',
+      'getProfileShortcutStatus',
+      'addProfileShortcut',
+      'removeProfileShortcut',
+    ])
+  }
+
+  getAvailableIcons() {
+    this.methodCalled('getAvailableIcons')
+    return Promise.resolve([
+      {
+        url: 'fake-icon-1.png',
+        label: 'fake-icon-1',
+        index: 1,
+        isGaiaAvatar: false,
+        selected: true,
+      },
+      {
+        url: 'fake-icon-2.png',
+        label: 'fake-icon-2',
+        index: 2,
+        isGaiaAvatar: false,
+        selected: false,
+      },
+    ])
+  }
+
+  setProfileIconToGaiaAvatar() {
+    this.methodCalled('setProfileIconToGaiaAvatar')
+  }
+
+  setProfileIconToDefaultAvatar(index: number) {
+    this.methodCalled('setProfileIconToDefaultAvatar', [index])
+  }
+
+  setProfileName(name: string) {
+    this.methodCalled('setProfileName', [name])
+  }
+
+  getProfileShortcutStatus() {
+    this.methodCalled('getProfileShortcutStatus')
+    return Promise.resolve(ProfileShortcutStatus.PROFILE_SHORTCUT_SETTING_HIDDEN)
+  }
+
+  addProfileShortcut() {
+    this.methodCalled('addProfileShortcut')
+  }
+
+  removeProfileShortcut() {
+    this.methodCalled('removeProfileShortcut')
+  }
+}
+
+function createManageProfileElement(): SettingsManageProfileElement {
+  const element = document.createElement('settings-manage-profile')
+  document.body.append(element)
+  webUIListenerCallback('sync-status-changed', {
+    supervisedUser: false,
+    statusAction: StatusAction.NO_ACTION,
+  })
+  webUIListenerCallback(
+    'profile-info-changed',
+    {name: 'Initial Fake Name', iconUrl: ''},
+  )
+  Router.getInstance().navigateTo(routes.MANAGE_PROFILE)
+  return element
+}
+
+function getCustomProfileImageRow(
+  manageProfile: SettingsManageProfileElement,
+): BrCustomProfileImageRowElement | null {
+  return manageProfile.shadowRoot!.querySelector('br-custom-profile-image-row')
+}
+
+function getRequiredElement<T extends Element>(
+  root: ParentNode,
+  selector: string,
+): T {
+  const element = root.querySelector<T>(selector)
+  assertTrue(!!element, `Missing ${selector}`)
+  return element
+}
+
+function getRequiredCustomProfileImageRow(
+  manageProfile: SettingsManageProfileElement,
+): BrCustomProfileImageRowElement {
+  return getRequiredElement<BrCustomProfileImageRowElement>(
+    manageProfile.shadowRoot!,
+    'br-custom-profile-image-row',
+  )
+}
+
+function getPreviewUrl(row: BrCustomProfileImageRowElement): string | null {
+  return row.shadowRoot
+    .querySelector<HTMLImageElement>('#previewImage')
+    ?.getAttribute('src') ?? null
+}
+
+function useDeferredImageDecodes(): PromiseResolver<void>[] {
+  const resolvers: PromiseResolver<void>[] = []
+  HTMLImageElement.prototype.decode = () => {
+    const resolver = new PromiseResolver<void>()
+    resolvers.push(resolver)
+    return resolver.promise
+  }
+  return resolvers
+}
+
+function selectFile(
+  row: BrCustomProfileImageRowElement,
+  name: string,
+  type = 'image/png',
+) {
+  const input = getRequiredElement<HTMLInputElement>(
+    row.shadowRoot,
+    '#fileInput',
+  )
+  Object.defineProperty(input, 'files', {
+    configurable: true,
+    value: [new File(['image'], name, {type})],
+  })
+  input.dispatchEvent(new Event('change'))
+}
+
+async function settleRow(row: BrCustomProfileImageRowElement) {
+  await microtasksFinished()
+  await row.updateComplete
+  await microtasksFinished()
+  await row.updateComplete
+}
+
+function braveManageProfileFeatureDisabledTests() {
+  let manageProfile: SettingsManageProfileElement
+
+  setup(function() {
+    document.body.replaceChildren()
+    loadTimeData.overrideValues({profileShortcutsEnabled: false})
+    ManageProfileBrowserProxyImpl.setInstance(
+      new BraveTestManageProfileBrowserProxy(),
+    )
+    manageProfile = createManageProfileElement()
+  })
+
+  teardown(function() {
+    manageProfile.remove()
+  })
+
+  test('DoesNotRenderCustomProfileImageRow', function() {
+    assertFalse(loadTimeData.getBoolean('customProfileImageEnabled'))
+    assertEquals(null, getCustomProfileImageRow(manageProfile))
+  })
+}
+
+function braveManageProfileFeatureEnabledTests() {
+  let browserProxy: BraveTestManageProfileBrowserProxy
+  let createdUrls: string[]
+  let manageProfile: SettingsManageProfileElement
+  let originalCreateObjectUrl: typeof URL.createObjectURL
+  let originalDecode: typeof HTMLImageElement.prototype.decode
+  let originalRevokeObjectUrl: typeof URL.revokeObjectURL
+  let revokedUrls: string[]
+
+  setup(function() {
+    document.body.replaceChildren()
+    loadTimeData.overrideValues({profileShortcutsEnabled: false})
+
+    browserProxy = new BraveTestManageProfileBrowserProxy()
+    ManageProfileBrowserProxyImpl.setInstance(browserProxy)
+
+    createdUrls = []
+    revokedUrls = []
+    originalCreateObjectUrl = URL.createObjectURL
+    originalRevokeObjectUrl = URL.revokeObjectURL
+    originalDecode = HTMLImageElement.prototype.decode
+    URL.createObjectURL = () => {
+      const url = `blob:custom-profile-image-${createdUrls.length + 1}`
+      createdUrls.push(url)
+      return url
+    }
+    URL.revokeObjectURL = (url: string) => revokedUrls.push(url)
+    HTMLImageElement.prototype.decode = () => Promise.resolve()
+
+    manageProfile = createManageProfileElement()
+  })
+
+  teardown(function() {
+    manageProfile.remove()
+    URL.createObjectURL = originalCreateObjectUrl
+    URL.revokeObjectURL = originalRevokeObjectUrl
+    HTMLImageElement.prototype.decode = originalDecode
+  })
+
+  test('RendersLocalizedRowBetweenPickers', async function() {
+    assertTrue(loadTimeData.getBoolean('customProfileImageEnabled'))
+
+    const row = getCustomProfileImageRow(manageProfile)
+    assertTrue(!!row)
+    await row.updateComplete
+
+    const themePicker = getRequiredElement(
+      manageProfile.shadowRoot!,
+      'cr-theme-color-picker',
+    )
+    const avatarSelector = getRequiredElement(
+      manageProfile.shadowRoot!,
+      'cr-profile-avatar-selector',
+    )
+    const sections = Array.from(
+      manageProfile.shadowRoot!.querySelectorAll('.manage-profile-section'),
+    )
+    const themeSection = themePicker.closest('.manage-profile-section')
+    const customSection = row.closest('.manage-profile-section')
+    const avatarSection = avatarSelector.closest('.manage-profile-section')
+
+    assertEquals(sections.indexOf(themeSection!), sections.indexOf(customSection!) - 1)
+    assertEquals(sections.indexOf(customSection!), sections.indexOf(avatarSection!) - 1)
+    assertEquals('7', themePicker.getAttribute('columns'))
+    assertEquals('7', avatarSelector.getAttribute('columns'))
+
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION'),
+      row.titleLabel,
+    )
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REPLACE_ACTION'),
+      row.replaceLabel,
+    )
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REMOVE_ACTION'),
+      row.removeLabel,
+    )
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_PREVIEW_LABEL'),
+      row.previewLabel,
+    )
+    assertEquals(
+      loadTimeData.getStringF(
+        'CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL',
+        row.previewLabel,
+      ),
+      row.selectedPreviewLabel,
+    )
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP'),
+      row.uploadTooltip,
+    )
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_REMOVE_TOOLTIP'),
+      row.removeTooltip,
+    )
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_INVALID_IMAGE'),
+      row.invalidImageLabel,
+    )
+
+    const title = getRequiredElement<HTMLElement>(
+      customSection!,
+      '.cr-title-text',
+    )
+    assertEquals(
+      loadTimeData.getString('CUSTOM_PROFILE_IMAGE_TITLE'),
+      title.textContent.trim(),
+    )
+
+    assertEquals('empty', row.state)
+    assertTrue(row.hideTitle)
+    const preview = getRequiredElement<HTMLElement>(row.shadowRoot, '#preview')
+    assertEquals('CR-ICON-BUTTON', preview.tagName)
+    assertEquals('cr:add', preview.getAttribute('iron-icon'))
+    assertEquals(row.uploadTooltip, preview.getAttribute('aria-label'))
+
+    const uploadButton = getRequiredElement<HTMLElement>(
+      row.shadowRoot,
+      '#uploadButton',
+    )
+    assertEquals('CR-BUTTON', uploadButton.tagName)
+    assertEquals(row.titleLabel, uploadButton.textContent.trim())
+    assertEquals(
+      'image/*',
+      getRequiredElement<HTMLInputElement>(row.shadowRoot, '#fileInput').accept,
+    )
+    assertEquals(null, row.shadowRoot.querySelector('#removeButton'))
+  })
+
+  test('OpensFilePickerFromPreviewAndUploadButton', async function() {
+    const row = getRequiredCustomProfileImageRow(manageProfile)
+    await row.updateComplete
+
+    const fileInput = getRequiredElement<HTMLInputElement>(
+      row.shadowRoot,
+      '#fileInput',
+    )
+    let inputClickCount = 0
+    fileInput.click = () => ++inputClickCount
+
+    getRequiredElement<HTMLElement>(row.shadowRoot, '#preview').click()
+    assertEquals(1, inputClickCount)
+    getRequiredElement<HTMLElement>(row.shadowRoot, '#uploadButton').click()
+    assertEquals(2, inputClickCount)
+  })
+
+  test('UploadsValidImage', async function() {
+    const row = getRequiredCustomProfileImageRow(manageProfile)
+    selectFile(row, 'first.png')
+    await settleRow(row)
+
+    assertEquals('saved-active', row.state)
+    assertEquals(createdUrls[0], getPreviewUrl(row))
+    const preview = getRequiredElement<HTMLElement>(row.shadowRoot, '#preview')
+    assertEquals(row.selectedPreviewLabel, preview.getAttribute('aria-label'))
+    assertEquals(
+      'CR-ICON',
+      getRequiredElement<HTMLElement>(
+        row.shadowRoot,
+        '#selectedIndicator',
+      ).tagName,
+    )
+
+    const replaceButton = getRequiredElement<HTMLElement>(
+      row.shadowRoot,
+      '#uploadButton',
+    )
+    assertEquals('CR-BUTTON', replaceButton.tagName)
+    assertEquals(row.replaceLabel, replaceButton.textContent.trim())
+    assertEquals(row.replaceLabel, replaceButton.getAttribute('aria-label'))
+    assertEquals(
+      'CR-BUTTON',
+      getRequiredElement<HTMLElement>(row.shadowRoot, '#removeButton').tagName,
+    )
+    assertDeepEquals([], revokedUrls)
+  })
+
+  test('UsesConfiguredActionSpacing', async function() {
+    const row = getRequiredCustomProfileImageRow(manageProfile)
+    selectFile(row, 'first.png')
+    await settleRow(row)
+
+    const actions = getRequiredElement<HTMLElement>(row.shadowRoot, '#actions')
+    assertEquals('10px', getComputedStyle(actions).gap)
+  })
+
+  test('ReplacesImageAndChangesPreviewUrl', async function() {
+    const row = getRequiredCustomProfileImageRow(manageProfile)
+    selectFile(row, 'first.png')
+    await settleRow(row)
+    const firstPreviewUrl = getPreviewUrl(row)
+
+    selectFile(row, 'second.png')
+    await settleRow(row)
+
+    assertEquals(createdUrls[1], getPreviewUrl(row))
+    assertFalse(firstPreviewUrl === getPreviewUrl(row))
+    assertDeepEquals([createdUrls[0]], revokedUrls)
+  })
+
+  test('RemovesImageAndRevokesUrl', async function() {
+    const row = getRequiredCustomProfileImageRow(manageProfile)
+    selectFile(row, 'first.png')
+    await settleRow(row)
+
+    getRequiredElement<HTMLElement>(row.shadowRoot, '#removeButton').click()
+    await settleRow(row)
+
+    assertEquals('empty', row.state)
+    assertEquals(null, getPreviewUrl(row))
+    assertEquals(null, row.shadowRoot.querySelector('#removeButton'))
+    assertDeepEquals([createdUrls[0]], revokedUrls)
+  })
+
+  test('RejectsNonImageFile', async function() {
+    const row = getRequiredCustomProfileImageRow(manageProfile)
+    selectFile(row, 'not-an-image.txt', 'text/plain')
+    await settleRow(row)
+
+    assertEquals('empty', row.state)
+    assertEquals(null, getPreviewUrl(row))
+    assertDeepEquals([], createdUrls)
+    assertDeepEquals([], revokedUrls)
+    assertEquals(
+      row.invalidImageLabel,
+      getRequiredElement(row.shadowRoot, '#fileError').textContent,
+    )
+  })
+
+  test('RejectsCorruptImageAndPreservesPreview', async function() {
+    const row = getRequiredCustomProfileImageRow(manageProfile)
+    selectFile(row, 'first.png')
+    await settleRow(row)
+    const firstPreviewUrl = getPreviewUrl(row)
+
+    HTMLImageElement.prototype.decode = () =>
+      Promise.reject(new Error('Image decode failed'))
+    selectFile(row, 'corrupt.png')
+    await settleRow(row)
+
+    assertEquals('saved-active', row.state)
+    assertEquals(firstPreviewUrl, getPreviewUrl(row))
+    assertEquals(
+      row.invalidImageLabel,
+      getRequiredElement(row.shadowRoot, '#fileError').textContent,
+    )
+    assertDeepEquals([createdUrls[1]], revokedUrls)
+  })
+
+  test('NewestOverlappingUploadWins', async function() {
+    const row = getRequiredCustomProfileImageRow(manageProfile)
+    const decodeResolvers = useDeferredImageDecodes()
+
+    selectFile(row, 'stale.png')
+    selectFile(row, 'newest.png')
+    assertEquals(2, decodeResolvers.length)
+
+    decodeResolvers[1]!.resolve()
+    await settleRow(row)
+    assertEquals('saved-active', row.state)
+    assertEquals(createdUrls[1], getPreviewUrl(row))
+
+    decodeResolvers[0]!.resolve()
+    await settleRow(row)
+    assertEquals(createdUrls[1], getPreviewUrl(row))
+    assertDeepEquals([createdUrls[0]], revokedUrls)
+  })
+
+  test('RemovalWhileDecodePendingCleansUpUrls', async function() {
+    const row = getRequiredCustomProfileImageRow(manageProfile)
+    selectFile(row, 'active.png')
+    await settleRow(row)
+
+    const decodeResolvers = useDeferredImageDecodes()
+    selectFile(row, 'pending.png')
+    assertEquals(1, decodeResolvers.length)
+
+    getRequiredElement<HTMLElement>(row.shadowRoot, '#removeButton').click()
+    await settleRow(row)
+    assertEquals('empty', row.state)
+    assertDeepEquals([createdUrls[0]], revokedUrls)
+
+    decodeResolvers[0]!.resolve()
+    await settleRow(row)
+    assertEquals('empty', row.state)
+    assertEquals(null, getPreviewUrl(row))
+    assertDeepEquals(createdUrls, revokedUrls)
+  })
+
+  test('DisconnectWhileDecodePendingRevokesUrl', async function() {
+    const row = getRequiredCustomProfileImageRow(manageProfile)
+    const decodeResolvers = useDeferredImageDecodes()
+    selectFile(row, 'pending.png')
+    assertEquals(1, decodeResolvers.length)
+
+    manageProfile.remove()
+    decodeResolvers[0]!.resolve()
+    await settleRow(row)
+
+    assertEquals('empty', row.state)
+    assertEquals(null, getPreviewUrl(row))
+    assertDeepEquals([createdUrls[0]], revokedUrls)
+  })
+
+  test('DisconnectWhileActiveRevokesUrl', async function() {
+    const row = getRequiredCustomProfileImageRow(manageProfile)
+    selectFile(row, 'active.png')
+    await settleRow(row)
+
+    manageProfile.remove()
+    await settleRow(row)
+
+    assertEquals('empty', row.state)
+    assertEquals(null, getPreviewUrl(row))
+    assertDeepEquals([createdUrls[0]], revokedUrls)
+  })
+
+  test('RecreatingPageDropsSessionImageAndRevokesUrl', async function() {
+    const row = getRequiredCustomProfileImageRow(manageProfile)
+    selectFile(row, 'active.png')
+    await settleRow(row)
+    assertEquals(createdUrls[0], getPreviewUrl(row))
+
+    manageProfile.remove()
+    assertDeepEquals([createdUrls[0]], revokedUrls)
+    manageProfile = createManageProfileElement()
+
+    const recreatedRow = getRequiredCustomProfileImageRow(manageProfile)
+    await recreatedRow.updateComplete
+    assertEquals('empty', recreatedRow.state)
+    assertEquals(null, getPreviewUrl(recreatedRow))
+    assertDeepEquals([createdUrls[0]], revokedUrls)
+  })
+
+  test('KeepsPresetAvatarSelectionWorkingAfterUpload', async function() {
+    const row = getRequiredCustomProfileImageRow(manageProfile)
+    selectFile(row, 'active.png')
+    await settleRow(row)
+    const customPreviewUrl = getPreviewUrl(row)
+
+    await browserProxy.whenCalled('getAvailableIcons')
+    await microtasksFinished()
+    const avatarSelector = getRequiredElement(
+      manageProfile.shadowRoot!,
+      'cr-profile-avatar-selector',
+    )
+    const avatar = getRequiredElement<HTMLElement>(
+      avatarSelector.shadowRoot!,
+      '.avatar-container > .avatar',
+    )
+    avatar.click()
+
+    const args = await browserProxy.whenCalled('setProfileIconToDefaultAvatar')
+    assertEquals(1, args[0])
+    assertEquals('saved-active', row.state)
+    assertEquals(customPreviewUrl, getPreviewUrl(row))
+  })
+}
+
+if (loadTimeData.getBoolean('customProfileImageEnabled')) {
+  suite(
+    'BraveManageProfileFeatureEnabledTests',
+    braveManageProfileFeatureEnabledTests,
+  )
+} else {
+  suite(
+    'BraveManageProfileFeatureDisabledTests',
+    braveManageProfileFeatureDisabledTests,
+  )
+}
+
+// </if>

--- a/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
+++ b/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
@@ -318,6 +318,7 @@ function braveManageProfileFeatureEnabledTests() {
     const preview = getRequiredElement<HTMLElement>(row.shadowRoot, '#preview')
     assertEquals('CR-ICON-BUTTON', preview.tagName)
     assertEquals('cr:add', preview.getAttribute('iron-icon'))
+    assertEquals(row.uploadTooltip, preview.getAttribute('title'))
     assertEquals(row.uploadTooltip, preview.getAttribute('aria-label'))
 
     const uploadButton = getRequiredElement<HTMLElement>(

--- a/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
+++ b/chromium_src/chrome/test/data/webui/settings/people_page_manage_profile_test.ts
@@ -26,7 +26,6 @@ import {
   ProfileShortcutStatus,
 } from 'chrome://settings/lazy_load.js'
 import {
-  assertDeepEquals,
   assertEquals,
   assertFalse,
   assertTrue,
@@ -165,13 +164,6 @@ function selectFile(
   input.dispatchEvent(new Event('change'))
 }
 
-async function settleRow(row: BrCustomProfileImageRowElement) {
-  await microtasksFinished()
-  await row.updateComplete
-  await microtasksFinished()
-  await row.updateComplete
-}
-
 function braveManageProfileFeatureDisabledTests() {
   let manageProfile: SettingsManageProfileElement
 
@@ -200,8 +192,6 @@ function braveManageProfileFeatureEnabledTests() {
   let manageProfile: SettingsManageProfileElement
   let originalCreateObjectUrl: typeof URL.createObjectURL
   let originalDecode: typeof HTMLImageElement.prototype.decode
-  let originalRevokeObjectUrl: typeof URL.revokeObjectURL
-  let revokedUrls: string[]
 
   setup(function() {
     document.body.replaceChildren()
@@ -211,16 +201,13 @@ function braveManageProfileFeatureEnabledTests() {
     ManageProfileBrowserProxyImpl.setInstance(browserProxy)
 
     createdUrls = []
-    revokedUrls = []
     originalCreateObjectUrl = URL.createObjectURL
-    originalRevokeObjectUrl = URL.revokeObjectURL
     originalDecode = HTMLImageElement.prototype.decode
     URL.createObjectURL = () => {
       const url = `blob:custom-profile-image-${createdUrls.length + 1}`
       createdUrls.push(url)
       return url
     }
-    URL.revokeObjectURL = (url: string) => revokedUrls.push(url)
     HTMLImageElement.prototype.decode = () => Promise.resolve()
 
     manageProfile = createManageProfileElement()
@@ -229,7 +216,6 @@ function braveManageProfileFeatureEnabledTests() {
   teardown(function() {
     manageProfile.remove()
     URL.createObjectURL = originalCreateObjectUrl
-    URL.revokeObjectURL = originalRevokeObjectUrl
     HTMLImageElement.prototype.decode = originalDecode
   })
 
@@ -292,68 +278,63 @@ function braveManageProfileFeatureEnabledTests() {
   test('UploadsValidImage', async function() {
     const row = getRequiredCustomProfileImageRow(manageProfile)
     selectFile(row, 'first.png')
-    await settleRow(row)
+    await microtasksFinished()
 
     assertEquals(createdUrls[0], getPreviewUrl(row))
     getRequiredElement(row.shadowRoot, '#preview')
     getRequiredElement(row.shadowRoot, '#selectedIndicator')
     getRequiredElement(row.shadowRoot, '#uploadButton')
     getRequiredElement(row.shadowRoot, '#removeButton')
-    assertDeepEquals([], revokedUrls)
   })
 
   test('ReplacesImageAndChangesPreviewUrl', async function() {
     const row = getRequiredCustomProfileImageRow(manageProfile)
     selectFile(row, 'first.png')
-    await settleRow(row)
+    await microtasksFinished()
 
     selectFile(row, 'second.png')
-    await settleRow(row)
+    await microtasksFinished()
 
     assertEquals(createdUrls[1], getPreviewUrl(row))
-    assertDeepEquals([createdUrls[0]], revokedUrls)
   })
 
-  test('RemovesImageAndRevokesUrl', async function() {
+  test('RemovesImage', async function() {
     const row = getRequiredCustomProfileImageRow(manageProfile)
     selectFile(row, 'first.png')
-    await settleRow(row)
+    await microtasksFinished()
 
     getRequiredElement<HTMLElement>(row.shadowRoot, '#removeButton').click()
-    await settleRow(row)
+    await microtasksFinished()
 
     assertEquals(null, getPreviewUrl(row))
     assertEquals(null, row.shadowRoot.querySelector('#removeButton'))
     getRequiredElement(row.shadowRoot, '#uploadButton')
-    assertDeepEquals([createdUrls[0]], revokedUrls)
   })
 
   test('RejectsNonImageFile', async function() {
     const row = getRequiredCustomProfileImageRow(manageProfile)
     selectFile(row, 'not-an-image.txt', 'text/plain')
-    await settleRow(row)
+    await microtasksFinished()
 
     assertEquals(null, getPreviewUrl(row))
     assertEquals(null, row.shadowRoot.querySelector('#removeButton'))
-    assertDeepEquals([], createdUrls)
-    assertDeepEquals([], revokedUrls)
+    assertEquals(0, createdUrls.length)
     getRequiredElement(row.shadowRoot, '#fileError')
   })
 
   test('RejectsCorruptImageAndPreservesPreview', async function() {
     const row = getRequiredCustomProfileImageRow(manageProfile)
     selectFile(row, 'first.png')
-    await settleRow(row)
+    await microtasksFinished()
     const firstPreviewUrl = getPreviewUrl(row)
 
     HTMLImageElement.prototype.decode = () =>
       Promise.reject(new Error('Image decode failed'))
     selectFile(row, 'corrupt.png')
-    await settleRow(row)
+    await microtasksFinished()
 
     assertEquals(firstPreviewUrl, getPreviewUrl(row))
     getRequiredElement(row.shadowRoot, '#fileError')
-    assertDeepEquals([createdUrls[1]], revokedUrls)
   })
 
   test('NewestOverlappingUploadWins', async function() {
@@ -365,83 +346,52 @@ function braveManageProfileFeatureEnabledTests() {
     assertEquals(2, decodeResolvers.length)
 
     decodeResolvers[1]!.resolve()
-    await settleRow(row)
+    await microtasksFinished()
     assertEquals(createdUrls[1], getPreviewUrl(row))
 
     decodeResolvers[0]!.resolve()
-    await settleRow(row)
+    await microtasksFinished()
     assertEquals(createdUrls[1], getPreviewUrl(row))
-    assertDeepEquals([createdUrls[0]], revokedUrls)
   })
 
-  test('RemovalWhileDecodePendingCleansUpUrls', async function() {
+  test('RemovalInvalidatesPendingUpload', async function() {
     const row = getRequiredCustomProfileImageRow(manageProfile)
     selectFile(row, 'active.png')
-    await settleRow(row)
+    await microtasksFinished()
 
     const decodeResolvers = useDeferredImageDecodes()
     selectFile(row, 'pending.png')
     assertEquals(1, decodeResolvers.length)
 
     getRequiredElement<HTMLElement>(row.shadowRoot, '#removeButton').click()
-    await settleRow(row)
+    await microtasksFinished()
     assertEquals(null, getPreviewUrl(row))
     assertEquals(null, row.shadowRoot.querySelector('#removeButton'))
-    assertDeepEquals([createdUrls[0]], revokedUrls)
 
     decodeResolvers[0]!.resolve()
-    await settleRow(row)
+    await microtasksFinished()
     assertEquals(null, getPreviewUrl(row))
-    assertDeepEquals(createdUrls, revokedUrls)
   })
 
-  test('DisconnectWhileDecodePendingRevokesUrl', async function() {
-    const row = getRequiredCustomProfileImageRow(manageProfile)
-    const decodeResolvers = useDeferredImageDecodes()
-    selectFile(row, 'pending.png')
-    assertEquals(1, decodeResolvers.length)
-
-    manageProfile.remove()
-    decodeResolvers[0]!.resolve()
-    await settleRow(row)
-
-    assertEquals(null, getPreviewUrl(row))
-    assertDeepEquals([createdUrls[0]], revokedUrls)
-  })
-
-  test('DisconnectWhileActiveRevokesUrl', async function() {
+  test('RecreatingPageDropsSessionImage', async function() {
     const row = getRequiredCustomProfileImageRow(manageProfile)
     selectFile(row, 'active.png')
-    await settleRow(row)
-
-    manageProfile.remove()
-    await settleRow(row)
-
-    assertEquals(null, getPreviewUrl(row))
-    assertDeepEquals([createdUrls[0]], revokedUrls)
-  })
-
-  test('RecreatingPageDropsSessionImageAndRevokesUrl', async function() {
-    const row = getRequiredCustomProfileImageRow(manageProfile)
-    selectFile(row, 'active.png')
-    await settleRow(row)
+    await microtasksFinished()
     assertEquals(createdUrls[0], getPreviewUrl(row))
 
     manageProfile.remove()
-    assertDeepEquals([createdUrls[0]], revokedUrls)
     manageProfile = createManageProfileElement()
 
     const recreatedRow = getRequiredCustomProfileImageRow(manageProfile)
     await recreatedRow.updateComplete
     assertEquals(null, getPreviewUrl(recreatedRow))
     assertEquals(null, recreatedRow.shadowRoot.querySelector('#removeButton'))
-    assertDeepEquals([createdUrls[0]], revokedUrls)
   })
 
   test('KeepsPresetAvatarSelectionWorkingAfterUpload', async function() {
     const row = getRequiredCustomProfileImageRow(manageProfile)
     selectFile(row, 'active.png')
-    await settleRow(row)
+    await microtasksFinished()
     const customPreviewUrl = getPreviewUrl(row)
 
     await browserProxy.whenCalled('getAvailableIcons')

--- a/ui/webui/resources/BUILD.gn
+++ b/ui/webui/resources/BUILD.gn
@@ -6,6 +6,7 @@
 import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//brave/components/common/typescript.gni")
 import("//brave/components/speedreader/common/buildflags/buildflags.gni")
+import("//brave/ui/webui/custom_profile_image_config.gni")
 import("//tools/grit/preprocess_if_expr.gni")
 import("//tools/polymer/css_to_wrapper.gni")
 import("//tools/polymer/html_to_wrapper.gni")
@@ -56,6 +57,14 @@ if (include_polymer) {
       "page_specific/settings/br_settings_shared.css",
       "page_specific/settings/br_settings_shared_lit.css",
     ]
+
+    if (enable_brave_custom_profile_image_webui) {
+      ts_files += [
+        "custom_profile_image_row.html.ts",
+        "custom_profile_image_row.ts",
+      ]
+      css_files += [ "custom_profile_image_row.css" ]
+    }
 
     ts_composite = true
     generate_grdp = true

--- a/ui/webui/resources/BUILD.gn
+++ b/ui/webui/resources/BUILD.gn
@@ -63,6 +63,10 @@ if (include_polymer) {
         "custom_profile_image_row.html.ts",
         "custom_profile_image_row.ts",
       ]
+      mojo_files += [
+        "$root_gen_dir/brave/grit/brave_generated_resources_webui_strings.ts",
+      ]
+      mojo_files_deps += [ "//brave/app:brave_generated_resources_grit" ]
       css_files += [ "custom_profile_image_row.css" ]
     }
 

--- a/ui/webui/resources/custom_profile_image_row.css
+++ b/ui/webui/resources/custom_profile_image_row.css
@@ -8,40 +8,41 @@
  * #css_wrapper_metadata_end */
 
 :host {
-  color: var(--cr-primary-text-color, currentColor);
+  color: var(--leo-color-text-primary);
   display: block;
   width: 100%;
 }
 
 #row {
-  --avatar-size: var(--icon-size, 66px);
-  --selected-border: 4px;
+  --avatar-size: var(--icon-size, var(--leo-spacing-6xl));
+  --selected-border: var(--leo-spacing-s);
 
   align-items: center;
   box-sizing: border-box;
-  column-gap: var(--icon-grid-gap, 22px);
+  column-gap: var(--icon-grid-gap, var(--leo-spacing-2xl));
   display: grid;
   grid-template-areas:
     'title title'
     'preview actions';
-  grid-template-columns: calc(var(--avatar-size) + 2px) auto;
+  grid-template-columns:
+    calc(var(--avatar-size) + var(--leo-spacing-xs)) auto;
   justify-content: start;
   min-height: 0;
-  padding-block-start: 4px;
-  padding-inline-start: 3px;
-  row-gap: 18px;
+  padding-block-start: var(--leo-spacing-s);
+  padding-inline-start: var(--leo-spacing-s);
+  row-gap: var(--leo-spacing-xl);
   width: 100%;
 }
 
 #preview {
-  --avatar-selected-color: rgba(var(--google-blue-600-rgb), 0.4);
+  --avatar-selected-color: var(--leo-color-divider-interactive);
 
   align-items: center;
-  background: var(--cr-hover-background-color, rgba(0, 0, 0, 0.06));
-  border: 1px solid var(--google-grey-300);
-  border-radius: 100%;
+  background: var(--leo-color-container-highlight);
+  border: 1px solid var(--leo-color-divider-subtle);
+  border-radius: var(--leo-radius-full);
   box-sizing: content-box;
-  color: var(--cr-secondary-text-color, currentColor);
+  color: var(--leo-color-icon-default);
   display: inline-flex;
   height: var(--avatar-size);
   justify-content: center;
@@ -50,10 +51,10 @@
   width: var(--avatar-size);
 }
 
-cr-icon-button#preview {
-  --cr-icon-button-fill-color: var(--cr-secondary-text-color, currentColor);
-  --cr-icon-button-icon-size: 24px;
-  --cr-icon-button-size: var(--avatar-size);
+leo-button#preview {
+  --leo-button-color: var(--leo-color-icon-default);
+
+  flex: none;
 }
 
 #preview.selected {
@@ -61,26 +62,33 @@ cr-icon-button#preview {
 }
 
 #previewImage {
-  border-radius: 100%;
+  border-radius: var(--leo-radius-full);
   height: 100%;
   object-fit: cover;
   width: 100%;
 }
 
 #plusIcon {
-  --iron-icon-fill-color: var(--cr-secondary-text-color, currentColor);
-  --iron-icon-height: 24px;
-  --iron-icon-width: 24px;
+  --iron-icon-fill-color: var(--leo-color-icon-default);
+  --iron-icon-height: var(--leo-icon-l);
+  --iron-icon-width: var(--leo-icon-l);
+  --leo-icon-color: var(--leo-color-icon-default);
+  --leo-icon-size: var(--leo-icon-l);
+}
+
+#previewLabel {
+  clip-path: inset(100%);
+  position: fixed;
 }
 
 #selectedIndicator {
-  --checkmark-size: 21px;
-  --iron-icon-fill-color: white;
-  --iron-icon-height: var(--checkmark-size);
-  --iron-icon-width: var(--checkmark-size);
+  --checkmark-size: var(--leo-icon-m);
+  --leo-icon-color: var(--leo-color-schemes-on-primary);
+  --leo-icon-height: var(--checkmark-size);
+  --leo-icon-width: var(--checkmark-size);
 
-  background: var(--google-blue-600);
-  border-radius: 100%;
+  background: var(--leo-color-icon-interactive);
+  border-radius: var(--leo-radius-full);
   height: var(--checkmark-size);
   inset-inline-end: -1px;
   padding: 1px;
@@ -89,27 +97,18 @@ cr-icon-button#preview {
   width: var(--checkmark-size);
 }
 
-@media (prefers-color-scheme: dark) {
-  #selectedIndicator {
-    --iron-icon-fill-color: var(--google-grey-900);
-
-    background: var(--google-blue-300);
-  }
-}
-
 #actions {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: var(--leo-spacing-l);
   justify-content: flex-start;
 }
 
 #fileError {
-  color: var(--cr-error-text-color, var(--google-red-600));
-  font-size: 12px;
+  color: var(--leo-color-systemfeedback-error-text);
+  font: var(--leo-font-small-regular);
   grid-column: 1 / -1;
-  line-height: 16px;
 }
 
 #row.title-hidden {
@@ -118,10 +117,8 @@ cr-icon-button#preview {
 }
 
 #row #title {
+  font: var(--leo-font-heading-h3);
   grid-area: title;
-  font-size: 20px;
-  font-weight: 600;
-  line-height: 28px;
 }
 
 #row #preview {
@@ -132,11 +129,9 @@ cr-icon-button#preview {
   grid-area: actions;
 }
 
-#row #actions cr-button {
-  --cr-button-height: 40px;
-  --leo-button-padding: 0 26px;
+#row #actions leo-button {
+  --leo-button-padding: 0 var(--leo-spacing-2xl);
 
-  font-size: 16px;
-  font-weight: 500;
+  flex: none;
   min-width: 104px;
 }

--- a/ui/webui/resources/custom_profile_image_row.css
+++ b/ui/webui/resources/custom_profile_image_row.css
@@ -108,9 +108,13 @@ leo-button#preview {
   grid-column: 1 / -1;
 }
 
-#row.title-hidden {
+:host([hide-title]) #row {
   grid-template-areas: 'preview actions';
   row-gap: 0;
+}
+
+:host([hide-title]) #title {
+  display: none;
 }
 
 #row #title {

--- a/ui/webui/resources/custom_profile_image_row.css
+++ b/ui/webui/resources/custom_profile_image_row.css
@@ -1,0 +1,142 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/* #css_wrapper_metadata_start
+ * #type=style-lit
+ * #css_wrapper_metadata_end */
+
+:host {
+  color: var(--cr-primary-text-color, currentColor);
+  display: block;
+  width: 100%;
+}
+
+#row {
+  --avatar-size: var(--icon-size, 66px);
+  --selected-border: 4px;
+
+  align-items: center;
+  box-sizing: border-box;
+  column-gap: var(--icon-grid-gap, 22px);
+  display: grid;
+  grid-template-areas:
+    'title title'
+    'preview actions';
+  grid-template-columns: calc(var(--avatar-size) + 2px) auto;
+  justify-content: start;
+  min-height: 0;
+  padding-block-start: 4px;
+  padding-inline-start: 3px;
+  row-gap: 18px;
+  width: 100%;
+}
+
+#preview {
+  --avatar-selected-color: rgba(var(--google-blue-600-rgb), 0.4);
+
+  align-items: center;
+  background: var(--cr-hover-background-color, rgba(0, 0, 0, 0.06));
+  border: 1px solid var(--google-grey-300);
+  border-radius: 100%;
+  box-sizing: content-box;
+  color: var(--cr-secondary-text-color, currentColor);
+  display: inline-flex;
+  height: var(--avatar-size);
+  justify-content: center;
+  padding: 0;
+  position: relative;
+  width: var(--avatar-size);
+}
+
+cr-icon-button#preview {
+  --cr-icon-button-fill-color: var(--cr-secondary-text-color, currentColor);
+  --cr-icon-button-icon-size: 24px;
+  --cr-icon-button-size: var(--avatar-size);
+}
+
+#preview.selected {
+  outline: var(--selected-border) solid var(--avatar-selected-color);
+}
+
+#previewImage {
+  border-radius: 100%;
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+#plusIcon {
+  --iron-icon-fill-color: var(--cr-secondary-text-color, currentColor);
+  --iron-icon-height: 24px;
+  --iron-icon-width: 24px;
+}
+
+#selectedIndicator {
+  --checkmark-size: 21px;
+  --iron-icon-fill-color: white;
+  --iron-icon-height: var(--checkmark-size);
+  --iron-icon-width: var(--checkmark-size);
+
+  background: var(--google-blue-600);
+  border-radius: 100%;
+  height: var(--checkmark-size);
+  inset-inline-end: -1px;
+  padding: 1px;
+  position: absolute;
+  top: -1px;
+  width: var(--checkmark-size);
+}
+
+@media (prefers-color-scheme: dark) {
+  #selectedIndicator {
+    --iron-icon-fill-color: var(--google-grey-900);
+
+    background: var(--google-blue-300);
+  }
+}
+
+#actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-start;
+}
+
+#fileError {
+  color: var(--cr-error-text-color, var(--google-red-600));
+  font-size: 12px;
+  grid-column: 1 / -1;
+  line-height: 16px;
+}
+
+#row.title-hidden {
+  grid-template-areas: 'preview actions';
+  row-gap: 0;
+}
+
+#row #title {
+  grid-area: title;
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 28px;
+}
+
+#row #preview {
+  grid-area: preview;
+}
+
+#row #actions {
+  grid-area: actions;
+}
+
+#row #actions cr-button {
+  --cr-button-height: 40px;
+  --leo-button-padding: 0 26px;
+
+  font-size: 16px;
+  font-weight: 500;
+  min-width: 104px;
+}

--- a/ui/webui/resources/custom_profile_image_row.css
+++ b/ui/webui/resources/custom_profile_image_row.css
@@ -36,6 +36,7 @@
 
 #preview {
   --avatar-selected-color: var(--leo-color-divider-interactive);
+  --leo-button-color: var(--leo-color-icon-default);
 
   align-items: center;
   background: var(--leo-color-container-highlight);
@@ -49,12 +50,6 @@
   padding: 0;
   position: relative;
   width: var(--avatar-size);
-}
-
-leo-button#preview {
-  --leo-button-color: var(--leo-color-icon-default);
-
-  flex: none;
 }
 
 #preview.selected {
@@ -79,19 +74,17 @@ leo-button#preview {
 }
 
 #selectedIndicator {
-  --checkmark-size: var(--leo-icon-m);
   --leo-icon-color: var(--leo-color-schemes-on-primary);
-  --leo-icon-height: var(--checkmark-size);
-  --leo-icon-width: var(--checkmark-size);
+  --leo-icon-size: var(--leo-icon-m);
 
   background: var(--leo-color-icon-interactive);
   border-radius: var(--leo-radius-full);
-  height: var(--checkmark-size);
+  height: var(--leo-icon-m);
   inset-inline-end: -1px;
   padding: 1px;
   position: absolute;
   top: -1px;
-  width: var(--checkmark-size);
+  width: var(--leo-icon-m);
 }
 
 #actions {

--- a/ui/webui/resources/custom_profile_image_row.css
+++ b/ui/webui/resources/custom_profile_image_row.css
@@ -69,9 +69,6 @@ leo-button#preview {
 }
 
 #plusIcon {
-  --iron-icon-fill-color: var(--leo-color-icon-default);
-  --iron-icon-height: var(--leo-icon-l);
-  --iron-icon-width: var(--leo-icon-l);
   --leo-icon-color: var(--leo-color-icon-default);
   --leo-icon-size: var(--leo-icon-l);
 }

--- a/ui/webui/resources/custom_profile_image_row.html.ts
+++ b/ui/webui/resources/custom_profile_image_row.html.ts
@@ -12,7 +12,7 @@ import {CustomProfileImageStrings as S} from './brave_generated_resources_webui_
 import type {BrCustomProfileImageRowElement} from './custom_profile_image_row.js'
 
 export function getHtml(this: BrCustomProfileImageRowElement) {
-  return html`<!--_html_template_start_-->
+  return html`
     <section id="row" aria-labelledby="title">
       ${this.hasPreview_()
         ? html`
@@ -20,7 +20,9 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
               id="preview"
               class="selected"
               role="img"
-              aria-label="$i18n{CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL}"
+              aria-label="${loadTimeData.getString(
+                S.CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL,
+              )}"
             >
               <img
                 id="previewImage"
@@ -110,5 +112,5 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
         @change="${this.onFileChange_}"
       />
     </section>
-    <!--_html_template_end_-->`
+  `
 }

--- a/ui/webui/resources/custom_profile_image_row.html.ts
+++ b/ui/webui/resources/custom_profile_image_row.html.ts
@@ -27,7 +27,7 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
               id="preview"
               class="selected"
               role="img"
-              aria-label="${this.selectedPreviewLabel || this.previewLabel}"
+              aria-label="${this.selectedPreviewLabel}"
             >
               ${this.localPreviewUrl_
                 ? html`<img
@@ -53,7 +53,7 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
               class="no-overlap"
               iron-icon="cr:add"
               title="${this.uploadTooltip || nothing}"
-              aria-label="${this.uploadTooltip || this.previewLabel}"
+              aria-label="${this.uploadTooltip}"
               @click="${this.onUploadClick_}"
             ></cr-icon-button>
           `}

--- a/ui/webui/resources/custom_profile_image_row.html.ts
+++ b/ui/webui/resources/custom_profile_image_row.html.ts
@@ -3,9 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import '//resources/cr_elements/cr_button/cr_button.js'
+import '//resources/brave/leo.bundle.js'
 import '//resources/cr_elements/cr_icon/cr_icon.js'
-import '//resources/cr_elements/cr_icon_button/cr_icon_button.js'
 import '//resources/cr_elements/icons.html.js'
 
 import {html, nothing} from '//resources/lit/v3_0/lit.rollup.js'
@@ -40,22 +39,30 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
                     icon="cr:add"
                     aria-hidden="true"
                   ></cr-icon>`}
-              <cr-icon
+              <leo-icon
                 id="selectedIndicator"
-                icon="cr:check"
+                name="check-normal"
                 aria-hidden="true"
-              ></cr-icon>
+              ></leo-icon>
             </div>
           `
         : html`
-            <cr-icon-button
+            <leo-button
               id="preview"
-              class="no-overlap"
-              iron-icon="cr:add"
+              kind="plain-faint"
+              size="jumbo"
+              fab
               title="${this.uploadTooltip}"
-              aria-label="${this.uploadTooltip}"
               @click="${this.onUploadClick_}"
-            ></cr-icon-button>
+            >
+              <leo-icon
+                id="plusIcon"
+                name="plus-add"
+                slot="icon-before"
+                aria-hidden="true"
+              ></leo-icon>
+              <span id="previewLabel">${this.uploadTooltip}</span>
+            </leo-button>
           `}
 
       ${this.shouldRenderTitle_()
@@ -63,25 +70,29 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
         : nothing}
 
       <div id="actions">
-        <cr-button
+        <leo-button
           id="uploadButton"
           class="action-button"
+          kind="filled"
+          size="small"
           title="${this.getUploadButtonTooltip_()}"
           aria-label="${this.getUploadButtonTooltip_()}"
           @click="${this.onUploadClick_}"
         >
           ${this.isSaved_() ? this.replaceLabel : this.titleLabel}
-        </cr-button>
+        </leo-button>
         ${this.isSaved_()
           ? html`
-              <cr-button
+              <leo-button
                 id="removeButton"
+                kind="outline"
+                size="small"
                 title="${this.removeTooltip}"
                 aria-label="${this.removeTooltip}"
                 @click="${this.onRemoveClick_}"
               >
                 ${this.removeLabel}
-              </cr-button>
+              </leo-button>
             `
           : nothing}
       </div>

--- a/ui/webui/resources/custom_profile_image_row.html.ts
+++ b/ui/webui/resources/custom_profile_image_row.html.ts
@@ -13,10 +13,8 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
   return html`
     <section
       id="row"
-      class="state-${this.getState_()}
-        ${this.shouldRenderTitle_() ? '' : 'title-hidden'}"
-      aria-labelledby="${this.shouldRenderTitle_() ? 'title' : nothing}"
-      aria-label="${this.shouldRenderTitle_() ? nothing : this.titleLabel}"
+      class="state-${this.getState_()}"
+      aria-labelledby="title"
     >
       ${this.isSaved_()
         ? html`
@@ -57,9 +55,7 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
             </leo-button>
           `}
 
-      ${this.shouldRenderTitle_()
-        ? html`<div id="title">${this.titleLabel}</div>`
-        : nothing}
+      <div id="title">${this.titleLabel}</div>
 
       <div id="actions">
         <leo-button

--- a/ui/webui/resources/custom_profile_image_row.html.ts
+++ b/ui/webui/resources/custom_profile_image_row.html.ts
@@ -52,6 +52,7 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
               id="preview"
               class="no-overlap"
               iron-icon="cr:add"
+              title="${this.uploadTooltip || nothing}"
               aria-label="${this.uploadTooltip || this.previewLabel}"
               @click="${this.onUploadClick_}"
             ></cr-icon-button>

--- a/ui/webui/resources/custom_profile_image_row.html.ts
+++ b/ui/webui/resources/custom_profile_image_row.html.ts
@@ -4,8 +4,6 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import '//resources/brave/leo.bundle.js'
-import '//resources/cr_elements/cr_icon/cr_icon.js'
-import '//resources/cr_elements/icons.html.js'
 
 import {html, nothing} from '//resources/lit/v3_0/lit.rollup.js'
 
@@ -15,7 +13,7 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
   return html`
     <section
       id="row"
-      class="state-${this.state}
+      class="state-${this.getState_()}
         ${this.shouldRenderTitle_() ? '' : 'title-hidden'}"
       aria-labelledby="${this.shouldRenderTitle_() ? 'title' : nothing}"
       aria-label="${this.shouldRenderTitle_() ? nothing : this.titleLabel}"
@@ -28,17 +26,11 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
               role="img"
               aria-label="${this.selectedPreviewLabel}"
             >
-              ${this.localPreviewUrl_
-                ? html`<img
-                    id="previewImage"
-                    alt=""
-                    src="${this.localPreviewUrl_}"
-                  />`
-                : html`<cr-icon
-                    id="plusIcon"
-                    icon="cr:add"
-                    aria-hidden="true"
-                  ></cr-icon>`}
+              <img
+                id="previewImage"
+                alt=""
+                src="${this.localPreviewUrl_}"
+              />
               <leo-icon
                 id="selectedIndicator"
                 name="check-normal"

--- a/ui/webui/resources/custom_profile_image_row.html.ts
+++ b/ui/webui/resources/custom_profile_image_row.html.ts
@@ -52,7 +52,7 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
               id="preview"
               class="no-overlap"
               iron-icon="cr:add"
-              title="${this.uploadTooltip || nothing}"
+              title="${this.uploadTooltip}"
               aria-label="${this.uploadTooltip}"
               @click="${this.onUploadClick_}"
             ></cr-icon-button>
@@ -66,8 +66,8 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
         <cr-button
           id="uploadButton"
           class="action-button"
-          title="${this.getUploadButtonTooltip_() || nothing}"
-          aria-label="${this.getUploadButtonTooltip_() || nothing}"
+          title="${this.getUploadButtonTooltip_()}"
+          aria-label="${this.getUploadButtonTooltip_()}"
           @click="${this.onUploadClick_}"
         >
           ${this.isSaved_() ? this.replaceLabel : this.titleLabel}
@@ -76,8 +76,8 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
           ? html`
               <cr-button
                 id="removeButton"
-                title="${this.removeTooltip || nothing}"
-                aria-label="${this.removeTooltip || nothing}"
+                title="${this.removeTooltip}"
+                aria-label="${this.removeTooltip}"
                 @click="${this.onRemoveClick_}"
               >
                 ${this.removeLabel}

--- a/ui/webui/resources/custom_profile_image_row.html.ts
+++ b/ui/webui/resources/custom_profile_image_row.html.ts
@@ -64,7 +64,6 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
       <div id="actions">
         <leo-button
           id="uploadButton"
-          class="action-button"
           kind="filled"
           size="small"
           title="${this.actionTooltip_()}"

--- a/ui/webui/resources/custom_profile_image_row.html.ts
+++ b/ui/webui/resources/custom_profile_image_row.html.ts
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import '//resources/cr_elements/cr_button/cr_button.js'
+import '//resources/cr_elements/cr_icon/cr_icon.js'
+import '//resources/cr_elements/cr_icon_button/cr_icon_button.js'
+import '//resources/cr_elements/icons.html.js'
+
+import {html, nothing} from '//resources/lit/v3_0/lit.rollup.js'
+
+import type {BrCustomProfileImageRowElement} from './custom_profile_image_row.js'
+
+export function getHtml(this: BrCustomProfileImageRowElement) {
+  return html`
+    <section
+      id="row"
+      class="state-${this.state}
+        ${this.shouldRenderTitle_() ? '' : 'title-hidden'}"
+      aria-labelledby="${this.shouldRenderTitle_() ? 'title' : nothing}"
+      aria-label="${this.shouldRenderTitle_() ? nothing : this.titleLabel}"
+    >
+      ${this.isSaved_()
+        ? html`
+            <div
+              id="preview"
+              class="selected"
+              role="img"
+              aria-label="${this.selectedPreviewLabel || this.previewLabel}"
+            >
+              ${this.localPreviewUrl_
+                ? html`<img
+                    id="previewImage"
+                    alt=""
+                    src="${this.localPreviewUrl_}"
+                  />`
+                : html`<cr-icon
+                    id="plusIcon"
+                    icon="cr:add"
+                    aria-hidden="true"
+                  ></cr-icon>`}
+              <cr-icon
+                id="selectedIndicator"
+                icon="cr:check"
+                aria-hidden="true"
+              ></cr-icon>
+            </div>
+          `
+        : html`
+            <cr-icon-button
+              id="preview"
+              class="no-overlap"
+              iron-icon="cr:add"
+              aria-label="${this.uploadTooltip || this.previewLabel}"
+              @click="${this.onUploadClick_}"
+            ></cr-icon-button>
+          `}
+
+      ${this.shouldRenderTitle_()
+        ? html`<div id="title">${this.titleLabel}</div>`
+        : nothing}
+
+      <div id="actions">
+        <cr-button
+          id="uploadButton"
+          class="action-button"
+          title="${this.getUploadButtonTooltip_() || nothing}"
+          aria-label="${this.getUploadButtonTooltip_() || nothing}"
+          @click="${this.onUploadClick_}"
+        >
+          ${this.isSaved_() ? this.replaceLabel : this.titleLabel}
+        </cr-button>
+        ${this.isSaved_()
+          ? html`
+              <cr-button
+                id="removeButton"
+                title="${this.removeTooltip || nothing}"
+                aria-label="${this.removeTooltip || nothing}"
+                @click="${this.onRemoveClick_}"
+              >
+                ${this.removeLabel}
+              </cr-button>
+            `
+          : nothing}
+      </div>
+
+      ${this.hasValidationError_
+        ? html`
+            <div id="fileError" role="alert">${this.invalidImageLabel}</div>
+          `
+        : nothing}
+
+      <input
+        id="fileInput"
+        type="file"
+        accept="image/*"
+        hidden
+        @change="${this.onFileChange_}"
+      />
+    </section>
+  `
+}

--- a/ui/webui/resources/custom_profile_image_row.html.ts
+++ b/ui/webui/resources/custom_profile_image_row.html.ts
@@ -13,12 +13,8 @@ import type {BrCustomProfileImageRowElement} from './custom_profile_image_row.js
 
 export function getHtml(this: BrCustomProfileImageRowElement) {
   return html`
-    <section
-      id="row"
-      class="state-${this.getState_()}"
-      aria-labelledby="title"
-    >
-      ${this.isSaved_()
+    <section id="row" aria-labelledby="title">
+      ${this.hasPreview_()
         ? html`
             <div
               id="preview"
@@ -46,9 +42,7 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
               kind="plain-faint"
               size="jumbo"
               fab
-              title="${loadTimeData.getString(
-                S.CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP,
-              )}"
+              title="${this.actionTooltip_()}"
               @click="${this.onUploadClick_}"
             >
               <leo-icon
@@ -57,11 +51,7 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
                 slot="icon-before"
                 aria-hidden="true"
               ></leo-icon>
-              <span id="previewLabel"
-                >${loadTimeData.getString(
-                  S.CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP,
-                )}</span
-              >
+              <span id="previewLabel">${this.actionTooltip_()}</span>
             </leo-button>
           `}
 
@@ -77,25 +67,13 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
           class="action-button"
           kind="filled"
           size="small"
-          title="${loadTimeData.getString(
-            this.isSaved_()
-              ? S.CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP
-              : S.CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP,
-          )}"
-          aria-label="${loadTimeData.getString(
-            this.isSaved_()
-              ? S.CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP
-              : S.CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP,
-          )}"
+          title="${this.actionTooltip_()}"
+          aria-label="${this.actionTooltip_()}"
           @click="${this.onUploadClick_}"
         >
-          ${loadTimeData.getString(
-            this.isSaved_()
-              ? S.CUSTOM_PROFILE_IMAGE_REPLACE_ACTION
-              : S.CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION,
-          )}
+          ${this.actionLabel_()}
         </leo-button>
-        ${this.isSaved_()
+        ${this.hasPreview_()
           ? html`
               <leo-button
                 id="removeButton"

--- a/ui/webui/resources/custom_profile_image_row.html.ts
+++ b/ui/webui/resources/custom_profile_image_row.html.ts
@@ -5,8 +5,10 @@
 
 import '//resources/brave/leo.bundle.js'
 
+import {loadTimeData} from '//resources/js/load_time_data.js'
 import {html, nothing} from '//resources/lit/v3_0/lit.rollup.js'
 
+import {CustomProfileImageStrings as S} from './brave_generated_resources_webui_strings.js'
 import type {BrCustomProfileImageRowElement} from './custom_profile_image_row.js'
 
 export function getHtml(this: BrCustomProfileImageRowElement) {
@@ -22,7 +24,9 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
               id="preview"
               class="selected"
               role="img"
-              aria-label="${this.selectedPreviewLabel}"
+              aria-label="${loadTimeData.getString(
+                S.CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL,
+              )}"
             >
               <img
                 id="previewImage"
@@ -42,7 +46,9 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
               kind="plain-faint"
               size="jumbo"
               fab
-              title="${this.uploadTooltip}"
+              title="${loadTimeData.getString(
+                S.CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP,
+              )}"
               @click="${this.onUploadClick_}"
             >
               <leo-icon
@@ -51,11 +57,19 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
                 slot="icon-before"
                 aria-hidden="true"
               ></leo-icon>
-              <span id="previewLabel">${this.uploadTooltip}</span>
+              <span id="previewLabel"
+                >${loadTimeData.getString(
+                  S.CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP,
+                )}</span
+              >
             </leo-button>
           `}
 
-      <div id="title">${this.titleLabel}</div>
+      <div id="title"
+        >${loadTimeData.getString(
+          S.CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION,
+        )}</div
+      >
 
       <div id="actions">
         <leo-button
@@ -63,11 +77,23 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
           class="action-button"
           kind="filled"
           size="small"
-          title="${this.getUploadButtonTooltip_()}"
-          aria-label="${this.getUploadButtonTooltip_()}"
+          title="${loadTimeData.getString(
+            this.isSaved_()
+              ? S.CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP
+              : S.CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP,
+          )}"
+          aria-label="${loadTimeData.getString(
+            this.isSaved_()
+              ? S.CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP
+              : S.CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP,
+          )}"
           @click="${this.onUploadClick_}"
         >
-          ${this.isSaved_() ? this.replaceLabel : this.titleLabel}
+          ${loadTimeData.getString(
+            this.isSaved_()
+              ? S.CUSTOM_PROFILE_IMAGE_REPLACE_ACTION
+              : S.CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION,
+          )}
         </leo-button>
         ${this.isSaved_()
           ? html`
@@ -75,11 +101,17 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
                 id="removeButton"
                 kind="outline"
                 size="small"
-                title="${this.removeTooltip}"
-                aria-label="${this.removeTooltip}"
+                title="${loadTimeData.getString(
+                  S.CUSTOM_PROFILE_IMAGE_REMOVE_TOOLTIP,
+                )}"
+                aria-label="${loadTimeData.getString(
+                  S.CUSTOM_PROFILE_IMAGE_REMOVE_TOOLTIP,
+                )}"
                 @click="${this.onRemoveClick_}"
               >
-                ${this.removeLabel}
+                ${loadTimeData.getString(
+                  S.CUSTOM_PROFILE_IMAGE_REMOVE_ACTION,
+                )}
               </leo-button>
             `
           : nothing}
@@ -87,7 +119,11 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
 
       ${this.hasValidationError_
         ? html`
-            <div id="fileError" role="alert">${this.invalidImageLabel}</div>
+            <div id="fileError" role="alert"
+              >${loadTimeData.getString(
+                S.CUSTOM_PROFILE_IMAGE_INVALID_IMAGE,
+              )}</div
+            >
           `
         : nothing}
 

--- a/ui/webui/resources/custom_profile_image_row.html.ts
+++ b/ui/webui/resources/custom_profile_image_row.html.ts
@@ -12,7 +12,7 @@ import {CustomProfileImageStrings as S} from './brave_generated_resources_webui_
 import type {BrCustomProfileImageRowElement} from './custom_profile_image_row.js'
 
 export function getHtml(this: BrCustomProfileImageRowElement) {
-  return html`
+  return html`<!--_html_template_start_-->
     <section id="row" aria-labelledby="title">
       ${this.hasPreview_()
         ? html`
@@ -20,9 +20,7 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
               id="preview"
               class="selected"
               role="img"
-              aria-label="${loadTimeData.getString(
-                S.CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL,
-              )}"
+              aria-label="$i18n{CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL}"
             >
               <img
                 id="previewImage"
@@ -112,5 +110,5 @@ export function getHtml(this: BrCustomProfileImageRowElement) {
         @change="${this.onFileChange_}"
       />
     </section>
-  `
+    <!--_html_template_end_-->`
 }

--- a/ui/webui/resources/custom_profile_image_row.ts
+++ b/ui/webui/resources/custom_profile_image_row.ts
@@ -28,7 +28,11 @@ export class BrCustomProfileImageRowElement extends CrLitElement {
 
   static override get properties() {
     return {
-      hideTitle: {type: Boolean, attribute: 'hide-title'},
+      hideTitle: {
+        type: Boolean,
+        attribute: 'hide-title',
+        reflect: true,
+      },
       invalidImageLabel: {type: String, attribute: 'invalid-image-label'},
       replaceLabel: {type: String, attribute: 'replace-label'},
       replaceTooltip: {type: String, attribute: 'replace-tooltip'},
@@ -69,10 +73,6 @@ export class BrCustomProfileImageRowElement extends CrLitElement {
 
   protected getState_(): CustomProfileImageState {
     return this.isSaved_() ? 'saved-active' : 'empty'
-  }
-
-  protected shouldRenderTitle_(): boolean {
-    return !this.hideTitle
   }
 
   protected getUploadButtonTooltip_(): string {

--- a/ui/webui/resources/custom_profile_image_row.ts
+++ b/ui/webui/resources/custom_profile_image_row.ts
@@ -4,10 +4,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import {CrLitElement} from '//resources/lit/v3_0/lit.rollup.js'
-import type {
-  CSSResultGroup,
-  PropertyValues,
-} from '//resources/lit/v3_0/lit.rollup.js'
+import type {CSSResultGroup} from '//resources/lit/v3_0/lit.rollup.js'
 
 import {getCss} from './custom_profile_image_row.css.js'
 import {getHtml} from './custom_profile_image_row.html.js'
@@ -31,7 +28,6 @@ export class BrCustomProfileImageRowElement extends CrLitElement {
 
   static override get properties() {
     return {
-      state: {type: String, reflect: true},
       hideTitle: {type: Boolean, attribute: 'hide-title'},
       invalidImageLabel: {type: String, attribute: 'invalid-image-label'},
       replaceLabel: {type: String, attribute: 'replace-label'},
@@ -49,7 +45,6 @@ export class BrCustomProfileImageRowElement extends CrLitElement {
     }
   }
 
-  accessor state: CustomProfileImageState = 'empty'
   accessor hideTitle: boolean = false
   accessor invalidImageLabel: string = ''
   accessor replaceLabel: string = ''
@@ -64,8 +59,16 @@ export class BrCustomProfileImageRowElement extends CrLitElement {
 
   private uploadAttemptId_: number = 0
 
+  get state(): CustomProfileImageState {
+    return this.getState_()
+  }
+
   protected isSaved_(): boolean {
-    return this.state === 'saved-active'
+    return !!this.localPreviewUrl_
+  }
+
+  protected getState_(): CustomProfileImageState {
+    return this.isSaved_() ? 'saved-active' : 'empty'
   }
 
   protected shouldRenderTitle_(): boolean {
@@ -79,14 +82,6 @@ export class BrCustomProfileImageRowElement extends CrLitElement {
   override disconnectedCallback() {
     this.clearLocalPreview_()
     super.disconnectedCallback()
-  }
-
-  override willUpdate(changedProperties: PropertyValues<this>) {
-    super.willUpdate(changedProperties)
-
-    if (this.state !== 'empty' && this.state !== 'saved-active') {
-      throw new Error(`Unsupported custom profile image state: ${this.state}`)
-    }
   }
 
   protected onUploadClick_() {
@@ -110,7 +105,6 @@ export class BrCustomProfileImageRowElement extends CrLitElement {
     ++this.uploadAttemptId_
     this.hasValidationError_ = false
     this.revokeLocalPreviewUrl_()
-    this.state = 'empty'
   }
 
   private async replaceLocalPreview_(file: File) {
@@ -139,7 +133,6 @@ export class BrCustomProfileImageRowElement extends CrLitElement {
     this.revokeLocalPreviewUrl_()
     this.localPreviewUrl_ = previewUrl
     this.hasValidationError_ = false
-    this.state = 'saved-active'
   }
 
   private showValidationError_(uploadAttemptId: number) {

--- a/ui/webui/resources/custom_profile_image_row.ts
+++ b/ui/webui/resources/custom_profile_image_row.ts
@@ -33,31 +33,12 @@ export class BrCustomProfileImageRowElement extends CrLitElement {
         attribute: 'hide-title',
         reflect: true,
       },
-      invalidImageLabel: {type: String, attribute: 'invalid-image-label'},
-      replaceLabel: {type: String, attribute: 'replace-label'},
-      replaceTooltip: {type: String, attribute: 'replace-tooltip'},
-      removeLabel: {type: String, attribute: 'remove-label'},
-      removeTooltip: {type: String, attribute: 'remove-tooltip'},
-      selectedPreviewLabel: {
-        type: String,
-        attribute: 'selected-preview-label',
-      },
-      titleLabel: {type: String, attribute: 'title-label'},
-      uploadTooltip: {type: String, attribute: 'upload-tooltip'},
       hasValidationError_: {type: Boolean, state: true},
       localPreviewUrl_: {type: String, state: true},
     }
   }
 
   accessor hideTitle: boolean = false
-  accessor invalidImageLabel: string = ''
-  accessor replaceLabel: string = ''
-  accessor replaceTooltip: string = ''
-  accessor removeLabel: string = ''
-  accessor removeTooltip: string = ''
-  accessor selectedPreviewLabel: string = ''
-  accessor titleLabel: string = ''
-  accessor uploadTooltip: string = ''
   protected accessor hasValidationError_: boolean = false
   protected accessor localPreviewUrl_: string = ''
 
@@ -73,10 +54,6 @@ export class BrCustomProfileImageRowElement extends CrLitElement {
 
   protected getState_(): CustomProfileImageState {
     return this.isSaved_() ? 'saved-active' : 'empty'
-  }
-
-  protected getUploadButtonTooltip_(): string {
-    return this.isSaved_() ? this.replaceTooltip : this.uploadTooltip
   }
 
   override disconnectedCallback() {

--- a/ui/webui/resources/custom_profile_image_row.ts
+++ b/ui/webui/resources/custom_profile_image_row.ts
@@ -11,6 +11,12 @@ import {CustomProfileImageStrings as S} from './brave_generated_resources_webui_
 import {getCss} from './custom_profile_image_row.css.js'
 import {getHtml} from './custom_profile_image_row.html.js'
 
+export interface BrCustomProfileImageRowElement {
+  $: {
+    fileInput: HTMLInputElement
+  }
+}
+
 /** Shared custom-profile image control with a session-only local preview. */
 export class BrCustomProfileImageRowElement extends CrLitElement {
   static get is() {
@@ -69,7 +75,7 @@ export class BrCustomProfileImageRowElement extends CrLitElement {
   }
 
   protected onUploadClick_() {
-    this.shadowRoot.querySelector<HTMLInputElement>('#fileInput')!.click()
+    this.$.fileInput.click()
   }
 
   protected onRemoveClick_() {

--- a/ui/webui/resources/custom_profile_image_row.ts
+++ b/ui/webui/resources/custom_profile_image_row.ts
@@ -34,8 +34,8 @@ export class BrCustomProfileImageRowElement extends CrLitElement {
       state: {type: String, reflect: true},
       hideTitle: {type: Boolean, attribute: 'hide-title'},
       invalidImageLabel: {type: String, attribute: 'invalid-image-label'},
-      previewLabel: {type: String, attribute: 'preview-label'},
       replaceLabel: {type: String, attribute: 'replace-label'},
+      replaceTooltip: {type: String, attribute: 'replace-tooltip'},
       removeLabel: {type: String, attribute: 'remove-label'},
       removeTooltip: {type: String, attribute: 'remove-tooltip'},
       selectedPreviewLabel: {
@@ -52,8 +52,8 @@ export class BrCustomProfileImageRowElement extends CrLitElement {
   accessor state: CustomProfileImageState = 'empty'
   accessor hideTitle: boolean = false
   accessor invalidImageLabel: string = ''
-  accessor previewLabel: string = ''
   accessor replaceLabel: string = ''
+  accessor replaceTooltip: string = ''
   accessor removeLabel: string = ''
   accessor removeTooltip: string = ''
   accessor selectedPreviewLabel: string = ''
@@ -73,7 +73,7 @@ export class BrCustomProfileImageRowElement extends CrLitElement {
   }
 
   protected getUploadButtonTooltip_(): string {
-    return this.isSaved_() ? this.replaceLabel : this.uploadTooltip
+    return this.isSaved_() ? this.replaceTooltip : this.uploadTooltip
   }
 
   override disconnectedCallback() {

--- a/ui/webui/resources/custom_profile_image_row.ts
+++ b/ui/webui/resources/custom_profile_image_row.ts
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import {CrLitElement} from '//resources/lit/v3_0/lit.rollup.js'
+import type {
+  CSSResultGroup,
+  PropertyValues,
+} from '//resources/lit/v3_0/lit.rollup.js'
+
+import {getCss} from './custom_profile_image_row.css.js'
+import {getHtml} from './custom_profile_image_row.html.js'
+
+/** States supported by the custom profile image row. */
+export type CustomProfileImageState = 'empty' | 'saved-active'
+
+/** Shared custom-profile image control with a session-only local preview. */
+export class BrCustomProfileImageRowElement extends CrLitElement {
+  static get is() {
+    return 'br-custom-profile-image-row'
+  }
+
+  static override get styles(): CSSResultGroup {
+    return getCss()
+  }
+
+  override render() {
+    return getHtml.bind(this)()
+  }
+
+  static override get properties() {
+    return {
+      state: {type: String, reflect: true},
+      hideTitle: {type: Boolean, attribute: 'hide-title'},
+      invalidImageLabel: {type: String, attribute: 'invalid-image-label'},
+      previewLabel: {type: String, attribute: 'preview-label'},
+      replaceLabel: {type: String, attribute: 'replace-label'},
+      removeLabel: {type: String, attribute: 'remove-label'},
+      removeTooltip: {type: String, attribute: 'remove-tooltip'},
+      selectedPreviewLabel: {
+        type: String,
+        attribute: 'selected-preview-label',
+      },
+      titleLabel: {type: String, attribute: 'title-label'},
+      uploadTooltip: {type: String, attribute: 'upload-tooltip'},
+      hasValidationError_: {type: Boolean, state: true},
+      localPreviewUrl_: {type: String, state: true},
+    }
+  }
+
+  accessor state: CustomProfileImageState = 'empty'
+  accessor hideTitle: boolean = false
+  accessor invalidImageLabel: string = ''
+  accessor previewLabel: string = ''
+  accessor replaceLabel: string = ''
+  accessor removeLabel: string = ''
+  accessor removeTooltip: string = ''
+  accessor selectedPreviewLabel: string = ''
+  accessor titleLabel: string = ''
+  accessor uploadTooltip: string = ''
+  protected accessor hasValidationError_: boolean = false
+  protected accessor localPreviewUrl_: string = ''
+
+  private uploadAttemptId_: number = 0
+
+  protected isSaved_(): boolean {
+    return this.state === 'saved-active'
+  }
+
+  protected shouldRenderTitle_(): boolean {
+    return !this.hideTitle
+  }
+
+  protected getUploadButtonTooltip_(): string {
+    return this.isSaved_() ? this.replaceLabel : this.uploadTooltip
+  }
+
+  override disconnectedCallback() {
+    this.clearLocalPreview_()
+    super.disconnectedCallback()
+  }
+
+  override willUpdate(changedProperties: PropertyValues<this>) {
+    super.willUpdate(changedProperties)
+
+    if (this.state !== 'empty' && this.state !== 'saved-active') {
+      throw new Error(`Unsupported custom profile image state: ${this.state}`)
+    }
+  }
+
+  protected onUploadClick_() {
+    this.shadowRoot.querySelector<HTMLInputElement>('#fileInput')!.click()
+  }
+
+  protected onRemoveClick_() {
+    this.clearLocalPreview_()
+  }
+
+  protected onFileChange_(event: Event) {
+    const input = event.target as HTMLInputElement
+    const file = input.files?.[0]
+    input.value = ''
+    if (file) {
+      void this.replaceLocalPreview_(file)
+    }
+  }
+
+  private clearLocalPreview_() {
+    ++this.uploadAttemptId_
+    this.hasValidationError_ = false
+    this.revokeLocalPreviewUrl_()
+    this.state = 'empty'
+  }
+
+  private async replaceLocalPreview_(file: File) {
+    const uploadAttemptId = ++this.uploadAttemptId_
+    if (!file.type.toLowerCase().startsWith('image/')) {
+      this.showValidationError_(uploadAttemptId)
+      return
+    }
+
+    const previewUrl = URL.createObjectURL(file)
+    const image = new Image()
+    image.src = previewUrl
+    try {
+      await image.decode()
+    } catch {
+      URL.revokeObjectURL(previewUrl)
+      this.showValidationError_(uploadAttemptId)
+      return
+    }
+
+    if (!this.isConnected || uploadAttemptId !== this.uploadAttemptId_) {
+      URL.revokeObjectURL(previewUrl)
+      return
+    }
+
+    this.revokeLocalPreviewUrl_()
+    this.localPreviewUrl_ = previewUrl
+    this.hasValidationError_ = false
+    this.state = 'saved-active'
+  }
+
+  private showValidationError_(uploadAttemptId: number) {
+    if (!this.isConnected || uploadAttemptId !== this.uploadAttemptId_) {
+      return
+    }
+    this.hasValidationError_ = true
+  }
+
+  private revokeLocalPreviewUrl_() {
+    if (!this.localPreviewUrl_) {
+      return
+    }
+    URL.revokeObjectURL(this.localPreviewUrl_)
+    this.localPreviewUrl_ = ''
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'br-custom-profile-image-row': BrCustomProfileImageRowElement
+  }
+}
+
+customElements.define(
+  BrCustomProfileImageRowElement.is,
+  BrCustomProfileImageRowElement,
+)

--- a/ui/webui/resources/custom_profile_image_row.ts
+++ b/ui/webui/resources/custom_profile_image_row.ts
@@ -3,14 +3,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import {loadTimeData} from '//resources/js/load_time_data.js'
 import {CrLitElement} from '//resources/lit/v3_0/lit.rollup.js'
 import type {CSSResultGroup} from '//resources/lit/v3_0/lit.rollup.js'
 
+import {CustomProfileImageStrings as S} from './brave_generated_resources_webui_strings.js'
 import {getCss} from './custom_profile_image_row.css.js'
 import {getHtml} from './custom_profile_image_row.html.js'
-
-/** States supported by the custom profile image row. */
-export type CustomProfileImageState = 'empty' | 'saved-active'
 
 /** Shared custom-profile image control with a session-only local preview. */
 export class BrCustomProfileImageRowElement extends CrLitElement {
@@ -44,16 +43,24 @@ export class BrCustomProfileImageRowElement extends CrLitElement {
 
   private uploadAttemptId_: number = 0
 
-  get state(): CustomProfileImageState {
-    return this.getState_()
+  protected hasPreview_(): boolean {
+    return this.localPreviewUrl_ !== ''
   }
 
-  protected isSaved_(): boolean {
-    return !!this.localPreviewUrl_
+  protected actionLabel_(): string {
+    return loadTimeData.getString(
+      this.hasPreview_()
+        ? S.CUSTOM_PROFILE_IMAGE_REPLACE_ACTION
+        : S.CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION,
+    )
   }
 
-  protected getState_(): CustomProfileImageState {
-    return this.isSaved_() ? 'saved-active' : 'empty'
+  protected actionTooltip_(): string {
+    return loadTimeData.getString(
+      this.hasPreview_()
+        ? S.CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP
+        : S.CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP,
+    )
   }
 
   override disconnectedCallback() {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58430
- Resolves https://github.com/brave/brave-browser/issues/58372

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

## Screenshots

https://github.com/user-attachments/assets/b99906b4-3f38-442b-9c10-0352e7760ca0

## String Usage

`IDS_CUSTOM_PROFILE_IMAGE_TITLE`
`IDS_CUSTOM_PROFILE_IMAGE_UPLOAD_ACTION`
`IDS_CUSTOM_PROFILE_IMAGE_UPLOAD_TOOLTIP`:
<img width="1014" height="328" alt="Screenshot_2026-08-27 at 06 26 18" src="https://github.com/user-attachments/assets/b962c805-9501-4d9d-8a77-10cc0a707b01" />

`IDS_CUSTOM_PROFILE_IMAGE_REPLACE_ACTION`
`IDS_CUSTOM_PROFILE_IMAGE_REPLACE_TOOLTIP`:
<img width="758" height="274" alt="Screenshot_2026-08-27 at 12 42 20" src="https://github.com/user-attachments/assets/4ffa14f5-e80f-4587-880a-1aade7095c3f" />

`IDS_CUSTOM_PROFILE_IMAGE_REMOVE_ACTION`
`IDS_CUSTOM_PROFILE_IMAGE_REMOVE_TOOLTIP`:
<img width="1024" height="276" alt="Screenshot_2026-08-27 at 06 27 27" src="https://github.com/user-attachments/assets/2de38139-dc52-426a-ac63-2398e00a7387" />

`IDS_CUSTOM_PROFILE_IMAGE_INVALID_IMAGE`:
<img width="822" height="320" alt="Screenshot_2026-08-27 at 06 28 01" src="https://github.com/user-attachments/assets/12473b6f-aa2e-44a3-8bb2-32ad4a8f08e1" />

`IDS_CUSTOM_PROFILE_IMAGE_SELECTED_PREVIEW_LABEL`:
<img width="1274" height="1646" alt="Screenshot_2026-08-27 at 12 45 22" src="https://github.com/user-attachments/assets/9887d10f-a627-4d5d-b1ea-cb9e4a9d7db7" />


