### PR TITLE
Allow Android paste from Shields

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -391,6 +391,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/share/BraveShareDelegateImpl.java",
   "../../brave/android/java/org/chromium/chrome/browser/shields/AddCustomFilterListsFragment.java",
   "../../brave/android/java/org/chromium/chrome/browser/shields/BraveContentFilteringListener.java",
+  "../../brave/android/java/org/chromium/chrome/browser/shields/BraveForcePasteHelper.java",
   "../../brave/android/java/org/chromium/chrome/browser/shields/BraveShieldsMenuObserver.java",
   "../../brave/android/java/org/chromium/chrome/browser/shields/BraveShieldsScreenshotUtil.java",
   "../../brave/android/java/org/chromium/chrome/browser/shields/BraveShieldsUtils.java",

--- a/android/java/brave-res/layout/brave_shields_tab_content.xml
+++ b/android/java/brave-res/layout/brave_shields_tab_content.xml
@@ -443,7 +443,35 @@
                 android:layout_height="1dp"
                 android:background="?attr/colorSurfaceContainer"/>
 
-            <!-- 7. Block element (action with launch icon) -->
+            <!-- 7. Enable paste (action) -->
+            <LinearLayout
+                android:id="@+id/enable_paste_item"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:paddingHorizontal="16dp"
+                android:paddingVertical="12dp"
+                android:clickable="true"
+                android:focusable="true"
+                android:background="?android:attr/selectableItemBackground">
+
+                <TextView
+                    style="@style/LargeRegular"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/enable_paste"
+                    android:textColor="?attr/colorOnSurface"/>
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="?attr/colorSurfaceContainer"/>
+
+            <!-- 8. Block element (action with launch icon) -->
             <LinearLayout
                 android:id="@+id/block_element_item"
                 android:layout_width="match_parent"
@@ -479,7 +507,7 @@
                 android:layout_height="1dp"
                 android:background="?attr/colorSurfaceContainer"/>
 
-            <!-- 8. Clear all blocked elements button -->
+            <!-- 9. Clear all blocked elements button -->
             <TextView
                 android:id="@+id/clear_blocked_elements_button"
                 style="@style/LargeRegular"
@@ -499,7 +527,7 @@
                 android:layout_height="1dp"
                 android:background="?attr/colorSurfaceContainer"/>
 
-            <!-- 9. Reset to defaults button -->
+            <!-- 10. Reset to defaults button -->
             <TextView
                 android:id="@+id/reset_shields_button"
                 style="@style/LargeRegular"
@@ -518,7 +546,7 @@
                 android:layout_height="1dp"
                 android:background="?attr/colorSurfaceContainer"/>
 
-            <!-- 9. Shields global settings -->
+            <!-- 11. Shields global settings -->
             <LinearLayout
                 android:id="@+id/global_settings_item"
                 android:layout_width="match_parent"

--- a/android/java/brave-res/layout/brave_shields_tab_content.xml
+++ b/android/java/brave-res/layout/brave_shields_tab_content.xml
@@ -443,15 +443,14 @@
                 android:layout_height="1dp"
                 android:background="?attr/colorSurfaceContainer"/>
 
-            <!-- 7. Enable paste (action) -->
+            <!-- 7. Enable paste (toggle action) -->
             <LinearLayout
                 android:id="@+id/enable_paste_item"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="48dp"
                 android:orientation="horizontal"
                 android:gravity="center_vertical"
                 android:paddingHorizontal="16dp"
-                android:paddingVertical="12dp"
                 android:clickable="true"
                 android:focusable="true"
                 android:background="?android:attr/selectableItemBackground">
@@ -463,6 +462,13 @@
                     android:layout_weight="1"
                     android:text="@string/enable_paste"
                     android:textColor="?attr/colorOnSurface"/>
+
+                <com.google.android.material.materialswitch.MaterialSwitch
+                    android:id="@+id/enable_paste_toggle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:minHeight="0dp"
+                    android:contentDescription="@string/enable_paste"/>
 
             </LinearLayout>
 

