### PR TITLE
Fix `BackupResultsServiceImpl` crash (uplift to 1.95.x)

### DIFF
--- a/browser/brave_search/backup_results_service_impl.cc
+++ b/browser/brave_search/backup_results_service_impl.cc
@@ -32,6 +32,7 @@
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/content_settings/page_specific_content_settings_delegate.h"
 #include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/profiles/profile_destroyer.h"
 #include "components/content_settings/browser/page_specific_content_settings.h"
 #include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "components/content_settings/core/common/content_settings.h"
@@ -275,8 +276,8 @@ void BackupResultsServiceImpl::FetchBackupResults(
   }
 
   auto request = pending_requests_.emplace(
-      pending_requests_.end(), std::move(web_contents), headers, profile_,
-      otr_profile, low_latency_required, std::move(callback));
+      pending_requests_.end(), std::move(web_contents), headers, otr_profile,
+      low_latency_required, std::move(callback));
   request->view_manager = std::move(view_manager);
 
   if (should_render) {
@@ -302,7 +303,6 @@ void BackupResultsServiceImpl::FetchBackupResults(
 BackupResultsServiceImpl::PendingRequest::PendingRequest(
     std::unique_ptr<content::WebContents> web_contents,
     std::optional<net::HttpRequestHeaders> headers,
-    Profile* original_profile,
     Profile* otr_profile,
     bool low_latency_required,
     BackupResultsCallback callback)
@@ -310,14 +310,13 @@ BackupResultsServiceImpl::PendingRequest::PendingRequest(
       callback(std::move(callback)),
       low_latency_required(low_latency_required),
       web_contents(std::move(web_contents)),
-      original_profile(original_profile),
       otr_profile(otr_profile) {}
 
 BackupResultsServiceImpl::PendingRequest::~PendingRequest() {
   web_contents = nullptr;
   auto* profile_to_destroy = otr_profile.get();
   otr_profile = nullptr;
-  original_profile->DestroyOffTheRecordProfile(profile_to_destroy);
+  ProfileDestroyer::DestroyOTRProfileWhenAppropriate(profile_to_destroy);
 }
 
 BackupResultsServiceImpl::PendingRequestList::iterator

--- a/browser/brave_search/backup_results_service_impl.h
+++ b/browser/brave_search/backup_results_service_impl.h
@@ -83,7 +83,6 @@ class BackupResultsServiceImpl : public BackupResultsService,
   struct PendingRequest {
     PendingRequest(std::unique_ptr<content::WebContents> web_contents,
                    std::optional<net::HttpRequestHeaders> headers,
-                   Profile* original_profile,
                    Profile* otr_profile,
                    bool low_latency_required,
                    BackupResultsCallback callback);
@@ -98,7 +97,6 @@ class BackupResultsServiceImpl : public BackupResultsService,
     std::unique_ptr<content::WebContents> web_contents;
     GURL target_url;
 
-    raw_ptr<Profile> original_profile;
     raw_ptr<Profile> otr_profile;
     scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory;
     std::unique_ptr<network::SimpleURLLoader> simple_url_loader;


### PR DESCRIPTION
Uplift of #39403
Resolves https://github.com/brave/brave-browser/issues/58429

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.