### PR TITLE
[Vertical Tabs] Hide tabs scrolled below the viewport

### DIFF
--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_browsertest.cc
@@ -1437,6 +1437,42 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, ToggleWithGroups) {
   ToggleVerticalTabStrip();  // To horizontal tab strip
 }
 
+IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest,
+                       TabsBelowViewportAreHidden) {
+  ToggleVerticalTabStrip();
+
+  auto* brave_tab_container = views::AsViewClass<BraveTabContainer>(
+      views::AsViewClass<BraveTabStrip>(
+          browser_view()->horizontal_tab_strip_for_testing())
+          ->GetTabContainerForTesting());
+  ASSERT_TRUE(brave_tab_container);
+
+  auto* model = browser()->tab_strip_model();
+  browser_view()->horizontal_tab_strip_for_testing()->StopAnimating();
+
+  // Add tabs until the strip overflows the viewport by a few tab heights.
+  while (brave_tab_container->GetMaxScrollOffsetForTesting() <
+         3 * tabs::kVerticalTabHeight) {
+    AppendTab(browser());
+    browser_view()->horizontal_tab_strip_for_testing()->StopAnimating();
+    InvalidateAndRunLayoutForVerticalTabStrip();
+  }
+
+  // Scroll to the top: the first tab is in the viewport, the last tab is
+  // below it and must be hidden.
+  brave_tab_container->SetScrollOffsetForTesting(0);
+  InvalidateAndRunLayoutForVerticalTabStrip();
+  EXPECT_TRUE(GetTabAt(browser(), 0)->GetVisible());
+  EXPECT_FALSE(GetTabAt(browser(), model->count() - 1)->GetVisible());
+
+  // Scroll to the bottom: visibility flips.
+  brave_tab_container->SetScrollOffsetForTesting(
+      brave_tab_container->GetMaxScrollOffsetForTesting());
+  InvalidateAndRunLayoutForVerticalTabStrip();
+  EXPECT_FALSE(GetTabAt(browser(), 0)->GetVisible());
+  EXPECT_TRUE(GetTabAt(browser(), model->count() - 1)->GetVisible());
+}
+
 IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, ScrollOffset) {
   ToggleVerticalTabStrip();
 

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -309,16 +309,22 @@ bool BraveTabContainer::ShouldTabBeVisible(const Tab* tab) const {
       return true;
     }
 
-    // Handle unpinned tabs in vertical tabs mode.
-    // Only show tab if it is not hidden under the pinned tab area.
+    // Handle unpinned tabs in vertical tabs mode. Only show tabs that
+    // intersect the viewport: tabs scrolled up under the pinned tab area and
+    // tabs scrolled down below the container bottom are hidden. Ideal bounds
+    // already include the current scroll offset (see UpdateIdealBounds), so
+    // comparing against [pinned area bottom, height()] tests viewport
+    // intersection.
     if (auto tab_index = GetTabIndex(tab)) {
-      const auto tab_bottom =
-          tabs_view_model_.ideal_bounds(*tab_index).bottom();
+      const auto& ideal_bounds = tabs_view_model_.ideal_bounds(*tab_index);
       const int pinned_tabs_area_bottom =
           visibility_pass_cache_
               ? visibility_pass_cache_->pinned_tabs_area_bottom
               : GetPinnedTabsAreaBottom();
-      return tab_bottom > pinned_tabs_area_bottom;
+      if (ideal_bounds.bottom() <= pinned_tabs_area_bottom) {
+        return false;
+      }
+      return ideal_bounds.y() < height();
     }
   } else if (scroll_direction == views::LayoutOrientation::kHorizontal) {
     if (tab->data().pinned || tab->dragging()) {


### PR DESCRIPTION
Related to brave/brave-browser#52225

`ShouldTabBeVisible()` previously hid only unpinned tabs occluded by the pinned
tabs area. Tabs scrolled below the container bottom were still reported visible,
so with a large tab count every offscreen tab continued participating in paint,
hit testing, and accessibility even though the children are clipped and cannot
be seen.

This PR hides tabs whose scroll-adjusted ideal bounds start below the container
height, so a tab is visible only while it intersects the viewport. Dragging and
detached tabs retain their unconditional visibility.

## Benchmark

Real-world 1759-tab session on Windows 11 (dev Component build):

| Metric | before | after |
|---|---:|---:|
| Average `PaintChildren()` cost per frame while scrolling | 30.5 ms | **10.0 ms (−67%)** |


## Test plan

- `VerticalTabStripBrowserTest.TabsBelowViewportAreHidden`

```sh
npm run test -- brave_browser_tests --filter=VerticalTabStripBrowserTest.*