### PR TITLE
Fix multi window PiP issue on Samsung devices

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -112,6 +112,7 @@ import org.chromium.chrome.browser.InternetConnection;
 import org.chromium.chrome.browser.LaunchIntentDispatcher;
 import org.chromium.chrome.browser.OpenYtInBraveDialogFragment;
 import org.chromium.chrome.browser.app.domain.WalletModel;
+import org.chromium.chrome.browser.app.tabwindow.TabWindowManagerSingleton;
 import org.chromium.chrome.browser.billing.InAppPurchaseWrapper;
 import org.chromium.chrome.browser.billing.PurchaseModel;
 import org.chromium.chrome.browser.bookmarks.TabBookmarker;
@@ -203,6 +204,7 @@ import org.chromium.chrome.browser.tabmodel.TabClosureParams;
 import org.chromium.chrome.browser.tabmodel.TabList;
 import org.chromium.chrome.browser.tabmodel.TabModel;
 import org.chromium.chrome.browser.tabmodel.TabModelUtils;
+import org.chromium.chrome.browser.tabwindow.TabWindowManager;
 import org.chromium.chrome.browser.toolbar.BraveToolbarManager;
 import org.chromium.chrome.browser.toolbar.bottom.BottomToolbarConfiguration;
 import org.chromium.chrome.browser.toolbar.top.BraveToolbarLayoutImpl;
@@ -626,6 +628,77 @@ public abstract class BraveActivity extends ChromeActivity
             return;
         }
         super.onNightModeStateChanged();
