### PR TITLE
[Vertical Tabs] Coalesce tab strip layout during session restore

### DIFF
--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
@@ -550,6 +550,65 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest,
   ASSERT_EQ(region_view->original_region_view_->height(), contents_view_height);
 }
 
+IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, LockLayoutCoalescesLayout) {
+  ToggleVerticalTabStrip();
+
+  auto* brave_tab_container = views::AsViewClass<BraveTabContainer>(
+      views::AsViewClass<BraveTabStrip>(
+          browser_view()->horizontal_tab_strip_for_testing())
+          ->GetTabContainerForTesting());
+  ASSERT_TRUE(brave_tab_container);
+
+  browser_view()->horizontal_tab_strip_for_testing()->StopAnimating();
+  InvalidateAndRunLayoutForVerticalTabStrip();
+
+  // Freeze layout the way AddTabs() does during session restore.
+  base::OnceClosure unlock = brave_tab_container->LockLayout();
+
+  AppendTab(browser());
+  AppendTab(browser());
+  InvalidateAndRunLayoutForVerticalTabStrip();
+
+  // While locked, inserts must not run any layout: the new tabs' ideal
+  // bounds stay unset and the preferred size is collapsed.
+  EXPECT_TRUE(brave_tab_container->CalculatePreferredSize({}).IsEmpty());
+  EXPECT_TRUE(brave_tab_container->GetIdealBounds(1).IsEmpty());
+  EXPECT_TRUE(brave_tab_container->GetIdealBounds(2).IsEmpty());
+
+  // Running the unlock closure lays out the whole batch in a single pass.
+  std::move(unlock).Run();
+  browser_view()->horizontal_tab_strip_for_testing()->StopAnimating();
+  InvalidateAndRunLayoutForVerticalTabStrip();
+
+  ASSERT_EQ(3, browser()->tab_strip_model()->count());
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_FALSE(brave_tab_container->GetIdealBounds(i).IsEmpty());
+  }
+  EXPECT_LT(brave_tab_container->GetIdealBounds(0).y(),
+            brave_tab_container->GetIdealBounds(1).y());
+  EXPECT_LT(brave_tab_container->GetIdealBounds(1).y(),
+            brave_tab_container->GetIdealBounds(2).y());
+}
+
+IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest,
+                       LockLayoutClosureOutlivesTabContainer) {
+  ToggleVerticalTabStrip();
+
+  auto* brave_tab_container = views::AsViewClass<BraveTabContainer>(
+      views::AsViewClass<BraveTabStrip>(
+          browser_view()->horizontal_tab_strip_for_testing())
+          ->GetTabContainerForTesting());
+  ASSERT_TRUE(brave_tab_container);
+
+  base::OnceClosure unlock = brave_tab_container->LockLayout();
+  CloseBrowserSynchronously(browser());
+
+  // The unlock closure is bound to a weak pointer, so running it after the
+  // container has been destroyed (e.g. the window was closed while a
+  // session-restore batch held the lock) must be a safe no-op.
+  std::move(unlock).Run();
+}
+
 IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, ScrollBarMode) {
   ToggleVerticalTabStrip();
 

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -18,6 +18,7 @@
 #include "base/debug/stack_trace.h"
 #include "base/feature_list.h"
 #include "base/notimplemented.h"
+#include "base/task/sequenced_task_runner.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/tabs/public/vertical_tab_controller.h"
@@ -157,15 +158,19 @@ BraveTabContainer::~BraveTabContainer() {
   // closed tabs were cleaned up from OnTabCloseAnimationCompleted().
   CancelAnimation();
   DCHECK(closing_tabs_.empty()) << "There are dangling closed tabs.";
-  DCHECK(!layout_locked_)
-      << "The lock returned by LockLayout() shouldn't outlive this object";
+  // Note: |layout_locked_| may still be true here. The unlock closure
+  // returned by LockLayout() is bound to a weak pointer, so a lock that
+  // outlives this object is benign (e.g. the window is closed while a
+  // session-restore insert batch holds the lock).
 }
 
 base::OnceClosure BraveTabContainer::LockLayout() {
   DCHECK(!layout_locked_) << "LockLayout() doesn't allow reentrance";
   layout_locked_ = true;
+  // Bind weakly: during session restore the closure is posted to the task
+  // queue, and the window (with this container) can be closed before it runs.
   return base::BindOnce(&BraveTabContainer::OnUnlockLayout,
-                        base::Unretained(this));
+                        weak_factory_.GetWeakPtr());
 }
 
 bool BraveTabContainer::ShouldShowVerticalTabs() const {
@@ -349,6 +354,15 @@ bool BraveTabContainer::ShouldTabBeVisible(const Tab* tab) const {
 
 std::vector<Tab*> BraveTabContainer::AddTabs(
     std::vector<TabInsertionParams> tabs_params) {
+  // Session restore inserts tabs one batch after another, and every insert
+  // triggers a full O(tab count) strip layout. Lock the layout for the rest
+  // of the current task batch and post the unlock closure, so all inserts
+  // that pile up in the task queue are laid out in a single pass.
+  if (GetScrollDirection() && !layout_locked_ && IsSessionRestoreInProgress()) {
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(FROM_HERE,
+                                                             LockLayout());
+  }
+
   std::vector<Tab*> added_tabs =
       TabContainerImpl::AddTabs(std::move(tabs_params));
   // Session restore inserts many background tabs back-to-back; scrolling to
@@ -573,6 +587,7 @@ void BraveTabContainer::PaintBoundingBoxForSplitTab(
 }
 
 void BraveTabContainer::OnUnlockLayout() {
+  CHECK(!IsSessionRestoreInProgress());
   layout_locked_ = false;
 
   InvalidateIdealBounds();

--- a/browser/ui/views/tabs/brave_tab_container.h
+++ b/browser/ui/views/tabs/brave_tab_container.h
@@ -14,6 +14,7 @@
 #include "base/callback_list.h"
 #include "base/containers/flat_map.h"
 #include "base/gtest_prod_util.h"
+#include "base/memory/weak_ptr.h"
 #include "chrome/browser/ui/tabs/tab_style.h"
 #include "chrome/browser/ui/views/tabs/dragging/tab_drag_context.h"
 #include "chrome/browser/ui/views/tabs/tab_container_impl.h"
@@ -366,6 +367,8 @@ class BraveTabContainer : public TabContainerImpl,
 
   // Separator view between pinned and unpinned tabs
   raw_ptr<views::View> separator_ = nullptr;
+
+  base::WeakPtrFactory<BraveTabContainer> weak_factory_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_CONTAINER_H_


### PR DESCRIPTION
Related to brave/brave-browser#52225

During session restore every inserted tab runs a full O(tab count) layout of the
vertical tab strip, so restoring N tabs performs N full passes (O(n²) total
layout work). This PR reuses the existing `LockLayout()` mechanism: when a tab
is inserted into a scrollable tab strip while `SessionRestore::IsRestoring()` is
true, layout gets locked and the unlock closure is posted to the current task
runner. All inserts that pile up in the task queue are then laid out in one
consolidated pass instead of one pass each. Normal user-initiated tab opening is
unaffected.

The unlock closure is bound through a `WeakPtr`, so closing the window before it
runs is safe.

## Benchmark

Real-world 1759-tab session restored on Windows 11 (dev Component build):

| Metric | before | after |
|---|---:|---:|
| Total session restore time | 123.0 s | **110.3 s (−10%)** |
| Strip `Layout()` passes during insertion | 1766 (14.9 s) | **1 consolidated pass (2.9 s)** |


## Test plan

- `VerticalTabStripBrowserTest.LockLayoutCoalescesLayout`
- `VerticalTabStripBrowserTest.LockLayoutClosureOutlivesTabContainer`

```sh
npm run test -- brave_browser_tests --filter=VerticalTabStripBrowserTest.*