### PR TITLE
Added untunneled traffic control option to vpn panel

### DIFF
--- a/components/brave_vpn/browser/brave_vpn_service_impl.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_impl.cc
@@ -383,7 +383,12 @@ void BraveVpnServiceImpl::GetBlockUntunneledTraffic(
     GetBlockUntunneledTrafficCallback callback) {
 #if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
   std::move(callback).Run(
-      local_prefs_->GetBoolean(prefs::kBraveVPNWireguardEnabled),
+      // For now, only VPN panel UI is ready for untunneled traffic
+      // control. Hide this option till its business logic is available
+      // by sending false for available param.
+      // Use local_prefs_->GetBoolean(prefs::kBraveVPNWireguardEnabled)
+      // when it's ready.
+      /*available*/ false,
       local_prefs_->GetBoolean(
           prefs::kBraveVPNWireguardBlockUntunneledTraffic));
 #else

--- a/components/brave_vpn/resources/panel/components/settings-panel/index.tsx
+++ b/components/brave_vpn/resources/panel/components/settings-panel/index.tsx
@@ -23,10 +23,16 @@ function SettingsPanel(props: Props) {
     enabled: false
   })
 
+  const [blockUntunneledTraffic, setBlockUntunneledTraffic] = React.useState({
+    available: false,
+    blocked: true
+  })
+
   const smartProxyRoutingEnabled = useSelector((state) => state.smartProxyRoutingEnabled)
 
   React.useEffect(() => {
     getPanelBrowserAPI().serviceHandler.getOnDemandState().then(setOnDemand)
+    getPanelBrowserAPI().serviceHandler.getBlockUntunneledTraffic().then(setBlockUntunneledTraffic)
   }, [])
 
   const handleClick = (entry: ManageURLType) => {
@@ -50,6 +56,11 @@ function SettingsPanel(props: Props) {
   const handleToggleChange = ({ checked }: { checked: boolean }) => {
     setOnDemand({ ...onDemand, enabled: checked })
     getPanelBrowserAPI().serviceHandler.enableOnDemand(checked)
+  }
+
+  const handleBlockUntunneledTrafficChange = ({ checked }: { checked: boolean }) => {
+    setBlockUntunneledTraffic({ ...blockUntunneledTraffic, blocked: checked })
+    getPanelBrowserAPI().serviceHandler.blockUntunneledTraffic(checked)
   }
 
   const handleSmartProxyRoutingChange = ({ checked }: { checked: boolean }) => {
@@ -86,6 +97,30 @@ function SettingsPanel(props: Props) {
                   onChange={handleToggleChange}
                   size='small'
                   aria-label='Reconnect automatically'
+                />
+              </Styles.Setting>
+            </>
+          )}
+          {blockUntunneledTraffic.available && (
+            <>
+              <Styles.Setting
+                onClick={
+                  e => handleBlockUntunneledTrafficChange({
+                    checked: !blockUntunneledTraffic.blocked
+                  })
+                }
+              >
+                <Styles.StyledIcon name='refresh'></Styles.StyledIcon>
+                <Styles.SettingLabelBox>
+                  <Styles.SettingLabel>
+                    {getLocale(S.BRAVE_VPN_BLOCK_UNTUNNELED_TRAFFIC)}
+                  </Styles.SettingLabel>
+                </Styles.SettingLabelBox>
+                <Toggle
+                  checked={blockUntunneledTraffic.blocked}
+                  onChange={handleBlockUntunneledTrafficChange}
+                  size='small'
+                  aria-label={getLocale(S.BRAVE_VPN_BLOCK_UNTUNNELED_TRAFFIC)}
                 />
               </Styles.Setting>
             </>

--- a/components/resources/brave_vpn_strings.grdp
+++ b/components/resources/brave_vpn_strings.grdp
@@ -90,6 +90,10 @@
     Reconnect automatically
   </message>
 
+  <message name="IDS_BRAVE_VPN_BLOCK_UNTUNNELED_TRAFFIC" desc="Label to toggle block untunneled traffic toggle" formatter_data="webui=Vpn">
+    Block untunneled traffic
+  </message>
+
   <message name="IDS_BRAVE_VPN_SMART_PROXY_ROUTING" desc="Label to toggle smart proxy routing" formatter_data="webui=Vpn">
     Smart proxy routing
   </message>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Issue - https://github.com/brave/brave-browser/issues/56320

Below is WIP. Needs UI review from @aguscruiz @bsclifton @rebron 
Maybe we'll have checked state by default.
If user want to allow LAN traffic while VPN is on, user should uncheck it explicitely.
Maybe we need description as a sub label and learn more link.

<img width="655" height="466" alt="Screenshot 2026-08-27 120703" src="https://github.com/user-attachments/assets/3f4126a9-f25a-4a68-8ce6-97f574dd0d65" />

Wireguard offical app's:
<img width="366" height="91" alt="image" src="https://github.com/user-attachments/assets/1d2a206d-94d5-4453-a951-c2b7102494dd" />



<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