+    }
+
+    @Override
+    protected boolean isStartedUpCorrectly(Intent intent) {
+        if (maybeRedirectLaunchToYouTubePictureInPictureWindow(intent)) {
+            return false;
+        }
+        return super.isStartedUpCorrectly(intent);
+    }
+
+    /**
+     * Hands a launcher tap to the window that owns a Brave YouTube Picture-in-Picture session,
+     * rather than letting it open a second window holding someone else's tabs.
+     *
+     * <p>PiP pins the browser task, leaving the launcher nothing to resume. Where the OS reads
+     * ChromeTabbedActivity as {@code singleInstancePerTask} (Samsung, via the {@code
+     * android.activity.launch_mode} meta-data) it answers by creating a second task, and {@code
+     * MultiInstanceManagerApi31#allocInstanceId} gives that unmapped task a different window id: a
+     * stale or empty set of tabs, while the real session sits behind the PiP window.
+     *
+     * <p>Fronting the PiP window unpins it, and aborting this activity drops the task it would have
+     * used.
+     *
+     * @return true if the launch was handed over and this activity should not start.
+     */
+    private boolean maybeRedirectLaunchToYouTubePictureInPictureWindow(Intent intent) {
+        // Only a bare launcher tap, and never one Brave sent itself: the new window flows use
+        // trusted intents and really do mean to open another window.
+        if (!Intent.ACTION_MAIN.equals(intent.getAction())
+                || !intent.hasCategory(Intent.CATEGORY_LAUNCHER)
+                || IntentHandler.wasIntentSenderChrome(intent)) {
+            return false;
+        }
+
+        // The bytecode rewrite re-parents only ChromeTabbedActivity onto BraveActivity, so this
+        // instanceof picks out exactly the browser windows. isInPictureInPictureMode() goes first
+        // because it just reads a field; the other call would build a controller for every window.
+        BraveActivity pictureInPictureActivity = null;
+        for (Activity activity : ApplicationStatus.getRunningActivities()) {
+            if (activity == this || !(activity instanceof BraveActivity braveActivity)) {
+                continue;
+            }
+            if (!braveActivity.isInPictureInPictureMode()
+                    || !braveActivity.isYouTubePictureInPictureActive()) {
+                // An ordinary window is still alive, so the launcher had something to resume
+                // and this launch really is a request for another one.
+                return false;
+            }
+            pictureInPictureActivity = braveActivity;
+        }
+        if (pictureInPictureActivity == null) {
+            return false;
+        }
+
+        // Last, because it copies the whole shared-preference map. Only a task that never hosted
+        // a window can be the one Android just made for this launch. A window being recreated or
+        // restored reuses its own task and reaches here looking like a launcher tap too, since
+        // IntentHandler#rewriteFromHistoryIntent swaps in a synthetic MAIN/LAUNCHER intent;
+        // redirecting that would strand the user and remove the restored window's task.
+        if (BraveMultiWindowUtils.isTaskMappedToInstance(ApplicationStatus.getTaskId(this))) {
+            return false;
+        }
+
+        // Cannot select ourselves: this activity has no tab model selector yet, so it resolves
+        // to no window id.
+        final int windowId =
+                TabWindowManagerSingleton.getInstance().getIdForWindow(pictureInPictureActivity);
+        if (windowId == TabWindowManager.INVALID_WINDOW_ID) {
+            return false;
+        }
+        return MultiWindowUtils.launchIntentInInstance(intent, windowId);
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -654,11 +654,11 @@ public abstract class BraveActivity extends ChromeActivity
      * @return true if the launch was handed over and this activity should not start.
      */
     private boolean maybeRedirectLaunchToYouTubePictureInPictureWindow(Intent intent) {
-        // Only a bare launcher tap, and never one Brave sent itself: the new window flows use
-        // trusted intents and really do mean to open another window.
+        // Launcher taps only. Upstream already routes stray VIEW intents to an existing window
+        // from maybeDispatchIntentInExistingActivity, and its own new window intents carry no
+        // action at all (MultiWindowUtils#createNewWindowIntent), so neither reaches this.
         if (!Intent.ACTION_MAIN.equals(intent.getAction())
-                || !intent.hasCategory(Intent.CATEGORY_LAUNCHER)
-                || IntentHandler.wasIntentSenderChrome(intent)) {
+                || !intent.hasCategory(Intent.CATEGORY_LAUNCHER)) {
             return false;
         }
 

--- a/android/java/org/chromium/chrome/browser/multiwindow/BraveMultiWindowUtils.java
+++ b/android/java/org/chromium/chrome/browser/multiwindow/BraveMultiWindowUtils.java
@@ -84,6 +84,15 @@ public class BraveMultiWindowUtils extends MultiWindowUtils {
                 .writeBoolean(BravePreferenceKeys.ENABLE_MULTI_WINDOWS_UPGRADE, isUpgradeCheck);
     }
 
+    /**
+     * Returns whether a window instance is already mapped to {@code taskId}. An unmapped task has
+     * never hosted a window, so an activity starting in one is a new window rather than one being
+     * restored or recreated. Lives here for access to the package private store.
+     */
+    public static boolean isTaskMappedToInstance(final int taskId) {
+        return ChromeMultiInstancePersistentStore.readTaskMap().containsValue(taskId);
+    }
+
     public static void mergeWindows(Activity activity) {
         try {
             MultiInstanceManager multiInstanceManager =


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/50550

Tapping the Brave icon while a Brave managed YouTube Picture-in-Picture session is running opens a second browser window with a different, usually stale or empty, set of tabs. The real session stays alive behind the PiP window and comes back only once PiP is closed, leaving the user with two Brave windows.

This only reproduces on Samsung devices, because multi-instance support in Chromium on Android phones is effectively Samsung only. This PR hands such a launch to the window that already owns the PiP session instead of letting a second window be created.

## Why this is Samsung only

Chromium gates its whole multi-instance stack behind one check, `MultiWindowUtils#isMultiInstanceApi31Enabled` (`chrome/android/java/src/org/chromium/chrome/browser/multiwindow/MultiWindowUtils.java:187`):

```java
ActivityInfo info = context.getPackageManager().getActivityInfo(comp, 0);
int launchMode = info == null ? ActivityInfo.LAUNCH_MULTIPLE : info.launchMode;
boolean isSingleInstancePerTaskConfigured =
        launchMode == ActivityInfo.LAUNCH_SINGLE_INSTANCE_PER_TASK;
```

It asks the platform what launch mode `ChromeTabbedActivity` has, and requires `singleInstancePerTask`. The manifest, however, declares `android:launchMode="singleTask"` and adds a separate meta-data tag (`chrome/android/java/AndroidManifest.xml:633`):

```xml
<activity android:name="org.chromium.chrome.browser.ChromeTabbedActivity"
    android:launchMode="singleTask"
    ...>
    <meta-data
        android:name="android.activity.launch_mode"
        android:value="singleInstancePerTask"/>
```

`android.activity.launch_mode` is not an AOSP concept. It is an OEM hook, and the manifest says whose, a hundred lines earlier where the same mechanism is used for the drag and drop launcher (`chrome/android/java/AndroidManifest.xml:508`):

```xml
<!-- The singleInstancePerTask launch mode is required by Samsung OS to determine
     support for multi-instance in the drag & drop use case. See b/232168063 for
     future reference. -->
```

So the manifest keeps `singleTask` for AOSP, which behaves as a single window browser, and signals `singleInstancePerTask` to Samsung's framework, which honors it. On a Pixel `getActivityInfo` returns `singleTask`, `isMultiInstanceApi31Enabled` is false, and `MultiInstanceManagerFactory#create` returns the legacy `MultiInstanceManagerImpl`. On a Samsung it returns `singleInstancePerTask`, and the browser becomes genuinely multi-instance: several `ChromeTabbedActivity` tasks may exist, each with its own window id and its own persisted tab state.

The manifest carries other Samsung specific opt-ins alongside it, which is consistent with this reading: `com.samsung.android.sdk.multiwindow.enable` and `com.samsung.android.sdk.multiwindow.penwindow.enable` (`:1394`, `:1397`), `com.sec.android.support.multiwindow` (`:1407`), and the `com.sec.android.airview.HOVER` intent filter (`:392`).

Upstream also acknowledges that this OEM path launches new windows through plain `MAIN` intents, in `MultiWindowUtils#getExtraPreferNewFromIntent` (`:590`):

```java
// Default to creating a new instance when FLAG_ACTIVITY_MULTIPLE_TASK is set. This is
// required to fulfill new window creation requests initiated for MAIN intents from the OS.
```

## What changed

`BraveActivity` overrides `isStartedUpCorrectly(Intent)`, the veto hook Chromium calls from `AsyncInitializationActivity#onCreateInternal` before the window, native, or any tab state exists. Returning false runs `abortLaunch(FINISH_ACTIVITY_REMOVE_TASK)`, so the activity never starts and the task Android just created for it is removed. `ChromeTabbedActivity` already uses this hook for the same class of decision, including `maybeDispatchIntentInExistingActivity`, which hands a stray VIEW intent to an existing window and aborts. This change reuses both the hook and the same helper, `MultiWindowUtils#launchIntentInInstance`.

The redirect fires under four conditions:

* the intent is a plain `ACTION_MAIN` + `CATEGORY_LAUNCHER` tap. Upstream already routes stray VIEW intents through `maybeDispatchIntentInExistingActivity`, and its own new window intents carry no action at all (`MultiWindowUtils#createNewWindowIntent`), so neither reaches this code;
* every other live browser window is a Brave YouTube PiP window. If an ordinary window is still running the launcher had something to resume, and the launch is treated as a genuine request for another window;
* this task has never hosted a window. `IntentHandler#rewriteFromHistoryIntent` replaces the intent with a synthetic `MAIN`/`LAUNCHER` one for every Recents launch and every recreation with saved state, so without this check a window being restored while another sits in PiP would be redirected and have its own task removed;
* the PiP window resolves to a valid window id.

A small helper, `BraveMultiWindowUtils#isTaskMappedToInstance`, answers the third condition. It lives in the `multiwindow` package because `ChromeMultiInstancePersistentStore` is package private. It is deliberately the last guard evaluated, since it copies the whole shared preference map and must not run on ordinary launches.

Fronting the PiP window unpins it, so the user lands back in their real session, which is the expected result in the issue.

## Test plan

QA has to be on a Samsung device, an S24 or S25 class phone running Android 15 or 16. A Pixel or an emulator cannot reproduce this before or after the change, so a "cannot reproduce" result on those devices is not a signal.

* Open `m.youtube.com`, play a video, tap the PiP button in the toolbar.
* With PiP running, tap the Brave icon in the launcher. Brave should come back to the session that was playing, expanding the PiP window, and no second window should appear.
* Close PiP and confirm only one Brave window exists in Recents.
* With PiP running, tap the Brave card in Recents instead of the launcher icon. Behavior should be unchanged.
* Regression sweep on a Pixel: normal cold start, launch from Recents, launch from a notification, open a link from another app, and the YouTube PiP flow itself. None of these should change.


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