--- a/android/java/org/chromium/chrome/browser/shields/BraveForcePasteHelper.java
+++ b/android/java/org/chromium/chrome/browser/shields/BraveForcePasteHelper.java
@@ -1,0 +1,25 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.shields;
+
+import org.jni_zero.JNINamespace;
+import org.jni_zero.NativeMethods;
+
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.content_public.browser.WebContents;
+
+@JNINamespace("brave_shields")
+@NullMarked
+public class BraveForcePasteHelper {
+    public static void forcePaste(WebContents webContents) {
+        BraveForcePasteHelperJni.get().forcePaste(webContents);
+    }
+
+    @NativeMethods
+    interface Natives {
+        void forcePaste(WebContents webContents);
+    }
+}

--- a/android/java/org/chromium/chrome/browser/shields/BraveUnifiedPanelHandler.java
+++ b/android/java/org/chromium/chrome/browser/shields/BraveUnifiedPanelHandler.java
@@ -192,6 +192,7 @@ public class BraveUnifiedPanelHandler {
     // Advanced options switches (no Forget Me in new design)
     private SwitchCompat mBlockScriptsSwitch;
     private SwitchCompat mFingerprintingSwitch;
+    private SwitchCompat mEnablePasteSwitch;
 
     // Observer for notifying toolbar of shields changes (icon update, page reload)
     private @Nullable BraveShieldsMenuObserver mMenuObserver;
@@ -488,6 +489,7 @@ public class BraveUnifiedPanelHandler {
         // Advanced options switches
         mBlockScriptsSwitch = popupView.findViewById(R.id.scripts_toggle);
         mFingerprintingSwitch = popupView.findViewById(R.id.fingerprinting_toggle);
+        mEnablePasteSwitch = popupView.findViewById(R.id.enable_paste_toggle);
 
         // Report broken site section
         mReportBrokenSiteSection = popupView.findViewById(R.id.report_broken_site_section);
@@ -558,7 +560,10 @@ public class BraveUnifiedPanelHandler {
 
         View enablePasteItem = mAdvancedOptionsContent.findViewById(R.id.enable_paste_item);
         if (enablePasteItem != null) {
-            enablePasteItem.setOnClickListener(v -> forcePaste());
+            enablePasteItem.setOnClickListener(v -> mEnablePasteSwitch.performClick());
+        }
+        if (mEnablePasteSwitch != null) {
+            mEnablePasteSwitch.setOnClickListener(v -> onEnablePasteClicked());
         }
 
         View blockElementItem = mAdvancedOptionsContent.findViewById(R.id.block_element_item);
@@ -602,18 +607,28 @@ public class BraveUnifiedPanelHandler {
         }
     }
 
-    private void forcePaste() {
+    private boolean forcePaste() {
         if (mCurrentTab == null) {
-            return;
+            return false;
         }
 
         WebContents webContents = mCurrentTab.getWebContents();
         if (webContents == null) {
-            return;
+            return false;
         }
 
         BraveForcePasteHelper.forcePaste(webContents);
         hide();
+        return true;
+    }
+
+    private void onEnablePasteClicked() {
+        if (mEnablePasteSwitch != null && !mEnablePasteSwitch.isChecked()) {
+            return;
+        }
+        if (!forcePaste() && mEnablePasteSwitch != null) {
+            mEnablePasteSwitch.setChecked(false);
+        }
     }
 
     private void resetSiteToShieldsDefaults() {
@@ -708,6 +723,11 @@ public class BraveUnifiedPanelHandler {
                 mFingerprintingSwitch.setEnabled(false);
                 mFingerprintingSwitch.setChecked(false);
             }
+        }
+
+        if (mEnablePasteSwitch != null) {
+            mEnablePasteSwitch.setEnabled(shieldsEnabled);
+            mEnablePasteSwitch.setChecked(false);
         }
     }
 

--- a/android/java/org/chromium/chrome/browser/shields/BraveUnifiedPanelHandler.java
+++ b/android/java/org/chromium/chrome/browser/shields/BraveUnifiedPanelHandler.java
@@ -87,6 +87,7 @@ import org.chromium.components.embedder_support.util.UrlUtilities;
 import org.chromium.components.url_formatter.UrlFormatter;
 import org.chromium.components.version_info.BraveVersionConstants;
 import org.chromium.content_public.browser.LoadUrlParams;
+import org.chromium.content_public.browser.WebContents;
 import org.chromium.ui.base.ViewUtils;
 import org.chromium.ui.widget.Toast;
 import org.chromium.url.GURL;
@@ -555,6 +556,11 @@ public class BraveUnifiedPanelHandler {
             }
         }
 
+        View enablePasteItem = mAdvancedOptionsContent.findViewById(R.id.enable_paste_item);
+        if (enablePasteItem != null) {
+            enablePasteItem.setOnClickListener(v -> forcePaste());
+        }
+
         View blockElementItem = mAdvancedOptionsContent.findViewById(R.id.block_element_item);
         if (blockElementItem != null) {
 
@@ -594,6 +600,20 @@ public class BraveUnifiedPanelHandler {
         if (globalSettingsItem != null) {
             globalSettingsItem.setOnClickListener(v -> openGlobalShieldsSettings());
         }
+    }
+
+    private void forcePaste() {
+        if (mCurrentTab == null) {
+            return;
+        }
+
+        WebContents webContents = mCurrentTab.getWebContents();
+        if (webContents == null) {
+            return;
+        }
+
+        BraveForcePasteHelper.forcePaste(webContents);
+        hide();
     }
 
     private void resetSiteToShieldsDefaults() {

--- a/browser/android/BUILD.gn
+++ b/browser/android/BUILD.gn
@@ -10,6 +10,7 @@ assert(is_android)
 
 source_set("android_browser_process") {
   sources = [
+    "brave_force_paste_helper.cc",
     "brave_feature_util.cc",
     "brave_local_state_android.cc",
     "brave_relaunch_utils.cc",
@@ -55,6 +56,7 @@ source_set("android_browser_process") {
     "//components/translate/core/browser",
     "//components/unified_consent",
     "//components/webui/flags",
+    "//ui/base/clipboard",
     "//url",
   ]
 

--- a/browser/android/brave_force_paste_helper.cc
+++ b/browser/android/brave_force_paste_helper.cc
@@ -15,7 +15,7 @@
 #include "content/public/browser/web_contents.h"
 #include "ui/base/clipboard/clipboard.h"
 #include "ui/base/clipboard/clipboard_buffer.h"
-#include "ui/base/clipboard/data_transfer_endpoint.h"
+#include "ui/base/data_transfer_policy/data_transfer_endpoint.h"
 
 namespace brave_shields {
 

--- a/browser/android/brave_force_paste_helper.cc
+++ b/browser/android/brave_force_paste_helper.cc
@@ -1,0 +1,58 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <optional>
+#include <string>
+
+#include "base/android/jni_android.h"
+#include "base/android/scoped_java_ref.h"
+#include "base/functional/bind.h"
+#include "chrome/android/chrome_jni_headers/BraveForcePasteHelper_jni.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/web_contents.h"
+#include "ui/base/clipboard/clipboard.h"
+#include "ui/base/clipboard/clipboard_buffer.h"
+#include "ui/base/clipboard/data_transfer_endpoint.h"
+
+namespace brave_shields {
+
+static void JNI_BraveForcePasteHelper_ForcePaste(
+    JNIEnv* env,
+    const base::android::JavaRef<jobject>& jweb_contents) {
+  content::WebContents* web_contents =
+      content::WebContents::FromJavaWebContents(jweb_contents);
+  if (!web_contents) {
+    return;
+  }
+
+  content::RenderFrameHost* frame = web_contents->GetFocusedFrame();
+  if (!frame) {
+    return;
+  }
+
+  std::optional<ui::DataTransferEndpoint> data = ui::DataTransferEndpoint(
+      frame->GetMainFrame()->GetLastCommittedURL(),
+      ui::DataTransferEndpointOptions{
+          .notify_if_restricted = true,
+          .off_the_record = frame->GetBrowserContext()->IsOffTheRecord()});
+
+  ui::Clipboard::GetForCurrentThread()->ReadText(
+      ui::ClipboardBuffer::kCopyPaste, data,
+      base::BindOnce(
+          [](base::WeakPtr<content::WebContents> web_contents,
+             std::u16string result) {
+            if (!web_contents || result.empty()) {
+              return;
+            }
+
+            web_contents->Replace(result);
+          },
+          web_contents->GetWeakPtr()));
+}
+
+}  // namespace brave_shields
+
+DEFINE_JNI(BraveForcePasteHelper)

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -662,6 +662,9 @@ This file contains all "about" strings.  It is set to NOT be translated, in tran
       <message name="IDS_BRAVE_SHIELDS_GLOBAL_SETTINGS_TITLE" desc="Label for the global shields settings link.">
         Shields global settings
       </message>
+      <message name="IDS_ENABLE_PASTE" desc="Label for the Brave Shields action that inserts clipboard text into the focused field without allowing page JavaScript paste handlers to cancel it.">
+        Enable paste
+      </message>
       <message name="IDS_REPORT_BROKEN_SITE_PROMPT" desc="Prompt asking the user to report a broken site.">
         Tell us if the site wasn't working properly with Shields up.
       </message>

--- a/build/android/config.gni
+++ b/build/android/config.gni
@@ -156,6 +156,7 @@ brave_jni_headers_sources = [
   "//brave/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java",
   "//brave/android/java/org/chromium/chrome/browser/preferences/website/BraveShieldsContentSettings.java",
   "//brave/android/java/org/chromium/chrome/browser/referrer/BraveReferrer.java",
+  "//brave/android/java/org/chromium/chrome/browser/shields/BraveForcePasteHelper.java",
   "//brave/android/java/org/chromium/chrome/browser/shields/FilterListServiceFactory.java",
   "//brave/android/java/org/chromium/chrome/browser/shields/UrlSanitizerServiceFactory.java",
   "//brave/android/java/org/chromium/chrome/browser/sync/BraveSyncDevices.java",

--- a/build/webpack/polyfill.ts
+++ b/build/webpack/polyfill.ts
@@ -11,6 +11,7 @@ const require = createRequire(import.meta.url)
 // NodeJS polyfills for the browser - these are only included when needed.
 export const fallback: { [key: string]: string | false } = {
   stream: require.resolve('stream-browserify'),
+  string_decoder: require.resolve('string_decoder/'),
   path: require.resolve('path-browserify'),
   querystring: require.resolve('querystring-es3'),
   crypto: require.resolve('crypto-browserify'),

--- a/chromium_src/third_party/blink/renderer/core/dom/events/event_dispatcher.cc
+++ b/chromium_src/third_party/blink/renderer/core/dom/events/event_dispatcher.cc
@@ -12,11 +12,15 @@
 namespace blink {
 namespace {
 
-// Function to determine if contextmenu event should bypass preventDefault so
-// that users can always open context menu by holding Shift key. This method is
-// called inside EventDispatcher::DispatchEventPostProcess, so that
+// Function to determine if an event should bypass preventDefault so that
 // Node::DefaultEventHandler() can be called.
 bool ShouldBypassDefaultPreventedForContextMenu(Event* event) {
+#if BUILDFLAG(IS_ANDROID)
+  if (event->type() == event_type_names::kPaste) {
+    return true;
+  }
+#endif
+
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)
   if (!base::FeatureList::IsEnabled(
           blink::features::kForceContextMenuOnShiftRightClick)) {

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "storybook": "8.6.17",
     "stream-browserify": "3.0.0",
     "stream-http": "3.2.0",
+    "string_decoder": "1.1.1",
     "style-loader": "2.0.0",
     "styled-components": "catalog:",
     "teamcity-service-messages": "0.1.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,6 +442,9 @@ importers:
       stream-http:
         specifier: 3.2.0
         version: 3.2.0
+      string_decoder:
+        specifier: 1.1.1
+        version: 1.1.1
       style-loader:
         specifier: 2.0.0
         version: 2.0.0(webpack@5.105.0)

--- a/rewrite/third_party/blink/renderer/core/dom/events/event_dispatcher.cc.yaml
+++ b/rewrite/third_party/blink/renderer/core/dom/events/event_dispatcher.cc.yaml
@@ -5,7 +5,7 @@
 
 substitutions:
   - description:
-      'Adding ShouldBypassDefaultPreventedForContextMenu() in context menu
+      'Adding ShouldBypassDefaultPreventedForContextMenu() in default event
       handling'
     regex:
       re_pattern:


### PR DESCRIPTION
## Summary
- add an Android Shields panel action labeled "Enable paste"
- force-insert the clipboard contents through WebContents when selected, bypassing page JavaScript paste cancellation
- allow Android paste events to proceed even when pages call preventDefault on paste

## Verification
- Built Android Debug arm64 APK on buntu with the infra_ansible Brave Android build playbook
- Build artifact: /home/ubuntu/src/out/android_Debug_arm64/apks/BraveMonoarm64.apk
- Copied final APK to termux: ~/apks/brave-enable-paste.apk
- SHA-256: d8cc644581c17765c78c33942c0335f20cf54ae35472a0778c6abf9509648082