### PR TITLE
[iOS] Use 24-hour format in iOS bots run script

### DIFF
--- a/patches/ios-build-bots-scripts-run.py.patch
+++ b/patches/ios-build-bots-scripts-run.py.patch
@@ -1,0 +1,13 @@
+diff --git a/ios/build/bots/scripts/run.py b/ios/build/bots/scripts/run.py
+index 6e8a80f27dc70eaa64f5413d147249f61fee3f95..ea437c32bc1192457a53655e024342f3f1f63889 100755
+--- a/ios/build/bots/scripts/run.py
++++ b/ios/build/bots/scripts/run.py
+@@ -679,7 +679,7 @@ def main(args):
+   logging.basicConfig(
+       format='[%(asctime)s:%(levelname)s] %(message)s',
+       level=logging.DEBUG,
+-      datefmt='%I:%M:%S')
++      datefmt='%H:%M:%S')
+ 
+   test_runner.defaults_delete('com.apple.CoreSimulator',
+                               'FramebufferServerRendererPolicy')

--- a/rewrite/ios/build/bots/scripts/run.py.yaml
+++ b/rewrite/ios/build/bots/scripts/run.py.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |-
+      Log timestamps in 24-hour time.
+
+      The default 12-hour format omits AM/PM, making bot log timestamps
+      ambiguous.
+    regex:
+      pattern: "datefmt='%I:%M:%S'"
+      replace: "datefmt='%H:%M:%S'"


### PR DESCRIPTION
Introduces a small plaster patch on Chromium's `ios/build/bots/scripts/run.py` file to update the basic logging config to use 24 hour time.
