### PR TITLE
[iptc] Remove fbmd iptc data from file selector flow

### DIFF
--- a/browser/file_select/BUILD.gn
+++ b/browser/file_select/BUILD.gn
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("file_select") {
+  sources = [
+    "brave_file_select_image_metadata_stripper.cc",
+    "brave_file_select_image_metadata_stripper.h",
+  ]
+
+  deps = [
+    "//base",
+    "//brave/components/image_metadata_stripper",
+    "//brave/components/image_metadata_stripper/common",
+    "//content/public/browser",
+  ]
+
+  public_deps = [ "//third_party/blink/public/mojom:mojom_platform" ]
+}

--- a/browser/file_select/BUILD.gn
+++ b/browser/file_select/BUILD.gn
@@ -11,7 +11,7 @@ source_set("file_select") {
 
   public_deps = [
     "//base",
-    "//third_party/blink/public/mojom:mojom_platform",
+    "//third_party/blink/public/mojom:mojom_platform_headers",
   ]
 
   deps = [

--- a/browser/file_select/BUILD.gn
+++ b/browser/file_select/BUILD.gn
@@ -9,12 +9,14 @@ source_set("file_select") {
     "brave_file_select_image_metadata_stripper.h",
   ]
 
-  deps = [
+  public_deps = [
     "//base",
+    "//third_party/blink/public/mojom:mojom_platform",
+  ]
+
+  deps = [
     "//brave/components/image_metadata_stripper",
     "//brave/components/image_metadata_stripper/common",
     "//content/public/browser",
   ]
-
-  public_deps = [ "//third_party/blink/public/mojom:mojom_platform" ]
 }

--- a/browser/file_select/brave_file_select_image_metadata_stripper.cc
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.cc
@@ -26,6 +26,13 @@ namespace brave {
 
 namespace {
 
+struct StripResult {
+  std::vector<blink::mojom::FileChooserFileInfoPtr> list;
+  std::vector<base::FilePath> temp_files;
+};
+
+// TODO(https://github.com/brave/brave-browser/issues/5238): PNG formats needs
+// more investigation whether FBMD is present or not. So, tackling only jpeg.
 bool IsStrippableImagePath(const base::FilePath& path) {
   return path.MatchesExtension(FILE_PATH_LITERAL(".jpg")) ||
          path.MatchesExtension(FILE_PATH_LITERAL(".jpeg"));
@@ -40,14 +47,15 @@ bool HasStrippableImage(
       });
 }
 
-struct StripResult {
-  std::vector<blink::mojom::FileChooserFileInfoPtr> list;
-  std::vector<base::FilePath> temp_files;
-};
-
-// Copies each strippable image to a temporary file,
-// scrubs the copy, and rewrites the entry to point at it. On any failure the
-// original path is left in place so a bad copy is never uploaded.
+// Algorithm:
+// 1) Iterate over each item in the |list|.
+// 2) If the "ith" item is not strippable, continue with 1.
+// 3) If the "ith" is stripppable then:
+//    3.a) Copy the contents of "ith" item into a temporary file.
+//    3.b) Try and strip the metadata from the temporary file.
+//         3.b.1) If failed: Delete the temporary file and go to Step 1.
+//         3.b.2) Otherwise, mark the temporay file for upload and then later
+//         for deletion.
 StripResult StripListOnBlockingThread(
     std::vector<blink::mojom::FileChooserFileInfoPtr> list) {
   StripResult result;
@@ -71,16 +79,25 @@ StripResult StripListOnBlockingThread(
                   "temporary file.";
     }
 
-    const auto resultCode = RemoveIptcMetadata(
+    // We try and remove the iptc metadata from the file.
+    const bool success = RemoveIptcMetadata(
         image_metadata_stripper::StrippingClient::kFileSelect, temp);
-
-    if (resultCode != image_metadata_stripper::StrippingResultCode::kStripped) {
-      DVLOG(1) << "Upload strip failed; keeping original: " << src;
-      base::DeleteFile(temp);
+    if (!success) {
+      DVLOG(1) << "No stripping occured; keeping original: " << src;
+      // The gaurd helps to schedule the delete to upstream's delete lifecycle
+      // if ever our own attempt to delete the temporary file failed.
+      if (!base::DeleteFile(temp)) {
+        result.temp_files.push_back(std::move(temp));
+      }
       continue;
     }
 
+    // Re-write the file path of the original upload file, with our temporary's
+    // file path. This keeps the overall |list| untouched which is then moved
+    // directly to the result.
     info->get_native_file()->file_path = temp;
+    // Mark the temporary file for deletion later via the upstream's
+    // DeleteTemporaryFiles method.
     result.temp_files.push_back(std::move(temp));
   }
   result.list = std::move(list);
@@ -93,8 +110,8 @@ void OnStripComplete(
         notify,
     StripResult result) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-  // Hand the temporary copies to FileSelectHelper so they are deleted once the
-  // upload finishes, via its existing DeleteTemporaryFiles() teardown.
+  // Update the |temporary_files| list to mark the deletion of our newly created
+  // tmp files.
   for (auto& temp : result.temp_files) {
     temporary_files.push_back(std::move(temp));
   }
@@ -111,23 +128,25 @@ bool MaybeStripImageMetadataForUpload(
         notify) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
-  // Base level checks.
   if (!base::FeatureList::IsEnabled(
-          image_metadata_stripper::features::kStripImageMetadataV1) ||
-      !HasStrippableImage(list)) {
+          image_metadata_stripper::features::kStripImageMetadataV1)) {
     return false;
   }
 
-  // Second pass, re-entered with the sanitized list: let the upstream path run.
+  if (!HasStrippableImage(list)) {
+    return false;
+  }
+
+  // A flag to ensure we don't have infinite loops between the caller and
+  // callee once the metadata removal task get posted and the instruction
+  // pointer returns back to the caller.
   if (already_processed) {
     return false;
   }
 
   already_processed = true;
 
-  // I/O-blocking copy + scrub off the UI thread. `notify` keeps the
-  // FileSelectHelper alive across the hop, so the `temporary_files` reference
-  // handed to the reply stays valid.
+  // Stripping begins.
   base::ThreadPool::PostTaskAndReplyWithResult(
       FROM_HERE,
       {base::MayBlock(), base::TaskPriority::USER_VISIBLE,

--- a/browser/file_select/brave_file_select_image_metadata_stripper.cc
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.cc
@@ -38,6 +38,8 @@ bool IsStrippableImagePath(const base::FilePath& path) {
          path.MatchesExtension(FILE_PATH_LITERAL(".jpeg"));
 }
 
+// Returns true if any of the items in the |list| could be a candidate for
+// stripping metadata.
 bool HasStrippableImage(
     const std::vector<blink::mojom::FileChooserFileInfoPtr>& list) {
   return std::ranges::any_of(
@@ -95,7 +97,17 @@ StripResult StripListOnBlockingThread(
     // Re-write the file path of the original upload file, with our temporary's
     // file path. This keeps the overall |list| untouched which is then moved
     // directly to the result.
+    // TODO(https://github.com/brave/brave-browser/issues/5238): On macOS the
+    // file control shows the temp basename (e.g.
+    // .com.brave.Browser.channelNameHere.XXXXXX). From LLM it seems the reason
+    // to be the following: LayoutThemeMac::DisplayNameForFile uses
+    // NSFileManager displayNameAtPath of the backing path so even setting
+    // display_name / File.name is not enough. See
+    // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/
+    // renderer/core/layout/layout_theme_mac.mm;l=60 for details.
+    // Need to figure out how to handle this issue.
     info->get_native_file()->file_path = temp;
+
     // Mark the temporary file for deletion later via the upstream's
     // DeleteTemporaryFiles method.
     result.temp_files.push_back(std::move(temp));
@@ -104,6 +116,7 @@ StripResult StripListOnBlockingThread(
   return result;
 }
 
+// The callback which gets fired after all the stripping was completed.
 void OnStripComplete(
     std::vector<base::FilePath>& temporary_files,
     base::OnceCallback<void(std::vector<blink::mojom::FileChooserFileInfoPtr>)>

--- a/browser/file_select/brave_file_select_image_metadata_stripper.cc
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.cc
@@ -1,0 +1,141 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/file_select/brave_file_select_image_metadata_stripper.h"
+
+#include <algorithm>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include "base/feature_list.h"
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/functional/bind.h"
+#include "base/functional/callback.h"
+#include "base/logging.h"
+#include "base/task/task_traits.h"
+#include "base/task/thread_pool.h"
+#include "brave/components/image_metadata_stripper/common/features.h"
+#include "brave/components/image_metadata_stripper/image_metadata_stripper.h"
+#include "content/public/browser/browser_thread.h"
+
+namespace brave {
+
+namespace {
+
+bool IsStrippableImagePath(const base::FilePath& path) {
+  return path.MatchesExtension(FILE_PATH_LITERAL(".jpg")) ||
+         path.MatchesExtension(FILE_PATH_LITERAL(".jpeg"));
+}
+
+bool HasStrippableImage(
+    const std::vector<blink::mojom::FileChooserFileInfoPtr>& list) {
+  return std::ranges::any_of(
+      list, [](const blink::mojom::FileChooserFileInfoPtr& info) {
+        return info && info->is_native_file() &&
+               IsStrippableImagePath(info->get_native_file()->file_path);
+      });
+}
+
+struct StripResult {
+  std::vector<blink::mojom::FileChooserFileInfoPtr> list;
+  std::vector<base::FilePath> temp_files;
+};
+
+// Copies each strippable image to a temporary file,
+// scrubs the copy, and rewrites the entry to point at it. On any failure the
+// original path is left in place so a bad copy is never uploaded.
+StripResult StripListOnBlockingThread(
+    std::vector<blink::mojom::FileChooserFileInfoPtr> list) {
+  StripResult result;
+  for (auto& info : list) {
+    if (!info || !info->is_native_file()) {
+      continue;
+    }
+    const base::FilePath src = info->get_native_file()->file_path;
+    if (!IsStrippableImagePath(src)) {
+      continue;
+    }
+
+    base::FilePath temp;
+    if (!base::CreateTemporaryFile(&temp)) {
+      DVLOG(1) << "Upload strip skipped; no temp file for: " << src;
+      continue;
+    }
+
+    if (!base::CopyFile(src, temp)) {
+      DVLOG(1) << "Upload strip skipped; Failed to copy the image file to a "
+                  "temporary file.";
+    }
+
+    const auto resultCode = RemoveIptcMetadata(
+        image_metadata_stripper::StrippingClient::kFileSelect, temp);
+
+    if (resultCode != image_metadata_stripper::StrippingResultCode::kStripped) {
+      DVLOG(1) << "Upload strip failed; keeping original: " << src;
+      base::DeleteFile(temp);
+      continue;
+    }
+
+    info->get_native_file()->file_path = temp;
+    result.temp_files.push_back(std::move(temp));
+  }
+  result.list = std::move(list);
+  return result;
+}
+
+void OnStripComplete(
+    std::vector<base::FilePath>& temporary_files,
+    base::OnceCallback<void(std::vector<blink::mojom::FileChooserFileInfoPtr>)>
+        notify,
+    StripResult result) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  // Hand the temporary copies to FileSelectHelper so they are deleted once the
+  // upload finishes, via its existing DeleteTemporaryFiles() teardown.
+  for (auto& temp : result.temp_files) {
+    temporary_files.push_back(std::move(temp));
+  }
+  std::move(notify).Run(std::move(result.list));
+}
+
+}  // namespace
+
+bool MaybeStripImageMetadataForUpload(
+    bool& already_processed,
+    std::vector<base::FilePath>& temporary_files,
+    std::vector<blink::mojom::FileChooserFileInfoPtr>& list,
+    base::OnceCallback<void(std::vector<blink::mojom::FileChooserFileInfoPtr>)>
+        notify) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  // Base level checks.
+  if (!base::FeatureList::IsEnabled(
+          image_metadata_stripper::features::kStripImageMetadataV1) ||
+      !HasStrippableImage(list)) {
+    return false;
+  }
+
+  // Second pass, re-entered with the sanitized list: let the upstream path run.
+  if (already_processed) {
+    return false;
+  }
+
+  already_processed = true;
+
+  // I/O-blocking copy + scrub off the UI thread. `notify` keeps the
+  // FileSelectHelper alive across the hop, so the `temporary_files` reference
+  // handed to the reply stays valid.
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE,
+      {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
+       base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
+      base::BindOnce(&StripListOnBlockingThread, std::move(list)),
+      base::BindOnce(&OnStripComplete, std::ref(temporary_files),
+                     std::move(notify)));
+  return true;
+}
+
+}  // namespace brave

--- a/browser/file_select/brave_file_select_image_metadata_stripper.cc
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.cc
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/containers/extend.h"
 #include "base/feature_list.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
@@ -61,6 +62,14 @@ bool HasStrippableImage(
 StripResult StripListOnBlockingThread(
     std::vector<blink::mojom::FileChooserFileInfoPtr> list) {
   StripResult result;
+  auto temp_file_deletor = [&result](const base::FilePath& temp) {
+    // The gaurd helps to schedule the delete to upstream's delete lifecycle
+    // if ever our own attempt to delete the temporary file failed.
+    if (!base::DeleteFile(temp)) {
+      result.temp_files.push_back(std::move(temp));
+    }
+  };
+
   for (auto& info : list) {
     if (!info || !info->is_native_file()) {
       continue;
@@ -79,6 +88,8 @@ StripResult StripListOnBlockingThread(
     if (!base::CopyFile(src, temp)) {
       DVLOG(1) << "Upload strip skipped; Failed to copy the image file to a "
                   "temporary file.";
+      temp_file_deletor(temp);
+      continue;
     }
 
     // We try and remove the iptc metadata from the file.
@@ -86,11 +97,7 @@ StripResult StripListOnBlockingThread(
         image_metadata_stripper::StrippingClient::kFileSelect, temp);
     if (!success) {
       DVLOG(1) << "No stripping occured; keeping original: " << src;
-      // The gaurd helps to schedule the delete to upstream's delete lifecycle
-      // if ever our own attempt to delete the temporary file failed.
-      if (!base::DeleteFile(temp)) {
-        result.temp_files.push_back(std::move(temp));
-      }
+      temp_file_deletor(temp);
       continue;
     }
 
@@ -99,10 +106,10 @@ StripResult StripListOnBlockingThread(
     // directly to the result.
     // TODO(https://github.com/brave/brave-browser/issues/5238): On macOS the
     // file control shows the temp basename (e.g.
-    // .com.brave.Browser.channelNameHere.XXXXXX). From LLM it seems the reason
-    // to be the following: LayoutThemeMac::DisplayNameForFile uses
-    // NSFileManager displayNameAtPath of the backing path so even setting
-    // display_name / File.name is not enough. See
+    // .com.brave.Browser.channelNameHere.XXXXXX).
+    // LayoutThemeMac::DisplayNameForFile uses NSFileManager displayNameAtPath
+    // of the backing path so even setting display_name / File.name is not
+    // enough. See
     // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/
     // renderer/core/layout/layout_theme_mac.mm;l=60 for details.
     // Need to figure out how to handle this issue.
@@ -124,10 +131,8 @@ void OnStripComplete(
     StripResult result) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
   // Update the |temporary_files| list to mark the deletion of our newly created
-  // tmp files.
-  for (auto& temp : result.temp_files) {
-    temporary_files.push_back(std::move(temp));
-  }
+  // temp files.
+  base::Extend(temporary_files, std::move(result.temp_files));
   std::move(notify).Run(std::move(result.list));
 }
 

--- a/browser/file_select/brave_file_select_image_metadata_stripper.cc
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.cc
@@ -22,6 +22,7 @@
 #include "brave/components/image_metadata_stripper/common/features.h"
 #include "brave/components/image_metadata_stripper/image_metadata_stripper.h"
 #include "content/public/browser/browser_thread.h"
+#include "third_party/blink/public/mojom/choosers/file_chooser.mojom.h"
 
 namespace brave {
 

--- a/browser/file_select/brave_file_select_image_metadata_stripper.cc
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.cc
@@ -29,8 +29,22 @@ namespace brave {
 namespace {
 
 struct StripResult {
-  std::vector<blink::mojom::FileChooserFileInfoPtr> list;
+  // The final list of selected files where the original image file(s)
+  // containing flagged metadata gets replaced with a stripped-out
+  // temporary image file w/o the flagged metadata.
+  std::vector<blink::mojom::FileChooserFileInfoPtr> selected_files;
+  // Temporary files which are created during the stripping process. These files
+  // are passed down to the upstream for deletion at `OnStripComplete`.
   std::vector<base::FilePath> temp_files;
+
+  StripResult() = default;
+  ~StripResult() = default;
+
+  StripResult(const StripResult&) = delete;
+  StripResult& operator=(const StripResult&) = delete;
+
+  StripResult(StripResult&&) = default;
+  StripResult& operator=(StripResult&&) = default;
 };
 
 // TODO(https://github.com/brave/brave-browser/issues/5238): PNG formats needs
@@ -40,19 +54,19 @@ bool IsStrippableImagePath(const base::FilePath& path) {
          path.MatchesExtension(FILE_PATH_LITERAL(".jpeg"));
 }
 
-// Returns true if any of the items in the |list| could be a candidate for
-// stripping metadata.
+// Returns true if any of the items in the |selected_files| could be a candidate
+// for stripping metadata.
 bool HasStrippableImage(
-    const std::vector<blink::mojom::FileChooserFileInfoPtr>& list) {
+    const std::vector<blink::mojom::FileChooserFileInfoPtr>& selected_files) {
   return std::ranges::any_of(
-      list, [](const blink::mojom::FileChooserFileInfoPtr& info) {
+      selected_files, [](const blink::mojom::FileChooserFileInfoPtr& info) {
         return info && info->is_native_file() &&
                IsStrippableImagePath(info->get_native_file()->file_path);
       });
 }
 
 // Algorithm:
-// 1) Iterate over each item in the |list|.
+// 1) Iterate over each item in the |selected_files|.
 // 2) If the "ith" item is not strippable, continue with 1.
 // 3) If the "ith" is stripppable then:
 //    3.a) Copy the contents of "ith" item into a temporary file.
@@ -61,28 +75,29 @@ bool HasStrippableImage(
 //         3.b.2) Otherwise, mark the temporay file for upload and then later
 //         for deletion.
 StripResult StripListOnBlockingThread(
-    std::vector<blink::mojom::FileChooserFileInfoPtr> list) {
+    std::vector<blink::mojom::FileChooserFileInfoPtr> selected_files) {
   StripResult result;
   auto temp_file_deleter = [&result](base::FilePath&& temp) {
-    // The gaurd helps to schedule the delete to upstream's delete lifecycle
+    // The guard helps to schedule the delete to upstream's delete lifecycle
     // if ever our own attempt to delete the temporary file failed.
     if (!base::DeleteFile(temp)) {
       result.temp_files.push_back(std::move(temp));
     }
   };
 
-  for (auto& info : list) {
+  for (auto& info : selected_files) {
     if (!info || !info->is_native_file()) {
       continue;
     }
-    const base::FilePath src = info->get_native_file()->file_path;
+    const base::FilePath& src = info->get_native_file()->file_path;
     if (!IsStrippableImagePath(src)) {
       continue;
     }
 
     base::FilePath temp;
     if (!base::CreateTemporaryFile(&temp)) {
-      DVLOG(1) << "Upload strip skipped; no temp file for: " << src;
+      LOG(ERROR) << "Upload strip skipped; temp file could not be created: "
+                 << src;
       continue;
     }
 
@@ -103,8 +118,8 @@ StripResult StripListOnBlockingThread(
     }
 
     // Re-write the file path of the original upload file, with our temporary's
-    // file path. This keeps the overall |list| untouched which is then moved
-    // directly to the result.
+    // file path. This keeps the overall |selected_files| untouched which is
+    // then moved directly to the result.
     // TODO(https://github.com/brave/brave-browser/issues/5238): On macOS the
     // file control shows the temp basename (e.g.
     // .com.brave.Browser.channelNameHere.XXXXXX).
@@ -120,7 +135,7 @@ StripResult StripListOnBlockingThread(
     // DeleteTemporaryFiles method.
     result.temp_files.push_back(std::move(temp));
   }
-  result.list = std::move(list);
+  result.selected_files = std::move(selected_files);
   return result;
 }
 
@@ -134,7 +149,7 @@ void OnStripComplete(
   // Update the |temporary_files| list to mark the deletion of our newly created
   // temp files.
   base::Extend(temporary_files, std::move(result.temp_files));
-  std::move(notify).Run(std::move(result.list));
+  std::move(notify).Run(std::move(result.selected_files));
 }
 
 }  // namespace

--- a/browser/file_select/brave_file_select_image_metadata_stripper.cc
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.cc
@@ -62,7 +62,7 @@ bool HasStrippableImage(
 StripResult StripListOnBlockingThread(
     std::vector<blink::mojom::FileChooserFileInfoPtr> list) {
   StripResult result;
-  auto temp_file_deletor = [&result](const base::FilePath& temp) {
+  auto temp_file_deleter = [&result](base::FilePath&& temp) {
     // The gaurd helps to schedule the delete to upstream's delete lifecycle
     // if ever our own attempt to delete the temporary file failed.
     if (!base::DeleteFile(temp)) {
@@ -88,7 +88,7 @@ StripResult StripListOnBlockingThread(
     if (!base::CopyFile(src, temp)) {
       DVLOG(1) << "Upload strip skipped; Failed to copy the image file to a "
                   "temporary file.";
-      temp_file_deletor(temp);
+      temp_file_deleter(std::move(temp));
       continue;
     }
 
@@ -97,7 +97,7 @@ StripResult StripListOnBlockingThread(
         image_metadata_stripper::StrippingClient::kFileSelect, temp);
     if (!success) {
       DVLOG(1) << "No stripping occured; keeping original: " << src;
-      temp_file_deletor(temp);
+      temp_file_deleter(std::move(temp));
       continue;
     }
 

--- a/browser/file_select/brave_file_select_image_metadata_stripper.h
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.h
@@ -17,29 +17,21 @@ class FilePath;
 
 namespace brave {
 
-// Strips tracking metadata (e.g. Facebook FBMD IPTC identifiers) from the JPEG
-// files a user picked for upload. This is the file-picker counterpart to the
-// download-completion strip in BraveDownloadManagerDelegate.
-//
-// The user's original files are never modified: each strippable image is copied
-// to a temporary file which is then scrubbed, and the corresponding entry
-// in |list| is rewritten to point at the sanitized copy (its display name is
-// left unchanged, so the site still sees the original filename). Any temporary
-// copies created are appended to `temporary_files`, so the existing
-// FileSelectHelper teardown deletes them once the upload completes.
-//
-// Returns true when stripping has been started asynchronously and the caller
-// took no ownership decision: the interposition now owns `list` and will run
-// `notify` on the UI thread with the sanitized list once stripping finishes.
-// The caller must return immediately without notifying its listener.
-//
-// Returns false when there is nothing to do (feature disabled, already run, or
-// no strippable image selected); |list| is left untouched and the caller should
-// proceed to notify it synchronously as usual.
-//
-// |already_processed| guards against re-entrancy: the caller is expected to be
-// re-invoked with the sanitized list via |notify| callback, and this flag lets
-// the strip run exactly once before falling through to the upstream path.
+// A method which is called when the browser is about to hand over the selected
+// files via `NotifyListenerAndEnd`. This method is responsible for stripping
+// out the flagged metadata from the uploaded jpeg image.
+// For cases where it's clear no metadata needs to be stripped it returns false
+// to continue with the synchronous execution of `NotifyListenerAndEnd` path;
+// and true otherwise where it runs the metadata removal and call the
+// `NotifyListenerAndEnd` asynchronously via |notify| callback to join back with
+// the regular execution.
+// The method does not actually strip any metadata from
+// the original file while uploading instead it create a temporary file and that
+// gets uploaded. This temporary file path gets added to the |temporary_files|
+// list to flag it for deletion once the upload is complete.
+// |already_processed| helps to avoid looping between `NotifyListenerAndEnd`
+// and `MaybeStripImageMetadataForUpload` by letting `NotifyListenerAndEnd` know
+// that the stripping work has been scheduled.
 bool MaybeStripImageMetadataForUpload(
     bool& already_processed,
     std::vector<base::FilePath>& temporary_files,

--- a/browser/file_select/brave_file_select_image_metadata_stripper.h
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.h
@@ -1,0 +1,52 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_FILE_SELECT_BRAVE_FILE_SELECT_IMAGE_METADATA_STRIPPER_H_
+#define BRAVE_BROWSER_FILE_SELECT_BRAVE_FILE_SELECT_IMAGE_METADATA_STRIPPER_H_
+
+#include <vector>
+
+#include "base/functional/callback_forward.h"
+#include "third_party/blink/public/mojom/choosers/file_chooser.mojom.h"
+
+namespace base {
+class FilePath;
+}  // namespace base
+
+namespace brave {
+
+// Strips tracking metadata (e.g. Facebook FBMD IPTC identifiers) from the JPEG
+// files a user picked for upload. This is the file-picker counterpart to the
+// download-completion strip in BraveDownloadManagerDelegate.
+//
+// The user's original files are never modified: each strippable image is copied
+// to a temporary file which is then scrubbed, and the corresponding entry
+// in |list| is rewritten to point at the sanitized copy (its display name is
+// left unchanged, so the site still sees the original filename). Any temporary
+// copies created are appended to `temporary_files`, so the existing
+// FileSelectHelper teardown deletes them once the upload completes.
+//
+// Returns true when stripping has been started asynchronously and the caller
+// took no ownership decision: the interposition now owns `list` and will run
+// `notify` on the UI thread with the sanitized list once stripping finishes.
+// The caller must return immediately without notifying its listener.
+//
+// Returns false when there is nothing to do (feature disabled, already run, or
+// no strippable image selected); |list| is left untouched and the caller should
+// proceed to notify it synchronously as usual.
+//
+// |already_processed| guards against re-entrancy: the caller is expected to be
+// re-invoked with the sanitized list via |notify| callback, and this flag lets
+// the strip run exactly once before falling through to the upstream path.
+bool MaybeStripImageMetadataForUpload(
+    bool& already_processed,
+    std::vector<base::FilePath>& temporary_files,
+    std::vector<blink::mojom::FileChooserFileInfoPtr>& list,
+    base::OnceCallback<void(std::vector<blink::mojom::FileChooserFileInfoPtr>)>
+        notify);
+
+}  // namespace brave
+
+#endif  // BRAVE_BROWSER_FILE_SELECT_BRAVE_FILE_SELECT_IMAGE_METADATA_STRIPPER_H_

--- a/browser/file_select/brave_file_select_image_metadata_stripper.h
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.h
@@ -20,18 +20,26 @@ namespace brave {
 // A method which is called when the browser is about to hand over the selected
 // files via `NotifyListenerAndEnd`. This method is responsible for stripping
 // out the flagged metadata from the uploaded jpeg image.
+//
 // For cases where it's clear no metadata needs to be stripped it returns false
 // to continue with the synchronous execution of `NotifyListenerAndEnd` path;
 // and true otherwise where it runs the metadata removal and call the
 // `NotifyListenerAndEnd` asynchronously via |notify| callback to join back with
 // the regular execution.
+//
 // The method does not actually strip any metadata from
 // the original file while uploading instead it create a temporary file and that
 // gets uploaded. This temporary file path gets added to the |temporary_files|
 // list to flag it for deletion once the upload is complete.
+//
 // |already_processed| helps to avoid looping between `NotifyListenerAndEnd`
 // and `MaybeStripImageMetadataForUpload` by letting `NotifyListenerAndEnd` know
 // that the stripping work has been scheduled.
+//
+// Note on the the |list| ownership. For cases where this method returns true
+// its ownership would be taken via move, but re-transferred back via the
+// |notify| callback. For false, regular execution would follow as the |list|
+// ownership would still be with the caller.
 bool MaybeStripImageMetadataForUpload(
     bool& already_processed,
     std::vector<base::FilePath>& temporary_files,

--- a/browser/file_select/brave_file_select_image_metadata_stripper.h
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.h
@@ -9,7 +9,7 @@
 #include <vector>
 
 #include "base/functional/callback_forward.h"
-#include "third_party/blink/public/mojom/choosers/file_chooser.mojom.h"
+#include "third_party/blink/public/mojom/choosers/file_chooser.mojom-forward.h"
 
 namespace base {
 class FilePath;

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -151,6 +151,7 @@ brave_chrome_browser_deps = [
   "//brave/browser/brave_stats",
   "//brave/browser/component_updater",
   "//brave/browser/download",
+  "//brave/browser/file_select",
   "//brave/browser/metrics/buildflags",
   "//brave/browser/misc_metrics",
   "//brave/browser/misc_metrics:misc_metrics_impl",

--- a/chromium_src/chrome/browser/file_select_helper.cc
+++ b/chromium_src/chrome/browser/file_select_helper.cc
@@ -1,0 +1,16 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/functional/bind.h"
+#include "base/memory/scoped_refptr.h"
+#include "brave/browser/file_select/brave_file_select_image_metadata_stripper.h"
+
+// The upload-metadata strip is spliced into
+// FileSelectHelper::NotifyListenerAndEnd by
+// rewrite/chrome/browser/file_select_helper.cc.yaml. The declaration above is
+// all this target needs; the implementation is linked from
+// //brave/browser/file_select, so chrome/browser does not depend on Brave
+// targets (mirroring the download-delegate factory approach).
+#include <chrome/browser/file_select_helper.cc>

--- a/chromium_src/chrome/browser/file_select_helper.cc
+++ b/chromium_src/chrome/browser/file_select_helper.cc
@@ -3,14 +3,30 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "base/functional/bind.h"
-#include "base/memory/scoped_refptr.h"
-#include "brave/browser/file_select/brave_file_select_image_metadata_stripper.h"
+#include <vector>
 
-// The upload-metadata strip is spliced into
-// FileSelectHelper::NotifyListenerAndEnd by
-// rewrite/chrome/browser/file_select_helper.cc.yaml. The declaration above is
-// all this target needs; the implementation is linked from
-// //brave/browser/file_select, so chrome/browser does not depend on Brave
-// targets (mirroring the download-delegate factory approach).
+#include "base/functional/bind.h"
+#include "base/functional/callback_forward.h"
+#include "base/memory/scoped_refptr.h"
+#include "third_party/blink/public/mojom/choosers/file_chooser.mojom.h"
+
+namespace base {
+class FilePath;
+}  // namespace base
+
+namespace brave {
+
+// The upload-metadata strip is spliced into NotifyListenerAndEnd by
+// rewrite/chrome/browser/file_select_helper.cc.yaml. Defined in
+// brave/browser/file_select/brave_file_select_image_metadata_stripper.cc, and
+// declared here so that chrome/browser does not depend on Brave targets.
+bool MaybeStripImageMetadataForUpload(
+    bool& already_processed,
+    std::vector<base::FilePath>& temporary_files,
+    std::vector<blink::mojom::FileChooserFileInfoPtr>& list,
+    base::OnceCallback<void(std::vector<blink::mojom::FileChooserFileInfoPtr>)>
+        notify);
+
+}  // namespace brave
+
 #include <chrome/browser/file_select_helper.cc>

--- a/components/image_metadata_stripper/image_metadata_stripper.cc
+++ b/components/image_metadata_stripper/image_metadata_stripper.cc
@@ -11,6 +11,7 @@
 
 #include "base/files/file_util.h"
 #include "base/logging.h"
+#include "base/notreached.h"
 #include "brave/components/image_metadata_stripper/internal/jpeg_iptc_metadata_stripper.h"
 
 namespace image_metadata_stripper {

--- a/patches/chrome-browser-file_select_helper.cc.patch
+++ b/patches/chrome-browser-file_select_helper.cc.patch
@@ -1,0 +1,17 @@
+diff --git a/chrome/browser/file_select_helper.cc b/chrome/browser/file_select_helper.cc
+index 50aa1c59b577aecef64933f994770d344f0e6145..de1133b2d0b23cb4ce039a092a25a835eb47133e 100644
+--- a/chrome/browser/file_select_helper.cc
++++ b/chrome/browser/file_select_helper.cc
+@@ -460,6 +460,12 @@ void FileSelectHelper::ContentAnalysisCompletionCallback(
+ 
+ void FileSelectHelper::NotifyListenerAndEnd(
+     std::vector<blink::mojom::FileChooserFileInfoPtr> list) {
++  if (brave::MaybeStripImageMetadataForUpload(
++          image_metadata_processed_, temporary_files_, list,
++          base::BindOnce(&FileSelectHelper::NotifyListenerAndEnd,
++                         base::WrapRefCounted(this)))) {
++    return;
++  }
+   listener_->FileSelected(std::move(list), base_dir_, dialog_mode_);
+   listener_.reset();
+ 

--- a/patches/chrome-browser-file_select_helper.cc.patch
+++ b/patches/chrome-browser-file_select_helper.cc.patch
@@ -1,15 +1,14 @@
 diff --git a/chrome/browser/file_select_helper.cc b/chrome/browser/file_select_helper.cc
-index 9b7c30c3b2f7c3489d32a0e82a3ce0288d249f98..82ebd228b3f14588da3649049c9f7cb3d1438c43 100644
+index 9b7c30c3b2f7c3489d32a0e82a3ce0288d249f98..68db99d19aeffe40a6abdcb7685c96978f59e09b 100644
 --- a/chrome/browser/file_select_helper.cc
 +++ b/chrome/browser/file_select_helper.cc
-@@ -463,6 +463,12 @@ void FileSelectHelper::ContentAnalysisCompletionCallback(
+@@ -463,6 +463,11 @@ void FileSelectHelper::ContentAnalysisCompletionCallback(
  
  void FileSelectHelper::NotifyListenerAndEnd(
      std::vector<blink::mojom::FileChooserFileInfoPtr> list) {
 +  if (brave::MaybeStripImageMetadataForUpload(
 +          image_metadata_processed_, temporary_files_, list,
-+          base::BindOnce(&FileSelectHelper::NotifyListenerAndEnd,
-+                         base::WrapRefCounted(this)))) {
++          base::BindOnce(&FileSelectHelper::NotifyListenerAndEnd, this))) {
 +    return;
 +  }
    listener_->FileSelected(std::move(list), base_dir_, dialog_mode_);

--- a/patches/chrome-browser-file_select_helper.cc.patch
+++ b/patches/chrome-browser-file_select_helper.cc.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/browser/file_select_helper.cc b/chrome/browser/file_select_helper.cc
-index 50aa1c59b577aecef64933f994770d344f0e6145..de1133b2d0b23cb4ce039a092a25a835eb47133e 100644
+index 9b7c30c3b2f7c3489d32a0e82a3ce0288d249f98..82ebd228b3f14588da3649049c9f7cb3d1438c43 100644
 --- a/chrome/browser/file_select_helper.cc
 +++ b/chrome/browser/file_select_helper.cc
-@@ -460,6 +460,12 @@ void FileSelectHelper::ContentAnalysisCompletionCallback(
+@@ -463,6 +463,12 @@ void FileSelectHelper::ContentAnalysisCompletionCallback(
  
  void FileSelectHelper::NotifyListenerAndEnd(
      std::vector<blink::mojom::FileChooserFileInfoPtr> list) {

--- a/patches/chrome-browser-file_select_helper.h.patch
+++ b/patches/chrome-browser-file_select_helper.h.patch
@@ -1,0 +1,14 @@
+diff --git a/chrome/browser/file_select_helper.h b/chrome/browser/file_select_helper.h
+index 16e77ae3d7c3576d36076e1f3133f2806fd759b3..2cac69ab51b3429dd4bdaf3aea24e96c22ef779d 100644
+--- a/chrome/browser/file_select_helper.h
++++ b/chrome/browser/file_select_helper.h
+@@ -77,6 +77,9 @@ class FileSelectHelper : public base::RefCountedThreadSafe<
+       scoped_refptr<content::FileSelectListener> listener,
+       const base::FilePath& path);
+ 
++ protected:
++  bool image_metadata_processed_ = false;
++
+  private:
+   friend class base::RefCountedThreadSafe<FileSelectHelper>;
+   friend class base::DeleteHelper<FileSelectHelper>;

--- a/rewrite/chrome/browser/file_select_helper.cc.yaml
+++ b/rewrite/chrome/browser/file_select_helper.cc.yaml
@@ -8,7 +8,7 @@ substitutions:
       Strip tracking metadata from uploaded images.
 
       NotifyListenerAndEnd is the point where the chosen files are
-      handed to the listener. Therefore we override this point to select the picked
+      handed to the renderer. Therefore we override this point to select the picked
       JPEG files, and pass to our metadata stripping pipeline.
     preempt_function_impl:
       function_name: FileSelectHelper::NotifyListenerAndEnd

--- a/rewrite/chrome/browser/file_select_helper.cc.yaml
+++ b/rewrite/chrome/browser/file_select_helper.cc.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |-
+      Strip tracking metadata from uploaded images.
+
+      NotifyListenerAndEnd is the point where the chosen files are
+      handed to the listener. Therefore we override this point to select the picked
+      JPEG files, and pass to our metadata stripping pipeline.
+    preempt_function_impl:
+      function_name: FileSelectHelper::NotifyListenerAndEnd
+      code: |-
+        if (brave::MaybeStripImageMetadataForUpload(
+                image_metadata_processed_, temporary_files_, list,
+                base::BindOnce(&FileSelectHelper::NotifyListenerAndEnd,
+                               base::WrapRefCounted(this)))) {
+          return;
+        }

--- a/rewrite/chrome/browser/file_select_helper.cc.yaml
+++ b/rewrite/chrome/browser/file_select_helper.cc.yaml
@@ -15,7 +15,6 @@ substitutions:
       code: |-
         if (brave::MaybeStripImageMetadataForUpload(
                 image_metadata_processed_, temporary_files_, list,
-                base::BindOnce(&FileSelectHelper::NotifyListenerAndEnd,
-                               base::WrapRefCounted(this)))) {
+                base::BindOnce(&FileSelectHelper::NotifyListenerAndEnd, this))) {
           return;
         }

--- a/rewrite/chrome/browser/file_select_helper.h.yaml
+++ b/rewrite/chrome/browser/file_select_helper.h.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |-
+      Guard the upload image-metadata strip so it runs once.
+
+      NotifyListenerAndEnd is re-entered with the sanitized list once the async
+      strip completes; this flag lets the Brave interposition take over on the
+      first pass and fall through to the upstream notification on the second.
+    add_to_protected:
+      class_name: FileSelectHelper
+      code: |-
+        bool image_metadata_processed_ = false;


### PR DESCRIPTION
This change hooks the IPTC stripping logic to the upload flow. 

Design document: https://docs.google.com/document/d/1r-6pXLCXubuhe3kzF1AW3M3z2yKiMeQOkz_MMaOOzO8/edit?usp=sharing

### Manual testing demo
https://github.com/user-attachments/assets/f86a52c0-2ed1-4aaa-872e-927d3aeae36d

<!-- Add brave-browser issue below that this PR will resolve -->
Related https://github.com/brave/brave-browser/issues/5238

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
