### PR TITLE
[iptc] Move the logging code to the image stripper component

### DIFF
--- a/browser/download/brave_download_manager_delegate.cc
+++ b/browser/download/brave_download_manager_delegate.cc
@@ -105,8 +105,8 @@ bool BraveDownloadManagerDelegate::IsDownloadReadyForCompletion(
   return false;
 }
 
-void BraveDownloadManagerDelegate::OnImageMetadataStripped(
-    uint32_t download_id) {
+void BraveDownloadManagerDelegate::OnImageMetadataStripped(uint32_t download_id,
+                                                           bool /*stripped*/) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
   // The download may have been removed while the stripping task was running, so

--- a/browser/download/brave_download_manager_delegate.cc
+++ b/browser/download/brave_download_manager_delegate.cc
@@ -105,10 +105,9 @@ bool BraveDownloadManagerDelegate::IsDownloadReadyForCompletion(
   return false;
 }
 
-void BraveDownloadManagerDelegate::OnImageMetadataStripped(uint32_t download_id,
-                                                           bool result) {
+void BraveDownloadManagerDelegate::OnImageMetadataStripped(
+    uint32_t download_id) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-  DVLOG(1) << "Download manager stripping result: " << result;
 
   // The download may have been removed while the stripping task was running, so
   // the item and its keyed state have to be looked up again.

--- a/browser/download/brave_download_manager_delegate.cc
+++ b/browser/download/brave_download_manager_delegate.cc
@@ -13,7 +13,6 @@
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/location.h"
-#include "base/logging.h"
 #include "base/task/task_traits.h"
 #include "base/task/thread_pool.h"
 #include "brave/components/image_metadata_stripper/common/features.h"
@@ -22,46 +21,6 @@
 #include "components/download/public/common/download_item.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/download_manager.h"
-
-namespace {
-
-void LogStrippingResult(
-    const image_metadata_stripper::StrippingResultCode result) {
-  // Debug logs.
-  switch (result) {
-    case image_metadata_stripper::StrippingResultCode::kFileNotFound: {
-      DVLOG(1) << "Stripping skipped as the download file does not exist.";
-      return;
-    }
-
-    case image_metadata_stripper::StrippingResultCode::kFileReadFailed: {
-      DVLOG(1) << "Failed to read the download file to check for metadata.";
-      return;
-    }
-
-    case image_metadata_stripper::StrippingResultCode::kFileWriteFailed: {
-      DVLOG(1) << "Failed to rewrite the download file without the metadata.";
-      return;
-    }
-
-    case image_metadata_stripper::StrippingResultCode::kMetadataNotFound: {
-      DVLOG(1) << "Stripping ignored as FBMD metadata may not be present.";
-      return;
-    }
-
-    case image_metadata_stripper::StrippingResultCode::kStrippingFailed: {
-      DVLOG(1) << "Failed to strip image metadata from download file.";
-      return;
-    }
-
-    case image_metadata_stripper::StrippingResultCode::kStripped: {
-      DVLOG(1) << "FBMD found and stripped from image metadata.";
-      return;
-    }
-  }
-  NOTREACHED();
-}
-}  // namespace
 
 // Factory used by the plastered download_core_service_impl.cc construction
 // site. Keeping the Brave header out of chrome/browser/download avoids pulling
@@ -139,18 +98,17 @@ bool BraveDownloadManagerDelegate::IsDownloadReadyForCompletion(
       {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
        base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
       base::BindOnce(&image_metadata_stripper::RemoveIptcMetadata,
+                     image_metadata_stripper::StrippingClient::kDownloadManager,
                      item->GetFullPath()),
       base::BindOnce(&BraveDownloadManagerDelegate::OnImageMetadataStripped,
                      weak_ptr_factory_.GetWeakPtr(), item->GetId()));
   return false;
 }
 
-void BraveDownloadManagerDelegate::OnImageMetadataStripped(
-    uint32_t download_id,
-    image_metadata_stripper::StrippingResultCode result) {
+void BraveDownloadManagerDelegate::OnImageMetadataStripped(uint32_t download_id,
+                                                           bool result) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-
-  LogStrippingResult(result);
+  DVLOG(1) << "Download manager stripping result: " << result;
 
   // The download may have been removed while the stripping task was running, so
   // the item and its keyed state have to be looked up again.

--- a/browser/download/brave_download_manager_delegate.h
+++ b/browser/download/brave_download_manager_delegate.h
@@ -9,7 +9,6 @@
 #include <stdint.h>
 
 #include "base/memory/weak_ptr.h"
-#include "brave/components/image_metadata_stripper/image_metadata_stripper.h"
 #include "chrome/browser/download/chrome_download_manager_delegate.h"
 
 class Profile;
@@ -41,7 +40,7 @@ class BraveDownloadManagerDelegate : public ChromeDownloadManagerDelegate {
  protected:
   // Marks the download as completed once the iptc metadata is stripped. Virtual
   // for testing purposes.
-  virtual void OnImageMetadataStripped(uint32_t download_id, bool result);
+  virtual void OnImageMetadataStripped(uint32_t download_id);
 
  private:
   // ChromeDownloadManagerDelegate override.

--- a/browser/download/brave_download_manager_delegate.h
+++ b/browser/download/brave_download_manager_delegate.h
@@ -41,9 +41,7 @@ class BraveDownloadManagerDelegate : public ChromeDownloadManagerDelegate {
  protected:
   // Marks the download as completed once the iptc metadata is stripped. Virtual
   // for testing purposes.
-  virtual void OnImageMetadataStripped(
-      uint32_t download_id,
-      image_metadata_stripper::StrippingResultCode result);
+  virtual void OnImageMetadataStripped(uint32_t download_id, bool result);
 
  private:
   // ChromeDownloadManagerDelegate override.

--- a/browser/download/brave_download_manager_delegate.h
+++ b/browser/download/brave_download_manager_delegate.h
@@ -39,8 +39,9 @@ class BraveDownloadManagerDelegate : public ChromeDownloadManagerDelegate {
 
  protected:
   // Marks the download as completed once the iptc metadata is stripped. Virtual
-  // for testing purposes.
-  virtual void OnImageMetadataStripped(uint32_t download_id);
+  // for testing purposes. |stripped| is true only when FBMD IPTC metadata was
+  // actually removed; the download is completed either way.
+  virtual void OnImageMetadataStripped(uint32_t download_id, bool stripped);
 
  private:
   // ChromeDownloadManagerDelegate override.

--- a/browser/download/brave_download_manager_delegate_browsertest.cc
+++ b/browser/download/brave_download_manager_delegate_browsertest.cc
@@ -105,8 +105,8 @@ class TestBraveDownloadManagerDelegate : public BraveDownloadManagerDelegate {
   }
 
  protected:
-  void OnImageMetadataStripped(uint32_t download_id, bool result) override {
-    BraveDownloadManagerDelegate::OnImageMetadataStripped(download_id, result);
+  void OnImageMetadataStripped(uint32_t download_id) override {
+    BraveDownloadManagerDelegate::OnImageMetadataStripped(download_id);
     if (on_image_metadata_stripped_callback_) {
       std::move(on_image_metadata_stripped_callback_).Run();
     }

--- a/browser/download/brave_download_manager_delegate_browsertest.cc
+++ b/browser/download/brave_download_manager_delegate_browsertest.cc
@@ -105,9 +105,7 @@ class TestBraveDownloadManagerDelegate : public BraveDownloadManagerDelegate {
   }
 
  protected:
-  void OnImageMetadataStripped(
-      uint32_t download_id,
-      image_metadata_stripper::StrippingResultCode result) override {
+  void OnImageMetadataStripped(uint32_t download_id, bool result) override {
     BraveDownloadManagerDelegate::OnImageMetadataStripped(download_id, result);
     if (on_image_metadata_stripped_callback_) {
       std::move(on_image_metadata_stripped_callback_).Run();

--- a/browser/download/brave_download_manager_delegate_browsertest.cc
+++ b/browser/download/brave_download_manager_delegate_browsertest.cc
@@ -105,8 +105,9 @@ class TestBraveDownloadManagerDelegate : public BraveDownloadManagerDelegate {
   }
 
  protected:
-  void OnImageMetadataStripped(uint32_t download_id) override {
-    BraveDownloadManagerDelegate::OnImageMetadataStripped(download_id);
+  void OnImageMetadataStripped(uint32_t download_id, bool stripped) override {
+    BraveDownloadManagerDelegate::OnImageMetadataStripped(download_id,
+                                                          stripped);
     if (on_image_metadata_stripped_callback_) {
       std::move(on_image_metadata_stripped_callback_).Run();
     }

--- a/components/image_metadata_stripper/image_metadata_stripper.cc
+++ b/components/image_metadata_stripper/image_metadata_stripper.cc
@@ -15,7 +15,76 @@
 
 namespace image_metadata_stripper {
 
-StrippingResultCode RemoveIptcMetadata(const base::FilePath& file_path) {
+namespace {
+
+// This enum lets the client know the result of their stripping request.
+enum class StrippingResultCode {
+  // The input file does not exist.
+  kFileNotFound,
+  // Initial file read failed to check for metadata.
+  kFileReadFailed,
+  // File rewrite failed with the stripped out metadata.
+  kFileWriteFailed,
+
+  // Metadata was not found.
+  kMetadataNotFound,
+  // Metadata was found but not able to be stripped.
+  kStrippingFailed,
+  // Metadata was found and stripped.
+  kStripped,
+};
+
+constexpr std::string_view GetStrippingClient(StrippingClient client) {
+  switch (client) {
+    case StrippingClient::kDownloadManager:
+      return "Download manager";
+    case StrippingClient::kFileSelect:
+      return "File selector";
+  }
+  NOTREACHED();
+}
+
+void LogStrippingResult(const StrippingClient client,
+                        const StrippingResultCode result) {
+  const auto tag = GetStrippingClient(client);
+
+  switch (result) {
+    case image_metadata_stripper::StrippingResultCode::kFileNotFound: {
+      DVLOG(1) << tag << ";Stripping skipped as the file does not exist.";
+      return;
+    }
+
+    case image_metadata_stripper::StrippingResultCode::kFileReadFailed: {
+      DVLOG(1) << tag << ";Failed to read the file to check for metadata.";
+      return;
+    }
+
+    case image_metadata_stripper::StrippingResultCode::kFileWriteFailed: {
+      DVLOG(1) << tag << ";Failed to rewrite the file without the metadata.";
+      return;
+    }
+
+    case image_metadata_stripper::StrippingResultCode::kMetadataNotFound: {
+      DVLOG(1) << tag
+               << ";Stripping ignored as FBMD metadata may not be present.";
+      return;
+    }
+
+    case image_metadata_stripper::StrippingResultCode::kStrippingFailed: {
+      DVLOG(1) << tag << ";Failed to strip image metadata from file.";
+      return;
+    }
+
+    case image_metadata_stripper::StrippingResultCode::kStripped: {
+      DVLOG(1) << tag << ";FBMD found and stripped from image metadata.";
+      return;
+    }
+  }
+  NOTREACHED();
+}
+
+StrippingResultCode RemoveIptcMetadataInternal(
+    const base::FilePath& file_path) {
   if (!base::PathExists(file_path)) {
     DVLOG(1) << "IPTC strip skipped; file missing: " << file_path;
     return StrippingResultCode::kFileNotFound;
@@ -45,6 +114,17 @@ StrippingResultCode RemoveIptcMetadata(const base::FilePath& file_path) {
   }
 
   return StrippingResultCode::kStripped;
+}
+
+}  // namespace
+
+bool RemoveIptcMetadata(const StrippingClient client,
+                        const base::FilePath& file_path) {
+  const StrippingResultCode result = RemoveIptcMetadataInternal(file_path);
+
+  LogStrippingResult(client, result);
+
+  return result == StrippingResultCode::kStripped;
 }
 
 }  // namespace image_metadata_stripper

--- a/components/image_metadata_stripper/image_metadata_stripper.h
+++ b/components/image_metadata_stripper/image_metadata_stripper.h
@@ -10,27 +10,21 @@
 
 namespace image_metadata_stripper {
 
-// This enum lets the client know the result of their stripping request.
-enum class StrippingResultCode {
-  // The input file does not exist.
-  kFileNotFound,
-  // Initial file read failed to check for metadata.
-  kFileReadFailed,
-  // File rewrite failed with the stripped out metadata.
-  kFileWriteFailed,
-
-  // Metadata was not found.
-  kMetadataNotFound,
-  // Metadata was found but not able to be stripped.
-  kStrippingFailed,
-  // Metadata was found and stripped.
-  kStripped,
+// The client requesting to strip the image metadata.
+enum class StrippingClient {
+  // Download flow.
+  kDownloadManager,
+  // Upload flow.
+  kFileSelect,
 };
 
-// Removes the FBMD metadata from the IPTC Instructions field
-// (https://www.iptc.org/std/photometadata/documentation/userguide/#_instructions)
-// for an image file in |file_path|.
-StrippingResultCode RemoveIptcMetadata(const base::FilePath& file_path);
+// Removes the FBMD metadata from the IPTC Instructions field for an image file
+// in |file_path|. The |client| is needed to log the stripping result code
+// tagged on client.
+// Returns true only when the fbmd iptc metadata was actually removed and false
+// otherwise.
+bool RemoveIptcMetadata(const StrippingClient client,
+                        const base::FilePath& file_path);
 
 }  // namespace image_metadata_stripper
 


### PR DESCRIPTION
This change adds a minor refactoring to move the stripping result logging directly to the component to avoid code duplication when we support the upload flow which is being tracked at (https://github.com/brave/brave-core/pull/39465). 

<!-- Add brave-browser issue below that this PR will resolve -->
Related https://github.com/brave/brave-browser/issues/5238 

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
