### PR TITLE
[VPN 2.0] Add browser identity capture scaffolding to the VPN agent

### DIFF
--- a/components/brave_vpn/app/v2/agent/BUILD.gn
+++ b/components/brave_vpn/app/v2/agent/BUILD.gn
@@ -23,6 +23,7 @@ source_set("core") {
     "browser_host_impl.h",
     "browser_host_provider_impl.cc",
     "browser_host_provider_impl.h",
+    "browser_identity.h",
     "browser_registry.cc",
     "browser_registry.h",
     "shutdown_handlers.cc",
@@ -32,6 +33,7 @@ source_set("core") {
 
   if (is_win) {
     sources += [
+      "win/browser_identity_win.cc",
       "win/shutdown_handlers_win.cc",
       "win/single_instance_win.cc",
     ]
@@ -42,6 +44,15 @@ source_set("core") {
       "posix/shutdown_handlers_posix.cc",
       "posix/single_instance_posix.cc",
     ]
+  }
+
+  if (is_linux) {
+    sources += [ "linux/browser_identity_linux.cc" ]
+  }
+
+  if (is_mac) {
+    sources += [ "mac/browser_identity_mac.cc" ]
+    libs = [ "bsm" ]
   }
 
   public_deps = [
@@ -164,14 +175,19 @@ source_set("test_support") {
     "test/fake_browser.h",
     "test/fake_browser_endpoint.cc",
     "test/fake_browser_endpoint.h",
+    "test/fake_browser_identity.cc",
+    "test/fake_browser_identity.h",
   ]
 
   public_deps = [
+    ":core",
     "//base",
     "//base/test:test_support",
     "//brave/components/brave_vpn/common/mojom:agent",
     "//mojo/public/cpp/bindings",
   ]
+
+  deps = [ "//components/named_mojo_ipc_server" ]
 }
 
 source_set("unit_tests") {

--- a/components/brave_vpn/app/v2/agent/BUILD.gn
+++ b/components/brave_vpn/app/v2/agent/BUILD.gn
@@ -23,6 +23,7 @@ source_set("core") {
     "browser_host_impl.h",
     "browser_host_provider_impl.cc",
     "browser_host_provider_impl.h",
+    "browser_identity.cc",
     "browser_identity.h",
     "browser_registry.cc",
     "browser_registry.h",
@@ -186,8 +187,6 @@ source_set("test_support") {
     "//brave/components/brave_vpn/common/mojom:agent",
     "//mojo/public/cpp/bindings",
   ]
-
-  deps = [ "//components/named_mojo_ipc_server" ]
 }
 
 source_set("unit_tests") {

--- a/components/brave_vpn/app/v2/agent/browser_host_provider_impl_unittest.cc
+++ b/components/brave_vpn/app/v2/agent/browser_host_provider_impl_unittest.cc
@@ -183,7 +183,9 @@ INSTANTIATE_TEST_SUITE_P(
         BrowserAuthResultParam{mojom::BrowserAuthResult::kVersionMismatch,
                                "VersionMismatch"},
         BrowserAuthResultParam{mojom::BrowserAuthResult::kHostAlreadyRequested,
-                               "HostAlreadyRequested"}),
+                               "HostAlreadyRequested"},
+        BrowserAuthResultParam{mojom::BrowserAuthResult::kInconclusive,
+                               "Inconclusive"}),
     [](const testing::TestParamInfo<BrowserAuthResultParam>& info) {
       return std::string(info.param.name);
     });

--- a/components/brave_vpn/app/v2/agent/browser_identity.cc
+++ b/components/brave_vpn/app/v2/agent/browser_identity.cc
@@ -1,0 +1,60 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/browser_identity.h"
+
+#include <utility>
+
+#include "base/auto_reset.h"
+#include "base/check.h"
+#include "base/check_is_test.h"
+#include "base/functional/callback.h"
+#include "base/location.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/no_destructor.h"
+#include "base/task/task_traits.h"
+#include "base/task/thread_pool.h"
+
+namespace brave_vpn::v2 {
+namespace {
+BrowserIdentityCaptureCallback& GetBrowserIdentityCaptureCallbackInstance() {
+  static base::NoDestructor<BrowserIdentityCaptureCallback> instance;
+  return *instance;
+}
+}  // namespace
+
+BrowserIdentity::BrowserIdentity(base::ProcessId pid) : pid_(pid) {}
+
+BrowserIdentity::~BrowserIdentity() = default;
+
+void BrowserIdentity::Verify(VerificationResponseCallback callback) const {
+  CHECK(callback);
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE,
+      {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
+       base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
+      BindVerificationRequest(), std::move(callback));
+}
+
+// static
+scoped_refptr<BrowserIdentity> BrowserIdentity::Create(
+    const named_mojo_ipc_server::ConnectionInfo& info) {
+  // In tests, the identity capture callback is used to capture the identity.
+  if (!GetBrowserIdentityCaptureCallbackInstance().is_null()) {
+    CHECK_IS_TEST();
+    return GetBrowserIdentityCaptureCallbackInstance().Run(info);
+  }
+  return Capture(info);
+}
+
+base::AutoReset<BrowserIdentityCaptureCallback>
+SetBrowserIdentityCaptureCallbackForTesting(  // IN-TEST
+    BrowserIdentityCaptureCallback callback) {
+  CHECK_IS_TEST();
+  return base::AutoReset<BrowserIdentityCaptureCallback>(
+      &GetBrowserIdentityCaptureCallbackInstance(), std::move(callback));
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/browser_identity.h
+++ b/components/brave_vpn/app/v2/agent/browser_identity.h
@@ -1,0 +1,104 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_BROWSER_IDENTITY_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_BROWSER_IDENTITY_H_
+
+#include <memory>
+#include <string>
+
+#include "base/memory/ref_counted.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/process/process_handle.h"
+
+namespace named_mojo_ipc_server {
+struct ConnectionInfo;
+}  // namespace named_mojo_ipc_server
+
+namespace brave_vpn::v2 {
+
+// BrowserIdentity is a reference to the process on the far end of one browser
+// connection, taken while that connection is being accepted. Abstract because
+// an identity is platform-specific.
+//
+// Refcounted because an instance is captured on the IPC sequence, read on a
+// blocking pool, and outlives the registry if the agent shuts down while a
+// verification is in flight.
+class BrowserIdentity : public base::RefCountedThreadSafe<BrowserIdentity> {
+ public:
+  enum class VerificationResult {
+    // Verified as Brave browser.
+    kAccepted,
+    // Verified as NOT a Brave browser: a verdict about the binary, which does
+    // not change while it runs.
+    kRejected,
+    // Could not tell: image replaced mid-update, cert rotated, etc. A later
+    // attempt may succeed, so this must never be treated as a rejection.
+    kInconclusive,
+  };
+
+  BrowserIdentity(const BrowserIdentity&) = delete;
+  BrowserIdentity& operator=(const BrowserIdentity&) = delete;
+
+  // The peer's pid. Only meaningful as a lookup key: a pid is not an identity,
+  // and one read at dispatch time may already name a different process than the
+  // one that connected.
+  virtual base::ProcessId pid() const = 0;
+
+  // Informational string for logging: a pid, a timestamp, etc.; no sensitive
+  // information.
+  virtual std::string GetDescription() const = 0;
+
+  // Runs the expensive half of verification: the code identity of the process
+  // this object names; blocking.
+  virtual VerificationResult Verify() const = 0;
+
+  // True if |other| names the same process instance, not merely the same pid.
+  // Used to notice that a cached identity went stale because its pid was
+  // recycled by an unrelated process.
+  virtual bool IsSameProcess(const BrowserIdentity& other) const = 0;
+
+ protected:
+  friend class base::RefCountedThreadSafe<BrowserIdentity>;
+
+  BrowserIdentity() = default;
+  virtual ~BrowserIdentity() = default;
+};
+
+// BrowserIdentityFactory is the only entity that knows what a ConnectionInfo
+// holds. ConnectionInfo belongs to named_mojo_ipc_server and carries the peer's
+// credentials in a different member on every platform, so keeping the knowledge
+// behind one seam is what lets BrowserRegistry stay platform-neutral and lets
+// unit tests describe a peer without fabricating kernel data.
+class BrowserIdentityFactory {
+ public:
+  BrowserIdentityFactory(const BrowserIdentityFactory&) = delete;
+  BrowserIdentityFactory& operator=(const BrowserIdentityFactory&) = delete;
+
+  virtual ~BrowserIdentityFactory() = default;
+
+  // Captures the peer described by |info|, or returns null if the peer cannot
+  // be pinned or is not running as this user; cheap and non-blocking.
+  //
+  // Called from two places, and |info| is not equally complete in both: the
+  // accept callback has the live endpoint, while the copy the server keeps as
+  // receiver context has had it consumed by the invitation. Which part of the
+  // connection info is valid is a Mojo IPC implementation detail, so only pid()
+  // and the comparison in IsSameProcess() are guaranteed on a capture taken at
+  // dispatch. Hence verification calls must only be performed on accept-time
+  // captures.
+  virtual scoped_refptr<BrowserIdentity> Capture(
+      const named_mojo_ipc_server::ConnectionInfo& info) const = 0;
+
+ protected:
+  BrowserIdentityFactory() = default;
+};
+
+// Defined once per platform.
+std::unique_ptr<BrowserIdentityFactory> CreateBrowserIdentityFactory();
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_BROWSER_IDENTITY_H_

--- a/components/brave_vpn/app/v2/agent/browser_identity.h
+++ b/components/brave_vpn/app/v2/agent/browser_identity.h
@@ -6,9 +6,10 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_BROWSER_IDENTITY_H_
 #define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_BROWSER_IDENTITY_H_
 
-#include <memory>
 #include <string>
 
+#include "base/auto_reset.h"
+#include "base/functional/callback.h"
 #include "base/memory/ref_counted.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/process/process_handle.h"
@@ -20,13 +21,15 @@ struct ConnectionInfo;
 namespace brave_vpn::v2 {
 
 // BrowserIdentity is a reference to the process on the far end of one browser
-// connection, taken while that connection is being accepted. Abstract because
-// an identity is platform-specific.
+// connection, taken while that connection is being accepted. All member
+// functions are cheap and non-blocking; the expensive part of verification is
+// posted to a thread pool and reported via a callback.
 //
-// Refcounted because an instance is captured on the IPC sequence, read on a
-// blocking pool, and outlives the registry if the agent shuts down while a
-// verification is in flight.
-class BrowserIdentity : public base::RefCountedThreadSafe<BrowserIdentity> {
+// Refcounted as its ownership is genuinely shared: one accept-time capture is
+// reachable from BrowserRegistry's pid-keyed capture map and from every
+// connection that resolved against it, and those connections outlive the
+// capture.
+class BrowserIdentity : public base::RefCounted<BrowserIdentity> {
  public:
   enum class VerificationResult {
     // Verified as Brave browser.
@@ -39,65 +42,70 @@ class BrowserIdentity : public base::RefCountedThreadSafe<BrowserIdentity> {
     kInconclusive,
   };
 
+  using VerificationRequestCallback = base::OnceCallback<VerificationResult()>;
+  using VerificationResponseCallback =
+      base::OnceCallback<void(VerificationResult)>;
+
+  // Creates a BrowserIdentity for the peer described by |info| by invoking the
+  // capture function. Returns null if the capture fails. The capture function
+  // can be overriden in tests by SetBrowserIdentityCaptureCallbackForTesting().
+  static scoped_refptr<BrowserIdentity> Create(
+      const named_mojo_ipc_server::ConnectionInfo& info);
+
   BrowserIdentity(const BrowserIdentity&) = delete;
   BrowserIdentity& operator=(const BrowserIdentity&) = delete;
 
   // The peer's pid. Only meaningful as a lookup key: a pid is not an identity,
   // and one read at dispatch time may already name a different process than the
   // one that connected.
-  virtual base::ProcessId pid() const = 0;
+  base::ProcessId pid() const { return pid_; }
 
   // Informational string for logging: a pid, a timestamp, etc.; no sensitive
   // information.
-  virtual std::string GetDescription() const = 0;
-
-  // Runs the expensive half of verification: the code identity of the process
-  // this object names; blocking.
-  virtual VerificationResult Verify() const = 0;
+  virtual std::string GetDescription() const;
 
   // True if |other| names the same process instance, not merely the same pid.
   // Used to notice that a cached identity went stale because its pid was
   // recycled by an unrelated process.
-  virtual bool IsSameProcess(const BrowserIdentity& other) const = 0;
+  virtual bool IsSameProcess(const BrowserIdentity& other) const;
+
+  // Posts an expensive part of verification to a thread pool with all the
+  // necessary platform-specific arguments, and calls |callback| with the
+  // result. |callback| is never invoked synchronously, and always runs on the
+  // sequence that called Verify(), which must therefore have a current default
+  // task runner. Safe to call more than once, and on any number of identities
+  // concurrently. Only meaningful on a capture taken at accept time: a capture
+  // taken while a message is dispatching may carry no platform data beyond the
+  // pid, since the ConnectionInfo the server keeps as receiver context has had
+  // its endpoint consumed by the invitation.
+  virtual void Verify(VerificationResponseCallback callback) const;
 
  protected:
-  friend class base::RefCountedThreadSafe<BrowserIdentity>;
+  friend class base::RefCounted<BrowserIdentity>;
 
-  BrowserIdentity() = default;
-  virtual ~BrowserIdentity() = default;
+  // Captures a BrowserIdentity for the peer described by |info|, with
+  // platform-specific data, or returns null if the peer cannot be pinned or is
+  // not running as this user.
+  static scoped_refptr<BrowserIdentity> Capture(
+      const named_mojo_ipc_server::ConnectionInfo& info);
+
+  explicit BrowserIdentity(base::ProcessId pid);
+  virtual ~BrowserIdentity();
+
+  // Returns a closure carrying copies of the platform data the blocking
+  // verification needs, so it can run without touching the object.
+  VerificationRequestCallback BindVerificationRequest() const;
+
+  const base::ProcessId pid_;
 };
 
-// BrowserIdentityFactory is the only entity that knows what a ConnectionInfo
-// holds. ConnectionInfo belongs to named_mojo_ipc_server and carries the peer's
-// credentials in a different member on every platform, so keeping the knowledge
-// behind one seam is what lets BrowserRegistry stay platform-neutral and lets
-// unit tests describe a peer without fabricating kernel data.
-class BrowserIdentityFactory {
- public:
-  BrowserIdentityFactory(const BrowserIdentityFactory&) = delete;
-  BrowserIdentityFactory& operator=(const BrowserIdentityFactory&) = delete;
+using BrowserIdentityCaptureCallback =
+    base::RepeatingCallback<scoped_refptr<BrowserIdentity>(
+        const named_mojo_ipc_server::ConnectionInfo& info)>;
 
-  virtual ~BrowserIdentityFactory() = default;
-
-  // Captures the peer described by |info|, or returns null if the peer cannot
-  // be pinned or is not running as this user; cheap and non-blocking.
-  //
-  // Called from two places, and |info| is not equally complete in both: the
-  // accept callback has the live endpoint, while the copy the server keeps as
-  // receiver context has had it consumed by the invitation. Which part of the
-  // connection info is valid is a Mojo IPC implementation detail, so only pid()
-  // and the comparison in IsSameProcess() are guaranteed on a capture taken at
-  // dispatch. Hence verification calls must only be performed on accept-time
-  // captures.
-  virtual scoped_refptr<BrowserIdentity> Capture(
-      const named_mojo_ipc_server::ConnectionInfo& info) const = 0;
-
- protected:
-  BrowserIdentityFactory() = default;
-};
-
-// Defined once per platform.
-std::unique_ptr<BrowserIdentityFactory> CreateBrowserIdentityFactory();
+[[nodiscard]] base::AutoReset<BrowserIdentityCaptureCallback>
+SetBrowserIdentityCaptureCallbackForTesting(  // IN-TEST
+    BrowserIdentityCaptureCallback callback);
 
 }  // namespace brave_vpn::v2
 

--- a/components/brave_vpn/app/v2/agent/browser_registry.cc
+++ b/components/brave_vpn/app/v2/agent/browser_registry.cc
@@ -5,19 +5,29 @@
 
 #include "brave/components/brave_vpn/app/v2/agent/browser_registry.h"
 
+#include <stddef.h>
+
 #include <memory>
 #include <utility>
 
 #include "base/check.h"
+#include "base/check_op.h"
+#include "base/containers/flat_map.h"
+#include "base/containers/map_util.h"
 #include "base/functional/bind.h"
 #include "base/location.h"
 #include "base/logging.h"
 #include "base/memory/ptr_util.h"
-#include "base/notimplemented.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/process/process_handle.h"
 #include "base/sequence_checker.h"
 #include "base/strings/strcat.h"
 #include "base/task/sequenced_task_runner.h"
+#include "base/task/task_traits.h"
+#include "base/task/thread_pool.h"
+#include "base/time/time.h"
 #include "brave/components/brave_vpn/app/v2/agent/browser_host_impl.h"
+#include "brave/components/brave_vpn/app/v2/agent/browser_identity.h"
 #include "build/build_config.h"
 #include "components/named_mojo_ipc_server/named_mojo_ipc_server.h"
 
@@ -31,6 +41,12 @@ namespace {
 // newest. Bumped only when support for older browsers is deliberately dropped,
 // which makes every such bump a compatibility break worth reviewing.
 constexpr uint32_t kMinSupportedProtocolVersion = 1;
+
+// How long an accepted connection may stay silent before the agent stops
+// holding the peer reference it captured. Prevents a connection that never
+// calls BindBrowserHost() from pinning a process handle for the life of the
+// agent.
+constexpr base::TimeDelta kCapturedPeerIdleTimeout = base::Seconds(10);
 
 named_mojo_ipc_server::EndpointOptions GetEndpointOptions(
     mojo::NamedPlatformChannel::ServerName server_name) {
@@ -46,6 +62,10 @@ named_mojo_ipc_server::EndpointOptions GetEndpointOptions(
 #endif  // BUILDFLAG(IS_WIN)
   return endpoint_options;
 }
+
+bool IsCapturedPeerExpired(base::TimeTicks captured_at, base::TimeTicks now) {
+  return now - captured_at > kCapturedPeerIdleTimeout;
+}
 }  // namespace
 
 BrowserRegistry::BrowserRegistry(
@@ -54,13 +74,18 @@ BrowserRegistry::BrowserRegistry(
                        brave_vpn::mojom::BrowserHostProvider>>(
           GetEndpointOptions(std::move(server_name)),
           base::BindRepeating(&BrowserRegistry::OnBrowserConnecting,
-                              base::Unretained(this)))) {
+                              base::Unretained(this)))),
+      identity_factory_(CreateBrowserIdentityFactory()) {
+  CHECK(identity_factory_);
   StartHostServer();
 }
 
 BrowserRegistry::BrowserRegistry(
-    std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server)
-    : host_server_(std::move(host_server)) {
+    std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server,
+    std::unique_ptr<BrowserIdentityFactory> identity_factory)
+    : host_server_(std::move(host_server)),
+      identity_factory_(std::move(identity_factory)) {
+  CHECK(identity_factory_);
   StartHostServer();
 }
 
@@ -68,8 +93,10 @@ BrowserRegistry::~BrowserRegistry() = default;
 
 // static
 std::unique_ptr<BrowserRegistry> BrowserRegistry::CreateForTesting(  // IN-TEST
-    std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server) {
-  return base::WrapUnique(new BrowserRegistry(std::move(host_server)));
+    std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server,
+    std::unique_ptr<BrowserIdentityFactory> identity_factory) {
+  return base::WrapUnique(
+      new BrowserRegistry(std::move(host_server), std::move(identity_factory)));
 }
 
 void BrowserRegistry::StartHostServer() {
@@ -82,9 +109,95 @@ void BrowserRegistry::StartHostServer() {
 brave_vpn::mojom::BrowserHostProvider* BrowserRegistry::OnBrowserConnecting(
     const named_mojo_ipc_server::ConnectionInfo& info) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  RemoveExpiredPeers();
 
-  VLOG(1) << "New browser connecting (pid " << info.pid << ")";
+  // Runs synchronously on the IPC sequence, so nothing blocking belongs here.
+  // The only jobs are to reject peers that are cheap to rule out, and to pin
+  // the peer so the expensive check later inspects the process that actually
+  // connected rather than whatever holds its pid by then.
+  scoped_refptr<BrowserIdentity> identity = identity_factory_->Capture(info);
+  if (!identity) {
+    return nullptr;
+  }
+
+  const base::ProcessId pid = identity->pid();
+  auto it = peers_.find(pid);
+  if (it != peers_.end() && !it->second.identity->IsSameProcess(*identity)) {
+    // Same pid, different process: the previous occupant exited and the pid was
+    // reused. Any connection still relying on the old entry must not be
+    // verified against this new process.
+    VLOG(1) << "Dropping stale accept-time identity for reused pid " << pid;
+    peers_.erase(it);
+    it = peers_.end();
+  }
+  if (it == peers_.end()) {
+    it = peers_
+             .emplace(pid, Peer{.identity = std::move(identity),
+                                .captured_at = base::TimeTicks::Now()})
+             .first;
+  }
+
+  VLOG(1) << "New browser connecting: "
+          << it->second.identity->GetDescription();
   return &host_provider_;
+}
+
+scoped_refptr<BrowserIdentity> BrowserRegistry::ResolveBrowserIdentity(
+    mojo::ReceiverId receiver_id) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  DCHECK_EQ(receiver_id, host_server_->current_receiver());
+
+  // Already bound: a browser may drop its host and authenticate again on the
+  // same connection, possibly long after the accept-time entry expired.
+  if (auto* bound = base::FindOrNull(identities_, receiver_id)) {
+    return *bound;
+  }
+
+  // Capturing the dispatching peer is how its pid is read; the identity itself
+  // is discarded, since the accept-time one is what pins the process.
+  scoped_refptr<BrowserIdentity> dispatching =
+      identity_factory_->Capture(host_server_->current_connection_info());
+  if (!dispatching) {
+    return nullptr;
+  }
+
+  // Must be on the accept-time entry list.
+  auto connecting = peers_.find(dispatching->pid());
+  if (connecting == peers_.end()) {
+    // The capture is gone: it aged out and was swept, or this connection was
+    // never accepted; there is nothing to verify against.
+    return nullptr;
+  }
+
+  // Check for expiry so a capture is never usable past its deadline no matter
+  // when storage is actually reclaimed.
+  if (IsCapturedPeerExpired(connecting->second.captured_at,
+                            base::TimeTicks::Now())) {
+    peers_.erase(connecting);
+    return nullptr;
+  }
+
+  // Same pid is not the same process. A peer whose connection outlives its own
+  // capture cannot be allowed to resolve against a capture taken for whoever
+  // inherited its pid afterwards. Refusing here is not a verdict about this
+  // peer, so it reads as retryable.
+  if (!connecting->second.identity->IsSameProcess(*dispatching)) {
+    VLOG(1) << "Refusing " << dispatching->GetDescription()
+            << ": the capture held for that pid belongs to another process ("
+            << connecting->second.identity->GetDescription() << ")";
+    peers_.erase(connecting);
+    return nullptr;
+  }
+
+  // The accept-time entry is deliberately left in place. A browser process
+  // holds one connection per profile, and at launch those may arrive together:
+  // all of them are captured under the same pid before any of them dispatches.
+  // Consuming the entry here would resolve the first profile and leave every
+  // other one unresolvable, which reads to the browser as rejected and takes
+  // those profiles to "unavailable" state for the life of the process.
+  scoped_refptr<BrowserIdentity> identity = connecting->second.identity;
+  identities_[receiver_id] = identity;
+  return identity;
 }
 
 void BrowserRegistry::Authenticate(
@@ -129,26 +242,41 @@ void BrowserRegistry::Authenticate(
     return;
   }
 
+  scoped_refptr<BrowserIdentity> identity = ResolveBrowserIdentity(receiver_id);
+  if (!identity) {
+    // No capture for this connection: it was never accepted, its peer could not
+    // be pinned just now, its pid resolves to another process's capture, or the
+    // capture expired. None is a verdict about the peer, so this is retryable
+    // rather than terminal.
+    VLOG(1) << "Refusing browser " << receiver_id
+            << ": no accept-time identity for the connection (expires "
+            << kCapturedPeerIdleTimeout << " after connect)";
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE, base::BindOnce(std::move(callback),
+                                  mojom::BrowserAuthResult::kInconclusive));
+    return;
+  }
+
   pending_auth_.insert(receiver_id);
   PendingAuth pending{.receiver_id = receiver_id,
+                      .identity = identity,
                       .browser_endpoint = std::move(browser_endpoint),
                       .host = std::move(host),
                       .reply = std::move(callback)};
 
-  // TODO(https://github.com/brave/brave-browser/issues/54623)
-  // Real peer verification will be asynchronous (inspecting the peer process,
-  // checking signatures), so the hop is posted even while it is a no-op, and
-  // nothing past this point may read dispatch state.
-  NOTIMPLEMENTED_LOG_ONCE()
-      << "Peer verification: accepting every browser for now";
-
-  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
-      FROM_HERE, base::BindOnce(&BrowserRegistry::OnPeerVerified,
-                                weak_factory_.GetWeakPtr(), std::move(pending),
-                                /*verified=*/true));
+  // Verification blocks, so it does not belong on the IPC sequence.
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE,
+      {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
+       base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
+      base::BindOnce(&BrowserIdentity::Verify, std::move(identity)),
+      base::BindOnce(&BrowserRegistry::OnPeerVerified,
+                     weak_factory_.GetWeakPtr(), std::move(pending)));
 }
 
-void BrowserRegistry::OnPeerVerified(PendingAuth pending, bool verified) {
+void BrowserRegistry::OnPeerVerified(
+    PendingAuth pending,
+    BrowserIdentity::VerificationResult result) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
   const mojo::ReceiverId receiver_id = pending.receiver_id;
@@ -160,14 +288,23 @@ void BrowserRegistry::OnPeerVerified(PendingAuth pending, bool verified) {
     VLOG(1) << "Browser " << receiver_id << " went away during verification";
     // The pipe is already closed, so this reply goes nowhere; run it anyway
     // rather than dropping a response callback.
-    std::move(pending.reply).Run(mojom::BrowserAuthResult::kRejected);
+    std::move(pending.reply).Run(mojom::BrowserAuthResult::kInconclusive);
     return;
   }
 
-  if (!verified) {
-    VLOG(1) << "Browser " << receiver_id << " failed verification";
-    std::move(pending.reply).Run(mojom::BrowserAuthResult::kRejected);
-    return;
+  switch (result) {
+    case BrowserIdentity::VerificationResult::kAccepted:
+      break;
+    case BrowserIdentity::VerificationResult::kRejected:
+      VLOG(1) << "Browser " << receiver_id
+              << " failed verification: " << pending.identity->GetDescription();
+      std::move(pending.reply).Run(mojom::BrowserAuthResult::kRejected);
+      return;
+    case BrowserIdentity::VerificationResult::kInconclusive:
+      VLOG(1) << "Browser " << receiver_id << " could not be verified: "
+              << pending.identity->GetDescription();
+      std::move(pending.reply).Run(mojom::BrowserAuthResult::kInconclusive);
+      return;
   }
 
   host_sessions_[receiver_id] = std::make_unique<BrowserHostImpl>(
@@ -175,8 +312,25 @@ void BrowserRegistry::OnPeerVerified(PendingAuth pending, bool verified) {
       base::BindOnce(&BrowserRegistry::OnHostDisconnected,
                      weak_factory_.GetWeakPtr(), receiver_id));
 
-  VLOG(1) << "Browser " << receiver_id << " authenticated";
+  // Nothing is removed from |peers_| here on purpose: sibling profiles of this
+  // same browser process may still be waiting to dispatch, and they resolve
+  // through that entry.
+  VLOG(1) << "Browser " << receiver_id
+          << " authenticated: " << pending.identity->GetDescription();
   std::move(pending.reply).Run(mojom::BrowserAuthResult::kAccepted);
+}
+
+void BrowserRegistry::RemoveExpiredPeers() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  const base::TimeTicks now = base::TimeTicks::Now();
+  const size_t reclaimed = base::EraseIf(peers_, [now](const auto& entry) {
+    return IsCapturedPeerExpired(entry.second.captured_at, now);
+  });
+  if (reclaimed) {
+    VLOG(1) << "Removed " << reclaimed
+            << " accept-time captures (expired after "
+            << kCapturedPeerIdleTimeout << ")";
+  }
 }
 
 void BrowserRegistry::OnHostProviderDisconnected() {
@@ -191,6 +345,7 @@ void BrowserRegistry::OnHostProviderDisconnected() {
   // too, and abandons any verification still in flight.
   host_sessions_.erase(receiver_id);
   pending_auth_.erase(receiver_id);
+  identities_.erase(receiver_id);
 }
 
 void BrowserRegistry::OnHostDisconnected(mojo::ReceiverId id) {

--- a/components/brave_vpn/app/v2/agent/browser_registry.cc
+++ b/components/brave_vpn/app/v2/agent/browser_registry.cc
@@ -12,7 +12,6 @@
 
 #include "base/check.h"
 #include "base/check_op.h"
-#include "base/containers/flat_map.h"
 #include "base/containers/map_util.h"
 #include "base/functional/bind.h"
 #include "base/location.h"
@@ -23,13 +22,13 @@
 #include "base/sequence_checker.h"
 #include "base/strings/strcat.h"
 #include "base/task/sequenced_task_runner.h"
-#include "base/task/task_traits.h"
-#include "base/task/thread_pool.h"
 #include "base/time/time.h"
+#include "base/timer/elapsed_timer.h"
 #include "brave/components/brave_vpn/app/v2/agent/browser_host_impl.h"
 #include "brave/components/brave_vpn/app/v2/agent/browser_identity.h"
 #include "build/build_config.h"
 #include "components/named_mojo_ipc_server/named_mojo_ipc_server.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 
 #if BUILDFLAG(IS_WIN)
 #include "base/win/win_util.h"
@@ -63,8 +62,8 @@ named_mojo_ipc_server::EndpointOptions GetEndpointOptions(
   return endpoint_options;
 }
 
-bool IsCapturedPeerExpired(base::TimeTicks captured_at, base::TimeTicks now) {
-  return now - captured_at > kCapturedPeerIdleTimeout;
+bool IsCapturedPeerExpired(const base::ElapsedTimer& time_since_capture) {
+  return time_since_capture.Elapsed() > kCapturedPeerIdleTimeout;
 }
 }  // namespace
 
@@ -74,18 +73,13 @@ BrowserRegistry::BrowserRegistry(
                        brave_vpn::mojom::BrowserHostProvider>>(
           GetEndpointOptions(std::move(server_name)),
           base::BindRepeating(&BrowserRegistry::OnBrowserConnecting,
-                              base::Unretained(this)))),
-      identity_factory_(CreateBrowserIdentityFactory()) {
-  CHECK(identity_factory_);
+                              base::Unretained(this)))) {
   StartHostServer();
 }
 
 BrowserRegistry::BrowserRegistry(
-    std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server,
-    std::unique_ptr<BrowserIdentityFactory> identity_factory)
-    : host_server_(std::move(host_server)),
-      identity_factory_(std::move(identity_factory)) {
-  CHECK(identity_factory_);
+    std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server)
+    : host_server_(std::move(host_server)) {
   StartHostServer();
 }
 
@@ -93,10 +87,8 @@ BrowserRegistry::~BrowserRegistry() = default;
 
 // static
 std::unique_ptr<BrowserRegistry> BrowserRegistry::CreateForTesting(  // IN-TEST
-    std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server,
-    std::unique_ptr<BrowserIdentityFactory> identity_factory) {
-  return base::WrapUnique(
-      new BrowserRegistry(std::move(host_server), std::move(identity_factory)));
+    std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server) {
+  return base::WrapUnique(new BrowserRegistry(std::move(host_server)));
 }
 
 void BrowserRegistry::StartHostServer() {
@@ -115,48 +107,57 @@ brave_vpn::mojom::BrowserHostProvider* BrowserRegistry::OnBrowserConnecting(
   // The only jobs are to reject peers that are cheap to rule out, and to pin
   // the peer so the expensive check later inspects the process that actually
   // connected rather than whatever holds its pid by then.
-  scoped_refptr<BrowserIdentity> identity = identity_factory_->Capture(info);
+  scoped_refptr<BrowserIdentity> identity = BrowserIdentity::Create(info);
   if (!identity) {
     return nullptr;
   }
 
   const base::ProcessId pid = identity->pid();
-  auto it = peers_.find(pid);
-  if (it != peers_.end() && !it->second.identity->IsSameProcess(*identity)) {
+  if (auto it = peers_.find(pid); it != peers_.end()) {
+    if (it->second.identity->IsSameProcess(*identity)) {
+      // The process already has a live capture; sibling profile connections
+      // share it, and the timeout stays measured from the first one.
+      VLOG(1) << "New browser connecting: "
+              << it->second.identity->GetDescription();
+      return &host_provider_;
+    }
     // Same pid, different process: the previous occupant exited and the pid was
     // reused. Any connection still relying on the old entry must not be
     // verified against this new process.
     VLOG(1) << "Dropping stale accept-time identity for reused pid " << pid;
     peers_.erase(it);
-    it = peers_.end();
-  }
-  if (it == peers_.end()) {
-    it = peers_
-             .emplace(pid, Peer{.identity = std::move(identity),
-                                .captured_at = base::TimeTicks::Now()})
-             .first;
   }
 
-  VLOG(1) << "New browser connecting: "
-          << it->second.identity->GetDescription();
+  VLOG(1) << "New browser connecting: " << identity->GetDescription();
+  peers_.emplace(pid, Peer{.identity = std::move(identity)});
   return &host_provider_;
 }
 
-scoped_refptr<BrowserIdentity> BrowserRegistry::ResolveBrowserIdentity(
+BrowserRegistry::Connection* BrowserRegistry::FindConnection(
+    mojo::ReceiverId receiver_id) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  auto* connection = base::FindOrNull(connections_, receiver_id);
+  if (!connection) {
+    return nullptr;
+  }
+  return connection->get();
+}
+
+BrowserRegistry::Connection* BrowserRegistry::ResolveConnection(
     mojo::ReceiverId receiver_id) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   DCHECK_EQ(receiver_id, host_server_->current_receiver());
 
-  // Already bound: a browser may drop its host and authenticate again on the
-  // same connection, possibly long after the accept-time entry expired.
-  if (auto* bound = base::FindOrNull(identities_, receiver_id)) {
-    return *bound;
+  // Already connected: a browser may drop its host and authenticate again on
+  // the same connection, possibly long after the accept-time entry expired.
+  if (auto* connection = FindConnection(receiver_id)) {
+    return connection;
   }
 
-  // Capturing the dispatching peer is how its pid is read; the identity itself
-  // is discarded, since the accept-time one is what pins the process.
+  // Capturing the dispatching peer is how its pid is read; this identity is
+  // discarded, since the accept-time one is what pins the process.
   scoped_refptr<BrowserIdentity> dispatching =
-      identity_factory_->Capture(host_server_->current_connection_info());
+      BrowserIdentity::Create(host_server_->current_connection_info());
   if (!dispatching) {
     return nullptr;
   }
@@ -171,8 +172,7 @@ scoped_refptr<BrowserIdentity> BrowserRegistry::ResolveBrowserIdentity(
 
   // Check for expiry so a capture is never usable past its deadline no matter
   // when storage is actually reclaimed.
-  if (IsCapturedPeerExpired(connecting->second.captured_at,
-                            base::TimeTicks::Now())) {
+  if (IsCapturedPeerExpired(connecting->second.time_since_capture)) {
     peers_.erase(connecting);
     return nullptr;
   }
@@ -181,10 +181,11 @@ scoped_refptr<BrowserIdentity> BrowserRegistry::ResolveBrowserIdentity(
   // capture cannot be allowed to resolve against a capture taken for whoever
   // inherited its pid afterwards. Refusing here is not a verdict about this
   // peer, so it reads as retryable.
-  if (!connecting->second.identity->IsSameProcess(*dispatching)) {
+  scoped_refptr<BrowserIdentity> identity = connecting->second.identity;
+  if (!identity->IsSameProcess(*dispatching)) {
     VLOG(1) << "Refusing " << dispatching->GetDescription()
             << ": the capture held for that pid belongs to another process ("
-            << connecting->second.identity->GetDescription() << ")";
+            << identity->GetDescription() << ")";
     peers_.erase(connecting);
     return nullptr;
   }
@@ -195,9 +196,11 @@ scoped_refptr<BrowserIdentity> BrowserRegistry::ResolveBrowserIdentity(
   // Consuming the entry here would resolve the first profile and leave every
   // other one unresolvable, which reads to the browser as rejected and takes
   // those profiles to "unavailable" state for the life of the process.
-  scoped_refptr<BrowserIdentity> identity = connecting->second.identity;
-  identities_[receiver_id] = identity;
-  return identity;
+  auto stored_connection = std::make_unique<Connection>();
+  stored_connection->identity = std::move(identity);
+  auto it =
+      connections_.emplace(receiver_id, std::move(stored_connection)).first;
+  return it->second.get();
 }
 
 void BrowserRegistry::Authenticate(
@@ -228,22 +231,8 @@ void BrowserRegistry::Authenticate(
     return;
   }
 
-  // One BrowserHost per connection, whether it is already bound or still being
-  // verified. A browser that drops its host may ask again on the same
-  // connection.
-  if (host_sessions_.contains(receiver_id) ||
-      pending_auth_.contains(receiver_id)) {
-    VLOG(1) << "Refusing browser " << receiver_id
-            << ": authentication in progress or succeeded already";
-    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
-        FROM_HERE,
-        base::BindOnce(std::move(callback),
-                       mojom::BrowserAuthResult::kHostAlreadyRequested));
-    return;
-  }
-
-  scoped_refptr<BrowserIdentity> identity = ResolveBrowserIdentity(receiver_id);
-  if (!identity) {
+  Connection* connection = ResolveConnection(receiver_id);
+  if (!connection) {
     // No capture for this connection: it was never accepted, its peer could not
     // be pinned just now, its pid resolves to another process's capture, or the
     // capture expired. None is a verdict about the peer, so this is retryable
@@ -257,21 +246,30 @@ void BrowserRegistry::Authenticate(
     return;
   }
 
-  pending_auth_.insert(receiver_id);
+  // One BrowserHost per connection, whether it is already bound or still being
+  // verified. A browser that drops its host may ask again on the same
+  // connection, which is the kIdentified state.
+  if (connection->state != ConnectionState::kIdentified) {
+    VLOG(1) << "Refusing browser " << receiver_id
+            << ": authentication in progress or succeeded already";
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE,
+        base::BindOnce(std::move(callback),
+                       mojom::BrowserAuthResult::kHostAlreadyRequested));
+    return;
+  }
+
+  connection->state = ConnectionState::kVerifying;
   PendingAuth pending{.receiver_id = receiver_id,
-                      .identity = identity,
                       .browser_endpoint = std::move(browser_endpoint),
                       .host = std::move(host),
                       .reply = std::move(callback)};
 
-  // Verification blocks, so it does not belong on the IPC sequence.
-  base::ThreadPool::PostTaskAndReplyWithResult(
-      FROM_HERE,
-      {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
-       base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
-      base::BindOnce(&BrowserIdentity::Verify, std::move(identity)),
-      base::BindOnce(&BrowserRegistry::OnPeerVerified,
-                     weak_factory_.GetWeakPtr(), std::move(pending)));
+  // Verification may block, so it is BrowserIdentity's task to keep the
+  // blocking part of the verification off the blocking pool entirely.
+  connection->identity->Verify(base::BindOnce(&BrowserRegistry::OnPeerVerified,
+                                              weak_factory_.GetWeakPtr(),
+                                              std::move(pending)));
 }
 
 void BrowserRegistry::OnPeerVerified(
@@ -281,10 +279,11 @@ void BrowserRegistry::OnPeerVerified(
 
   const mojo::ReceiverId receiver_id = pending.receiver_id;
 
-  // The connection may have gone away mid-verification; the pending marker is
-  // the only thing that still says whether it is around, and it is cleared by
+  // The connection may have gone away mid-verification; its entry is the only
+  // thing that still says whether it is around, and it is erased by
   // OnHostProviderDisconnected().
-  if (!pending_auth_.erase(receiver_id)) {
+  auto* connection = FindConnection(receiver_id);
+  if (!connection) {
     VLOG(1) << "Browser " << receiver_id << " went away during verification";
     // The pipe is already closed, so this reply goes nowhere; run it anyway
     // rather than dropping a response callback.
@@ -292,22 +291,28 @@ void BrowserRegistry::OnPeerVerified(
     return;
   }
 
+  DCHECK_EQ(ConnectionState::kVerifying, connection->state);
+  DCHECK(!connection->host_session);
+
   switch (result) {
     case BrowserIdentity::VerificationResult::kAccepted:
       break;
     case BrowserIdentity::VerificationResult::kRejected:
-      VLOG(1) << "Browser " << receiver_id
-              << " failed verification: " << pending.identity->GetDescription();
+      VLOG(1) << "Browser " << receiver_id << " failed verification: "
+              << connection->identity->GetDescription();
+      connection->state = ConnectionState::kIdentified;
       std::move(pending.reply).Run(mojom::BrowserAuthResult::kRejected);
       return;
     case BrowserIdentity::VerificationResult::kInconclusive:
       VLOG(1) << "Browser " << receiver_id << " could not be verified: "
-              << pending.identity->GetDescription();
+              << connection->identity->GetDescription();
+      connection->state = ConnectionState::kIdentified;
       std::move(pending.reply).Run(mojom::BrowserAuthResult::kInconclusive);
       return;
   }
 
-  host_sessions_[receiver_id] = std::make_unique<BrowserHostImpl>(
+  connection->state = ConnectionState::kVerified;
+  connection->host_session = std::make_unique<BrowserHostImpl>(
       std::move(pending.browser_endpoint), std::move(pending.host),
       base::BindOnce(&BrowserRegistry::OnHostDisconnected,
                      weak_factory_.GetWeakPtr(), receiver_id));
@@ -316,15 +321,14 @@ void BrowserRegistry::OnPeerVerified(
   // same browser process may still be waiting to dispatch, and they resolve
   // through that entry.
   VLOG(1) << "Browser " << receiver_id
-          << " authenticated: " << pending.identity->GetDescription();
+          << " authenticated: " << connection->identity->GetDescription();
   std::move(pending.reply).Run(mojom::BrowserAuthResult::kAccepted);
 }
 
 void BrowserRegistry::RemoveExpiredPeers() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  const base::TimeTicks now = base::TimeTicks::Now();
-  const size_t reclaimed = base::EraseIf(peers_, [now](const auto& entry) {
-    return IsCapturedPeerExpired(entry.second.captured_at, now);
+  const size_t reclaimed = absl::erase_if(peers_, [](const auto& entry) {
+    return IsCapturedPeerExpired(entry.second.time_since_capture);
   });
   if (reclaimed) {
     VLOG(1) << "Removed " << reclaimed
@@ -343,19 +347,23 @@ void BrowserRegistry::OnHostProviderDisconnected() {
 
   // Per the mojom contract, losing the connection tears down its BrowserHost
   // too, and abandons any verification still in flight.
-  host_sessions_.erase(receiver_id);
-  pending_auth_.erase(receiver_id);
-  identities_.erase(receiver_id);
+  connections_.erase(receiver_id);
 }
 
 void BrowserRegistry::OnHostDisconnected(mojo::ReceiverId id) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
   VLOG(1) << "Browser " << id << " dropped a session pipe";
-  // Destroys the BrowserHostImpl whose pipe is invoking this, which is safe
-  // for a mojo disconnect handler. The connection stays up, so the browser may
-  // authenticate again.
-  host_sessions_.erase(id);
+
+  auto* connection = FindConnection(id);
+  if (connection) {
+    // The connection stays up and keeps its identity, so the browser may
+    // authenticate again; only the session goes away. State is set first so
+    // nothing reads the entry after the BrowserHostImpl whose pipe is invoking
+    // this is destroyed, which is safe for a mojo disconnect handler.
+    connection->state = ConnectionState::kIdentified;
+    connection->host_session.reset();
+  }
 }
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/browser_registry.h
+++ b/components/brave_vpn/app/v2/agent/browser_registry.h
@@ -13,9 +13,13 @@
 #include "base/containers/flat_map.h"
 #include "base/containers/flat_set.h"
 #include "base/functional/callback.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
+#include "base/process/process_handle.h"
 #include "base/sequence_checker.h"
+#include "base/time/time.h"
 #include "brave/components/brave_vpn/app/v2/agent/browser_host_provider_impl.h"
+#include "brave/components/brave_vpn/app/v2/agent/browser_identity.h"
 #include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
 #include "components/named_mojo_ipc_server/connection_info.h"
 #include "components/named_mojo_ipc_server/ipc_server.h"
@@ -41,18 +45,31 @@ class BrowserRegistry : public BrowserHostProviderImpl::Delegate {
   BrowserRegistry& operator=(const BrowserRegistry&) = delete;
 
   // Takes the IPC server directly, so a test can choose connection ids and
-  // report disconnects without a real endpoint.
+  // report disconnects without a real endpoint, and a factory so it can
+  // describe a peer without fabricating kernel credentials.
   static std::unique_ptr<BrowserRegistry> CreateForTesting(
-      std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server);
+      std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server,
+      std::unique_ptr<BrowserIdentityFactory> identity_factory);
 
  private:
-  explicit BrowserRegistry(
-      std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server);
+  friend class BrowserRegistryTest;
+
+  BrowserRegistry(std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server,
+                  std::unique_ptr<BrowserIdentityFactory> identity_factory);
+
+  // A peer captured at accept time that has not called BindBrowserHost() yet.
+  // Keyed by pid, so two connections from one process share an entry and would
+  // have identical identities anyway.
+  struct Peer {
+    scoped_refptr<BrowserIdentity> identity;
+    base::TimeTicks captured_at;
+  };
 
   // Everything Authenticate() must carry across the verification hop, since
   // none of it can be re-read from dispatch state afterwards.
   struct PendingAuth {
     mojo::ReceiverId receiver_id = 0;
+    scoped_refptr<BrowserIdentity> identity;
     mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint;
     mojo::PendingReceiver<mojom::BrowserHost> host;
     base::OnceCallback<void(mojom::BrowserAuthResult)> reply;
@@ -73,8 +90,19 @@ class BrowserRegistry : public BrowserHostProviderImpl::Delegate {
   brave_vpn::mojom::BrowserHostProvider* OnBrowserConnecting(
       const named_mojo_ipc_server::ConnectionInfo& info);
 
+  // Binds the identity captured for the connection currently dispatching, to
+  // the receiver id so a browser that drops its host and asks again resolves to
+  // the same peer. Null if the connection was never captured or its accept-time
+  // entry already timed out.
+  scoped_refptr<BrowserIdentity> ResolveBrowserIdentity(
+      mojo::ReceiverId receiver_id);
+
   // Second half of Authenticate(): creates the browser host on success.
-  void OnPeerVerified(PendingAuth pending, bool verified);
+  void OnPeerVerified(PendingAuth pending,
+                      BrowserIdentity::VerificationResult result);
+
+  // Drops expired entries, releasing the process references they pin.
+  void RemoveExpiredPeers();
 
   void OnHostProviderDisconnected();
   void OnHostDisconnected(mojo::ReceiverId id);
@@ -84,9 +112,12 @@ class BrowserRegistry : public BrowserHostProviderImpl::Delegate {
   BrowserHostProviderImpl host_provider_{this};
 
   std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server_;
+  std::unique_ptr<BrowserIdentityFactory> identity_factory_;
   base::flat_map<mojo::ReceiverId, std::unique_ptr<BrowserHostImpl>>
       host_sessions_;
   base::flat_set<mojo::ReceiverId> pending_auth_;
+  base::flat_map<base::ProcessId, Peer> peers_;
+  base::flat_map<mojo::ReceiverId, scoped_refptr<BrowserIdentity>> identities_;
 
   SEQUENCE_CHECKER(sequence_checker_);
   base::WeakPtrFactory<BrowserRegistry> weak_factory_{this};

--- a/components/brave_vpn/app/v2/agent/browser_registry.h
+++ b/components/brave_vpn/app/v2/agent/browser_registry.h
@@ -10,14 +10,12 @@
 
 #include <memory>
 
-#include "base/containers/flat_map.h"
-#include "base/containers/flat_set.h"
 #include "base/functional/callback.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/process/process_handle.h"
 #include "base/sequence_checker.h"
-#include "base/time/time.h"
+#include "base/timer/elapsed_timer.h"
 #include "brave/components/brave_vpn/app/v2/agent/browser_host_provider_impl.h"
 #include "brave/components/brave_vpn/app/v2/agent/browser_identity.h"
 #include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
@@ -27,15 +25,32 @@
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver_set.h"
 #include "mojo/public/cpp/platform/named_platform_channel.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 
 namespace brave_vpn::v2 {
 
 class BrowserHostImpl;
 
 // Owns the IPC server and every browser to agent connection on it, plus the
-// authentication policy the unauthenticated surface delegates to. Sessions are
-// keyed by the BrowserHostProvider receiver id, which identifies the
+// authentication policy the unauthenticated surface delegates to. Sessions
+// are keyed by the BrowserHostProvider receiver id, which identifies the
 // connection: one authenticated BrowserHost per connection at a time.
+//
+// Authentication state is split across two maps:
+//
+// |peers_| is keyed by pid and holds the accept-time capture of each connecting
+// browser process. The capture pins the process, so verification inspects the
+// process that connected rather than whatever holds its pid later. Entries are
+// dropped on timeout, on a reused pid, or on a mismatch at dispatch. They are
+// never dropped on success, because sibling profile connections from the same
+// process resolve through them.
+//
+// |connections_| is keyed by receiver id and holds per-connection state,
+// including a reference to that same accept-time capture. A capture taken at
+// dispatch is not used: only pid() and IsSameProcess() are meaningful on one.
+// An entry lives until its connection goes away, so it outlives the |peers_|
+// entry and lets a browser re-bind a host after the capture expires. Values are
+// heap-allocated because ResolveConnection() returns a pointer into the map.
 class BrowserRegistry : public BrowserHostProviderImpl::Delegate {
  public:
   explicit BrowserRegistry(mojo::NamedPlatformChannel::ServerName server_name);
@@ -45,31 +60,46 @@ class BrowserRegistry : public BrowserHostProviderImpl::Delegate {
   BrowserRegistry& operator=(const BrowserRegistry&) = delete;
 
   // Takes the IPC server directly, so a test can choose connection ids and
-  // report disconnects without a real endpoint, and a factory so it can
-  // describe a peer without fabricating kernel credentials.
+  // report disconnects without a real endpoint.
   static std::unique_ptr<BrowserRegistry> CreateForTesting(
-      std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server,
-      std::unique_ptr<BrowserIdentityFactory> identity_factory);
+      std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server);
 
  private:
   friend class BrowserRegistryTest;
 
-  BrowserRegistry(std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server,
-                  std::unique_ptr<BrowserIdentityFactory> identity_factory);
+  explicit BrowserRegistry(
+      std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server);
 
-  // A peer captured at accept time that has not called BindBrowserHost() yet.
-  // Keyed by pid, so two connections from one process share an entry and would
-  // have identical identities anyway.
+  // Enum describing where a connection is in the authentication sequence.
+  enum class ConnectionState {
+    // Resolved against an accept-time capture, but with no host bound and no
+    // verification running: either it has not authenticated yet, or a previous
+    // attempt was refused, or its host pipe was dropped. May authenticate.
+    kIdentified,
+    // A verification is in flight.
+    kVerifying,
+    // Verified, with a live BrowserHostImpl.
+    kVerified,
+  };
+
+  // Per-connection state, keyed by BrowserHostProvider receiver id.
+  struct Connection {
+    ConnectionState state = ConnectionState::kIdentified;
+    scoped_refptr<BrowserIdentity> identity;
+    std::unique_ptr<BrowserHostImpl> host_session;
+  };
+
+  // A peer captured at accept time. Keyed by pid, so two connections from one
+  // process share an identity.
   struct Peer {
     scoped_refptr<BrowserIdentity> identity;
-    base::TimeTicks captured_at;
+    base::ElapsedTimer time_since_capture;
   };
 
   // Everything Authenticate() must carry across the verification hop, since
   // none of it can be re-read from dispatch state afterwards.
   struct PendingAuth {
     mojo::ReceiverId receiver_id = 0;
-    scoped_refptr<BrowserIdentity> identity;
     mojo::PendingRemote<mojom::BrowserEndpoint> browser_endpoint;
     mojo::PendingReceiver<mojom::BrowserHost> host;
     base::OnceCallback<void(mojom::BrowserAuthResult)> reply;
@@ -90,12 +120,14 @@ class BrowserRegistry : public BrowserHostProviderImpl::Delegate {
   brave_vpn::mojom::BrowserHostProvider* OnBrowserConnecting(
       const named_mojo_ipc_server::ConnectionInfo& info);
 
-  // Binds the identity captured for the connection currently dispatching, to
-  // the receiver id so a browser that drops its host and asks again resolves to
-  // the same peer. Null if the connection was never captured or its accept-time
-  // entry already timed out.
-  scoped_refptr<BrowserIdentity> ResolveBrowserIdentity(
-      mojo::ReceiverId receiver_id);
+  // Null if the connection is not known.
+  Connection* FindConnection(mojo::ReceiverId receiver_id);
+
+  // Returns the entry for the connection currently dispatching, creating it
+  // from the accept-time capture on first use so a browser that drops its host
+  // and asks again resolves to the same peer. Null if the connection was never
+  // captured or its accept-time entry already timed out.
+  Connection* ResolveConnection(mojo::ReceiverId receiver_id);
 
   // Second half of Authenticate(): creates the browser host on success.
   void OnPeerVerified(PendingAuth pending,
@@ -112,13 +144,9 @@ class BrowserRegistry : public BrowserHostProviderImpl::Delegate {
   BrowserHostProviderImpl host_provider_{this};
 
   std::unique_ptr<named_mojo_ipc_server::IpcServer> host_server_;
-  std::unique_ptr<BrowserIdentityFactory> identity_factory_;
-  base::flat_map<mojo::ReceiverId, std::unique_ptr<BrowserHostImpl>>
-      host_sessions_;
-  base::flat_set<mojo::ReceiverId> pending_auth_;
-  base::flat_map<base::ProcessId, Peer> peers_;
-  base::flat_map<mojo::ReceiverId, scoped_refptr<BrowserIdentity>> identities_;
-
+  absl::flat_hash_map<base::ProcessId, Peer> peers_;
+  absl::flat_hash_map<mojo::ReceiverId, std::unique_ptr<Connection>>
+      connections_;
   SEQUENCE_CHECKER(sequence_checker_);
   base::WeakPtrFactory<BrowserRegistry> weak_factory_{this};
 };

--- a/components/brave_vpn/app/v2/agent/browser_registry_unittest.cc
+++ b/components/brave_vpn/app/v2/agent/browser_registry_unittest.cc
@@ -9,9 +9,12 @@
 
 #include <memory>
 
+#include "base/auto_reset.h"
 #include "base/containers/flat_map.h"
-#include "base/memory/raw_ptr.h"
+#include "base/functional/bind.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/process/process_handle.h"
+#include "base/test/bind.h"
 #include "base/test/task_environment.h"
 #include "base/time/time.h"
 #include "brave/components/brave_vpn/app/v2/agent/browser_host_provider_impl.h"
@@ -35,12 +38,25 @@ base::ProcessId PidForConnection(mojo::ReceiverId connection) {
 
 class BrowserRegistryTest : public testing::Test {
  protected:
-  BrowserRegistryTest() {
-    auto identity_factory = std::make_unique<FakeBrowserIdentityFactory>();
-    identity_factory_ = identity_factory.get();
+  BrowserRegistryTest()
+      : identity_capture_callback_reset_(
+            SetBrowserIdentityCaptureCallbackForTesting(base::BindRepeating(
+                &BrowserRegistryTest::CaptureIdentityForConnection,
+                base::Unretained(this)))) {
     registry_ = BrowserRegistry::CreateForTesting(
-        std::make_unique<named_mojo_ipc_server::FakeIpcServer>(&server_state_),
-        std::move(identity_factory));
+        std::make_unique<named_mojo_ipc_server::FakeIpcServer>(&server_state_));
+  }
+
+  scoped_refptr<BrowserIdentity> CaptureIdentityForConnection(
+      const named_mojo_ipc_server::ConnectionInfo&) {
+    if (identity_capture_fails_) {
+      return nullptr;
+    }
+    return base::MakeRefCounted<FakeBrowserIdentity>(
+        current_connection_pid_, base::BindLambdaForTesting([this]() {
+          return identity_verification_result_;
+        }),
+        identity_is_same_process_);
   }
 
   brave_vpn::mojom::BrowserHostProvider* CallOnBrowserConnecting() {
@@ -64,8 +80,8 @@ class BrowserRegistryTest : public testing::Test {
     server_state_.current_connection_info =
         std::make_unique<named_mojo_ipc_server::ConnectionInfo>();
     const auto it = connection_pids_.find(connection);
-    identity_factory_->set_peer_pid(
-        it == connection_pids_.end() ? base::kNullProcessId : it->second);
+    current_connection_pid_ =
+        it == connection_pids_.end() ? base::kNullProcessId : it->second;
   }
 
   // Drives the accept-time callback the real IPC server would make, which is
@@ -107,10 +123,16 @@ class BrowserRegistryTest : public testing::Test {
   base::test::TaskEnvironment task_environment_{
       base::test::TaskEnvironment::TimeSource::MOCK_TIME};
   named_mojo_ipc_server::FakeIpcServer::TestState server_state_;
-  std::unique_ptr<BrowserRegistry> registry_;
-  raw_ptr<FakeBrowserIdentityFactory> identity_factory_ = nullptr;
   mojo::ReceiverId last_connection_id_ = 0;
   base::flat_map<mojo::ReceiverId, base::ProcessId> connection_pids_;
+  base::ProcessId current_connection_pid_ = base::kNullProcessId;
+  bool identity_capture_fails_ = false;
+  bool identity_is_same_process_ = true;
+  BrowserIdentity::VerificationResult identity_verification_result_ =
+      BrowserIdentity::VerificationResult::kAccepted;
+  base::AutoReset<BrowserIdentityCaptureCallback>
+      identity_capture_callback_reset_;
+  std::unique_ptr<BrowserRegistry> registry_;
 };
 
 TEST_F(BrowserRegistryTest, StartsServingOnConstruction) {
@@ -277,7 +299,6 @@ TEST_F(BrowserRegistryTest, DestroyedWhileVerificationPendingIsSafe) {
   StartAuthenticate(browser, NextConnectionId(), mojom::kProtocolVersion);
   browser.WatchEndpoint();
 
-  identity_factory_ = nullptr;
   registry_.reset();
 
   // The abandoned request takes the browser's endpoint down with it, which is
@@ -311,7 +332,7 @@ TEST_F(BrowserRegistryTest, KeepsOneSessionPerConnection) {
 // BindBrowserHost(): returning null from the accept callback is what refuses
 // the connection.
 TEST_F(BrowserRegistryTest, RefusesConnectionWhosePeerCannotBeCaptured) {
-  identity_factory_->set_capture_fails(true);
+  identity_capture_fails_ = true;
   SetDispatchingConnection(NextConnectionId());
   EXPECT_FALSE(CallOnBrowserConnecting());
 }
@@ -387,7 +408,7 @@ TEST_F(BrowserRegistryTest, DoesNotResolveAgainstAnotherProcessCapture) {
 TEST_F(BrowserRegistryTest, RefusesBrowserWhosePidWasRecycled) {
   const mojo::ReceiverId connection = NextConnectionId();
 
-  identity_factory_->set_is_same_process(false);
+  identity_is_same_process_ = false;
   SimulateConnect(connection, PidForConnection(connection));
 
   FakeBrowser browser;
@@ -400,14 +421,14 @@ TEST_F(BrowserRegistryTest, RefusesBrowserWhosePidWasRecycled) {
 TEST_F(BrowserRegistryTest, RecapturesAfterPidWasRecycled) {
   constexpr base::ProcessId kSharedPid{12345};
 
-  identity_factory_->set_is_same_process(false);
+  identity_is_same_process_ = false;
   const mojo::ReceiverId stale_connection = NextConnectionId();
   SimulateConnect(stale_connection, kSharedPid);
   FakeBrowser stale;
   ASSERT_EQ(mojom::BrowserAuthResult::kInconclusive,
             Authenticate(stale, stale_connection));
 
-  identity_factory_->set_is_same_process(true);
+  identity_is_same_process_ = true;
   const mojo::ReceiverId fresh_connection = NextConnectionId();
   SimulateConnect(fresh_connection, kSharedPid);
   FakeBrowser fresh;
@@ -455,8 +476,8 @@ TEST_F(BrowserRegistryTest, ForgetsIdentityWhenTheConnectionGoesAway) {
 // A verdict that the peer is not our browser reaches the browser as a rejection
 // and leaves no session behind.
 TEST_F(BrowserRegistryTest, RejectsBrowserThatFailsVerification) {
-  identity_factory_->set_verification_result(
-      BrowserIdentity::VerificationResult::kRejected);
+  identity_verification_result_ =
+      BrowserIdentity::VerificationResult::kRejected;
 
   FakeBrowser browser;
   StartAuthenticate(browser, NextConnectionId(), mojom::kProtocolVersion);
@@ -472,8 +493,8 @@ TEST_F(BrowserRegistryTest, RejectsBrowserThatFailsVerification) {
 // as the retryable answer, which is what keeps a browser whose image was
 // replaced mid-update from going permanently unavailable.
 TEST_F(BrowserRegistryTest, ReportsInconclusiveVerificationAsRetryable) {
-  identity_factory_->set_verification_result(
-      BrowserIdentity::VerificationResult::kInconclusive);
+  identity_verification_result_ =
+      BrowserIdentity::VerificationResult::kInconclusive;
 
   FakeBrowser browser;
   StartAuthenticate(browser, NextConnectionId(), mojom::kProtocolVersion);
@@ -488,16 +509,16 @@ TEST_F(BrowserRegistryTest, ReportsInconclusiveVerificationAsRetryable) {
 // A refused verdict is about that one request: the connection stays usable, so
 // the same peer can authenticate afterwards.
 TEST_F(BrowserRegistryTest, AllowsAuthenticatingAfterFailedVerification) {
-  identity_factory_->set_verification_result(
-      BrowserIdentity::VerificationResult::kRejected);
+  identity_verification_result_ =
+      BrowserIdentity::VerificationResult::kRejected;
 
   const mojo::ReceiverId connection = NextConnectionId();
   FakeBrowser first;
   ASSERT_EQ(mojom::BrowserAuthResult::kRejected,
             Authenticate(first, connection));
 
-  identity_factory_->set_verification_result(
-      BrowserIdentity::VerificationResult::kAccepted);
+  identity_verification_result_ =
+      BrowserIdentity::VerificationResult::kAccepted;
 
   FakeBrowser second;
   EXPECT_EQ(mojom::BrowserAuthResult::kAccepted,

--- a/components/brave_vpn/app/v2/agent/browser_registry_unittest.cc
+++ b/components/brave_vpn/app/v2/agent/browser_registry_unittest.cc
@@ -9,41 +9,91 @@
 
 #include <memory>
 
+#include "base/containers/flat_map.h"
+#include "base/memory/raw_ptr.h"
+#include "base/process/process_handle.h"
 #include "base/test/task_environment.h"
+#include "base/time/time.h"
 #include "brave/components/brave_vpn/app/v2/agent/browser_host_provider_impl.h"
+#include "brave/components/brave_vpn/app/v2/agent/browser_identity.h"
 #include "brave/components/brave_vpn/app/v2/agent/test/fake_browser.h"
+#include "brave/components/brave_vpn/app/v2/agent/test/fake_browser_identity.h"
 #include "brave/components/brave_vpn/common/mojom/browser_agent.mojom.h"
+#include "components/named_mojo_ipc_server/connection_info.h"
 #include "components/named_mojo_ipc_server/fake_ipc_server.h"
 #include "mojo/public/cpp/bindings/receiver_set.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace brave_vpn::v2 {
+namespace {
+// A distinct pid per connection unless a test says otherwise, so the common
+// case looks like separate browser processes.
+base::ProcessId PidForConnection(mojo::ReceiverId connection) {
+  return static_cast<base::ProcessId>(1000 + connection);
+}
+}  // namespace
 
 class BrowserRegistryTest : public testing::Test {
  protected:
-  BrowserRegistryTest()
-      : registry_(BrowserRegistry::CreateForTesting(
-            std::make_unique<named_mojo_ipc_server::FakeIpcServer>(
-                &server_state_))) {}
+  BrowserRegistryTest() {
+    auto identity_factory = std::make_unique<FakeBrowserIdentityFactory>();
+    identity_factory_ = identity_factory.get();
+    registry_ = BrowserRegistry::CreateForTesting(
+        std::make_unique<named_mojo_ipc_server::FakeIpcServer>(&server_state_),
+        std::move(identity_factory));
+  }
+
+  brave_vpn::mojom::BrowserHostProvider* CallOnBrowserConnecting() {
+    return registry_->OnBrowserConnecting(
+        *server_state_.current_connection_info);
+  }
+
+  void CallAuthenticate(FakeBrowser& browser, uint32_t protocol_version) {
+    registry_->Authenticate(protocol_version, browser.BindEndpoint(),
+                            browser.BindHost(), browser.GetReplyCallback());
+  }
 
   // Mojo's ReceiverSet hands out ids from a monotonic counter and never reuses
   // them, so a dropped connection's id can never come back.
   mojo::ReceiverId NextConnectionId() { return ++last_connection_id_; }
 
+  // Points the fake server at |connection| and the fake factory at the pid that
+  // connection belongs to, the way the real pair agree on both.
+  void SetDispatchingConnection(mojo::ReceiverId connection) {
+    server_state_.current_receiver = connection;
+    server_state_.current_connection_info =
+        std::make_unique<named_mojo_ipc_server::ConnectionInfo>();
+    const auto it = connection_pids_.find(connection);
+    identity_factory_->set_peer_pid(
+        it == connection_pids_.end() ? base::kNullProcessId : it->second);
+  }
+
+  // Drives the accept-time callback the real IPC server would make, which is
+  // where the peer is captured. Nothing can authenticate without it.
+  void SimulateConnect(mojo::ReceiverId connection, base::ProcessId pid) {
+    connection_pids_[connection] = pid;
+    SetDispatchingConnection(connection);
+    EXPECT_TRUE(CallOnBrowserConnecting());
+  }
+
   void StartAuthenticate(FakeBrowser& browser,
                          mojo::ReceiverId connection,
-                         uint32_t protocol_version) {
-    server_state_.current_receiver = connection;
-    static_cast<BrowserHostProviderImpl::Delegate&>(*registry_)
-        .Authenticate(protocol_version, browser.BindEndpoint(),
-                      browser.BindHost(), browser.GetReplyCallback());
+                         uint32_t protocol_version,
+                         bool simulate_connect = true) {
+    if (simulate_connect && !connection_pids_.contains(connection)) {
+      SimulateConnect(connection, PidForConnection(connection));
+    } else {
+      SetDispatchingConnection(connection);
+    }
+    CallAuthenticate(browser, protocol_version);
   }
 
   mojom::BrowserAuthResult Authenticate(
       FakeBrowser& browser,
       mojo::ReceiverId connection,
       uint32_t protocol_version = mojom::kProtocolVersion) {
-    StartAuthenticate(browser, connection, protocol_version);
+    StartAuthenticate(browser, connection, protocol_version,
+                      /*simulate_connect=*/true);
     return browser.WaitForReply();
   }
 
@@ -54,10 +104,13 @@ class BrowserRegistryTest : public testing::Test {
     server_state_.disconnect_handler.Run();
   }
 
-  base::test::TaskEnvironment task_environment_;
+  base::test::TaskEnvironment task_environment_{
+      base::test::TaskEnvironment::TimeSource::MOCK_TIME};
   named_mojo_ipc_server::FakeIpcServer::TestState server_state_;
   std::unique_ptr<BrowserRegistry> registry_;
+  raw_ptr<FakeBrowserIdentityFactory> identity_factory_ = nullptr;
   mojo::ReceiverId last_connection_id_ = 0;
+  base::flat_map<mojo::ReceiverId, base::ProcessId> connection_pids_;
 };
 
 TEST_F(BrowserRegistryTest, StartsServingOnConstruction) {
@@ -78,11 +131,13 @@ TEST_F(BrowserRegistryTest, AcceptsBrowserAndBindsItsHost) {
 }
 
 TEST_F(BrowserRegistryTest, RefusesProtocolVersionAboveTheAgentsOwn) {
-  FakeBrowser browser;
-
-  EXPECT_EQ(
-      mojom::BrowserAuthResult::kVersionMismatch,
-      Authenticate(browser, NextConnectionId(), mojom::kProtocolVersion + 1));
+  for (const bool simulate_connect : {false, true}) {
+    FakeBrowser browser;
+    StartAuthenticate(browser, NextConnectionId(), mojom::kProtocolVersion + 1,
+                      simulate_connect);
+    EXPECT_EQ(mojom::BrowserAuthResult::kVersionMismatch,
+              browser.WaitForReply());
+  }
 }
 
 TEST_F(BrowserRegistryTest, RefusesProtocolVersionBelowTheSupportedFloor) {
@@ -207,7 +262,7 @@ TEST_F(BrowserRegistryTest, ConnectionDropDuringVerificationAnswersRequest) {
 
   DisconnectConnection(connection);
 
-  EXPECT_EQ(mojom::BrowserAuthResult::kRejected, browser.WaitForReply());
+  EXPECT_EQ(mojom::BrowserAuthResult::kInconclusive, browser.WaitForReply());
 
   // Nothing was left behind for the next connection.
   FakeBrowser next;
@@ -222,6 +277,7 @@ TEST_F(BrowserRegistryTest, DestroyedWhileVerificationPendingIsSafe) {
   StartAuthenticate(browser, NextConnectionId(), mojom::kProtocolVersion);
   browser.WatchEndpoint();
 
+  identity_factory_ = nullptr;
   registry_.reset();
 
   // The abandoned request takes the browser's endpoint down with it, which is
@@ -249,6 +305,221 @@ TEST_F(BrowserRegistryTest, KeepsOneSessionPerConnection) {
   second.FlushHost();
   EXPECT_TRUE(second.host_connected());
   EXPECT_FALSE(second.host_closed());
+}
+
+// A peer that cannot be pinned is refused before it ever reaches
+// BindBrowserHost(): returning null from the accept callback is what refuses
+// the connection.
+TEST_F(BrowserRegistryTest, RefusesConnectionWhosePeerCannotBeCaptured) {
+  identity_factory_->set_capture_fails(true);
+  SetDispatchingConnection(NextConnectionId());
+  EXPECT_FALSE(CallOnBrowserConnecting());
+}
+
+// A BindBrowserHost() on a connection the agent never accepted has no peer to
+// verify. That is not a verdict about the caller, so it must be the retryable
+// answer rather than a rejection.
+TEST_F(BrowserRegistryTest, RefusesBrowserWithNoCaptureForItsConnection) {
+  FakeBrowser browser;
+  StartAuthenticate(browser, NextConnectionId(), mojom::kProtocolVersion,
+                    /*simulate_connect=*/false);
+  EXPECT_EQ(mojom::BrowserAuthResult::kInconclusive, browser.WaitForReply());
+}
+
+// The capture is only good for a bounded window, so a connection that sits
+// silent past it can no longer authenticate.
+TEST_F(BrowserRegistryTest, RefusesBrowserAfterItsCaptureExpires) {
+  const mojo::ReceiverId connection = NextConnectionId();
+  SimulateConnect(connection, PidForConnection(connection));
+
+  task_environment_.FastForwardBy(base::Minutes(5));
+
+  FakeBrowser browser;
+  EXPECT_EQ(mojom::BrowserAuthResult::kInconclusive,
+            Authenticate(browser, connection));
+}
+
+// A browser process holds one connection per profile and they arrive together,
+// so every one of them has to resolve against the capture, not just whichever
+// dispatches first.
+TEST_F(BrowserRegistryTest, AcceptsSiblingConnectionsFromOneProcess) {
+  constexpr base::ProcessId kSharedPid{12345};
+  const mojo::ReceiverId first_connection = NextConnectionId();
+  const mojo::ReceiverId second_connection = NextConnectionId();
+
+  // Both connections are accepted before either authenticates.
+  SimulateConnect(first_connection, kSharedPid);
+  SimulateConnect(second_connection, kSharedPid);
+
+  FakeBrowser first;
+  ASSERT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(first, first_connection));
+
+  FakeBrowser second;
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(second, second_connection));
+}
+
+// A capture belongs to the process it was taken for, so a connection reporting
+// a different process must not resolve against it.
+TEST_F(BrowserRegistryTest, DoesNotResolveAgainstAnotherProcessCapture) {
+  const mojo::ReceiverId captured = NextConnectionId();
+  SimulateConnect(captured, /*pid=*/1);
+
+  // A connection that never went through the accept callback, reporting a pid
+  // the registry holds no capture for.
+  const mojo::ReceiverId uncaptured = NextConnectionId();
+  connection_pids_[uncaptured] = 2;
+
+  FakeBrowser browser;
+  StartAuthenticate(browser, uncaptured, mojom::kProtocolVersion,
+                    /*simulate_connect=*/false);
+  EXPECT_EQ(mojom::BrowserAuthResult::kInconclusive, browser.WaitForReply());
+
+  // The captured connection is unaffected.
+  FakeBrowser other;
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted, Authenticate(other, captured));
+}
+
+// A pid says which entry to look at; it does not say the entry describes the
+// same process. When the two disagree the request must be refused rather than
+// verified against a capture that was taken for someone else.
+TEST_F(BrowserRegistryTest, RefusesBrowserWhosePidWasRecycled) {
+  const mojo::ReceiverId connection = NextConnectionId();
+
+  identity_factory_->set_is_same_process(false);
+  SimulateConnect(connection, PidForConnection(connection));
+
+  FakeBrowser browser;
+  EXPECT_EQ(mojom::BrowserAuthResult::kInconclusive,
+            Authenticate(browser, connection));
+}
+
+// The mismatched capture is dropped, so the process that really holds the pid
+// now can connect and authenticate on a capture of its own.
+TEST_F(BrowserRegistryTest, RecapturesAfterPidWasRecycled) {
+  constexpr base::ProcessId kSharedPid{12345};
+
+  identity_factory_->set_is_same_process(false);
+  const mojo::ReceiverId stale_connection = NextConnectionId();
+  SimulateConnect(stale_connection, kSharedPid);
+  FakeBrowser stale;
+  ASSERT_EQ(mojom::BrowserAuthResult::kInconclusive,
+            Authenticate(stale, stale_connection));
+
+  identity_factory_->set_is_same_process(true);
+  const mojo::ReceiverId fresh_connection = NextConnectionId();
+  SimulateConnect(fresh_connection, kSharedPid);
+  FakeBrowser fresh;
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(fresh, fresh_connection));
+}
+
+// Once a connection has authenticated, its identity belongs to the connection
+// rather than to the accept-time capture, so re-binding a host still works long
+// after that capture would have expired.
+TEST_F(BrowserRegistryTest, AllowsRebindingAfterTheCaptureExpires) {
+  const mojo::ReceiverId connection = NextConnectionId();
+  FakeBrowser first;
+  ASSERT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(first, connection));
+
+  first.DropHost();
+  task_environment_.FastForwardBy(base::Minutes(5));
+
+  FakeBrowser second;
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(second, connection));
+}
+
+// Dropping the connection drops its identity with it, so the new connection
+// with the same receiver id cannot resolve against it and must authenticate on
+// a fresh capture (which we intentionally leave out). This is not supposed to
+// happen in practice, since ReceiverSet never reuses ids, but it is a safety
+// check.
+TEST_F(BrowserRegistryTest, ForgetsIdentityWhenTheConnectionGoesAway) {
+  const mojo::ReceiverId connection = NextConnectionId();
+  FakeBrowser first;
+  ASSERT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(first, connection, mojom::kProtocolVersion));
+
+  DisconnectConnection(connection);
+  task_environment_.FastForwardBy(base::Minutes(5));
+
+  FakeBrowser second;
+  StartAuthenticate(second, connection, mojom::kProtocolVersion,
+                    /*simulate_connect=*/false);
+  EXPECT_EQ(mojom::BrowserAuthResult::kInconclusive, second.WaitForReply());
+}
+
+// A verdict that the peer is not our browser reaches the browser as a rejection
+// and leaves no session behind.
+TEST_F(BrowserRegistryTest, RejectsBrowserThatFailsVerification) {
+  identity_factory_->set_verification_result(
+      BrowserIdentity::VerificationResult::kRejected);
+
+  FakeBrowser browser;
+  StartAuthenticate(browser, NextConnectionId(), mojom::kProtocolVersion);
+  browser.WatchEndpoint();
+
+  EXPECT_EQ(mojom::BrowserAuthResult::kRejected, browser.WaitForReply());
+
+  // No session was created, so the handles the request carried are gone.
+  EXPECT_TRUE(browser.WaitForEndpointClosed());
+}
+
+// Not being able to tell must never read as a rejection: it reaches the browser
+// as the retryable answer, which is what keeps a browser whose image was
+// replaced mid-update from going permanently unavailable.
+TEST_F(BrowserRegistryTest, ReportsInconclusiveVerificationAsRetryable) {
+  identity_factory_->set_verification_result(
+      BrowserIdentity::VerificationResult::kInconclusive);
+
+  FakeBrowser browser;
+  StartAuthenticate(browser, NextConnectionId(), mojom::kProtocolVersion);
+  browser.WatchEndpoint();
+
+  EXPECT_EQ(mojom::BrowserAuthResult::kInconclusive, browser.WaitForReply());
+
+  // No session was created, so the handles the request carried are gone.
+  EXPECT_TRUE(browser.WaitForEndpointClosed());
+}
+
+// A refused verdict is about that one request: the connection stays usable, so
+// the same peer can authenticate afterwards.
+TEST_F(BrowserRegistryTest, AllowsAuthenticatingAfterFailedVerification) {
+  identity_factory_->set_verification_result(
+      BrowserIdentity::VerificationResult::kRejected);
+
+  const mojo::ReceiverId connection = NextConnectionId();
+  FakeBrowser first;
+  ASSERT_EQ(mojom::BrowserAuthResult::kRejected,
+            Authenticate(first, connection));
+
+  identity_factory_->set_verification_result(
+      BrowserIdentity::VerificationResult::kAccepted);
+
+  FakeBrowser second;
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(second, connection));
+}
+
+// A capture that has expired must not hold a later connection from the same
+// process to its old deadline.
+TEST_F(BrowserRegistryTest, ReconnectingAfterExpiryGetsFreshCapture) {
+  constexpr base::ProcessId kSharedPid{12345};
+
+  const mojo::ReceiverId first_connection = NextConnectionId();
+  SimulateConnect(first_connection, kSharedPid);
+
+  task_environment_.FastForwardBy(base::Minutes(5));
+
+  const mojo::ReceiverId second_connection = NextConnectionId();
+  SimulateConnect(second_connection, kSharedPid);
+
+  FakeBrowser browser;
+  EXPECT_EQ(mojom::BrowserAuthResult::kAccepted,
+            Authenticate(browser, second_connection));
 }
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/linux/browser_identity_linux.cc
+++ b/components/brave_vpn/app/v2/agent/linux/browser_identity_linux.cc
@@ -1,0 +1,75 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/browser_identity.h"
+
+#include <memory>
+#include <string>
+
+#include "base/memory/scoped_refptr.h"
+#include "base/notimplemented.h"
+#include "base/process/process_handle.h"
+#include "components/named_mojo_ipc_server/connection_info.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
+
+namespace brave_vpn::v2 {
+namespace {
+
+class BrowserIdentityLinux : public BrowserIdentity {
+ public:
+  explicit BrowserIdentityLinux(base::ProcessId pid) : pid_(pid) {}
+
+  BrowserIdentityLinux(const BrowserIdentityLinux&) = delete;
+  BrowserIdentityLinux& operator=(const BrowserIdentityLinux&) = delete;
+
+  // BrowserIdentity overrides:
+  base::ProcessId pid() const override { return pid_; }
+
+  std::string GetDescription() const override {
+    return absl::StrFormat("pid=%d", pid_);
+  }
+
+  BrowserIdentity::VerificationResult Verify() const override {
+    // TODO(https://github.com/brave/brave-browser/issues/54635)
+    // Implement the verification step on Linux.
+    NOTIMPLEMENTED() << "Identity verification is not yet implemented on Linux";
+    return VerificationResult::kAccepted;
+  }
+
+  bool IsSameProcess(const BrowserIdentity& /*other*/) const override {
+    // TODO(https://github.com/brave/brave-browser/issues/54635)
+    // Implement the comparison step on Linux: check if the process this object
+    // names is the same as the one |other| names.
+    NOTIMPLEMENTED() << "IsSameProcess is not yet implemented on Linux";
+    return true;
+  }
+
+ private:
+  ~BrowserIdentityLinux() override = default;
+
+  const base::ProcessId pid_;
+};
+
+class BrowserIdentityFactoryLinux : public BrowserIdentityFactory {
+ public:
+  // BrowserIdentityFactory overrides:
+  scoped_refptr<BrowserIdentity> Capture(
+      const named_mojo_ipc_server::ConnectionInfo& info) const override {
+    // TODO(https://github.com/brave/brave-browser/issues/54635)
+    // Implement the capture step on Linux: pin the peer process and take the
+    // platform-specific data BrowserIdentityLinux needs. Returning null here
+    // refuses the connection outright.
+    NOTIMPLEMENTED() << "Identity capture is not yet implemented on Linux";
+    return base::MakeRefCounted<BrowserIdentityLinux>(info.credentials.pid);
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<BrowserIdentityFactory> CreateBrowserIdentityFactory() {
+  return std::make_unique<BrowserIdentityFactoryLinux>();
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/linux/browser_identity_linux.cc
+++ b/components/brave_vpn/app/v2/agent/linux/browser_identity_linux.cc
@@ -5,9 +5,9 @@
 
 #include "brave/components/brave_vpn/app/v2/agent/browser_identity.h"
 
-#include <memory>
 #include <string>
 
+#include "base/functional/bind.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/notimplemented.h"
 #include "base/process/process_handle.h"
@@ -16,60 +16,42 @@
 
 namespace brave_vpn::v2 {
 namespace {
-
-class BrowserIdentityLinux : public BrowserIdentity {
- public:
-  explicit BrowserIdentityLinux(base::ProcessId pid) : pid_(pid) {}
-
-  BrowserIdentityLinux(const BrowserIdentityLinux&) = delete;
-  BrowserIdentityLinux& operator=(const BrowserIdentityLinux&) = delete;
-
-  // BrowserIdentity overrides:
-  base::ProcessId pid() const override { return pid_; }
-
-  std::string GetDescription() const override {
-    return absl::StrFormat("pid=%d", pid_);
-  }
-
-  BrowserIdentity::VerificationResult Verify() const override {
-    // TODO(https://github.com/brave/brave-browser/issues/54635)
-    // Implement the verification step on Linux.
-    NOTIMPLEMENTED() << "Identity verification is not yet implemented on Linux";
-    return VerificationResult::kAccepted;
-  }
-
-  bool IsSameProcess(const BrowserIdentity& /*other*/) const override {
-    // TODO(https://github.com/brave/brave-browser/issues/54635)
-    // Implement the comparison step on Linux: check if the process this object
-    // names is the same as the one |other| names.
-    NOTIMPLEMENTED() << "IsSameProcess is not yet implemented on Linux";
-    return true;
-  }
-
- private:
-  ~BrowserIdentityLinux() override = default;
-
-  const base::ProcessId pid_;
-};
-
-class BrowserIdentityFactoryLinux : public BrowserIdentityFactory {
- public:
-  // BrowserIdentityFactory overrides:
-  scoped_refptr<BrowserIdentity> Capture(
-      const named_mojo_ipc_server::ConnectionInfo& info) const override {
-    // TODO(https://github.com/brave/brave-browser/issues/54635)
-    // Implement the capture step on Linux: pin the peer process and take the
-    // platform-specific data BrowserIdentityLinux needs. Returning null here
-    // refuses the connection outright.
-    NOTIMPLEMENTED() << "Identity capture is not yet implemented on Linux";
-    return base::MakeRefCounted<BrowserIdentityLinux>(info.credentials.pid);
-  }
-};
-
+BrowserIdentity::VerificationResult VerifyImpl(base::ProcessId /*pid*/) {
+  // TODO(https://github.com/brave/brave-browser/issues/54635)
+  // Implement the verification step on Linux.
+  // The passed arguments are copied from the BrowserIdentity object, so this
+  // function can be posted to a thread pool and run without any other context.
+  NOTIMPLEMENTED() << "Identity verification is not yet implemented on Linux";
+  return BrowserIdentity::VerificationResult::kAccepted;
+}
 }  // namespace
 
-std::unique_ptr<BrowserIdentityFactory> CreateBrowserIdentityFactory() {
-  return std::make_unique<BrowserIdentityFactoryLinux>();
+// static
+scoped_refptr<BrowserIdentity> BrowserIdentity::Capture(
+    const named_mojo_ipc_server::ConnectionInfo& info) {
+  // TODO(https://github.com/brave/brave-browser/issues/54635)
+  // Implement the capture step on Linux: pin the peer process and take the
+  // platform-specific data BrowserIdentity needs. Returning null here refuses
+  // the connection outright.
+  NOTIMPLEMENTED() << "Identity capture is not yet implemented on Linux";
+  return base::WrapRefCounted(new BrowserIdentity(info.credentials.pid));
+}
+
+std::string BrowserIdentity::GetDescription() const {
+  return absl::StrFormat("pid=%d", pid_);
+}
+
+bool BrowserIdentity::IsSameProcess(const BrowserIdentity& /*other*/) const {
+  // TODO(https://github.com/brave/brave-browser/issues/54635)
+  // Implement the comparison step on Linux: check if the process this object
+  // names is the same as the one |other| names.
+  NOTIMPLEMENTED() << "IsSameProcess is not yet implemented on Linux";
+  return true;
+}
+
+BrowserIdentity::VerificationRequestCallback
+BrowserIdentity::BindVerificationRequest() const {
+  return base::BindOnce(&VerifyImpl, pid_);
 }
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/mac/browser_identity_mac.cc
+++ b/components/brave_vpn/app/v2/agent/mac/browser_identity_mac.cc
@@ -1,0 +1,78 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/browser_identity.h"
+
+#include <bsm/libbsm.h>
+
+#include <memory>
+#include <string>
+
+#include "base/memory/scoped_refptr.h"
+#include "base/notimplemented.h"
+#include "base/process/process_handle.h"
+#include "components/named_mojo_ipc_server/connection_info.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
+
+namespace brave_vpn::v2 {
+namespace {
+
+class BrowserIdentityMac : public BrowserIdentity {
+ public:
+  explicit BrowserIdentityMac(base::ProcessId pid) : pid_(pid) {}
+
+  BrowserIdentityMac(const BrowserIdentityMac&) = delete;
+  BrowserIdentityMac& operator=(const BrowserIdentityMac&) = delete;
+
+  // BrowserIdentity overrides:
+  base::ProcessId pid() const override { return pid_; }
+
+  std::string GetDescription() const override {
+    return absl::StrFormat("pid=%d", pid_);
+  }
+
+  BrowserIdentity::VerificationResult Verify() const override {
+    // TODO(https://github.com/brave/brave-browser/issues/54634)
+    // Implement the verification step on macOS.
+    NOTIMPLEMENTED() << "Identity verification is not yet implemented on macOS";
+    return VerificationResult::kAccepted;
+  }
+
+  bool IsSameProcess(const BrowserIdentity& /*other*/) const override {
+    // TODO(https://github.com/brave/brave-browser/issues/54634)
+    // Implement the comparison step on macOS: check if the process this object
+    // names is the same as the one |other| names.
+    NOTIMPLEMENTED() << "IsSameProcess is not yet implemented on macOS";
+    return true;
+  }
+
+ private:
+  ~BrowserIdentityMac() override = default;
+
+  const base::ProcessId pid_;
+};
+
+class BrowserIdentityFactoryMac : public BrowserIdentityFactory {
+ public:
+  // BrowserIdentityFactory overrides:
+  scoped_refptr<BrowserIdentity> Capture(
+      const named_mojo_ipc_server::ConnectionInfo& info) const override {
+    // TODO(https://github.com/brave/brave-browser/issues/54634)
+    // Implement the capture step on macOS: pin the peer process and take the
+    // platform-specific data BrowserIdentityMac needs. Returning null here
+    // refuses the connection outright.
+    NOTIMPLEMENTED() << "Identity capture is not yet implemented on macOS";
+    return base::MakeRefCounted<BrowserIdentityMac>(
+        audit_token_to_pid(info.audit_token));
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<BrowserIdentityFactory> CreateBrowserIdentityFactory() {
+  return std::make_unique<BrowserIdentityFactoryMac>();
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/mac/browser_identity_mac.cc
+++ b/components/brave_vpn/app/v2/agent/mac/browser_identity_mac.cc
@@ -7,9 +7,9 @@
 
 #include <bsm/libbsm.h>
 
-#include <memory>
 #include <string>
 
+#include "base/functional/bind.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/notimplemented.h"
 #include "base/process/process_handle.h"
@@ -18,61 +18,43 @@
 
 namespace brave_vpn::v2 {
 namespace {
-
-class BrowserIdentityMac : public BrowserIdentity {
- public:
-  explicit BrowserIdentityMac(base::ProcessId pid) : pid_(pid) {}
-
-  BrowserIdentityMac(const BrowserIdentityMac&) = delete;
-  BrowserIdentityMac& operator=(const BrowserIdentityMac&) = delete;
-
-  // BrowserIdentity overrides:
-  base::ProcessId pid() const override { return pid_; }
-
-  std::string GetDescription() const override {
-    return absl::StrFormat("pid=%d", pid_);
-  }
-
-  BrowserIdentity::VerificationResult Verify() const override {
-    // TODO(https://github.com/brave/brave-browser/issues/54634)
-    // Implement the verification step on macOS.
-    NOTIMPLEMENTED() << "Identity verification is not yet implemented on macOS";
-    return VerificationResult::kAccepted;
-  }
-
-  bool IsSameProcess(const BrowserIdentity& /*other*/) const override {
-    // TODO(https://github.com/brave/brave-browser/issues/54634)
-    // Implement the comparison step on macOS: check if the process this object
-    // names is the same as the one |other| names.
-    NOTIMPLEMENTED() << "IsSameProcess is not yet implemented on macOS";
-    return true;
-  }
-
- private:
-  ~BrowserIdentityMac() override = default;
-
-  const base::ProcessId pid_;
-};
-
-class BrowserIdentityFactoryMac : public BrowserIdentityFactory {
- public:
-  // BrowserIdentityFactory overrides:
-  scoped_refptr<BrowserIdentity> Capture(
-      const named_mojo_ipc_server::ConnectionInfo& info) const override {
-    // TODO(https://github.com/brave/brave-browser/issues/54634)
-    // Implement the capture step on macOS: pin the peer process and take the
-    // platform-specific data BrowserIdentityMac needs. Returning null here
-    // refuses the connection outright.
-    NOTIMPLEMENTED() << "Identity capture is not yet implemented on macOS";
-    return base::MakeRefCounted<BrowserIdentityMac>(
-        audit_token_to_pid(info.audit_token));
-  }
-};
-
+BrowserIdentity::VerificationResult VerifyImpl(base::ProcessId /*pid*/) {
+  // TODO(https://github.com/brave/brave-browser/issues/54634)
+  // Implement the verification step on macOS.
+  // The passed arguments are copied from the BrowserIdentity object, so this
+  // function can be posted to a thread pool and run without any other context.
+  NOTIMPLEMENTED() << "Identity verification is not yet implemented on macOS";
+  return BrowserIdentity::VerificationResult::kAccepted;
+}
 }  // namespace
 
-std::unique_ptr<BrowserIdentityFactory> CreateBrowserIdentityFactory() {
-  return std::make_unique<BrowserIdentityFactoryMac>();
+// static
+scoped_refptr<BrowserIdentity> BrowserIdentity::Capture(
+    const named_mojo_ipc_server::ConnectionInfo& info) {
+  // TODO(https://github.com/brave/brave-browser/issues/54634)
+  // Implement the capture step on macOS: pin the peer process and take the
+  // platform-specific data BrowserIdentity needs. Returning null here refuses
+  // the connection outright.
+  NOTIMPLEMENTED() << "Identity capture is not yet implemented on macOS";
+  return base::WrapRefCounted(
+      new BrowserIdentity(audit_token_to_pid(info.audit_token)));
+}
+
+std::string BrowserIdentity::GetDescription() const {
+  return absl::StrFormat("pid=%d", pid_);
+}
+
+bool BrowserIdentity::IsSameProcess(const BrowserIdentity& /*other*/) const {
+  // TODO(https://github.com/brave/brave-browser/issues/54634)
+  // Implement the comparison step on macOS: check if the process this object
+  // names is the same as the one |other| names.
+  NOTIMPLEMENTED() << "IsSameProcess is not yet implemented on macOS";
+  return true;
+}
+
+BrowserIdentity::VerificationRequestCallback
+BrowserIdentity::BindVerificationRequest() const {
+  return base::BindOnce(&VerifyImpl, pid_);
 }
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/test/fake_browser_identity.cc
+++ b/components/brave_vpn/app/v2/agent/test/fake_browser_identity.cc
@@ -1,0 +1,70 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/test/fake_browser_identity.h"
+
+#include <string>
+#include <utility>
+
+#include "base/memory/scoped_refptr.h"
+#include "base/process/process_handle.h"
+#include "brave/components/brave_vpn/app/v2/agent/browser_identity.h"
+#include "components/named_mojo_ipc_server/connection_info.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
+
+namespace brave_vpn::v2 {
+namespace {
+
+class FakeBrowserIdentity : public BrowserIdentity {
+ public:
+  FakeBrowserIdentity(base::ProcessId pid,
+                      scoped_refptr<FakeBrowserIdentitySettings> settings)
+      : pid_(pid), settings_(std::move(settings)) {}
+
+  FakeBrowserIdentity(const FakeBrowserIdentity&) = delete;
+  FakeBrowserIdentity& operator=(const FakeBrowserIdentity&) = delete;
+
+  // BrowserIdentity overrides:
+  base::ProcessId pid() const override { return pid_; }
+
+  std::string GetDescription() const override {
+    return absl::StrFormat("fake pid=%d", static_cast<int>(pid_));
+  }
+
+  VerificationResult Verify() const override {
+    return settings_->verification_result();
+  }
+
+  bool IsSameProcess(const BrowserIdentity& /*other*/) const override {
+    return settings_->is_same_process();
+  }
+
+ private:
+  ~FakeBrowserIdentity() override = default;
+
+  const base::ProcessId pid_;
+  const scoped_refptr<FakeBrowserIdentitySettings> settings_;
+};
+
+}  // namespace
+
+FakeBrowserIdentitySettings::FakeBrowserIdentitySettings() = default;
+
+FakeBrowserIdentitySettings::~FakeBrowserIdentitySettings() = default;
+
+FakeBrowserIdentityFactory::FakeBrowserIdentityFactory()
+    : settings_(base::MakeRefCounted<FakeBrowserIdentitySettings>()) {}
+
+FakeBrowserIdentityFactory::~FakeBrowserIdentityFactory() = default;
+
+scoped_refptr<BrowserIdentity> FakeBrowserIdentityFactory::Capture(
+    const named_mojo_ipc_server::ConnectionInfo& /*info*/) const {
+  if (capture_fails_) {
+    return nullptr;
+  }
+  return base::MakeRefCounted<FakeBrowserIdentity>(peer_pid_, settings_);
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/test/fake_browser_identity.cc
+++ b/components/brave_vpn/app/v2/agent/test/fake_browser_identity.cc
@@ -8,63 +8,40 @@
 #include <string>
 #include <utility>
 
-#include "base/memory/scoped_refptr.h"
+#include "base/check.h"
+#include "base/functional/bind.h"
+#include "base/location.h"
 #include "base/process/process_handle.h"
+#include "base/task/sequenced_task_runner.h"
 #include "brave/components/brave_vpn/app/v2/agent/browser_identity.h"
-#include "components/named_mojo_ipc_server/connection_info.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
 
 namespace brave_vpn::v2 {
-namespace {
 
-class FakeBrowserIdentity : public BrowserIdentity {
- public:
-  FakeBrowserIdentity(base::ProcessId pid,
-                      scoped_refptr<FakeBrowserIdentitySettings> settings)
-      : pid_(pid), settings_(std::move(settings)) {}
+FakeBrowserIdentity::FakeBrowserIdentity(
+    base::ProcessId pid,
+    FakeVerificationResultProvider result_provider,
+    bool is_same_process)
+    : BrowserIdentity(pid),
+      verification_result_(std::move(result_provider)),
+      is_same_process_(is_same_process) {}
 
-  FakeBrowserIdentity(const FakeBrowserIdentity&) = delete;
-  FakeBrowserIdentity& operator=(const FakeBrowserIdentity&) = delete;
+FakeBrowserIdentity::~FakeBrowserIdentity() = default;
 
-  // BrowserIdentity overrides:
-  base::ProcessId pid() const override { return pid_; }
+std::string FakeBrowserIdentity::GetDescription() const {
+  return absl::StrFormat("fake pid=%d", static_cast<int>(pid()));
+}
 
-  std::string GetDescription() const override {
-    return absl::StrFormat("fake pid=%d", static_cast<int>(pid_));
-  }
+bool FakeBrowserIdentity::IsSameProcess(
+    const BrowserIdentity& /*other*/) const {
+  return is_same_process_;
+}
 
-  VerificationResult Verify() const override {
-    return settings_->verification_result();
-  }
-
-  bool IsSameProcess(const BrowserIdentity& /*other*/) const override {
-    return settings_->is_same_process();
-  }
-
- private:
-  ~FakeBrowserIdentity() override = default;
-
-  const base::ProcessId pid_;
-  const scoped_refptr<FakeBrowserIdentitySettings> settings_;
-};
-
-}  // namespace
-
-FakeBrowserIdentitySettings::FakeBrowserIdentitySettings() = default;
-
-FakeBrowserIdentitySettings::~FakeBrowserIdentitySettings() = default;
-
-FakeBrowserIdentityFactory::FakeBrowserIdentityFactory()
-    : settings_(base::MakeRefCounted<FakeBrowserIdentitySettings>()) {}
-
-FakeBrowserIdentityFactory::~FakeBrowserIdentityFactory() = default;
-
-scoped_refptr<BrowserIdentity> FakeBrowserIdentityFactory::Capture(
-    const named_mojo_ipc_server::ConnectionInfo& /*info*/) const {
-  if (capture_fails_) {
-    return nullptr;
-  }
-  return base::MakeRefCounted<FakeBrowserIdentity>(peer_pid_, settings_);
+void FakeBrowserIdentity::Verify(VerificationResponseCallback callback) const {
+  CHECK(callback);
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE,
+      base::BindOnce(std::move(callback), verification_result_.Run()));
 }
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/test/fake_browser_identity.h
+++ b/components/brave_vpn/app/v2/agent/test/fake_browser_identity.h
@@ -1,0 +1,86 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_TEST_FAKE_BROWSER_IDENTITY_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_TEST_FAKE_BROWSER_IDENTITY_H_
+
+#include <atomic>
+
+#include "base/memory/ref_counted.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/process/process_handle.h"
+#include "brave/components/brave_vpn/app/v2/agent/browser_identity.h"
+
+namespace named_mojo_ipc_server {
+struct ConnectionInfo;
+}  // namespace named_mojo_ipc_server
+
+namespace brave_vpn::v2 {
+
+// FakeBrowserIdentitySettings encapsulates the answers the fake identities
+// give, shared by the factory and every identity it has handed out. Setting one
+// changes what an identity the registry is already holding will answer next.
+class FakeBrowserIdentitySettings
+    : public base::RefCountedThreadSafe<FakeBrowserIdentitySettings> {
+ public:
+  FakeBrowserIdentitySettings();
+
+  FakeBrowserIdentitySettings(const FakeBrowserIdentitySettings&) = delete;
+  FakeBrowserIdentitySettings& operator=(const FakeBrowserIdentitySettings&) =
+      delete;
+
+  BrowserIdentity::VerificationResult verification_result() const {
+    return verification_result_.load(std::memory_order_relaxed);
+  }
+  void set_verification_result(BrowserIdentity::VerificationResult result) {
+    verification_result_.store(result, std::memory_order_relaxed);
+  }
+
+  bool is_same_process() const {
+    return is_same_process_.load(std::memory_order_relaxed);
+  }
+  void set_is_same_process(bool same) {
+    is_same_process_.store(same, std::memory_order_relaxed);
+  }
+
+ private:
+  friend class base::RefCountedThreadSafe<FakeBrowserIdentitySettings>;
+
+  ~FakeBrowserIdentitySettings();
+
+  std::atomic<BrowserIdentity::VerificationResult> verification_result_{
+      BrowserIdentity::VerificationResult::kAccepted};
+  std::atomic<bool> is_same_process_{true};
+};
+
+// FakeBrowserIdentityFactory creates a fake identity which describes whatever
+// peer the test says is connecting. ConnectionInfo is never read, which is the
+// point: a test can name any pid and choose any verdict without fabricating the
+// kernel credentials each platform carries them in.
+class FakeBrowserIdentityFactory : public BrowserIdentityFactory {
+ public:
+  FakeBrowserIdentityFactory();
+  ~FakeBrowserIdentityFactory() override;
+
+  void set_peer_pid(base::ProcessId pid) { peer_pid_ = pid; }
+  void set_capture_fails(bool fails) { capture_fails_ = fails; }
+  void set_verification_result(BrowserIdentity::VerificationResult result) {
+    settings_->set_verification_result(result);
+  }
+  void set_is_same_process(bool same) { settings_->set_is_same_process(same); }
+
+  // BrowserIdentityFactory overrides:
+  scoped_refptr<BrowserIdentity> Capture(
+      const named_mojo_ipc_server::ConnectionInfo& info) const override;
+
+ private:
+  const scoped_refptr<FakeBrowserIdentitySettings> settings_;
+  base::ProcessId peer_pid_ = 1234;
+  bool capture_fails_ = false;
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_TEST_FAKE_BROWSER_IDENTITY_H_

--- a/components/brave_vpn/app/v2/agent/test/fake_browser_identity.h
+++ b/components/brave_vpn/app/v2/agent/test/fake_browser_identity.h
@@ -6,79 +6,37 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_TEST_FAKE_BROWSER_IDENTITY_H_
 #define BRAVE_COMPONENTS_BRAVE_VPN_APP_V2_AGENT_TEST_FAKE_BROWSER_IDENTITY_H_
 
-#include <atomic>
+#include <string>
 
-#include "base/memory/ref_counted.h"
-#include "base/memory/scoped_refptr.h"
+#include "base/functional/callback.h"
 #include "base/process/process_handle.h"
 #include "brave/components/brave_vpn/app/v2/agent/browser_identity.h"
 
-namespace named_mojo_ipc_server {
-struct ConnectionInfo;
-}  // namespace named_mojo_ipc_server
-
 namespace brave_vpn::v2 {
 
-// FakeBrowserIdentitySettings encapsulates the answers the fake identities
-// give, shared by the factory and every identity it has handed out. Setting one
-// changes what an identity the registry is already holding will answer next.
-class FakeBrowserIdentitySettings
-    : public base::RefCountedThreadSafe<FakeBrowserIdentitySettings> {
- public:
-  FakeBrowserIdentitySettings();
-
-  FakeBrowserIdentitySettings(const FakeBrowserIdentitySettings&) = delete;
-  FakeBrowserIdentitySettings& operator=(const FakeBrowserIdentitySettings&) =
-      delete;
-
-  BrowserIdentity::VerificationResult verification_result() const {
-    return verification_result_.load(std::memory_order_relaxed);
-  }
-  void set_verification_result(BrowserIdentity::VerificationResult result) {
-    verification_result_.store(result, std::memory_order_relaxed);
-  }
-
-  bool is_same_process() const {
-    return is_same_process_.load(std::memory_order_relaxed);
-  }
-  void set_is_same_process(bool same) {
-    is_same_process_.store(same, std::memory_order_relaxed);
-  }
-
- private:
-  friend class base::RefCountedThreadSafe<FakeBrowserIdentitySettings>;
-
-  ~FakeBrowserIdentitySettings();
-
-  std::atomic<BrowserIdentity::VerificationResult> verification_result_{
-      BrowserIdentity::VerificationResult::kAccepted};
-  std::atomic<bool> is_same_process_{true};
-};
-
-// FakeBrowserIdentityFactory creates a fake identity which describes whatever
+// FakeBrowserIdentity is a fake identity which describes whatever
 // peer the test says is connecting. ConnectionInfo is never read, which is the
 // point: a test can name any pid and choose any verdict without fabricating the
 // kernel credentials each platform carries them in.
-class FakeBrowserIdentityFactory : public BrowserIdentityFactory {
+class FakeBrowserIdentity : public BrowserIdentity {
  public:
-  FakeBrowserIdentityFactory();
-  ~FakeBrowserIdentityFactory() override;
+  using FakeVerificationResultProvider =
+      base::RepeatingCallback<BrowserIdentity::VerificationResult()>;
 
-  void set_peer_pid(base::ProcessId pid) { peer_pid_ = pid; }
-  void set_capture_fails(bool fails) { capture_fails_ = fails; }
-  void set_verification_result(BrowserIdentity::VerificationResult result) {
-    settings_->set_verification_result(result);
-  }
-  void set_is_same_process(bool same) { settings_->set_is_same_process(same); }
+  FakeBrowserIdentity(base::ProcessId pid,
+                      FakeVerificationResultProvider result_provider,
+                      bool is_same_process);
 
-  // BrowserIdentityFactory overrides:
-  scoped_refptr<BrowserIdentity> Capture(
-      const named_mojo_ipc_server::ConnectionInfo& info) const override;
+  // BrowserIdentity overrides:
+  std::string GetDescription() const override;
+  bool IsSameProcess(const BrowserIdentity& other) const override;
+  void Verify(VerificationResponseCallback callback) const override;
 
  private:
-  const scoped_refptr<FakeBrowserIdentitySettings> settings_;
-  base::ProcessId peer_pid_ = 1234;
-  bool capture_fails_ = false;
+  ~FakeBrowserIdentity() override;
+
+  FakeVerificationResultProvider verification_result_;
+  bool is_same_process_;
 };
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/win/browser_identity_win.cc
+++ b/components/brave_vpn/app/v2/agent/win/browser_identity_win.cc
@@ -1,0 +1,76 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/app/v2/agent/browser_identity.h"
+
+#include <memory>
+#include <string>
+
+#include "base/memory/scoped_refptr.h"
+#include "base/notimplemented.h"
+#include "base/process/process_handle.h"
+#include "components/named_mojo_ipc_server/connection_info.h"
+#include "third_party/abseil-cpp/absl/strings/str_format.h"
+
+namespace brave_vpn::v2 {
+namespace {
+
+class BrowserIdentityWin : public BrowserIdentity {
+ public:
+  explicit BrowserIdentityWin(base::ProcessId pid) : pid_(pid) {}
+
+  BrowserIdentityWin(const BrowserIdentityWin&) = delete;
+  BrowserIdentityWin& operator=(const BrowserIdentityWin&) = delete;
+
+  // BrowserIdentity overrides:
+  base::ProcessId pid() const override { return pid_; }
+
+  std::string GetDescription() const override {
+    return absl::StrFormat("pid=%lu", static_cast<unsigned long>(pid_));
+  }
+
+  BrowserIdentity::VerificationResult Verify() const override {
+    // TODO(https://github.com/brave/brave-browser/issues/54633)
+    // Implement the verification step on Windows.
+    NOTIMPLEMENTED()
+        << "Identity verification is not yet implemented on Windows";
+    return VerificationResult::kAccepted;
+  }
+
+  bool IsSameProcess(const BrowserIdentity& /*other*/) const override {
+    // TODO(https://github.com/brave/brave-browser/issues/54633)
+    // Implement the comparison step on Windows: check if the process this
+    // object names is the same as the one |other| names.
+    NOTIMPLEMENTED() << "IsSameProcess is not yet implemented on Windows";
+    return true;
+  }
+
+ private:
+  ~BrowserIdentityWin() override = default;
+
+  const base::ProcessId pid_;
+};
+
+class BrowserIdentityFactoryWin : public BrowserIdentityFactory {
+ public:
+  // BrowserIdentityFactory overrides:
+  scoped_refptr<BrowserIdentity> Capture(
+      const named_mojo_ipc_server::ConnectionInfo& info) const override {
+    // TODO(https://github.com/brave/brave-browser/issues/54633)
+    // Implement the capture step on Windows: pin the peer process and take the
+    // platform-specific data BrowserIdentityWin needs. Returning null here
+    // refuses the connection outright.
+    NOTIMPLEMENTED() << "Identity capture is not yet implemented on Windows";
+    return base::MakeRefCounted<BrowserIdentityWin>(info.pid);
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<BrowserIdentityFactory> CreateBrowserIdentityFactory() {
+  return std::make_unique<BrowserIdentityFactoryWin>();
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/app/v2/agent/win/browser_identity_win.cc
+++ b/components/brave_vpn/app/v2/agent/win/browser_identity_win.cc
@@ -5,9 +5,9 @@
 
 #include "brave/components/brave_vpn/app/v2/agent/browser_identity.h"
 
-#include <memory>
 #include <string>
 
+#include "base/functional/bind.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/notimplemented.h"
 #include "base/process/process_handle.h"
@@ -16,61 +16,42 @@
 
 namespace brave_vpn::v2 {
 namespace {
-
-class BrowserIdentityWin : public BrowserIdentity {
- public:
-  explicit BrowserIdentityWin(base::ProcessId pid) : pid_(pid) {}
-
-  BrowserIdentityWin(const BrowserIdentityWin&) = delete;
-  BrowserIdentityWin& operator=(const BrowserIdentityWin&) = delete;
-
-  // BrowserIdentity overrides:
-  base::ProcessId pid() const override { return pid_; }
-
-  std::string GetDescription() const override {
-    return absl::StrFormat("pid=%lu", static_cast<unsigned long>(pid_));
-  }
-
-  BrowserIdentity::VerificationResult Verify() const override {
-    // TODO(https://github.com/brave/brave-browser/issues/54633)
-    // Implement the verification step on Windows.
-    NOTIMPLEMENTED()
-        << "Identity verification is not yet implemented on Windows";
-    return VerificationResult::kAccepted;
-  }
-
-  bool IsSameProcess(const BrowserIdentity& /*other*/) const override {
-    // TODO(https://github.com/brave/brave-browser/issues/54633)
-    // Implement the comparison step on Windows: check if the process this
-    // object names is the same as the one |other| names.
-    NOTIMPLEMENTED() << "IsSameProcess is not yet implemented on Windows";
-    return true;
-  }
-
- private:
-  ~BrowserIdentityWin() override = default;
-
-  const base::ProcessId pid_;
-};
-
-class BrowserIdentityFactoryWin : public BrowserIdentityFactory {
- public:
-  // BrowserIdentityFactory overrides:
-  scoped_refptr<BrowserIdentity> Capture(
-      const named_mojo_ipc_server::ConnectionInfo& info) const override {
-    // TODO(https://github.com/brave/brave-browser/issues/54633)
-    // Implement the capture step on Windows: pin the peer process and take the
-    // platform-specific data BrowserIdentityWin needs. Returning null here
-    // refuses the connection outright.
-    NOTIMPLEMENTED() << "Identity capture is not yet implemented on Windows";
-    return base::MakeRefCounted<BrowserIdentityWin>(info.pid);
-  }
-};
-
+BrowserIdentity::VerificationResult VerifyImpl(base::ProcessId /*pid*/) {
+  // TODO(https://github.com/brave/brave-browser/issues/54633)
+  // Implement the verification step on Windows.
+  // The passed arguments are copied from the BrowserIdentity object, so this
+  // function can be posted to a thread pool and run without any other context.
+  NOTIMPLEMENTED() << "Identity verification is not yet implemented on Windows";
+  return BrowserIdentity::VerificationResult::kAccepted;
+}
 }  // namespace
 
-std::unique_ptr<BrowserIdentityFactory> CreateBrowserIdentityFactory() {
-  return std::make_unique<BrowserIdentityFactoryWin>();
+// static
+scoped_refptr<BrowserIdentity> BrowserIdentity::Capture(
+    const named_mojo_ipc_server::ConnectionInfo& info) {
+  // TODO(https://github.com/brave/brave-browser/issues/54633)
+  // Implement the capture step on Windows: pin the peer process and take the
+  // platform-specific data BrowserIdentity needs. Returning null here refuses
+  // the connection outright.
+  NOTIMPLEMENTED() << "Identity capture is not yet implemented on Windows";
+  return base::WrapRefCounted(new BrowserIdentity(info.pid));
+}
+
+std::string BrowserIdentity::GetDescription() const {
+  return absl::StrFormat("pid=%lu", static_cast<unsigned long>(pid_));
+}
+
+bool BrowserIdentity::IsSameProcess(const BrowserIdentity& /*other*/) const {
+  // TODO(https://github.com/brave/brave-browser/issues/54633)
+  // Implement the comparison step on Windows: check if the process this object
+  // names is the same as the one |other| names.
+  NOTIMPLEMENTED() << "IsSameProcess is not yet implemented on Windows";
+  return true;
+}
+
+BrowserIdentity::VerificationRequestCallback
+BrowserIdentity::BindVerificationRequest() const {
+  return base::BindOnce(&VerifyImpl, pid_);
 }
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/agent_client.cc
+++ b/components/brave_vpn/browser/v2/agent_client.cc
@@ -265,6 +265,14 @@ void AgentClient::OnAuthResult(mojom::BrowserAuthResult result) {
       observers_.Notify(&Observer::OnAgentConnected);
       return;
 
+    case mojom::BrowserAuthResult::kInconclusive:
+      // The agent couldn't determine whether this browser is Brave: its image
+      // was replaced mid-update, a signing cert rotated, the accept-time
+      // capture expired. None is a verdict about this binary, and a fresh
+      // connection may well succeed.
+      TeardownAndRetry("agent could not verify this browser");
+      return;
+
     case mojom::BrowserAuthResult::kVersionMismatch:
       // The agent accepts a range ending at the version it was built with, so
       // this is usually a browser that updated ahead of the agent it is talking

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
@@ -43,6 +43,8 @@ std::string_view BrowserAuthResultToString(
       return "version mismatch";
     case mojom::BrowserAuthResult::kHostAlreadyRequested:
       return "host already requested";
+    case mojom::BrowserAuthResult::kInconclusive:
+      return "inconclusive";
   }
 }
 

--- a/components/brave_vpn/common/mojom/browser_agent.mojom
+++ b/components/brave_vpn/common/mojom/browser_agent.mojom
@@ -26,6 +26,7 @@ enum BrowserAuthResult {
   kRejected,
   kVersionMismatch,
   kHostAlreadyRequested,
+  kInconclusive,
 };
 
 // The browser's connection to the agent, and the only interface reachable on


### PR DESCRIPTION
Two-phase authentication for deciding whether a connecting browser is really Brave. `BrowserIdentity` is captured in `OnBrowserConnecting()`, which is cheap and runs on the IPC sequence, and verified in `Authenticate()` on a blocking pool. Capturing at accept time is what keeps the verified process the same one that connected: a pid names a process only while it lives.

`BrowserIdentityFactory` is the only entity that reads a `ConnectionInfo`, so `BrowserRegistry` stays platform-neutral and tests can describe a peer without fabricating kernel credentials. Captures are keyed by pid, expire after 10s, and are kept while sibling profile connections are still waiting to dispatch.

Verification is tri-state: "inconclusive" keeps a browser whose image was replaced mid-update from being treated as a rejection, so it retries instead of going permanently unavailable.

`Capture()`, `Verify()` and `IsSameProcess()` are stubbed per platform and accept every local peer, so this changes no behaviour on its own.

Implements part of https://github.com/brave/brave-browser/issues/54623

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
