### PR TITLE
[Android] Fresh NTP after idle: 12 hour threshold, snackbar stays until dismissed (uplift to 1.95.x)

### DIFF
--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -310,6 +310,8 @@
 
 -keep class org.chromium.chrome.browser.ui.messages.snackbar.SnackbarView {
     *** mContainerView;
+    *** mSnackbarSwipeHandler;
+    *** mIsAnimating;
 }
 
 -keep class org.chromium.chrome.browser.ui.messages.snackbar.SnackbarManager {

--- a/android/java/org/chromium/chrome/browser/informers/BraveSyncAccountDeletedInformer.java
+++ b/android/java/org/chromium/chrome/browser/informers/BraveSyncAccountDeletedInformer.java
@@ -83,6 +83,7 @@ public class BraveSyncAccountDeletedInformer {
             if (snackbarManager instanceof BraveSnackbarManager) {
                 BraveSnackbarManager braveSnackbarManager = (BraveSnackbarManager) snackbarManager;
                 braveSnackbarManager.setActionBelowMessage(
+                        snackbar,
                         R.drawable.ic_close,
                         activity.getString(R.string.close),
                         () -> braveSnackbarManager.dismissSnackbars(controller));

--- a/android/java/org/chromium/chrome/browser/ntp/BraveNewTabTakeoverInfobar.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveNewTabTakeoverInfobar.java
@@ -100,6 +100,7 @@ public class BraveNewTabTakeoverInfobar {
         // button. Like the old infobar, closing dismisses the snackbar and suppresses future
         // displays so the notice is not shown again.
         braveSnackbarManager.setActionBelowMessage(
+                snackbar,
                 R.drawable.ic_close,
                 activity.getString(R.string.close),
                 () -> {

--- a/android/java/org/chromium/chrome/browser/ntp/BraveRecentTabsSnackbarHelper.java
+++ b/android/java/org/chromium/chrome/browser/ntp/BraveRecentTabsSnackbarHelper.java
@@ -45,7 +45,8 @@ import java.lang.ref.WeakReference;
 @NullMarked
 public class BraveRecentTabsSnackbarHelper {
     private static final String TAG = "RecentTabsSnackbar";
-    private static final int SNACKBAR_DISMISS_DELAY_MS = 8000; // 8 seconds
+    // Effectively no auto-close: the snackbar is dismissed by tap, swipe, or leaving the NTP.
+    private static final int SNACKBAR_DISMISS_DELAY_MS = Integer.MAX_VALUE;
     private static final int SNACKBAR_SHOW_DELAY_MS = 500; // Wait for view hierarchy to settle
 
     private @Nullable Tab mLastTab;
@@ -224,10 +225,11 @@ public class BraveRecentTabsSnackbarHelper {
 
                         // Set custom formatted text with title, page title, and URL
                         mSnackbarManager.setCustomText(
-                                mSnackbarTitle, mSnackbarPageTitle, mSnackbarUrl);
+                                mCurrentSnackbar, mSnackbarTitle, mSnackbarPageTitle, mSnackbarUrl);
 
                         // Make entire snackbar clickable
                         mSnackbarManager.makeSnackbarClickable(
+                                mCurrentSnackbar,
                                 () -> {
                                     if (!mUserClickedSnackbar && mSnackbarController != null) {
                                         mUserClickedSnackbar = true;
@@ -391,7 +393,8 @@ public class BraveRecentTabsSnackbarHelper {
             mSnackbarManager.showSnackbar(mCurrentSnackbar);
             // Restore custom text after re-showing
             if (!mSnackbarTitle.isEmpty()) {
-                mSnackbarManager.setCustomText(mSnackbarTitle, mSnackbarPageTitle, mSnackbarUrl);
+                mSnackbarManager.setCustomText(
+                        mCurrentSnackbar, mSnackbarTitle, mSnackbarPageTitle, mSnackbarUrl);
             }
         } finally {
             mIsUpdatingSnackbar = false;

--- a/android/java/org/chromium/chrome/browser/settings/BraveRadioButtonGroupOpeningScreenPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveRadioButtonGroupOpeningScreenPreference.java
@@ -28,7 +28,7 @@ public class BraveRadioButtonGroupOpeningScreenPreference extends Preference
 
     // Inactivity threshold shown in the option label, matching
     // BraveReturnToChromeUtil.INACTIVITY_THRESHOLD_MS.
-    private static final int INACTIVITY_HOURS = 1;
+    private static final int INACTIVITY_HOURS = 12;
 
     private int mSetting;
     @Nullable private RadioButtonWithDescription mSettingRadioButton;

--- a/android/java/org/chromium/chrome/browser/tasks/BraveReturnToChromeUtil.java
+++ b/android/java/org/chromium/chrome/browser/tasks/BraveReturnToChromeUtil.java
@@ -27,8 +27,9 @@ import org.chromium.url.GURL;
 @NullMarked
 public final class BraveReturnToChromeUtil {
 
-    // Inactivity threshold for variant B: 1 hour in milliseconds
-    private static final long INACTIVITY_THRESHOLD_MS = 60 * 60 * 1000L; // 1 hour
+    // Inactivity threshold for variant B: 12 hours in milliseconds. Keep in sync with
+    // BraveRadioButtonGroupOpeningScreenPreference.INACTIVITY_HOURS, which labels the setting.
+    private static final long INACTIVITY_THRESHOLD_MS = 12 * 60 * 60 * 1000L; // 12 hours
 
     /** Returns whether should show a NTP as the home surface at startup. */
     public static boolean shouldShowNtpAsHomeSurfaceAtStartup(
@@ -44,7 +45,7 @@ public final class BraveReturnToChromeUtil {
             return false;
         }
 
-        // Variant B, the default, shows the NTP if the app has been backgrounded for ≥ 1 hour and
+        // Variant B, the default, shows the NTP if the app has been backgrounded for ≥ 12 hours and
         // OPTION_NEW_TAB_AFTER_INACTIVITY is selected. Variant A is the study's control arm and
         // keeps the pre-experiment behavior of restoring the last open tab.
         boolean shouldShow =
@@ -164,7 +165,7 @@ public final class BraveReturnToChromeUtil {
      * <p>Note: unlike upstream's shouldShowNtpAsHomeSurfaceAtStartup which bails out on activity
      * recreate (isFromRecreate check), we intentionally allow the NTP to show in recreate scenarios
      * (e.g., rotation, process death restore, foldable transitions). This is because our
-     * inactivity-based NTP logic should still apply — if the user was away for 1+ hours, we want
+     * inactivity-based NTP logic should still apply — if the user was away for 12+ hours, we want
      * the NTP shown regardless of whether the activity was recreated on return.
      */
     public static boolean setInitialOverviewStateOnResumeWithNtp(

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -2826,6 +2826,14 @@ public class BytecodeTest {
                         "mContainerView"));
         Assert.assertTrue(
                 fieldExists(
+                        "org/chromium/chrome/browser/ui/messages/snackbar/SnackbarView",
+                        "mSnackbarSwipeHandler"));
+        Assert.assertTrue(
+                fieldExists(
+                        "org/chromium/chrome/browser/ui/messages/snackbar/SnackbarView",
+                        "mIsAnimating"));
+        Assert.assertTrue(
+                fieldExists(
                         "org/chromium/chrome/browser/ui/messages/snackbar/SnackbarManager",
                         "mView"));
         Assert.assertTrue(

--- a/android/junit/src/org/chromium/chrome/browser/tasks/BraveReturnToChromeUtilUnitTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/tasks/BraveReturnToChromeUtilUnitTest.java
@@ -141,7 +141,7 @@ public class BraveReturnToChromeUtilUnitTest {
     }
 
     /**
-     * Configures variant B (1-hour threshold) with the "new tab after inactivity" opening screen
+     * Configures variant B (12-hour threshold) with the "new tab after inactivity" opening screen
      * option and a background duration that comfortably exceeds the threshold.
      */
     private void setUpInactivityVariant() {
@@ -152,8 +152,8 @@ public class BraveReturnToChromeUtilUnitTest {
                         BravePreferenceKeys.BRAVE_OPENING_SCREEN_OPTION_NEW_TAB_AFTER_INACTIVITY);
         ChromeSharedPreferences.getInstance()
                 .writeBoolean(BravePreferenceKeys.BRAVE_SHOW_RECENT_TABS_SNACKBAR, false);
-        // Two hours, well beyond variant B's 1-hour threshold.
-        when(mInactivityTracker.getTimeSinceLastBackgroundedMs()).thenReturn(2 * 60 * 60 * 1000L);
+        // Thirteen hours, well beyond variant B's 12-hour threshold.
+        when(mInactivityTracker.getTimeSinceLastBackgroundedMs()).thenReturn(13 * 60 * 60 * 1000L);
     }
 
     /** Registers a media playback notification controller in the given paused state. */

--- a/android/junit/src/org/chromium/chrome/browser/ui/messages/snackbar/BraveSnackbarViewTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/ui/messages/snackbar/BraveSnackbarViewTest.java
@@ -119,12 +119,12 @@ public class BraveSnackbarViewTest {
                         .setAction(NOTICE_ACTION, /* actionData= */ null);
         BraveSnackbarView view = createView(notice);
         view.setActionBelowMessage(
-                android.R.drawable.ic_menu_close_clear_cancel, "Close", () -> {});
+                notice, android.R.drawable.ic_menu_close_clear_cancel, "Close", () -> {});
 
         // A notification snackbar takes the view over and restructures it for custom text.
         Snackbar recentTab = makeSnackbar(RECENT_TAB_MESSAGE, Snackbar.TYPE_NOTIFICATION);
         view.update(recentTab);
-        view.setCustomText(RECENT_TAB_TITLE, RECENT_TAB_PAGE_TITLE, RECENT_TAB_URL);
+        view.setCustomText(recentTab, RECENT_TAB_TITLE, RECENT_TAB_PAGE_TITLE, RECENT_TAB_URL);
 
         // Dismissing it hands the view back to the notice.
         view.update(notice);
@@ -139,12 +139,68 @@ public class BraveSnackbarViewTest {
         assertNull(findViewWithText(snackbarLayout, RECENT_TAB_TITLE));
     }
 
+    /**
+     * A snackbar queued behind the one being shown must not restyle it. The New Tab Takeover notice
+     * is enqueued while the recent-tab snackbar is up (it is persistent, so it waits for the
+     * notification snackbar to go away), and used to move its close button onto that snackbar.
+     */
+    @Test
+    public void actionBelowMessageNotAppliedToTheShowingSnackbar() {
+        Snackbar recentTab = makeSnackbar(RECENT_TAB_MESSAGE, Snackbar.TYPE_NOTIFICATION);
+        BraveSnackbarView view = createView(recentTab);
+        view.setCustomText(recentTab, RECENT_TAB_TITLE, RECENT_TAB_PAGE_TITLE, RECENT_TAB_URL);
+
+        Snackbar notice =
+                makeSnackbar(NOTICE_MESSAGE, Snackbar.TYPE_PERSISTENT)
+                        .setAction(NOTICE_ACTION, /* actionData= */ null);
+        view.setActionBelowMessage(
+                notice, android.R.drawable.ic_menu_close_clear_cancel, "Close", () -> {});
+
+        // The recent-tab snackbar is untouched by the queued notice.
+        LinearLayout snackbarLayout = (LinearLayout) view.getViewForTesting();
+        assertNotNull(findViewWithText(snackbarLayout, RECENT_TAB_TITLE));
+        assertNull(findViewWithText(snackbarLayout, NOTICE_ACTION));
+
+        // The notice gets its layout once it takes the view over.
+        view.update(notice);
+
+        assertNull(findViewWithText(snackbarLayout, RECENT_TAB_TITLE));
+        TextView actionButton = findViewWithText(snackbarLayout, NOTICE_ACTION);
+        assertNotNull(actionButton);
+        assertSame(snackbarLayout, actionButton.getParent().getParent());
+    }
+
+    /**
+     * A view does not survive every dismissal — SnackbarManager rebuilds it when a snackbar is
+     * swiped away — so a layout requested while its snackbar was queued must reach the view that
+     * finally shows it. The New Tab Takeover notice used to appear in the stock layout, without its
+     * close button, after the recent-tab snackbar in front of it was swiped away.
+     */
+    @Test
+    public void requestedLayoutAppliedToAViewBuiltLater() {
+        Snackbar notice =
+                makeSnackbar(NOTICE_MESSAGE, Snackbar.TYPE_PERSISTENT)
+                        .setAction(NOTICE_ACTION, /* actionData= */ null);
+        // The notice is queued behind another snackbar, so the request only reaches the manager.
+        mManager.setActionBelowMessage(
+                notice, android.R.drawable.ic_menu_close_clear_cancel, "Close", () -> {});
+
+        // The snackbar in front of it is swiped away and a fresh view is built for the notice.
+        BraveSnackbarView view = createView(notice);
+
+        LinearLayout snackbarLayout = (LinearLayout) view.getViewForTesting();
+        assertEquals(LinearLayout.VERTICAL, snackbarLayout.getOrientation());
+        TextView actionButton = findViewWithText(snackbarLayout, NOTICE_ACTION);
+        assertNotNull(actionButton);
+        assertSame(snackbarLayout, actionButton.getParent().getParent());
+    }
+
     /** The custom-text layout must not leak into an unrelated snackbar. */
     @Test
     public void customTextRevertedForAnotherSnackbar() {
         Snackbar recentTab = makeSnackbar(RECENT_TAB_MESSAGE, Snackbar.TYPE_NOTIFICATION);
         BraveSnackbarView view = createView(recentTab);
-        view.setCustomText(RECENT_TAB_TITLE, RECENT_TAB_PAGE_TITLE, RECENT_TAB_URL);
+        view.setCustomText(recentTab, RECENT_TAB_TITLE, RECENT_TAB_PAGE_TITLE, RECENT_TAB_URL);
 
         LinearLayout snackbarLayout = (LinearLayout) view.getViewForTesting();
         assertEquals(LinearLayout.VERTICAL, snackbarLayout.getOrientation());
@@ -166,7 +222,7 @@ public class BraveSnackbarViewTest {
     public void customTextReappliedForItsOwnSnackbar() {
         Snackbar recentTab = makeSnackbar(RECENT_TAB_MESSAGE, Snackbar.TYPE_NOTIFICATION);
         BraveSnackbarView view = createView(recentTab);
-        view.setCustomText(RECENT_TAB_TITLE, RECENT_TAB_PAGE_TITLE, RECENT_TAB_URL);
+        view.setCustomText(recentTab, RECENT_TAB_TITLE, RECENT_TAB_PAGE_TITLE, RECENT_TAB_URL);
 
         LinearLayout snackbarLayout = (LinearLayout) view.getViewForTesting();
         view.update(makeSnackbar(NOTICE_MESSAGE, Snackbar.TYPE_NOTIFICATION));

--- a/browser/ui/messages/android/java/src/org/chromium/chrome/browser/ui/messages/snackbar/BraveSnackbarManager.java
+++ b/browser/ui/messages/android/java/src/org/chromium/chrome/browser/ui/messages/snackbar/BraveSnackbarManager.java
@@ -24,6 +24,22 @@ public class BraveSnackbarManager extends SnackbarManager {
     @SuppressWarnings({"UnusedVariable", "HidingField"})
     protected @Nullable SnackbarView mView;
 
+    // Customizations requested for a snackbar, replayed onto whichever view ends up showing it
+    // (see applyCustomizations). They are held here rather than in the view because the view does
+    // not survive: SnackbarManager rebuilds it when a snackbar is swiped away, and callers rebuild
+    // it by dismissing and re-showing a snackbar to update it. Each slot holds the last requester
+    // of that kind, and is keyed by the snackbar so it can never be applied to an unrelated one.
+    private @Nullable Snackbar mCustomTextSnackbar;
+    private String mCustomTextTitle = "";
+    private String mCustomTextPageTitle = "";
+    private String mCustomTextUrl = "";
+
+    private @Nullable Snackbar mActionBelowSnackbar;
+    private int mActionBelowCloseIconResId;
+    private @Nullable String mActionBelowCloseContentDescription;
+    private @Nullable Runnable mActionBelowCloseCallback;
+
+    private @Nullable Snackbar mClickableSnackbar;
     private @Nullable Runnable mPendingClickCallback;
 
     // The single New Tab Takeover notice currently outstanding in this (window-scoped) manager, or
@@ -65,11 +81,35 @@ public class BraveSnackbarManager extends SnackbarManager {
                 persistentFullscreenModeSupplier);
     }
 
-    @Override
-    public void showSnackbar(Snackbar snackbar) {
-        super.showSnackbar(snackbar);
+    /**
+     * Applies to {@code view} everything requested for {@code snackbar}, which must be the snackbar
+     * the view is showing. Called by {@link BraveSnackbarView} whenever it is built or updated for
+     * a snackbar, so a request made while the snackbar was still queued is honoured as soon as it
+     * reaches the screen, in whichever view shows it.
+     */
+    void applyCustomizations(BraveSnackbarView view, Snackbar snackbar) {
+        if (snackbar == mCustomTextSnackbar) {
+            view.setCustomText(snackbar, mCustomTextTitle, mCustomTextPageTitle, mCustomTextUrl);
+        }
 
-        tryMakeSnackbarClickable();
+        if (snackbar == mActionBelowSnackbar) {
+            view.setActionBelowMessage(
+                    snackbar,
+                    mActionBelowCloseIconResId,
+                    mActionBelowCloseContentDescription,
+                    mActionBelowCloseCallback);
+        }
+
+        if (snackbar == mClickableSnackbar && mPendingClickCallback != null) {
+            view.makeClickable(snackbar, mPendingClickCallback);
+        }
+    }
+
+    /** Applies the customizations requested for {@code snackbar} to the view showing it, if any. */
+    private void applyCustomizations(Snackbar snackbar) {
+        if (mView instanceof BraveSnackbarView) {
+            applyCustomizations((BraveSnackbarView) mView, snackbar);
+        }
     }
 
     /** Returns whether a New Tab Takeover notice is currently outstanding (showing or queued). */
@@ -93,52 +133,47 @@ public class BraveSnackbarManager extends SnackbarManager {
     }
 
     /**
-     * Stores the callback to be executed when the snackbar is clicked.
+     * Makes the given snackbar clickable as a whole. The callback runs when that snackbar is
+     * tapped, and only while it is the snackbar being shown.
      *
-     * @param clickCallback Callback to execute when the snackbar is clicked.
+     * @param snackbar The snackbar the callback belongs to.
+     * @param clickCallback Callback to execute when the snackbar is tapped.
      */
-    public void makeSnackbarClickable(Runnable clickCallback) {
+    public void makeSnackbarClickable(Snackbar snackbar, Runnable clickCallback) {
         if (clickCallback == null) {
             Log.e(TAG, "makeSnackbarClickable: clickCallback is null");
             return;
         }
 
+        mClickableSnackbar = snackbar;
         mPendingClickCallback = clickCallback;
-    }
-
-    private void tryMakeSnackbarClickable() {
-        if (!isShowing()) {
-            return;
-        }
-
-        if (mView instanceof BraveSnackbarView) {
-            ((BraveSnackbarView) mView).makeClickable(mPendingClickCallback);
-        }
+        applyCustomizations(snackbar);
     }
 
     /**
-     * Sets custom text on the snackbar with title, page title, and URL.
+     * Sets custom text on the given snackbar, with title, page title, and URL.
      *
+     * @param snackbar The snackbar the text belongs to.
      * @param title The title text (e.g., "Get back to your most recent tab")
      * @param pageTitle The page title
      * @param url The URL to display
      */
-    public void setCustomText(String title, String pageTitle, String url) {
-        if (!isShowing()) {
-            return;
-        }
-
-        if (mView instanceof BraveSnackbarView) {
-            ((BraveSnackbarView) mView).setCustomText(title, pageTitle, url);
-        }
+    public void setCustomText(Snackbar snackbar, String title, String pageTitle, String url) {
+        mCustomTextSnackbar = snackbar;
+        mCustomTextTitle = title;
+        mCustomTextPageTitle = pageTitle;
+        mCustomTextUrl = url;
+        applyCustomizations(snackbar);
     }
 
     /**
-     * Switches the currently showing snackbar to a layout where the action button sits on its own
-     * line below the message, optionally with a trailing close button (see {@link
-     * BraveSnackbarView#setActionBelowMessage(int, String, Runnable)}). Must be called after {@link
-     * #showSnackbar(Snackbar)}.
+     * Switches the given snackbar to a layout where the action button sits on its own line below
+     * the message, optionally with a trailing close button (see {@link
+     * BraveSnackbarView#setActionBelowMessage(Snackbar, int, String, Runnable)}). Must be called
+     * after {@link #showSnackbar(Snackbar)}. The layout is applied when that snackbar is the one
+     * being shown, so a snackbar queued behind a higher priority one does not restyle it.
      *
+     * @param snackbar The snackbar the layout belongs to.
      * @param closeIconResId Drawable resource for the close button. Ignored when {@code
      *     onCloseCallback} is null.
      * @param closeContentDescription Accessibility label for the close button, or null.
@@ -146,17 +181,14 @@ public class BraveSnackbarManager extends SnackbarManager {
      *     added.
      */
     public void setActionBelowMessage(
+            Snackbar snackbar,
             int closeIconResId,
             @Nullable String closeContentDescription,
             @Nullable Runnable onCloseCallback) {
-        if (!isShowing()) {
-            return;
-        }
-
-        if (mView instanceof BraveSnackbarView) {
-            ((BraveSnackbarView) mView)
-                    .setActionBelowMessage(
-                            closeIconResId, closeContentDescription, onCloseCallback);
-        }
+        mActionBelowSnackbar = snackbar;
+        mActionBelowCloseIconResId = closeIconResId;
+        mActionBelowCloseContentDescription = closeContentDescription;
+        mActionBelowCloseCallback = onCloseCallback;
+        applyCustomizations(snackbar);
     }
 }

--- a/browser/ui/messages/android/java/src/org/chromium/chrome/browser/ui/messages/snackbar/BraveSnackbarView.java
+++ b/browser/ui/messages/android/java/src/org/chromium/chrome/browser/ui/messages/snackbar/BraveSnackbarView.java
@@ -5,6 +5,8 @@
 
 package org.chromium.chrome.browser.ui.messages.snackbar;
 
+import static org.chromium.build.NullUtil.assumeNonNull;
+
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Paint;
@@ -13,6 +15,8 @@ import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
 import android.text.style.StyleSpan;
+import android.view.GestureDetector;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageButton;
@@ -24,6 +28,7 @@ import org.chromium.base.supplier.NonNullObservableSupplier;
 import org.chromium.build.annotations.NullMarked;
 import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.ui.messages.R;
+import org.chromium.components.browser_ui.widget.gesture.SwipeGestureListener;
 import org.chromium.ui.KeyboardVisibilityDelegate;
 import org.chromium.ui.base.WindowAndroid;
 
@@ -43,9 +48,28 @@ public class BraveSnackbarView extends SnackbarView {
     // estimate.
     private static final int MINIMUM_AVAILABLE_WIDTH = 100;
 
-    // Will be deleted in bytecode. Variable from the parent class will be used instead.
+    // Will be deleted in bytecode. Variables from the parent class will be used instead.
     @SuppressWarnings({"UnusedVariable", "HidingField"})
     protected @Nullable ViewGroup mContainerView;
+
+    @SuppressWarnings({"UnusedVariable", "HidingField"})
+    protected @Nullable SnackbarSwipeHandler mSnackbarSwipeHandler;
+
+    @SuppressWarnings({"UnusedVariable", "HidingField"})
+    protected boolean mIsAnimating;
+
+    // Source of the customizations requested for the snackbar this view shows. This view is rebuilt
+    // on some dismissal paths, so the manager, not the view, outlives a queued snackbar's request.
+    private final @Nullable BraveSnackbarManager mBraveSnackbarManager;
+    // Recognizes the swipe-to-dismiss gesture, driving the same handler SnackbarView uses so the
+    // drag position and dismissal behave exactly as upstream.
+    private final SwipeGestureListener mSwipeGestureListener;
+    // Recognizes a completed tap on the snackbar; see makeClickable().
+    private final GestureDetector mTapDetector;
+    // The whole-snackbar click follows the snackbar that requested it, not this (reused) view, so
+    // a later snackbar shown in the same view does not run a stale callback.
+    private @Nullable Runnable mClickCallback;
+    private @Nullable Snackbar mClickableSnackbar;
 
     // Reference to the title TextView we add programmatically. Non-null only while the custom-text
     // layout is applied.
@@ -87,6 +111,62 @@ public class BraveSnackbarView extends SnackbarView {
                 windowAndroid,
                 additionalBottomMarginPxSupplier,
                 isFullscreenSupplier);
+
+        mBraveSnackbarManager =
+                manager instanceof BraveSnackbarManager ? (BraveSnackbarManager) manager : null;
+        mSwipeGestureListener =
+                new SwipeGestureListener(activity, assumeNonNull(mSnackbarSwipeHandler));
+        mTapDetector =
+                new GestureDetector(
+                        activity,
+                        new GestureDetector.SimpleOnGestureListener() {
+                            @Override
+                            public boolean onSingleTapUp(MotionEvent event) {
+                                runClickCallback();
+                                return true;
+                            }
+                        });
+
+        // Replaces the touch listener installed by SnackbarView, which calls performClick() for
+        // every touch event, ACTION_DOWN included. An OnClickListener would therefore fire the
+        // whole-snackbar action as soon as a finger lands, before the swipe gesture can be
+        // recognized. Swipe handling is unchanged; only the click is now reported for a completed
+        // tap.
+        assumeNonNull(mContainerView)
+                .setOnTouchListener(
+                        (view, event) -> {
+                            if (mSwipeGestureListener.onTouchEvent(event)) return true;
+                            // Disable touch inputs during animation.
+                            if (mIsAnimating) return true;
+                            mTapDetector.onTouchEvent(event);
+                            // Keeps SnackbarView's own click listener, which resets the dismiss
+                            // timeout on touch.
+                            view.performClick();
+                            return true;
+                        });
+
+        applyRequestedCustomizations(snackbar);
+    }
+
+    /**
+     * Applies whatever the manager holds for {@code snackbar}, the snackbar this view now shows. A
+     * request can be made while its snackbar is still queued behind another one, and the view that
+     * was current then is not necessarily the one that ends up showing it.
+     */
+    private void applyRequestedCustomizations(Snackbar snackbar) {
+        if (mBraveSnackbarManager == null) {
+            return;
+        }
+        mBraveSnackbarManager.applyCustomizations(this, snackbar);
+    }
+
+    /** Runs the whole-snackbar click callback, if the snackbar showing now asked for one. */
+    private void runClickCallback() {
+        Runnable clickCallback = mClickCallback;
+        if (clickCallback == null || mSnackbar != mClickableSnackbar) {
+            return;
+        }
+        clickCallback.run();
     }
 
     /**
@@ -110,26 +190,25 @@ public class BraveSnackbarView extends SnackbarView {
     }
 
     /**
-     * Makes the entire snackbar clickable by setting an OnClickListener on the container view.
+     * Makes the entire snackbar clickable. The callback runs on a completed tap only, so swiping
+     * the snackbar away does not trigger it.
      *
-     * @param clickCallback Callback to execute when the snackbar is clicked.
+     * @param snackbar The snackbar the callback belongs to.
+     * @param clickCallback Callback to execute when the snackbar is tapped.
      */
-    public void makeClickable(@Nullable Runnable clickCallback) {
-        if (mContainerView == null) {
-            Log.e(TAG, "makeClickable: mContainerView is null, cannot make snackbar clickable");
-            return;
-        }
-
+    public void makeClickable(Snackbar snackbar, @Nullable Runnable clickCallback) {
         if (clickCallback == null) {
             Log.e(TAG, "makeClickable: clickCallback is null");
             return;
         }
 
-        mContainerView.setOnClickListener(
-                v -> {
-                    clickCallback.run();
-                });
-        mContainerView.setClickable(true);
+        if (snackbar != mSnackbar) {
+            // The callback belongs to a snackbar that is not the one shown in this view.
+            return;
+        }
+
+        mClickCallback = clickCallback;
+        mClickableSnackbar = snackbar;
     }
 
     /**
@@ -147,6 +226,9 @@ public class BraveSnackbarView extends SnackbarView {
      * └─────────────────────────────────────────────┘
      * </pre>
      *
+     * @param snackbar The snackbar this layout belongs to. When it is not the snackbar currently
+     *     shown in this view — it is queued behind a higher priority one — the request is only
+     *     remembered, and applied once that snackbar takes the view over (see update()).
      * @param closeIconResId Drawable resource for the close button (resolved in the caller's
      *     resource package). Ignored when {@code onCloseCallback} is null.
      * @param closeContentDescription Accessibility label for the close button, or null.
@@ -154,15 +236,18 @@ public class BraveSnackbarView extends SnackbarView {
      *     added.
      */
     public void setActionBelowMessage(
+            Snackbar snackbar,
             int closeIconResId,
             @Nullable String closeContentDescription,
             @Nullable Runnable onCloseCallback) {
         // Remember the request so it can follow this snackbar across view reuse (see update()).
-        mActionBelowSnackbar = mSnackbar;
+        mActionBelowSnackbar = snackbar;
         mActionBelowCloseIconResId = closeIconResId;
         mActionBelowCloseContentDescription = closeContentDescription;
         mActionBelowCloseCallback = onCloseCallback;
-        applyActionBelowMessage();
+        if (snackbar == mSnackbar) {
+            applyActionBelowMessage();
+        }
     }
 
     /**
@@ -186,6 +271,7 @@ public class BraveSnackbarView extends SnackbarView {
         if (snackbar == mActionBelowSnackbar) {
             applyActionBelowMessage();
         }
+        applyRequestedCustomizations(snackbar);
         return result;
     }
 
@@ -341,17 +427,22 @@ public class BraveSnackbarView extends SnackbarView {
      * title appears on top of the entire snackbar (above favicon), followed by page title (bold)
      * and URL next to the favicon.
      *
+     * @param snackbar The snackbar this text belongs to. When it is not the snackbar currently
+     *     shown in this view — it is queued behind a higher priority one — the request is only
+     *     remembered, and applied once that snackbar takes the view over (see update()).
      * @param title The title text (e.g., "Get back to your most recent tab")
      * @param pageTitle The page title (displayed in bold)
      * @param url The URL to display
      */
-    public void setCustomText(String title, String pageTitle, String url) {
+    public void setCustomText(Snackbar snackbar, String title, String pageTitle, String url) {
         // Remember the request so it can follow this snackbar across view reuse (see update()).
-        mCustomTextSnackbar = mSnackbar;
+        mCustomTextSnackbar = snackbar;
         mCustomTextTitle = title;
         mCustomTextPageTitle = pageTitle;
         mCustomTextUrl = url;
-        applyCustomText();
+        if (snackbar == mSnackbar) {
+            applyCustomText();
+        }
     }
 
     /** Applies the text last passed to {@link #setCustomText} to the current view hierarchy. */

--- a/build/android/bytecode/java/org/brave/bytecode/BraveSnackbarViewClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveSnackbarViewClassAdapter.java
@@ -18,5 +18,11 @@ public class BraveSnackbarViewClassAdapter extends BraveClassVisitor {
 
         deleteField(sBraveSnackbarViewClassName, "mContainerView");
         makeProtectedField(sSnackbarViewClassName, "mContainerView");
+
+        deleteField(sBraveSnackbarViewClassName, "mSnackbarSwipeHandler");
+        makeProtectedField(sSnackbarViewClassName, "mSnackbarSwipeHandler");
+
+        deleteField(sBraveSnackbarViewClassName, "mIsAnimating");
+        makeProtectedField(sSnackbarViewClassName, "mIsAnimating");
     }
 }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/39473
Resolves of https://github.com/brave/brave-browser/issues/58514