### PR TITLE
[PSST] Incorrect behavior of the Disable feature in the context menu (Brave Origin)

### DIFF
--- a/browser/psst/psst_ui_delegate_impl.cc
+++ b/browser/psst/psst_ui_delegate_impl.cc
@@ -7,8 +7,10 @@
 
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
+#include "brave/components/brave_origin/brave_origin_service.h"
 #include "brave/components/psst/core/browser/pref_names.h"
 #include "brave/components/psst/core/common/psst_metadata_schema.h"
+#include "components/policy/policy_constants.h"
 #include "components/prefs/pref_service.h"
 
 namespace {
@@ -22,14 +24,17 @@ namespace psst {
 PsstUiDelegateImpl::PsstUiDelegateImpl(
     PsstSettingsService* psst_settings_service,
     PsstReporterService* psst_reporter_service,
+    brave_origin::BraveOriginService* brave_origin_service,
     PrefService* prefs,
     std::unique_ptr<PsstUiPresenter> ui_presenter)
     : ui_presenter_(std::move(ui_presenter)),
       psst_settings_service_(psst_settings_service),
       psst_reporter_service_(psst_reporter_service),
+      brave_origin_service_(brave_origin_service),
       prefs_(prefs) {
   CHECK(psst_settings_service_);
   CHECK(psst_reporter_service_);
+  CHECK(brave_origin_service_);
   CHECK(ui_presenter_);
   CHECK(prefs_);
   psst_settings_service_->AddObserver(this);
@@ -194,7 +199,12 @@ void PsstUiDelegateImpl::OnDontShowForThisSite() {
 }
 
 void PsstUiDelegateImpl::OnDisablePrivacySettingsTuning() {
-  psst_settings_service_->SetPsstEnabled(false);
+  if (brave_origin_service_->IsPolicyControlledByBraveOrigin(
+          policy::key::kPsstEnabled)) {
+    brave_origin_service_->SetPolicyValue(policy::key::kPsstEnabled, false);
+  } else {
+    psst_settings_service_->SetPsstEnabled(false);
+  }
   ui_presenter_->HideInfoBar();
   ui_presenter_->SetLocationBarIconStatus(LocationBarIconStatus::kHidden,
                                           base::NullCallback(),

--- a/browser/psst/psst_ui_delegate_impl.h
+++ b/browser/psst/psst_ui_delegate_impl.h
@@ -21,6 +21,10 @@
 
 class PrefService;
 
+namespace brave_origin {
+class BraveOriginService;
+}  // namespace brave_origin
+
 namespace psst {
 
 class PsstUiDelegateImpl : public PsstTabWebContentsObserver::PsstUiDelegate,
@@ -35,6 +39,7 @@ class PsstUiDelegateImpl : public PsstTabWebContentsObserver::PsstUiDelegate,
 
   explicit PsstUiDelegateImpl(PsstSettingsService* psst_settings_service,
                               PsstReporterService* psst_reporter_service,
+                              brave_origin::BraveOriginService* brave_origin_service,
                               PrefService* prefs,
                               std::unique_ptr<PsstUiPresenter> ui_presenter);
   ~PsstUiDelegateImpl() override;
@@ -85,6 +90,7 @@ class PsstUiDelegateImpl : public PsstTabWebContentsObserver::PsstUiDelegate,
   PsstTabWebContentsObserver::ConsentCallback apply_changes_callback_;
   raw_ptr<PsstSettingsService> psst_settings_service_ = nullptr;
   raw_ptr<PsstReporterService> psst_reporter_service_ = nullptr;
+  raw_ptr<brave_origin::BraveOriginService> brave_origin_service_ = nullptr;
   base::ObserverList<Observer> observer_list_;
   raw_ptr<PrefService> prefs_ = nullptr;  // not owned
   base::WeakPtrFactory<PsstUiDelegateImpl> weak_ptr_factory_{this};

--- a/browser/ui/tabs/brave_tab_features.cc
+++ b/browser/ui/tabs/brave_tab_features.cc
@@ -35,6 +35,7 @@
 #endif
 
 #if BUILDFLAG(ENABLE_PSST)
+#include "brave/browser/brave_origin/brave_origin_service_factory.h"
 #include "brave/browser/psst/psst_reporter_service_factory.h"
 #include "brave/browser/psst/psst_settings_service_factory.h"
 #include "brave/browser/psst/psst_tab_web_contents_observer.h"
@@ -94,6 +95,7 @@ void BraveTabFeatures::Init(TabInterface& tab, Profile* profile) {
             std::make_unique<psst::PsstUiDelegateImpl>(
                 psst_settings_service,
                 PsstReporterServiceFactory::GetForProfile(profile),
+                brave_origin::BraveOriginServiceFactory::GetForProfile(profile),
                 profile->GetPrefs(),
                 std::make_unique<psst::PsstUiDesktopPresenter>(
                     tab.GetContents()->GetWeakPtr(),


### PR DESCRIPTION
Fixes the problem with disabling of the PSST feature when the Brave Origin toggle controls it.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58494

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
