### PR TITLE
[iOS] Add BrowserViewController as last TabPolicyDecider

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -352,11 +352,14 @@ extension BrowserViewController: TabManagerDelegate {
       updateToolbarUsingTabManager(tabManager)
     }
     tab.addObserver(self)
-    tab.addPolicyDecider(self)
     tab.delegate = self
     tab.downloadDelegate = self
     tab.certificateStore = profile.certStore
     attachTabHelpers(to: tab)
+    /// Add BVC as the last TabPolicyDecider, so it only executes on requests
+    /// that all other policy deciders have decided to allow. This is for
+    /// legacy logic that hasn't been migrated to it's own TabPolicyDecider yet
+    tab.addPolicyDecider(self)
 
     SnackBarTabHelper.from(tab: tab)?.delegate = self
 


### PR DESCRIPTION
- `BVC+TabPolicyDecider.swift` contains some logic in `tab(_:shouldAllowRequest:requestInfo:) async -> WebPolicyDecision`, with some of it's logic being migrated out into separate `TabPolicyDecider`s (for example `BlockedDomainTabHelper`). Previously with this logic being contained in `BVC+TabPolicyDecider`, it was executed sequentially in a specific order. Now that `TabPolicyDecider`s [are executed sequentially](https://github.com/brave/brave-core/pull/38885) we want this BVC logic to run last so we can maintain the existing execution order (by ordering the `addPolicyDecider` calls to align).
- Right now only `BlockedDomainTabHelper` has landed so no re-ordering should be needed yet. Some of the legacy logic is being shifted to separate tab helpers / `TabPolicyDecider`s in PR (HTTPs upgrades, open in external app) and some remains in BVC (debounce, query stripping). We can align ordering in the respective PRs.

- Resolves https://github.com/brave/brave-browser/issues/58483

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
