### PR TITLE
[AI Chat]: Let the user allow or block individual WebMCP tools

### DIFF
--- a/browser/ai_chat/ai_chat_render_view_context_menu_browsertest.cc
+++ b/browser/ai_chat/ai_chat_render_view_context_menu_browsertest.cc
@@ -108,6 +108,12 @@ class MockConversationHandlerClient : public mojom::ConversationUI {
               (std::vector<mojom::AssociatedContentPtr>),
               (override));
 
+  MOCK_METHOD(void,
+              OnContentToolsChanged,
+              (const std::string& content_uuid,
+               std::vector<mojom::ToolInfoPtr> tools),
+              (override));
+
   MOCK_METHOD(void, OnConversationDeleted, (), (override));
 
  private:

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler_browsertest.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler_browsertest.cc
@@ -402,6 +402,8 @@ class FakeConversationUI : public mojom::ConversationUI {
                           std::vector<mojom::ModelPtr> all_models) override {}
   void OnAssociatedContentInfoChanged(
       std::vector<mojom::AssociatedContentPtr> associated_content) override {}
+  void OnContentToolsChanged(const std::string& content_uuid,
+                             std::vector<mojom::ToolInfoPtr> tools) override {}
   void OnConversationDeleted() override {}
 };
 

--- a/components/ai_chat/content/browser/content_tool.cc
+++ b/components/ai_chat/content/browser/content_tool.cc
@@ -154,7 +154,8 @@ std::optional<std::vector<std::string>> ContentTool::RequiredProperties()
 std::variant<bool, mojom::PermissionChallengePtr>
 ContentTool::RequiresUserInteractionBeforeHandling(
     const mojom::ToolUseEvent& tool_use) const {
-  if (user_permission_granted_) {
+  if (user_permission_granted_ ||
+      user_permission_ == mojom::ToolPermission::kAlwaysAllow) {
     return false;
   }
 
@@ -165,6 +166,10 @@ ContentTool::RequiresUserInteractionBeforeHandling(
 
 void ContentTool::UserPermissionGranted(const std::string& tool_use_id) {
   user_permission_granted_ = true;
+}
+
+void ContentTool::SetUserPermission(mojom::ToolPermission permission) {
+  user_permission_ = permission;
 }
 
 std::optional<std::string> ContentTool::GetPermissionChallengeDescription(

--- a/components/ai_chat/content/browser/content_tool.cc
+++ b/components/ai_chat/content/browser/content_tool.cc
@@ -155,7 +155,7 @@ std::variant<bool, mojom::PermissionChallengePtr>
 ContentTool::RequiresUserInteractionBeforeHandling(
     const mojom::ToolUseEvent& tool_use) const {
   if (user_permission_granted_ ||
-      user_permission_ == mojom::ToolPermission::kAlwaysAllow) {
+      user_permission_strategy_ == mojom::ToolPermission::kAlwaysAllow) {
     return false;
   }
 
@@ -168,8 +168,8 @@ void ContentTool::UserPermissionGranted(const std::string& tool_use_id) {
   user_permission_granted_ = true;
 }
 
-void ContentTool::SetUserPermission(mojom::ToolPermission permission) {
-  user_permission_ = permission;
+void ContentTool::SetUserPermissionStrategy(mojom::ToolPermission permission) {
+  user_permission_strategy_ = permission;
 }
 
 std::optional<std::string> ContentTool::GetPermissionChallengeDescription(

--- a/components/ai_chat/content/browser/content_tool.h
+++ b/components/ai_chat/content/browser/content_tool.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "brave/components/ai_chat/core/browser/tools/tool.h"
+#include "brave/components/ai_chat/core/common/mojom/common.mojom-shared.h"
 #include "content/public/browser/weak_document_ptr.h"
 #include "third_party/blink/public/mojom/content_extraction/script_tools.mojom-forward.h"
 
@@ -38,6 +39,7 @@ class ContentTool : public Tool {
   RequiresUserInteractionBeforeHandling(
       const mojom::ToolUseEvent& tool_use) const override;
   void UserPermissionGranted(const std::string& tool_use_id) override;
+  void SetUserPermission(mojom::ToolPermission permission) override;
   std::optional<std::string> GetPermissionChallengeDescription(
       const mojom::ToolUseEvent& tool_use) const override;
 
@@ -45,7 +47,11 @@ class ContentTool : public Tool {
                UseToolCallback callback) override;
 
  private:
+  // Granted for this tool use loop only, by answering a permission challenge.
   bool user_permission_granted_ = false;
+  // Never kNeverAllow: those tools are withheld from the model by
+  // AssociatedContentManager and so never reach here.
+  mojom::ToolPermission user_permission_ = mojom::ToolPermission::kAsk;
 
   content::WeakDocumentPtr rfh_;
   // As registered by the page. |name_| and |description_| are the model-facing

--- a/components/ai_chat/content/browser/content_tool.h
+++ b/components/ai_chat/content/browser/content_tool.h
@@ -39,7 +39,7 @@ class ContentTool : public Tool {
   RequiresUserInteractionBeforeHandling(
       const mojom::ToolUseEvent& tool_use) const override;
   void UserPermissionGranted(const std::string& tool_use_id) override;
-  void SetUserPermission(mojom::ToolPermission permission) override;
+  void SetUserPermissionStrategy(mojom::ToolPermission permission) override;
   std::optional<std::string> GetPermissionChallengeDescription(
       const mojom::ToolUseEvent& tool_use) const override;
 
@@ -51,7 +51,7 @@ class ContentTool : public Tool {
   bool user_permission_granted_ = false;
   // Never kNeverAllow: those tools are withheld from the model by
   // AssociatedContentManager and so never reach here.
-  mojom::ToolPermission user_permission_ = mojom::ToolPermission::kAsk;
+  mojom::ToolPermission user_permission_strategy_ = mojom::ToolPermission::kAsk;
 
   content::WeakDocumentPtr rfh_;
   // As registered by the page. |name_| and |description_| are the model-facing

--- a/components/ai_chat/content/browser/content_tool.h
+++ b/components/ai_chat/content/browser/content_tool.h
@@ -49,8 +49,8 @@ class ContentTool : public Tool {
  private:
   // Granted for this tool use loop only, by answering a permission challenge.
   bool user_permission_granted_ = false;
-  // Never kNeverAllow: those tools are withheld from the model by
-  // AssociatedContentManager and so never reach here.
+  // When the permission is set to kNeverAllow the content tool will be
+  // discarded so we don't need to handle it here.
   mojom::ToolPermission user_permission_strategy_ = mojom::ToolPermission::kAsk;
 
   content::WeakDocumentPtr rfh_;

--- a/components/ai_chat/content/browser/content_tool_unittest.cc
+++ b/components/ai_chat/content/browser/content_tool_unittest.cc
@@ -247,13 +247,13 @@ TEST_F(ContentToolTest, AlwaysAllowSkipsPermissionChallenge) {
   ContentTool tool(*mojo_tool, weak_document());
 
   auto tool_use = mojom::ToolUseEvent::New();
-  tool.SetUserPermission(mojom::ToolPermission::kAlwaysAllow);
+  tool.SetUserPermissionStrategy(mojom::ToolPermission::kAlwaysAllow);
 
   auto result = tool.RequiresUserInteractionBeforeHandling(*tool_use);
   ASSERT_TRUE(std::holds_alternative<bool>(result));
   EXPECT_FALSE(std::get<bool>(result));
 
-  tool.SetUserPermission(mojom::ToolPermission::kAsk);
+  tool.SetUserPermissionStrategy(mojom::ToolPermission::kAsk);
   EXPECT_TRUE(std::holds_alternative<mojom::PermissionChallengePtr>(
       tool.RequiresUserInteractionBeforeHandling(*tool_use)));
 }

--- a/components/ai_chat/content/browser/content_tool_unittest.cc
+++ b/components/ai_chat/content/browser/content_tool_unittest.cc
@@ -242,6 +242,22 @@ TEST_F(ContentToolTest, RequiresPermissionChallengeUntilGranted) {
   EXPECT_FALSE(std::get<bool>(after));
 }
 
+TEST_F(ContentToolTest, AlwaysAllowSkipsPermissionChallenge) {
+  auto mojo_tool = MakeScriptTool("echo", "");
+  ContentTool tool(*mojo_tool, weak_document());
+
+  auto tool_use = mojom::ToolUseEvent::New();
+  tool.SetUserPermission(mojom::ToolPermission::kAlwaysAllow);
+
+  auto result = tool.RequiresUserInteractionBeforeHandling(*tool_use);
+  ASSERT_TRUE(std::holds_alternative<bool>(result));
+  EXPECT_FALSE(std::get<bool>(result));
+
+  tool.SetUserPermission(mojom::ToolPermission::kAsk);
+  EXPECT_TRUE(std::holds_alternative<mojom::PermissionChallengePtr>(
+      tool.RequiresUserInteractionBeforeHandling(*tool_use)));
+}
+
 TEST_F(ContentToolTest, PermissionChallengeDescriptionEscapesToolName) {
   // Tool names are site-controlled. Characters outside the allowlist (here the
   // brackets and parens of a markdown link) are dropped outright, and the

--- a/components/ai_chat/core/browser/ai_chat_service_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_service_unittest.cc
@@ -178,6 +178,12 @@ class MockConversationHandlerClient : public mojom::ConversationUI {
               (std::vector<mojom::AssociatedContentPtr>),
               (override));
 
+  MOCK_METHOD(void,
+              OnContentToolsChanged,
+              (const std::string& content_uuid,
+               std::vector<mojom::ToolInfoPtr> tools),
+              (override));
+
   MOCK_METHOD(void, OnConversationDeleted, (), (override));
 
  private:

--- a/components/ai_chat/core/browser/associated_content_manager.cc
+++ b/components/ai_chat/core/browser/associated_content_manager.cc
@@ -244,20 +244,74 @@ void AssociatedContentManager::GetToolInfos(std::string_view content_uuid,
     return;
   }
 
-  (*it)->GetContentTools(base::BindOnce(
-      [](GetToolInfosCallback callback,
-         std::vector<std::unique_ptr<Tool>> tools) {
-        tools.resize(std::min(tools.size(), kMaxToolsPerContent));
-        std::vector<mojom::ToolInfoPtr> infos;
-        infos.reserve(tools.size());
-        for (const auto& tool : tools) {
-          infos.push_back(
-              mojom::ToolInfo::New(std::string(tool->DisplayName()),
-                                   std::string(tool->DisplayDescription())));
-        }
-        std::move(callback).Run(std::move(infos));
-      },
-      std::move(callback)));
+  (*it)->GetContentTools(
+      base::BindOnce(&AssociatedContentManager::OnToolInfosFetched,
+                     weak_ptr_factory_.GetWeakPtr(),
+                     url::Origin::Create((*it)->url()), std::move(callback)));
+}
+
+void AssociatedContentManager::OnToolInfosFetched(
+    const url::Origin& origin,
+    GetToolInfosCallback callback,
+    std::vector<std::unique_ptr<Tool>> tools) {
+  tools.resize(std::min(tools.size(), kMaxToolsPerContent));
+  std::vector<mojom::ToolInfoPtr> infos;
+  infos.reserve(tools.size());
+  // Blocked tools are listed too, so the user can see and undo the choice.
+  for (const auto& tool : tools) {
+    infos.push_back(
+        mojom::ToolInfo::New(std::string(tool->DisplayName()),
+                             std::string(tool->DisplayDescription()),
+                             GetToolPermission(origin, tool->DisplayName())));
+  }
+  std::move(callback).Run(std::move(infos));
+}
+
+void AssociatedContentManager::SetToolPermission(
+    std::string_view content_uuid,
+    std::string_view tool_name,
+    mojom::ToolPermission permission) {
+  auto it = std::ranges::find_if(content_delegates_,
+                                 [&content_uuid](const auto& delegate) {
+                                   return delegate->uuid() == content_uuid;
+                                 });
+  if (it == content_delegates_.end()) {
+    return;
+  }
+
+  // Each url::Origin::Create() of an opaque origin gets a fresh nonce, so
+  // there's no key to record the choice against that could be found again.
+  const url::Origin origin = url::Origin::Create((*it)->url());
+  if (origin.opaque()) {
+    return;
+  }
+
+  // kAsk is the default, so drop the entry rather than storing it.
+  if (permission == mojom::ToolPermission::kAsk) {
+    auto origin_it = tool_permissions_.find(origin);
+    if (origin_it == tool_permissions_.end()) {
+      return;
+    }
+    origin_it->second.erase(tool_name);
+    if (origin_it->second.empty()) {
+      tool_permissions_.erase(origin_it);
+    }
+    return;
+  }
+
+  tool_permissions_[origin][std::string(tool_name)] = permission;
+}
+
+mojom::ToolPermission AssociatedContentManager::GetToolPermission(
+    const url::Origin& origin,
+    std::string_view tool_name) const {
+  auto origin_it = tool_permissions_.find(origin);
+  if (origin_it == tool_permissions_.end()) {
+    return mojom::ToolPermission::kAsk;
+  }
+  auto tool_it = origin_it->second.find(tool_name);
+  return tool_it == origin_it->second.end() ? mojom::ToolPermission::kAsk
+                                            : tool_it->second;
 }
 
 void AssociatedContentManager::DetectContentTools(
@@ -598,18 +652,35 @@ void AssociatedContentManager::UpdateToolsForNewGenerationLoop(
       base::BarrierClosure(attached_delegates.size(), std::move(on_updated));
   for (auto* content : attached_delegates) {
     content->GetContentTools(base::BindOnce(
-        [](base::WeakPtr<AssociatedContentManager> self,
+        [](base::WeakPtr<AssociatedContentManager> self, url::Origin origin,
            base::RepeatingClosure done,
            std::vector<std::unique_ptr<Tool>> tools) {
           if (self) {
-            std::move(
-                tools.begin(),
-                tools.begin() + std::min(tools.size(), kMaxToolsPerContent),
-                std::back_inserter(self->tools_));
+            self->AddToolsForGenerationLoop(origin, std::move(tools));
           }
           done.Run();
         },
-        weak_ptr_factory_.GetWeakPtr(), barrier));
+        weak_ptr_factory_.GetWeakPtr(), url::Origin::Create(content->url()),
+        barrier));
+  }
+}
+
+void AssociatedContentManager::AddToolsForGenerationLoop(
+    const url::Origin& origin,
+    std::vector<std::unique_ptr<Tool>> tools) {
+  // Cap before filtering so the list the model sees is a subset of the one the
+  // website tools dialog shows, which caps the same way.
+  tools.resize(std::min(tools.size(), kMaxToolsPerContent));
+  for (auto& tool : tools) {
+    const mojom::ToolPermission permission =
+        GetToolPermission(origin, tool->DisplayName());
+    // Withheld rather than failed when called, so the model can't waste a turn
+    // asking for something it will never be given.
+    if (permission == mojom::ToolPermission::kNeverAllow) {
+      continue;
+    }
+    tool->SetUserPermission(permission);
+    tools_.push_back(std::move(tool));
   }
 }
 

--- a/components/ai_chat/core/browser/associated_content_manager.cc
+++ b/components/ai_chat/core/browser/associated_content_manager.cc
@@ -692,7 +692,7 @@ void AssociatedContentManager::AddToolsForGenerationLoop(
     if (permission == mojom::ToolPermission::kNeverAllow) {
       continue;
     }
-    tool->SetUserPermission(permission);
+    tool->SetUserPermissionStrategy(permission);
     tools_.push_back(std::move(tool));
   }
 }

--- a/components/ai_chat/core/browser/associated_content_manager.cc
+++ b/components/ai_chat/core/browser/associated_content_manager.cc
@@ -180,7 +180,10 @@ void AssociatedContentManager::RemoveContent(
 
   auto it = std::ranges::find(content_delegates_, delegate,
                               [](const auto& ptr) { return ptr; });
+  url::Origin origin;
   if (it != content_delegates_.end()) {
+    // Captured now, as erasing owned content below may delete |delegate|.
+    origin = url::Origin::Create(delegate->url());
     // Let the content know it isn't associated with this conversation
     // anymore.
     content_observations_.RemoveObservation(delegate);
@@ -195,6 +198,8 @@ void AssociatedContentManager::RemoveContent(
   if (owned_it != owned_content_.end()) {
     owned_content_.erase(owned_it);
   }
+
+  MaybeResetToolPermissionsForOrigin(origin);
 
   if (notify_updated) {
     conversation_->OnAssociatedContentUpdated();
@@ -713,6 +718,33 @@ void AssociatedContentManager::DetachContent() {
   content_delegates_.clear();
   owned_content_.clear();
   tools_attachment_overridden_.clear();
+  tool_permissions_.clear();
+}
+
+bool AssociatedContentManager::HasLiveContentForOrigin(
+    const url::Origin& origin) const {
+  for (auto* delegate : content_delegates_) {
+    // Archived content can't expose tools.
+    auto owned_it =
+        std::ranges::find(owned_content_, delegate,
+                          [](const auto& owned) { return owned.get(); });
+    if (owned_it != owned_content_.end()) {
+      continue;
+    }
+    if (url::Origin::Create(delegate->url()) == origin) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void AssociatedContentManager::MaybeResetToolPermissionsForOrigin(
+    const url::Origin& origin) {
+  auto origin_it = tool_permissions_.find(origin);
+  if (origin_it == tool_permissions_.end() || HasLiveContentForOrigin(origin)) {
+    return;
+  }
+  tool_permissions_.erase(origin_it);
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/associated_content_manager.cc
+++ b/components/ai_chat/core/browser/associated_content_manager.cc
@@ -296,10 +296,23 @@ void AssociatedContentManager::SetToolPermission(
     if (origin_it->second.empty()) {
       tool_permissions_.erase(origin_it);
     }
-    return;
+  } else {
+    tool_permissions_[origin][std::string(tool_name)] = permission;
   }
 
-  tool_permissions_[origin][std::string(tool_name)] = permission;
+  // The choice is conversation-wide, so tell every UI bound to the
+  // conversation rather than leaving the one it was made from to update
+  // itself.
+  GetToolInfos(content_uuid,
+               base::BindOnce(
+                   &AssociatedContentManager::NotifyContentToolsChanged,
+                   weak_ptr_factory_.GetWeakPtr(), std::string(content_uuid)));
+}
+
+void AssociatedContentManager::NotifyContentToolsChanged(
+    const std::string& content_uuid,
+    std::vector<mojom::ToolInfoPtr> tools) {
+  conversation_->OnContentToolsChanged(content_uuid, std::move(tools));
 }
 
 mojom::ToolPermission AssociatedContentManager::GetToolPermission(

--- a/components/ai_chat/core/browser/associated_content_manager.cc
+++ b/components/ai_chat/core/browser/associated_content_manager.cc
@@ -293,16 +293,16 @@ void AssociatedContentManager::SetToolPermission(
 
   // kAsk is the default, so drop the entry rather than storing it.
   if (permission == mojom::ToolPermission::kAsk) {
-    auto origin_it = tool_permissions_.find(origin);
-    if (origin_it == tool_permissions_.end()) {
+    auto origin_it = content_tool_permissions_.find(origin);
+    if (origin_it == content_tool_permissions_.end()) {
       return;
     }
     origin_it->second.erase(tool_name);
     if (origin_it->second.empty()) {
-      tool_permissions_.erase(origin_it);
+      content_tool_permissions_.erase(origin_it);
     }
   } else {
-    tool_permissions_[origin][std::string(tool_name)] = permission;
+    content_tool_permissions_[origin][std::string(tool_name)] = permission;
   }
 
   // The choice is conversation-wide, so tell every UI bound to the
@@ -323,8 +323,8 @@ void AssociatedContentManager::NotifyContentToolsChanged(
 mojom::ToolPermission AssociatedContentManager::GetToolPermission(
     const url::Origin& origin,
     std::string_view tool_name) const {
-  auto origin_it = tool_permissions_.find(origin);
-  if (origin_it == tool_permissions_.end()) {
+  auto origin_it = content_tool_permissions_.find(origin);
+  if (origin_it == content_tool_permissions_.end()) {
     return mojom::ToolPermission::kAsk;
   }
   auto tool_it = origin_it->second.find(tool_name);
@@ -718,7 +718,7 @@ void AssociatedContentManager::DetachContent() {
   content_delegates_.clear();
   owned_content_.clear();
   tools_attachment_overridden_.clear();
-  tool_permissions_.clear();
+  content_tool_permissions_.clear();
 }
 
 bool AssociatedContentManager::HasLiveContentForOrigin(
@@ -740,11 +740,12 @@ bool AssociatedContentManager::HasLiveContentForOrigin(
 
 void AssociatedContentManager::MaybeResetToolPermissionsForOrigin(
     const url::Origin& origin) {
-  auto origin_it = tool_permissions_.find(origin);
-  if (origin_it == tool_permissions_.end() || HasLiveContentForOrigin(origin)) {
+  auto origin_it = content_tool_permissions_.find(origin);
+  if (origin_it == content_tool_permissions_.end() ||
+      HasLiveContentForOrigin(origin)) {
     return;
   }
-  tool_permissions_.erase(origin_it);
+  content_tool_permissions_.erase(origin_it);
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/associated_content_manager.h
+++ b/components/ai_chat/core/browser/associated_content_manager.h
@@ -199,14 +199,15 @@ class AssociatedContentManager : public ToolProvider,
 
   std::vector<std::unique_ptr<Tool>> tools_;
 
-  // Origin -> tool name -> choice, for anything moved off the kAsk default.
+  // Content tools only (i.e. those a page exposes): origin -> tool name ->
+  // choice, for anything moved off the kAsk default.
   // Deliberately in-memory and per-conversation: granting a site's tool is a
   // decision about this conversation's context, so it shouldn't silently
   // carry over into the next one, nor outlive the site's content being
   // attached here.
   base::flat_map<url::Origin,
                  base::flat_map<std::string, mojom::ToolPermission>>
-      tool_permissions_;
+      content_tool_permissions_;
 
   std::vector<AssociatedContentDelegate*> content_delegates_;
   base::flat_map<std::string, std::string> content_uuid_to_conversation_turns_;

--- a/components/ai_chat/core/browser/associated_content_manager.h
+++ b/components/ai_chat/core/browser/associated_content_manager.h
@@ -175,6 +175,11 @@ class AssociatedContentManager : public ToolProvider,
                           GetToolInfosCallback callback,
                           std::vector<std::unique_ptr<Tool>> tools);
 
+  // Invoked with the result of GetToolInfos(), to push the list every UI bound
+  // to this conversation should now be showing.
+  void NotifyContentToolsChanged(const std::string& content_uuid,
+                                 std::vector<mojom::ToolInfoPtr> tools);
+
   mojom::ToolPermission GetToolPermission(const url::Origin& origin,
                                           std::string_view tool_name) const;
 

--- a/components/ai_chat/core/browser/associated_content_manager.h
+++ b/components/ai_chat/core/browser/associated_content_manager.h
@@ -13,6 +13,7 @@
 #include <string_view>
 #include <vector>
 
+#include "base/containers/flat_map.h"
 #include "base/containers/flat_set.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
@@ -24,6 +25,7 @@
 #include "brave/components/ai_chat/core/browser/tools/tool_provider.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom.h"
+#include "url/origin.h"
 
 namespace ai_chat {
 
@@ -88,6 +90,14 @@ class AssociatedContentManager : public ToolProvider,
       base::OnceCallback<void(std::vector<mojom::ToolInfoPtr>)>;
   void GetToolInfos(std::string_view content_uuid,
                     GetToolInfosCallback callback);
+
+  // Records how the tool named |tool_name| exposed by the content with
+  // |content_uuid| should be handled. Keyed by the content's origin rather
+  // than its uuid, so navigating away drops the choice rather than applying
+  // it to whatever loads next.
+  void SetToolPermission(std::string_view content_uuid,
+                         std::string_view tool_name,
+                         mojom::ToolPermission permission);
 
   // Clears all content from the conversation.
   void ClearContent();
@@ -160,9 +170,31 @@ class AssociatedContentManager : public ToolProvider,
   // attachment.
   bool IsEligibleForAutoToolsUpdate(const std::string& content_uuid) const;
 
+  // Invoked with the result of GetContentTools().
+  void OnToolInfosFetched(const url::Origin& origin,
+                          GetToolInfosCallback callback,
+                          std::vector<std::unique_ptr<Tool>> tools);
+
+  mojom::ToolPermission GetToolPermission(const url::Origin& origin,
+                                          std::string_view tool_name) const;
+
+  // Takes ownership of the tools |origin| exposes for the loop that's
+  // starting, dropping the ones the user has blocked.
+  void AddToolsForGenerationLoop(const url::Origin& origin,
+                                 std::vector<std::unique_ptr<Tool>> tools);
+
   raw_ptr<ConversationHandler> conversation_;
 
   std::vector<std::unique_ptr<Tool>> tools_;
+
+  // Origin -> tool name -> choice, for anything moved off the kAsk default.
+  // Deliberately in-memory and per-conversation: granting a site's tool is a
+  // decision about this conversation's context, so it shouldn't silently
+  // carry over into the next one.
+  base::flat_map<url::Origin,
+                 base::flat_map<std::string, mojom::ToolPermission>>
+      tool_permissions_;
+
   std::vector<AssociatedContentDelegate*> content_delegates_;
   base::flat_map<std::string, std::string> content_uuid_to_conversation_turns_;
 

--- a/components/ai_chat/core/browser/associated_content_manager.h
+++ b/components/ai_chat/core/browser/associated_content_manager.h
@@ -183,6 +183,13 @@ class AssociatedContentManager : public ToolProvider,
   mojom::ToolPermission GetToolPermission(const url::Origin& origin,
                                           std::string_view tool_name) const;
 
+  // Whether |origin| still has live (i.e. not archived) content here.
+  bool HasLiveContentForOrigin(const url::Origin& origin) const;
+
+  // Drops |origin|'s recorded choices once it has no live content left, so
+  // that attaching the site again starts from the kAsk default.
+  void MaybeResetToolPermissionsForOrigin(const url::Origin& origin);
+
   // Takes ownership of the tools |origin| exposes for the loop that's
   // starting, dropping the ones the user has blocked.
   void AddToolsForGenerationLoop(const url::Origin& origin,
@@ -195,7 +202,8 @@ class AssociatedContentManager : public ToolProvider,
   // Origin -> tool name -> choice, for anything moved off the kAsk default.
   // Deliberately in-memory and per-conversation: granting a site's tool is a
   // decision about this conversation's context, so it shouldn't silently
-  // carry over into the next one.
+  // carry over into the next one, nor outlive the site's content being
+  // attached here.
   base::flat_map<url::Origin,
                  base::flat_map<std::string, mojom::ToolPermission>>
       tool_permissions_;

--- a/components/ai_chat/core/browser/associated_content_manager_unittest.cc
+++ b/components/ai_chat/core/browser/associated_content_manager_unittest.cc
@@ -28,8 +28,10 @@
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom-forward.h"
 #include "brave/components/ai_chat/core/common/mojom/common.mojom-forward.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
+#include "build/build_config.h"
 #include "components/os_crypt/async/browser/test_utils.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "mojo/public/cpp/bindings/receiver.h"
 #include "services/network/public/cpp/network_context_getter.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
@@ -53,6 +55,44 @@ class MockAIChatCredentialManager : public AIChatCredentialManager {
                             mojom::PremiumInfo::New());
   }
   MOCK_METHOD(void, PutCredentialInCache, (CredentialCacheEntry), (override));
+};
+
+// Stands in for an open conversation UI, recording the tool lists the browser
+// pushes to it.
+class TestConversationUI : public mojom::ConversationUI {
+ public:
+  explicit TestConversationUI(ConversationHandler* handler) {
+    handler->Bind(receiver_.BindNewPipeAndPassRemote());
+  }
+  ~TestConversationUI() override = default;
+
+  const std::vector<mojom::ToolInfoPtr>& tools() const { return tools_; }
+
+  // mojom::ConversationUI:
+  void OnContentToolsChanged(const std::string& content_uuid,
+                             std::vector<mojom::ToolInfoPtr> tools) override {
+    tools_ = std::move(tools);
+  }
+  void OnConversationHistoryUpdate(mojom::ConversationTurnPtr entry) override {}
+  void OnAPIRequestInProgress(bool in_progress) override {}
+  void OnAPIResponseError(mojom::APIError error,
+                          mojom::APIErrorDetailsPtr details) override {}
+  void OnTaskStateChanged(mojom::TaskState task_state) override {}
+  void OnModelDataChanged(const std::string& conversation_model_key,
+                          const std::string& default_model_key,
+                          std::vector<mojom::ModelPtr> all_models) override {}
+#if BUILDFLAG(IS_IOS)
+  void OnSuggestedQuestionsChanged(
+      const std::vector<std::string>& questions,
+      mojom::SuggestionGenerationStatus status) override {}
+#endif
+  void OnAssociatedContentInfoChanged(
+      std::vector<mojom::AssociatedContentPtr> associated_content) override {}
+  void OnConversationDeleted() override {}
+
+ private:
+  std::vector<mojom::ToolInfoPtr> tools_;
+  mojo::Receiver<mojom::ConversationUI> receiver_{this};
 };
 
 }  // namespace
@@ -867,6 +907,56 @@ TEST_F(AssociatedContentManagerUnitTest,
   manager->GetToolInfos(content.uuid(), infos.GetCallback());
   ASSERT_EQ(1u, infos.Get().size());
   EXPECT_EQ(mojom::ToolPermission::kAsk, infos.Get()[0]->permission);
+}
+
+TEST_F(AssociatedContentManagerUnitTest,
+       SetToolPermission_IsPushedToEveryBoundUI) {
+  // The choice is conversation-wide, so a UI that didn't make it mustn't be
+  // left showing the tool's old permission.
+  NiceMock<MockAssociatedContent> content;
+  content.SetUrl(GURL("https://example.com/cart"));
+  EXPECT_CALL(content, GetContentTools)
+      .WillRepeatedly(
+          [](AssociatedContentDelegate::GetContentToolsCallback cb) {
+            std::vector<std::unique_ptr<Tool>> tools;
+            tools.push_back(
+                std::make_unique<NiceMock<MockTool>>("cancel_cart"));
+            std::move(cb).Run(std::move(tools));
+          });
+
+  auto* manager = conversation_handler_->associated_content_manager();
+  manager->AddContent(&content);
+
+  TestConversationUI acting_ui(conversation_handler_.get());
+  TestConversationUI other_ui(conversation_handler_.get());
+
+  manager->SetToolPermission(content.uuid(), "cancel_cart",
+                             mojom::ToolPermission::kNeverAllow);
+  task_environment_.RunUntilIdle();
+
+  for (const auto* ui : {&acting_ui, &other_ui}) {
+    ASSERT_EQ(1u, ui->tools().size());
+    EXPECT_EQ("cancel_cart", ui->tools()[0]->name);
+    EXPECT_EQ(mojom::ToolPermission::kNeverAllow, ui->tools()[0]->permission);
+  }
+}
+
+TEST_F(AssociatedContentManagerUnitTest,
+       SetToolPermission_UnstoredChoiceIsNotPushed) {
+  // Nothing was recorded, so there's nothing for the UIs to reflect - pushing
+  // would tell them the choice took effect.
+  NiceMock<MockAssociatedContent> content;
+  content.SetUrl(GURL("https://example.com/cart"));
+  auto* manager = conversation_handler_->associated_content_manager();
+  manager->AddContent(&content);
+
+  TestConversationUI ui(conversation_handler_.get());
+
+  manager->SetToolPermission("not-an-attached-content", "cancel_cart",
+                             mojom::ToolPermission::kNeverAllow);
+  task_environment_.RunUntilIdle();
+
+  EXPECT_TRUE(ui.tools().empty());
 }
 
 TEST_F(AssociatedContentManagerUnitTest, GetToolInfos_UnknownContentIsEmpty) {

--- a/components/ai_chat/core/browser/associated_content_manager_unittest.cc
+++ b/components/ai_chat/core/browser/associated_content_manager_unittest.cc
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include <map>
 #include <memory>
 #include <set>
 #include <string>
@@ -694,6 +695,178 @@ TEST_F(AssociatedContentManagerUnitTest, GetToolInfos_DescribesTools) {
   EXPECT_EQ("Browse OR navigate to store collections.", result[0]->description);
   EXPECT_EQ("cancel_cart", result[1]->name);
   EXPECT_EQ("Remove all items from the cart.", result[1]->description);
+}
+
+TEST_F(AssociatedContentManagerUnitTest, GetToolInfos_ReportsToolPermissions) {
+  NiceMock<MockAssociatedContent> content;
+  content.SetUrl(GURL("https://example.com/cart"));
+  EXPECT_CALL(content, GetContentTools)
+      .WillRepeatedly(
+          [](AssociatedContentDelegate::GetContentToolsCallback cb) {
+            std::vector<std::unique_ptr<Tool>> tools;
+            tools.push_back(
+                std::make_unique<NiceMock<MockTool>>("browse_store"));
+            tools.push_back(
+                std::make_unique<NiceMock<MockTool>>("cancel_cart"));
+            std::move(cb).Run(std::move(tools));
+          });
+
+  auto* manager = conversation_handler_->associated_content_manager();
+  manager->AddContent(&content);
+
+  base::test::TestFuture<std::vector<mojom::ToolInfoPtr>> initial;
+  manager->GetToolInfos(content.uuid(), initial.GetCallback());
+  ASSERT_EQ(2u, initial.Get().size());
+  EXPECT_EQ(mojom::ToolPermission::kAsk, initial.Get()[0]->permission);
+  EXPECT_EQ(mojom::ToolPermission::kAsk, initial.Get()[1]->permission);
+
+  manager->SetToolPermission(content.uuid(), "browse_store",
+                             mojom::ToolPermission::kAlwaysAllow);
+  manager->SetToolPermission(content.uuid(), "cancel_cart",
+                             mojom::ToolPermission::kNeverAllow);
+
+  base::test::TestFuture<std::vector<mojom::ToolInfoPtr>> updated;
+  manager->GetToolInfos(content.uuid(), updated.GetCallback());
+  ASSERT_EQ(2u, updated.Get().size());
+  EXPECT_EQ(mojom::ToolPermission::kAlwaysAllow, updated.Get()[0]->permission);
+  EXPECT_EQ(mojom::ToolPermission::kNeverAllow, updated.Get()[1]->permission);
+
+  // Blocked tools stay listed in the dialog, so the choice can be undone.
+  manager->SetToolPermission(content.uuid(), "cancel_cart",
+                             mojom::ToolPermission::kAsk);
+  base::test::TestFuture<std::vector<mojom::ToolInfoPtr>> reset;
+  manager->GetToolInfos(content.uuid(), reset.GetCallback());
+  ASSERT_EQ(2u, reset.Get().size());
+  EXPECT_EQ(mojom::ToolPermission::kAsk, reset.Get()[1]->permission);
+}
+
+TEST_F(AssociatedContentManagerUnitTest,
+       SetToolPermission_NeverAllowWithholdsToolFromGenerationLoop) {
+  NiceMock<MockAssociatedContent> content;
+  content.SetUrl(GURL("https://example.com/cart"));
+  EXPECT_CALL(content, GetContentTools)
+      .WillRepeatedly(
+          [](AssociatedContentDelegate::GetContentToolsCallback cb) {
+            std::vector<std::unique_ptr<Tool>> tools;
+            tools.push_back(
+                std::make_unique<NiceMock<MockTool>>("browse_store"));
+            tools.push_back(
+                std::make_unique<NiceMock<MockTool>>("cancel_cart"));
+            std::move(cb).Run(std::move(tools));
+          });
+
+  auto* manager = conversation_handler_->associated_content_manager();
+  manager->AddContent(&content);
+  manager->SetToolPermission(content.uuid(), "cancel_cart",
+                             mojom::ToolPermission::kNeverAllow);
+
+  base::test::TestFuture<void> done;
+  manager->UpdateToolsForNewGenerationLoop(done.GetCallback());
+  ASSERT_TRUE(done.Wait());
+
+  auto tools = manager->GetTools();
+  ASSERT_EQ(1u, tools.size());
+  EXPECT_EQ("browse_store", std::string(tools[0]->Name()));
+}
+
+TEST_F(AssociatedContentManagerUnitTest,
+       SetToolPermission_AppliesChoiceToToolsForGenerationLoop) {
+  // Tools are rebuilt for every generation loop, so the manager has to
+  // reapply the user's choice to each fresh instance.
+  std::map<std::string, mojom::ToolPermission> applied;
+  NiceMock<MockAssociatedContent> content;
+  content.SetUrl(GURL("https://example.com/cart"));
+  EXPECT_CALL(content, GetContentTools)
+      .WillRepeatedly(
+          [&applied](AssociatedContentDelegate::GetContentToolsCallback cb) {
+            std::vector<std::unique_ptr<Tool>> tools;
+            for (const char* name : {"browse_store", "cancel_cart"}) {
+              auto tool = std::make_unique<NiceMock<MockTool>>(name);
+              ON_CALL(*tool, SetUserPermission)
+                  .WillByDefault(
+                      [&applied, name](mojom::ToolPermission permission) {
+                        applied[name] = permission;
+                      });
+              tools.push_back(std::move(tool));
+            }
+            std::move(cb).Run(std::move(tools));
+          });
+
+  auto* manager = conversation_handler_->associated_content_manager();
+  manager->AddContent(&content);
+  manager->SetToolPermission(content.uuid(), "browse_store",
+                             mojom::ToolPermission::kAlwaysAllow);
+
+  base::test::TestFuture<void> done;
+  manager->UpdateToolsForNewGenerationLoop(done.GetCallback());
+  ASSERT_TRUE(done.Wait());
+
+  EXPECT_THAT(applied,
+              ::testing::UnorderedElementsAre(
+                  std::pair<const std::string, mojom::ToolPermission>(
+                      "browse_store", mojom::ToolPermission::kAlwaysAllow),
+                  std::pair<const std::string, mojom::ToolPermission>(
+                      "cancel_cart", mojom::ToolPermission::kAsk)));
+}
+
+TEST_F(AssociatedContentManagerUnitTest,
+       SetToolPermission_IsScopedToTheContentsOrigin) {
+  // Two sites can each expose a tool of the same name, and a choice about one
+  // must not silently apply to the other.
+  NiceMock<MockAssociatedContent> first_content;
+  first_content.SetUrl(GURL("https://example.com/cart"));
+  NiceMock<MockAssociatedContent> second_content;
+  second_content.SetUrl(GURL("https://other.example/cart"));
+  for (auto* content : {&first_content, &second_content}) {
+    EXPECT_CALL(*content, GetContentTools)
+        .WillRepeatedly(
+            [](AssociatedContentDelegate::GetContentToolsCallback cb) {
+              std::vector<std::unique_ptr<Tool>> tools;
+              tools.push_back(
+                  std::make_unique<NiceMock<MockTool>>("cancel_cart"));
+              std::move(cb).Run(std::move(tools));
+            });
+  }
+
+  auto* manager = conversation_handler_->associated_content_manager();
+  manager->AddContent(&first_content);
+  manager->AddContent(&second_content);
+  manager->SetToolPermission(first_content.uuid(), "cancel_cart",
+                             mojom::ToolPermission::kNeverAllow);
+
+  base::test::TestFuture<std::vector<mojom::ToolInfoPtr>> second_infos;
+  manager->GetToolInfos(second_content.uuid(), second_infos.GetCallback());
+  ASSERT_EQ(1u, second_infos.Get().size());
+  EXPECT_EQ(mojom::ToolPermission::kAsk, second_infos.Get()[0]->permission);
+
+  base::test::TestFuture<void> done;
+  manager->UpdateToolsForNewGenerationLoop(done.GetCallback());
+  ASSERT_TRUE(done.Wait());
+  EXPECT_EQ(1u, manager->GetTools().size());
+}
+
+TEST_F(AssociatedContentManagerUnitTest,
+       SetToolPermission_UnknownContentIsIgnored) {
+  NiceMock<MockAssociatedContent> content;
+  content.SetUrl(GURL("https://example.com/cart"));
+  EXPECT_CALL(content, GetContentTools)
+      .WillRepeatedly(
+          [](AssociatedContentDelegate::GetContentToolsCallback cb) {
+            std::vector<std::unique_ptr<Tool>> tools;
+            tools.push_back(
+                std::make_unique<NiceMock<MockTool>>("cancel_cart"));
+            std::move(cb).Run(std::move(tools));
+          });
+
+  auto* manager = conversation_handler_->associated_content_manager();
+  manager->AddContent(&content);
+  manager->SetToolPermission("not-an-attached-content", "cancel_cart",
+                             mojom::ToolPermission::kNeverAllow);
+
+  base::test::TestFuture<std::vector<mojom::ToolInfoPtr>> infos;
+  manager->GetToolInfos(content.uuid(), infos.GetCallback());
+  ASSERT_EQ(1u, infos.Get().size());
+  EXPECT_EQ(mojom::ToolPermission::kAsk, infos.Get()[0]->permission);
 }
 
 TEST_F(AssociatedContentManagerUnitTest, GetToolInfos_UnknownContentIsEmpty) {

--- a/components/ai_chat/core/browser/associated_content_manager_unittest.cc
+++ b/components/ai_chat/core/browser/associated_content_manager_unittest.cc
@@ -825,7 +825,7 @@ TEST_F(AssociatedContentManagerUnitTest,
             std::vector<std::unique_ptr<Tool>> tools;
             for (const char* name : {"browse_store", "cancel_cart"}) {
               auto tool = std::make_unique<NiceMock<MockTool>>(name);
-              ON_CALL(*tool, SetUserPermission)
+              ON_CALL(*tool, SetUserPermissionStrategy)
                   .WillByDefault(
                       [&applied, name](mojom::ToolPermission permission) {
                         applied[name] = permission;

--- a/components/ai_chat/core/browser/associated_content_manager_unittest.cc
+++ b/components/ai_chat/core/browser/associated_content_manager_unittest.cc
@@ -67,11 +67,13 @@ class TestConversationUI : public mojom::ConversationUI {
   ~TestConversationUI() override = default;
 
   const std::vector<mojom::ToolInfoPtr>& tools() const { return tools_; }
+  size_t push_count() const { return push_count_; }
 
   // mojom::ConversationUI:
   void OnContentToolsChanged(const std::string& content_uuid,
                              std::vector<mojom::ToolInfoPtr> tools) override {
     tools_ = std::move(tools);
+    ++push_count_;
   }
   void OnConversationHistoryUpdate(mojom::ConversationTurnPtr entry) override {}
   void OnAPIRequestInProgress(bool in_progress) override {}
@@ -92,6 +94,7 @@ class TestConversationUI : public mojom::ConversationUI {
 
  private:
   std::vector<mojom::ToolInfoPtr> tools_;
+  size_t push_count_ = 0;
   mojo::Receiver<mojom::ConversationUI> receiver_{this};
 };
 
@@ -932,7 +935,8 @@ TEST_F(AssociatedContentManagerUnitTest,
 
   manager->SetToolPermission(content.uuid(), "cancel_cart",
                              mojom::ToolPermission::kNeverAllow);
-  task_environment_.RunUntilIdle();
+  ASSERT_TRUE(base::test::RunUntil(
+      [&] { return acting_ui.push_count() > 0 && other_ui.push_count() > 0; }));
 
   for (const auto* ui : {&acting_ui, &other_ui}) {
     ASSERT_EQ(1u, ui->tools().size());
@@ -954,9 +958,13 @@ TEST_F(AssociatedContentManagerUnitTest,
 
   manager->SetToolPermission("not-an-attached-content", "cancel_cart",
                              mojom::ToolPermission::kNeverAllow);
-  task_environment_.RunUntilIdle();
+  // A choice that is recorded, to wait on. Pipes preserve order, so a push
+  // for the ignored call would have arrived before this one.
+  manager->SetToolPermission(content.uuid(), "cancel_cart",
+                             mojom::ToolPermission::kNeverAllow);
+  ASSERT_TRUE(base::test::RunUntil([&] { return ui.push_count() > 0; }));
 
-  EXPECT_TRUE(ui.tools().empty());
+  EXPECT_EQ(1u, ui.push_count());
 }
 
 TEST_F(AssociatedContentManagerUnitTest, GetToolInfos_UnknownContentIsEmpty) {

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -360,6 +360,14 @@ void ConversationHandler::OnAssociatedContentUpdated() {
   }
 }
 
+void ConversationHandler::OnContentToolsChanged(
+    const std::string& content_uuid,
+    std::vector<mojom::ToolInfoPtr> tools) {
+  for (auto& client : conversation_ui_handlers_) {
+    client->OnContentToolsChanged(content_uuid, mojo::Clone(tools));
+  }
+}
+
 bool ConversationHandler::IsAnyClientConnected() {
   return !receivers_.empty() || !conversation_ui_handlers_.empty();
 }

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -1994,6 +1994,14 @@ void ConversationHandler::GetContentTools(const std::string& content_uuid,
   associated_content_manager_->GetToolInfos(content_uuid, std::move(callback));
 }
 
+void ConversationHandler::SetContentToolPermission(
+    const std::string& content_uuid,
+    const std::string& tool_name,
+    mojom::ToolPermission permission) {
+  associated_content_manager_->SetToolPermission(content_uuid, tool_name,
+                                                 permission);
+}
+
 void ConversationHandler::OnTaskStateChanged(ToolProvider* tool_provider) {
   // A ToolProvider's task state has changed. Propogate this to the
   // conversation's task state.

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -2340,6 +2340,18 @@ bool ConversationHandler::MaybeRespondToNextToolUseRequest() {
       has_pending_tool_use_request = true;
       has_only_completed_tool_use_events = false;
 
+      // Initialize the task state for this tool loop if not already set. An
+      // unanswered tool use request means the loop is in flight, whether or
+      // not this particular tool needs the user first, so this has to happen
+      // before the user-interaction checks below - UI that must not change
+      // mid-loop (e.g. the website tools dialog's permission pickers) relies
+      // on the task state to know that. The cost is that a tool which only
+      // needs user interaction also puts the Task pause/stop UI up.
+      if (tool_use_task_state_ == mojom::TaskState::kNone) {
+        tool_use_task_state_ = mojom::TaskState::kRunning;
+        OnToolUseTaskStateChanged();
+      }
+
       // Now check if we're allowed to execute tools.
       if (tool_use_task_state_ == mojom::TaskState::kPaused ||
           tool_use_task_state_ == mojom::TaskState::kStopped) {
@@ -2430,18 +2442,6 @@ bool ConversationHandler::MaybeRespondToNextToolUseRequest() {
       }
 
       // No user interaction needed - execute tool
-
-      // Initialize the task state for this tool loop if not already set. We do
-      // this after checking for user interaction so that a tool requiring
-      // only user-interaction won't trigger a Task pause/stop UI. If we want
-      // the tool state to reset whenever there is a tool use that requires
-      // user interaction we should set it in the permission-challenge and
-      // user-output branches before they `break` (to kNone, or a new
-      // kWaitingForUser).
-      if (tool_use_task_state_ == mojom::TaskState::kNone) {
-        tool_use_task_state_ = mojom::TaskState::kRunning;
-        OnToolUseTaskStateChanged();
-      }
 
       is_tool_use_in_progress_ = true;
       OnAPIRequestInProgressChanged();

--- a/components/ai_chat/core/browser/conversation_handler.h
+++ b/components/ai_chat/core/browser/conversation_handler.h
@@ -184,6 +184,9 @@ class ConversationHandler : public mojom::ConversationHandler,
                         bool tools_attached) override;
   void GetContentTools(const std::string& content_uuid,
                        GetContentToolsCallback callback) override;
+  void SetContentToolPermission(const std::string& content_uuid,
+                                const std::string& tool_name,
+                                mojom::ToolPermission permission) override;
   void RateMessage(bool is_liked,
                    const std::string& turn_uuid,
                    RateMessageCallback callback) override;

--- a/components/ai_chat/core/browser/conversation_handler.h
+++ b/components/ai_chat/core/browser/conversation_handler.h
@@ -242,6 +242,8 @@ class ConversationHandler : public mojom::ConversationHandler,
                                   mojom::ActionType action_type,
                                   mojom::APIError error);
   void OnAssociatedContentUpdated();
+  void OnContentToolsChanged(const std::string& content_uuid,
+                             std::vector<mojom::ToolInfoPtr> tools);
 
   void OnUserOptedIn();
   size_t GetConversationHistorySize() override;

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -179,6 +179,12 @@ class MockConversationHandlerClient : public mojom::ConversationUI {
               (std::vector<mojom::AssociatedContentPtr>),
               (override));
 
+  MOCK_METHOD(void,
+              OnContentToolsChanged,
+              (const std::string& content_uuid,
+               std::vector<mojom::ToolInfoPtr> tools),
+              (override));
+
   MOCK_METHOD(void, OnConversationDeleted, (), (override));
 
  private:

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -4005,8 +4005,9 @@ TEST_F(ConversationHandlerUnitTest,
   // interaction.
   EXPECT_CALL(*tool1, UseTool).Times(0);
 
-  // State should not be running, since we're waiting
-  EXPECT_EQ(GetState()->tool_use_task_state, mojom::TaskState::kNone);
+  // The loop is in flight even though this tool is waiting on the user, so
+  // that UI which mustn't change mid-loop can tell.
+  EXPECT_EQ(GetState()->tool_use_task_state, mojom::TaskState::kRunning);
 
   // Verify the tool use event exists and has no output
   const auto& history_before = conversation_handler_->GetConversationHistory();

--- a/components/ai_chat/core/browser/tools/mock_tool.h
+++ b/components/ai_chat/core/browser/tools/mock_tool.h
@@ -79,6 +79,11 @@ class MockTool : public Tool {
               (override));
 
   MOCK_METHOD(void,
+              SetUserPermission,
+              (mojom::ToolPermission permission),
+              (override));
+
+  MOCK_METHOD(void,
               UseTool,
               (const std::string& input_json, UseToolCallback callback),
               (override));

--- a/components/ai_chat/core/browser/tools/mock_tool.h
+++ b/components/ai_chat/core/browser/tools/mock_tool.h
@@ -79,7 +79,7 @@ class MockTool : public Tool {
               (override));
 
   MOCK_METHOD(void,
-              SetUserPermission,
+              SetUserPermissionStrategy,
               (mojom::ToolPermission permission),
               (override));
 

--- a/components/ai_chat/core/browser/tools/tool.cc
+++ b/components/ai_chat/core/browser/tools/tool.cc
@@ -63,6 +63,11 @@ void Tool::UserPermissionGranted(const std::string& tool_use_id) {
   // Default: no-op. Tools can override if they need to track permission state.
 }
 
+void Tool::SetUserPermission(mojom::ToolPermission permission) {
+  // Default: no-op. Only tools which raise their own challenge have anything
+  // to skip.
+}
+
 std::optional<std::string> Tool::GetPermissionChallengeDescription(
     const mojom::ToolUseEvent& tool_use) const {
   return std::nullopt;

--- a/components/ai_chat/core/browser/tools/tool.cc
+++ b/components/ai_chat/core/browser/tools/tool.cc
@@ -63,7 +63,7 @@ void Tool::UserPermissionGranted(const std::string& tool_use_id) {
   // Default: no-op. Tools can override if they need to track permission state.
 }
 
-void Tool::SetUserPermission(mojom::ToolPermission permission) {
+void Tool::SetUserPermissionStrategy(mojom::ToolPermission permission) {
   // Default: no-op. Only tools which raise their own challenge have anything
   // to skip.
 }

--- a/components/ai_chat/core/browser/tools/tool.h
+++ b/components/ai_chat/core/browser/tools/tool.h
@@ -99,6 +99,12 @@ class Tool {
   // before UseTool is called.
   virtual void UserPermissionGranted(const std::string& tool_use_id);
 
+  // A decision the user has already made about this tool, so that
+  // RequiresUserInteractionBeforeHandling() can skip the challenge it would
+  // otherwise raise. kNeverAllow tools are withheld from the model by whoever
+  // provides them, so implementors only need to handle kAsk and kAlwaysAllow.
+  virtual void SetUserPermission(mojom::ToolPermission permission);
+
   // Returns a human-readable, markdown-formatted description of what this
   // tool use is asking permission for (e.g. naming a site-registered WebMCP
   // tool and its origin instead of a mangled, model-facing tool name).

--- a/components/ai_chat/core/browser/tools/tool.h
+++ b/components/ai_chat/core/browser/tools/tool.h
@@ -103,7 +103,7 @@ class Tool {
   // RequiresUserInteractionBeforeHandling() can skip the challenge it would
   // otherwise raise. kNeverAllow tools are withheld from the model by whoever
   // provides them, so implementors only need to handle kAsk and kAlwaysAllow.
-  virtual void SetUserPermission(mojom::ToolPermission permission);
+  virtual void SetUserPermissionStrategy(mojom::ToolPermission permission);
 
   // Returns a human-readable, markdown-formatted description of what this
   // tool use is asking permission for (e.g. naming a site-registered WebMCP

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -457,6 +457,11 @@ interface ConversationHandler {
   // Gets the tools the associated content with |content_uuid| currently
   // exposes, for the tools pill's dialog. Empty if it's no longer associated.
   GetContentTools(string content_uuid) => (array<ToolInfo> tools);
+
+  // Applies to every tool of that name from the content's origin, for the
+  // lifetime of this conversation.
+  SetContentToolPermission(string content_uuid, string tool_name,
+                           ToolPermission permission);
 };
 
 interface ConversationUI {

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -493,6 +493,13 @@ interface ConversationUI {
   // Associated page information has changed. If there is none then |associated_content|
   // will be |null|.
   OnAssociatedContentInfoChanged(array<AssociatedContent> associated_content);
+
+  // The tools exposed by the associated content with |content_uuid|, after a
+  // change the browser made to them - currently only a permission choice.
+  // Pushed rather than invalidated so every open UI for this conversation
+  // settles on the same list without each one re-asking the page.
+  OnContentToolsChanged(string content_uuid, array<ToolInfo> tools);
+
   OnConversationDeleted();
 };
 

--- a/components/ai_chat/core/common/mojom/common.mojom
+++ b/components/ai_chat/core/common/mojom/common.mojom
@@ -163,11 +163,22 @@ struct AssociatedContent {
   bool tools_attached;
 };
 
+// The user's choice for a website-provided tool. Only affects the client's own
+// permission check - a challenge raised by the server's alignment check is
+// always shown, whatever this says. kNeverAllow withholds the tool from the
+// model entirely rather than failing it when called.
+enum ToolPermission {
+  kAsk,
+  kAlwaysAllow,
+  kNeverAllow,
+};
+
 // Describes a tool for display to the user - its name and description as they
 // were registered, rather than the mangled model-facing variants.
 struct ToolInfo {
   string name;
   string description;
+  ToolPermission permission;
 };
 
 struct UploadedFile {

--- a/components/ai_chat/ios/browser/conversation_client.h
+++ b/components/ai_chat/ios/browser/conversation_client.h
@@ -49,6 +49,9 @@ class ConversationClient : public mojom::ConversationUI,
       mojom::SuggestionGenerationStatus status) override;
   void OnAssociatedContentInfoChanged(
       std::vector<mojom::AssociatedContentPtr> site_info) override;
+  // No-op: iOS has no UI for website tool permissions.
+  void OnContentToolsChanged(const std::string& content_uuid,
+                             std::vector<mojom::ToolInfoPtr> tools) override {}
   void OnConversationDeleted() override;
 
   // mojom::ServiceObserver

--- a/components/ai_chat/resources/page/api/conversation_api.ts
+++ b/components/ai_chat/resources/page/api/conversation_api.ts
@@ -96,6 +96,19 @@ export default function createConversationApi(
           // },
           mutationResponse: (result) => result.turn,
         },
+        // A mutation rather than an action so the dialog updates without a
+        // refetch - re-asking the page for its tools could return a different
+        // list mid-interaction.
+        setContentToolPermission: {
+          mutationResponse: () => {},
+          onMutate: ([contentUuid, toolName, permission]) => {
+            api.getContentTools.update(contentUuid, (tools) =>
+              tools.map((tool) =>
+                tool.name === toolName ? { ...tool, permission } : tool,
+              ),
+            )
+          },
+        },
         setTemporary: {
           // Instead of allow setTemporary as a pass through via actions,
           // we intercept it via a mutation so we can handle onMutate

--- a/components/ai_chat/resources/page/api/conversation_api.ts
+++ b/components/ai_chat/resources/page/api/conversation_api.ts
@@ -36,6 +36,7 @@ export default function createConversationApi(
         'resumeTask',
         'stopTask',
         'setToolsAttached',
+        'setContentToolPermission',
       ]),
     },
 
@@ -95,19 +96,6 @@ export default function createConversationApi(
           //   api.getState.update({ error: Mojom.APIError.None });
           // },
           mutationResponse: (result) => result.turn,
-        },
-        // A mutation rather than an action so the dialog updates without a
-        // refetch - re-asking the page for its tools could return a different
-        // list mid-interaction.
-        setContentToolPermission: {
-          mutationResponse: () => {},
-          onMutate: ([contentUuid, toolName, permission]) => {
-            api.getContentTools.update(contentUuid, (tools) =>
-              tools.map((tool) =>
-                tool.name === toolName ? { ...tool, permission } : tool,
-              ),
-            )
-          },
         },
         setTemporary: {
           // Instead of allow setTemporary as a pass through via actions,
@@ -185,6 +173,13 @@ export default function createConversationApi(
 
           onAssociatedContentInfoChanged: (associatedContent) => {
             api.getState.update({ associatedContent })
+          },
+
+          // Pushed by the browser when it changes a content's tools, so the
+          // dialog settles on the browser's list without re-asking the page
+          // itself - that could return a different list mid-interaction.
+          onContentToolsChanged: (contentUuid, tools) => {
+            api.getContentTools.update(contentUuid, tools)
           },
 
           // This event is subscribable by the UI

--- a/components/ai_chat/resources/page/api/mock_interfaces.ts
+++ b/components/ai_chat/resources/page/api/mock_interfaces.ts
@@ -123,6 +123,7 @@ export function createMockConversationHandler(
     getScreenshots: () => Promise.resolve({ screenshots: [] }),
     clearErrorAndGetFailedMessage: () => Promise.resolve({ turn: emptyTurn }),
     setTemporary: () => Promise.resolve({}),
+    setContentToolPermission: () => {},
     stopGenerationAndMaybeGetHumanEntry: () =>
       Promise.resolve({ humanEntry: null }),
     rateMessage: () => Promise.resolve({ ratingId: null }),

--- a/components/ai_chat/resources/page/api/mock_interfaces.ts
+++ b/components/ai_chat/resources/page/api/mock_interfaces.ts
@@ -123,7 +123,6 @@ export function createMockConversationHandler(
     getScreenshots: () => Promise.resolve({ screenshots: [] }),
     clearErrorAndGetFailedMessage: () => Promise.resolve({ turn: emptyTurn }),
     setTemporary: () => Promise.resolve({}),
-    setContentToolPermission: () => {},
     stopGenerationAndMaybeGetHumanEntry: () =>
       Promise.resolve({ humanEntry: null }),
     rateMessage: () => Promise.resolve({ ratingId: null }),
@@ -138,6 +137,7 @@ export function createMockConversationHandler(
     resumeTask: () => {},
     stopTask: () => {},
     setToolsAttached: () => {},
+    setContentToolPermission: () => {},
 
     // Apply overrides - these will replace defaults
     ...overrides,

--- a/components/ai_chat/resources/page/components/website_tools_modal/index.test.tsx
+++ b/components/ai_chat/resources/page/components/website_tools_modal/index.test.tsx
@@ -24,8 +24,16 @@ const CONTENT: Mojom.AssociatedContent = {
 }
 
 const TOOLS: Mojom.ToolInfo[] = [
-  { name: 'browse_store', description: 'Browse OR navigate to collections.' },
-  { name: 'cancel_cart', description: 'Remove all items from the cart.' },
+  {
+    name: 'browse_store',
+    description: 'Browse OR navigate to collections.',
+    permission: Mojom.ToolPermission.kAsk,
+  },
+  {
+    name: 'cancel_cart',
+    description: 'Remove all items from the cart.',
+    permission: Mojom.ToolPermission.kNeverAllow,
+  },
 ]
 
 async function renderModal(ui: React.ReactElement) {
@@ -68,6 +76,77 @@ describe('WebsiteToolsModal', () => {
     expect(
       screen.getByText('mywebsite.com/collections/water'),
     ).toBeInTheDocument()
+  })
+
+  it('shows each tool the permission it currently has', async () => {
+    const { container } = await renderModal(
+      <MockContext
+        conversationHandler={{
+          getContentTools: () => Promise.resolve({ tools: TOOLS }),
+        }}
+      >
+        <WebsiteToolsModal
+          content={CONTENT}
+          onClose={() => {}}
+        />
+      </MockContext>,
+    )
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('leo-dropdown')).toHaveLength(2)
+    })
+    const dropdowns = container.querySelectorAll('leo-dropdown')
+    expect(dropdowns[0]).toHaveProperty(
+      'value',
+      String(Mojom.ToolPermission.kAsk),
+    )
+    expect(dropdowns[1]).toHaveProperty(
+      'value',
+      String(Mojom.ToolPermission.kNeverAllow),
+    )
+  })
+
+  it('records the permission the user picks for a tool', async () => {
+    const setContentToolPermission = jest.fn()
+
+    const { container } = await renderModal(
+      <MockContext
+        conversationHandler={{
+          getContentTools: () => Promise.resolve({ tools: TOOLS }),
+          setContentToolPermission,
+        }}
+      >
+        <WebsiteToolsModal
+          content={CONTENT}
+          onClose={() => {}}
+        />
+      </MockContext>,
+    )
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('leo-dropdown')).toHaveLength(2)
+    })
+
+    await act(async () => {
+      container.querySelectorAll('leo-dropdown')[0].dispatchEvent(
+        Object.assign(new Event('change', { bubbles: true }), {
+          value: String(Mojom.ToolPermission.kAlwaysAllow),
+        }),
+      )
+    })
+
+    expect(setContentToolPermission).toHaveBeenCalledWith(
+      'content-uuid',
+      'browse_store',
+      Mojom.ToolPermission.kAlwaysAllow,
+    )
+    // Updated without asking the page for its tools again.
+    await waitFor(() => {
+      expect(container.querySelectorAll('leo-dropdown')[0]).toHaveProperty(
+        'value',
+        String(Mojom.ToolPermission.kAlwaysAllow),
+      )
+    })
   })
 
   it('counts the tools it lists', async () => {

--- a/components/ai_chat/resources/page/components/website_tools_modal/index.test.tsx
+++ b/components/ai_chat/resources/page/components/website_tools_modal/index.test.tsx
@@ -140,13 +140,45 @@ describe('WebsiteToolsModal', () => {
       'browse_store',
       Mojom.ToolPermission.kAlwaysAllow,
     )
-    // Updated without asking the page for its tools again.
+  })
+
+  it('shows a permission change the browser pushed', async () => {
+    // The choice is conversation-wide, so a dialog open in another view has to
+    // reflect it too - without asking the page for its tools again, which
+    // could answer with a different list mid-interaction.
+    const getContentTools = jest.fn(() => Promise.resolve({ tools: TOOLS }))
+    const observerRef: { current?: Mojom.ConversationUIInterface } = {}
+
+    const { container } = await renderModal(
+      <MockContext
+        conversationHandler={{ getContentTools }}
+        conversationUIObserverRef={observerRef}
+      >
+        <WebsiteToolsModal
+          content={CONTENT}
+          onClose={() => {}}
+        />
+      </MockContext>,
+    )
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('leo-dropdown')).toHaveLength(2)
+    })
+
+    await act(async () => {
+      observerRef.current!.onContentToolsChanged('content-uuid', [
+        { ...TOOLS[0], permission: Mojom.ToolPermission.kAlwaysAllow },
+        TOOLS[1],
+      ])
+    })
+
     await waitFor(() => {
       expect(container.querySelectorAll('leo-dropdown')[0]).toHaveProperty(
         'value',
         String(Mojom.ToolPermission.kAlwaysAllow),
       )
     })
+    expect(getContentTools).toHaveBeenCalledTimes(1)
   })
 
   it('counts the tools it lists', async () => {

--- a/components/ai_chat/resources/page/components/website_tools_modal/index.test.tsx
+++ b/components/ai_chat/resources/page/components/website_tools_modal/index.test.tsx
@@ -181,6 +181,29 @@ describe('WebsiteToolsModal', () => {
     expect(getContentTools).toHaveBeenCalledTimes(1)
   })
 
+  it('locks the permission pickers while a response is generating', async () => {
+    const { container } = await renderModal(
+      <MockContext
+        conversationHandler={{
+          getContentTools: () => Promise.resolve({ tools: TOOLS }),
+        }}
+        initialState={{ conversationState: { isRequestInProgress: true } }}
+      >
+        <WebsiteToolsModal
+          content={CONTENT}
+          onClose={() => {}}
+        />
+      </MockContext>,
+    )
+
+    await waitFor(() => {
+      expect(container.querySelectorAll('leo-dropdown')).toHaveLength(2)
+    })
+    for (const dropdown of container.querySelectorAll('leo-dropdown')) {
+      expect(dropdown).toHaveProperty('disabled', true)
+    }
+  })
+
   it('counts the tools it lists', async () => {
     await renderModal(
       <MockContext

--- a/components/ai_chat/resources/page/components/website_tools_modal/index.test.tsx
+++ b/components/ai_chat/resources/page/components/website_tools_modal/index.test.tsx
@@ -181,28 +181,80 @@ describe('WebsiteToolsModal', () => {
     expect(getContentTools).toHaveBeenCalledTimes(1)
   })
 
-  it('locks the permission pickers while a response is generating', async () => {
-    const { container } = await renderModal(
-      <MockContext
-        conversationHandler={{
-          getContentTools: () => Promise.resolve({ tools: TOOLS }),
-        }}
-        initialState={{ conversationState: { isRequestInProgress: true } }}
-      >
-        <WebsiteToolsModal
-          content={CONTENT}
-          onClose={() => {}}
-        />
-      </MockContext>,
-    )
+  it.each([
+    // The loop reads the choices once, when it starts, so a change made part
+    // way through wouldn't apply until the next one.
+    ['a response is generating', { isRequestInProgress: true }],
+    // The request is over by the time the tools run, so it's the task state
+    // that says the loop is still in flight - including while it waits on a
+    // permission challenge.
+    [
+      'a tool loop is running',
+      {
+        isRequestInProgress: false,
+        toolUseTaskState: Mojom.TaskState.kRunning,
+      },
+    ],
+    [
+      'a tool loop is paused',
+      { isRequestInProgress: false, toolUseTaskState: Mojom.TaskState.kPaused },
+    ],
+  ])(
+    'locks the permission pickers while %s',
+    async (_, conversationState: Partial<Mojom.ConversationState>) => {
+      const { container } = await renderModal(
+        <MockContext
+          conversationHandler={{
+            getContentTools: () => Promise.resolve({ tools: TOOLS }),
+          }}
+          initialState={{ conversationState }}
+        >
+          <WebsiteToolsModal
+            content={CONTENT}
+            onClose={() => {}}
+          />
+        </MockContext>,
+      )
 
-    await waitFor(() => {
-      expect(container.querySelectorAll('leo-dropdown')).toHaveLength(2)
-    })
-    for (const dropdown of container.querySelectorAll('leo-dropdown')) {
-      expect(dropdown).toHaveProperty('disabled', true)
-    }
-  })
+      await waitFor(() => {
+        expect(container.querySelectorAll('leo-dropdown')).toHaveLength(2)
+      })
+      for (const dropdown of container.querySelectorAll('leo-dropdown')) {
+        expect(dropdown).toHaveProperty('disabled', true)
+      }
+    },
+  )
+
+  it.each([
+    ['no tool loop has started', Mojom.TaskState.kNone],
+    ['the tool loop was stopped', Mojom.TaskState.kStopped],
+  ])(
+    'leaves the permission pickers usable when %s',
+    async (_, toolUseTaskState: Mojom.TaskState) => {
+      const { container } = await renderModal(
+        <MockContext
+          conversationHandler={{
+            getContentTools: () => Promise.resolve({ tools: TOOLS }),
+          }}
+          initialState={{
+            conversationState: { isRequestInProgress: false, toolUseTaskState },
+          }}
+        >
+          <WebsiteToolsModal
+            content={CONTENT}
+            onClose={() => {}}
+          />
+        </MockContext>,
+      )
+
+      await waitFor(() => {
+        expect(container.querySelectorAll('leo-dropdown')).toHaveLength(2)
+      })
+      for (const dropdown of container.querySelectorAll('leo-dropdown')) {
+        expect(dropdown).toHaveProperty('disabled', false)
+      }
+    },
+  )
 
   it('counts the tools it lists', async () => {
     await renderModal(

--- a/components/ai_chat/resources/page/components/website_tools_modal/index.tsx
+++ b/components/ai_chat/resources/page/components/website_tools_modal/index.tsx
@@ -5,6 +5,7 @@
 
 import * as React from 'react'
 import Dialog from '@brave/leo/react/dialog'
+import Dropdown from '@brave/leo/react/dropdown'
 import ProgressRing from '@brave/leo/react/progressRing'
 import classnames from '$web-common/classnames'
 import { formatLocale, getLocale } from '$web-common/locale'
@@ -19,10 +20,32 @@ interface Props {
   onClose: () => void
 }
 
+// Leo's Dropdown deals in strings, so the enum is stringified on the way in
+// and parsed back out.
+const PERMISSION_OPTIONS = [
+  {
+    permission: Mojom.ToolPermission.kAlwaysAllow,
+    label: S.CHAT_UI_WEBSITE_TOOL_PERMISSION_ALWAYS_ALLOW,
+  },
+  {
+    permission: Mojom.ToolPermission.kAsk,
+    label: S.CHAT_UI_WEBSITE_TOOL_PERMISSION_ASK,
+  },
+  {
+    permission: Mojom.ToolPermission.kNeverAllow,
+    label: S.CHAT_UI_WEBSITE_TOOL_PERMISSION_NEVER_ALLOW,
+  },
+] as const
+
+const DEFAULT_PERMISSION_OPTION = PERMISSION_OPTIONS.find(
+  (option) => option.permission === Mojom.ToolPermission.kAsk,
+)!
+
 function ToolItem(props: {
   tool: Mojom.ToolInfo
   isExpanded: boolean
   onToggle: () => void
+  onPermissionChange: (permission: Mojom.ToolPermission) => void
 }) {
   const [isClamped, setIsClamped] = React.useState(false)
   const descriptionRef = React.useRef<HTMLSpanElement>(null)
@@ -42,8 +65,36 @@ function ToolItem(props: {
     return () => observer.disconnect()
   }, [props.tool.description, props.isExpanded])
 
+  const selected =
+    PERMISSION_OPTIONS.find(
+      (option) => option.permission === props.tool.permission,
+    ) ?? DEFAULT_PERMISSION_OPTION
+
   return (
     <li className={styles.tool}>
+      <div className={styles.toolHeader}>
+        <span className={styles.toolName}>{props.tool.name}</span>
+        <Dropdown
+          size='small'
+          className={styles.toolPermission}
+          value={String(selected.permission)}
+          // The dialog scrolls, which would clip an absolutely positioned menu.
+          positionStrategy='fixed'
+          onChange={(e: { value: string }) =>
+            props.onPermissionChange(Number(e.value))
+          }
+        >
+          <div slot='value'>{getLocale(selected.label)}</div>
+          {PERMISSION_OPTIONS.map((option) => (
+            <leo-option
+              key={option.permission}
+              value={String(option.permission)}
+            >
+              {getLocale(option.label)}
+            </leo-option>
+          ))}
+        </Dropdown>
+      </div>
       <button
         type='button'
         disabled={!isClamped}
@@ -51,7 +102,6 @@ function ToolItem(props: {
         className={styles.toolToggle}
         onClick={props.onToggle}
       >
-        <span className={styles.toolName}>{props.tool.name}</span>
         {/* The clamp needs its own element: a button lays its content out in
             an anonymous box, which -webkit-box doesn't survive. */}
         <span
@@ -75,6 +125,8 @@ export default function WebsiteToolsModal(props: Props) {
   // Placeholder data means the page hasn't answered yet.
   const { getContentToolsData: tools, isPlaceholderData: isLoading } =
     conversation.api.useGetContentTools(props.content.uuid)
+  const { setContentToolPermission } =
+    conversation.api.useSetContentToolPermission()
   // Only one description is expanded at a time, to keep the list scannable.
   const [expandedToolName, setExpandedToolName] = React.useState<string | null>(
     null,
@@ -126,6 +178,13 @@ export default function WebsiteToolsModal(props: Props) {
                     setExpandedToolName((expanded) =>
                       expanded === tool.name ? null : tool.name,
                     )
+                  }
+                  onPermissionChange={(permission) =>
+                    setContentToolPermission([
+                      props.content.uuid,
+                      tool.name,
+                      permission,
+                    ])
                   }
                 />
               ))}

--- a/components/ai_chat/resources/page/components/website_tools_modal/index.tsx
+++ b/components/ai_chat/resources/page/components/website_tools_modal/index.tsx
@@ -125,8 +125,6 @@ export default function WebsiteToolsModal(props: Props) {
   // Placeholder data means the page hasn't answered yet.
   const { getContentToolsData: tools, isPlaceholderData: isLoading } =
     conversation.api.useGetContentTools(props.content.uuid)
-  const { setContentToolPermission } =
-    conversation.api.useSetContentToolPermission()
   // Only one description is expanded at a time, to keep the list scannable.
   const [expandedToolName, setExpandedToolName] = React.useState<string | null>(
     null,
@@ -180,11 +178,11 @@ export default function WebsiteToolsModal(props: Props) {
                     )
                   }
                   onPermissionChange={(permission) =>
-                    setContentToolPermission([
+                    conversation.api.conversationHandler.setContentToolPermission(
                       props.content.uuid,
                       tool.name,
                       permission,
-                    ])
+                    )
                   }
                 />
               ))}

--- a/components/ai_chat/resources/page/components/website_tools_modal/index.tsx
+++ b/components/ai_chat/resources/page/components/website_tools_modal/index.tsx
@@ -122,9 +122,15 @@ function ToolItem(props: {
 // pill above the input box.
 export default function WebsiteToolsModal(props: Props) {
   const conversation = useConversation()
-  // Placeholder data means the page hasn't answered yet.
-  const { getContentToolsData: tools, isPlaceholderData: isLoading } =
-    conversation.api.useGetContentTools(props.content.uuid)
+  // Placeholder data means the page hasn't answered yet. A cached answer isn't
+  // shown while re-fetching either: it could name a permission the browser has
+  // since forgotten.
+  const {
+    getContentToolsData: tools,
+    isPlaceholderData,
+    isFetching,
+  } = conversation.api.useGetContentTools(props.content.uuid)
+  const isLoading = isPlaceholderData || isFetching
   // Only one description is expanded at a time, to keep the list scannable.
   const [expandedToolName, setExpandedToolName] = React.useState<string | null>(
     null,

--- a/components/ai_chat/resources/page/components/website_tools_modal/index.tsx
+++ b/components/ai_chat/resources/page/components/website_tools_modal/index.tsx
@@ -137,8 +137,13 @@ export default function WebsiteToolsModal(props: Props) {
   } = conversation.api.useGetContentTools(props.content.uuid)
   const isLoading = isPlaceholderData || isFetching
 
-  // Don't allow changing permissions while a request is in progress
-  const { isRequestInProgress } = useConversationState()
+  // Don't allow changing permissions while a request is in progress, or while a
+  // tool loop is still in flight.
+  const { isRequestInProgress, toolUseTaskState } = useConversationState()
+  const isPermissionChangeDisabled =
+    isRequestInProgress
+    || (toolUseTaskState !== Mojom.TaskState.kNone
+      && toolUseTaskState !== Mojom.TaskState.kStopped)
   // Only one description is expanded at a time, to keep the list scannable.
   const [expandedToolName, setExpandedToolName] = React.useState<string | null>(
     null,
@@ -186,7 +191,7 @@ export default function WebsiteToolsModal(props: Props) {
                   key={tool.name}
                   tool={tool}
                   isExpanded={tool.name === expandedToolName}
-                  isPermissionChangeDisabled={isRequestInProgress}
+                  isPermissionChangeDisabled={isPermissionChangeDisabled}
                   onToggle={() =>
                     setExpandedToolName((expanded) =>
                       expanded === tool.name ? null : tool.name,

--- a/components/ai_chat/resources/page/components/website_tools_modal/index.tsx
+++ b/components/ai_chat/resources/page/components/website_tools_modal/index.tsx
@@ -10,7 +10,10 @@ import ProgressRing from '@brave/leo/react/progressRing'
 import classnames from '$web-common/classnames'
 import { formatLocale, getLocale } from '$web-common/locale'
 import * as Mojom from '../../../common/mojom'
-import { useConversation } from '../../state/conversation_context'
+import {
+  useConversation,
+  useConversationState,
+} from '../../state/conversation_context'
 import { AttachmentPageItem } from '../attachment_item'
 import styles from './style.module.scss'
 
@@ -44,6 +47,7 @@ const DEFAULT_PERMISSION_OPTION = PERMISSION_OPTIONS.find(
 function ToolItem(props: {
   tool: Mojom.ToolInfo
   isExpanded: boolean
+  isPermissionChangeDisabled: boolean
   onToggle: () => void
   onPermissionChange: (permission: Mojom.ToolPermission) => void
 }) {
@@ -78,6 +82,7 @@ function ToolItem(props: {
           size='small'
           className={styles.toolPermission}
           value={String(selected.permission)}
+          disabled={props.isPermissionChangeDisabled}
           // The dialog scrolls, which would clip an absolutely positioned menu.
           positionStrategy='fixed'
           onChange={(e: { value: string }) =>
@@ -131,6 +136,9 @@ export default function WebsiteToolsModal(props: Props) {
     isFetching,
   } = conversation.api.useGetContentTools(props.content.uuid)
   const isLoading = isPlaceholderData || isFetching
+
+  // Don't allow changing permissions while a request is in progress
+  const { isRequestInProgress } = useConversationState()
   // Only one description is expanded at a time, to keep the list scannable.
   const [expandedToolName, setExpandedToolName] = React.useState<string | null>(
     null,
@@ -178,6 +186,7 @@ export default function WebsiteToolsModal(props: Props) {
                   key={tool.name}
                   tool={tool}
                   isExpanded={tool.name === expandedToolName}
+                  isPermissionChangeDisabled={isRequestInProgress}
                   onToggle={() =>
                     setExpandedToolName((expanded) =>
                       expanded === tool.name ? null : tool.name,

--- a/components/ai_chat/resources/page/components/website_tools_modal/style.module.scss
+++ b/components/ai_chat/resources/page/components/website_tools_modal/style.module.scss
@@ -48,22 +48,27 @@
 }
 
 .tool {
+  padding: var(--leo-spacing-l) var(--leo-spacing-xl);
+
   & + & {
     border-top: 1px solid var(--leo-color-divider-subtle);
   }
 }
 
-// The whole row toggles its description, so it's a button spanning the row
-// rather than just the description text.
+.toolHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--leo-spacing-l);
+}
+
 .toolToggle {
   appearance: none;
-  display: flex;
-  flex-direction: column;
-  gap: var(--leo-spacing-s);
+  display: block;
   width: 100%;
   box-sizing: border-box;
-  margin: 0;
-  padding: var(--leo-spacing-l) var(--leo-spacing-xl);
+  margin: var(--leo-spacing-s) 0 0;
+  padding: 0;
   border: none;
   background: none;
   text-align: left;
@@ -79,6 +84,11 @@
   font: var(--leo-font-default-semibold);
   color: var(--leo-color-text-primary);
   word-break: break-word;
+}
+
+.toolPermission {
+  flex: none;
+  width: 160px;
 }
 
 .toolDescription {

--- a/components/ai_chat/resources/page/state/mock_context.tsx
+++ b/components/ai_chat/resources/page/state/mock_context.tsx
@@ -35,6 +35,10 @@ export interface MockContextProps {
   metrics?: Partial<Mojom.MetricsInterface>
   conversationHandler?: Partial<Mojom.ConversationHandlerInterface>
 
+  // Receives the observer the browser pushes conversation events to, so tests
+  // can simulate them.
+  conversationUIObserverRef?: { current?: Mojom.ConversationUIInterface }
+
   // Initial state for state-type endpoints
   initialState?: {
     tabs?: Mojom.TabData[]
@@ -119,6 +123,7 @@ export function MockContext(props: MockContextProps) {
     initialState = {},
     aiChatOverrides,
     conversationHandler,
+    conversationUIObserverRef,
     conversationOverrides,
     conversationProps = {},
     deps = [],
@@ -154,6 +159,10 @@ export function MockContext(props: MockContextProps) {
     )
 
     const conversation = createConversationApi(mockHandler)
+
+    if (conversationUIObserverRef) {
+      conversationUIObserverRef.current = conversation.conversationUIObserver
+    }
 
     return conversation
   })

--- a/components/ai_chat/resources/page/stories/components_panel.tsx
+++ b/components/ai_chat/resources/page/stories/components_panel.tsx
@@ -219,16 +219,19 @@ const SAMPLE_CONTENT_TOOLS: Mojom.ToolInfo[] = [
       + ' an invoice). With navigate=false (default), returns invoice data'
       + ' without changing the page — use this only when the user is asking a'
       + ' question about their invoices, not asking to view one.',
+    permission: Mojom.ToolPermission.kAsk,
   },
   {
     name: 'create_invoice',
     description: 'Create a new draft invoice for a given customer and amount.',
+    permission: Mojom.ToolPermission.kAlwaysAllow,
   },
   {
     name: 'send_invoice',
     description:
       'Email an existing draft invoice to its customer. Verifies the invoice'
       + ' has a customer and at least one line item first.',
+    permission: Mojom.ToolPermission.kNeverAllow,
   },
 ]
 

--- a/components/common/api/create_interface_api.ts
+++ b/components/common/api/create_interface_api.ts
@@ -411,7 +411,7 @@ export function createInterfaceApi<
       type QArgs = ArgsOf<typeof name>
       type QData = DataOf<typeof name>
 
-      if (!queryOptions.staleTime) {
+      if (queryOptions.staleTime === undefined) {
         // The default for staleTime is 0, meaning a result is stale as soon
         // as it is received. That results in every useQuery call causing a
         // re-fetch after returning the stale data.

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -699,6 +699,15 @@
   <message name="IDS_CHAT_UI_WEBSITE_TOOLS_LIST_LABEL" desc="Heading above the list of tools in the website tools dialog. The placeholder is the number of tools, e.g. 'Available tools (10)'" formatter_data="webui=AiChat">
     Available tools (<ph name="TOOL_COUNT">$1<ex>10</ex></ph>)
   </message>
+  <message name="IDS_CHAT_UI_WEBSITE_TOOL_PERMISSION_ALWAYS_ALLOW" desc="Dropdown option letting Leo use a website tool without asking each time" formatter_data="webui=AiChat">
+    Always allow
+  </message>
+  <message name="IDS_CHAT_UI_WEBSITE_TOOL_PERMISSION_ASK" desc="Dropdown option asking for approval each time Leo wants to use a website tool" formatter_data="webui=AiChat">
+    Ask every time
+  </message>
+  <message name="IDS_CHAT_UI_WEBSITE_TOOL_PERMISSION_NEVER_ALLOW" desc="Dropdown option preventing Leo from using a website tool at all" formatter_data="webui=AiChat">
+    Never allow
+  </message>
   <message name="IDS_CHAT_UI_SUBSCRIPTION_POLICY_INFO" desc="An info text that is shown below various subcription prices" formatter_data="webui=AiChat">
     All subscriptions are auto-renewed but can be cancelled at any time before renewal.
   </message>


### PR DESCRIPTION
Adds permission dropdowns to the list of WebMCP tools, allowing users to block/always allow tools for a conversation.

There are three states: 
- Ask (the current and default behavior)
- Allow always (always allows the tool for the current conversation)
- Never allow (doesn't even send the tool to the model, so it doesn't waste tokens trying to call a blocked tool).

These permissions only exist as long as the conversation is in memory.

<!-- Add brave-browser issue below that this PR will resolve -->
- Series https://github.com/brave/brave-browser/issues/55232

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
