### PR TITLE
Fix renderer kill on <fencedframe> creation with kFencedFrames disabled

### DIFF
--- a/browser/test/BUILD.gn
+++ b/browser/test/BUILD.gn
@@ -9,6 +9,7 @@ source_set("browser_tests") {
 
   sources = [
     "disabled_features/disable_client_hints_browsertest.cc",
+    "disabled_features/fenced_frame_browsertest.cc",
     "disabled_features/navigator_battery_browsertest.cc",
     "disabled_features/navigator_bluetooth_browsertest.cc",
     "disabled_features/navigator_storage_browsertest.cc",

--- a/browser/test/disabled_features/fenced_frame_browsertest.cc
+++ b/browser/test/disabled_features/fenced_frame_browsertest.cc
@@ -1,0 +1,35 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "url/gurl.h"
+
+class FencedFrameDisabledTest : public InProcessBrowserTest {};
+
+IN_PROC_BROWSER_TEST_F(FencedFrameDisabledTest,
+                       CreatingFencedFrameDoesNotKillTab) {
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), GURL("data:text/html,<body></body>")));
+  content::WebContents* contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+  ASSERT_TRUE(content::WaitForLoadStop(contents));
+
+  EXPECT_EQ(true, content::EvalJs(
+                      contents,
+                      "new Promise(resolve => {"
+                      "  document.body.appendChild("
+                      "      document.createElement('fencedframe'));"
+                      "  setTimeout(() => resolve("
+                      "      !!document.querySelector('fencedframe')), 1000);"
+                      "})"));
+
+  EXPECT_FALSE(contents->IsCrashed());
+  EXPECT_EQ(4, content::EvalJs(contents, "2 + 2"));
+}

--- a/patches/third_party-blink-renderer-platform-runtime_enabled_features.json5.patch
+++ b/patches/third_party-blink-renderer-platform-runtime_enabled_features.json5.patch
@@ -1,5 +1,5 @@
 diff --git a/third_party/blink/renderer/platform/runtime_enabled_features.json5 b/third_party/blink/renderer/platform/runtime_enabled_features.json5
-index 36b777784f45f99e198ee531293df11ee8cd0388..bd644045f859ccb39063baf4959052c19ac99480 100644
+index 36b777784f45f99e198ee531293df11ee8cd0388..0e8356be3679300536ca8894d1b89e9a1a77e2c9 100644
 --- a/third_party/blink/renderer/platform/runtime_enabled_features.json5
 +++ b/third_party/blink/renderer/platform/runtime_enabled_features.json5
 @@ -297,6 +297,7 @@
@@ -78,7 +78,17 @@ index 36b777784f45f99e198ee531293df11ee8cd0388..bd644045f859ccb39063baf4959052c1
        public: true,
        status: "stable",
      },
-@@ -2948,6 +2953,7 @@
+@@ -2847,7 +2852,8 @@
+     },
+     {
+       name: "FencedFrames",
+-      base_feature: "none",
++      base_feature_status: "disabled",  // feature state is enforced via plaster rewrite.
++      base_feature: "FencedFramesRuntime",
+       // This helps enable and expose the <fencedframe> element, but note that
+       // blink::features::kFencedFrames must be enabled as well, as we require
+       // the support of the browser process to fully enable the feature.
+@@ -2948,6 +2954,7 @@
      {
        // In-development features for the File System Access API.
        name: "FileSystemAccessAPIExperimental",
@@ -86,7 +96,7 @@ index 36b777784f45f99e198ee531293df11ee8cd0388..bd644045f859ccb39063baf4959052c1
        status: "experimental",
      },
      {
-@@ -2962,6 +2968,7 @@
+@@ -2962,6 +2969,7 @@
      {
        // Non-OPFS File System Access API.
        name: "FileSystemAccessLocal",
@@ -94,7 +104,7 @@ index 36b777784f45f99e198ee531293df11ee8cd0388..bd644045f859ccb39063baf4959052c1
        status: {"default": "stable"},
      },
      {
-@@ -3080,6 +3087,7 @@
+@@ -3080,6 +3088,7 @@
      },
      {
        name: "Fledge",
@@ -102,7 +112,7 @@ index 36b777784f45f99e198ee531293df11ee8cd0388..bd644045f859ccb39063baf4959052c1
        status: "stable",
        public: true,
      },
-@@ -3791,7 +3799,7 @@
+@@ -3791,7 +3800,7 @@
          "Android": "test",
          "default": "",
        },
@@ -111,7 +121,7 @@ index 36b777784f45f99e198ee531293df11ee8cd0388..bd644045f859ccb39063baf4959052c1
        copied_from_base_feature_if: "overridden",
      },
      {
-@@ -4149,6 +4157,7 @@
+@@ -4149,6 +4158,7 @@
      // "experimental" is the support on other platforms.
      {
        name: "MiddleClickAutoscroll",
@@ -119,7 +129,7 @@ index 36b777784f45f99e198ee531293df11ee8cd0388..bd644045f859ccb39063baf4959052c1
        status: "test",
      },
      // Killswitch for crbug.com/40062462 fix.
-@@ -4620,6 +4629,7 @@
+@@ -4620,6 +4630,7 @@
      {
        // PARAKEET ad serving runtime flag/JS API.
        name: "Parakeet",
@@ -127,7 +137,7 @@ index 36b777784f45f99e198ee531293df11ee8cd0388..bd644045f859ccb39063baf4959052c1
        origin_trial_feature_name: "Parakeet",
      },
      {
-@@ -4792,6 +4802,7 @@
+@@ -4792,6 +4803,7 @@
        //
        // It also has some feature params defined throughout the codebase.
        name: "Prerender2",
@@ -135,7 +145,7 @@ index 36b777784f45f99e198ee531293df11ee8cd0388..bd644045f859ccb39063baf4959052c1
        status: "stable",
      },
      {
-@@ -5023,6 +5034,7 @@
+@@ -5023,6 +5035,7 @@
      // but we still keep this flag for future phase tests.
      {
        name: "ReduceUserAgentMinorVersion",
@@ -143,7 +153,7 @@ index 36b777784f45f99e198ee531293df11ee8cd0388..bd644045f859ccb39063baf4959052c1
        status: "stable",
      },
      {
-@@ -6440,7 +6452,7 @@
+@@ -6440,7 +6453,7 @@
          "ChromeOS": "stable",
          "default": "",
        },
@@ -152,7 +162,7 @@ index 36b777784f45f99e198ee531293df11ee8cd0388..bd644045f859ccb39063baf4959052c1
        copied_from_base_feature_if: "overridden",
      },
      {
-@@ -6615,6 +6627,7 @@
+@@ -6615,6 +6628,7 @@
      },
      {
        name: "UserMediaElement",
@@ -160,7 +170,7 @@ index 36b777784f45f99e198ee531293df11ee8cd0388..bd644045f859ccb39063baf4959052c1
        status: "stable",
        public: true,
      },
-@@ -7420,5 +7433,10 @@
+@@ -7420,5 +7434,10 @@
        // crbug.com/435623334.
        name: "XSLTSpecialTrial",
      },

--- a/renderer/brave_content_renderer_client.cc
+++ b/renderer/brave_content_renderer_client.cc
@@ -124,6 +124,8 @@ void BraveContentRendererClient::
       SetRuntimeFeaturesDefaultsBeforeBlinkInitialization();
 
   blink::WebRuntimeFeatures::EnableFledge(false);
+  // Disable the fenced frames API; kFencedFrames is disabled browser-side.
+  blink::WebRuntimeFeatures::EnableFencedFrames(false);
   // Disable topics APIs because kBrowsingTopics feature is disabled
   blink::WebRuntimeFeatures::EnableTopicsAPI(false);
   blink::WebRuntimeFeatures::EnableWebGPUExperimentalFeatures(false);

--- a/rewrite/third_party/blink/renderer/platform/runtime_enabled_features.json5.yaml
+++ b/rewrite/third_party/blink/renderer/platform/runtime_enabled_features.json5.yaml
@@ -53,6 +53,16 @@ substitutions:
       re_flags: [MULTILINE]
       replace: '\1\2\n\1base_feature: "none",'
 
+  # FencedFrames declares `base_feature: "none"` upstream, so the runtime flag
+  # has no backing `base::Feature` and its state cannot be forced. Give it one
+  # (a generated `kFencedFramesRuntime`, not the manual `kFencedFrames` in
+  # third_party/blink/common/features.cc, which would collide) so the disabled
+  # state below is synced into the runtime flag at startup.
+  - description: 'Give FencedFrames a backing base::Feature.'
+    regex:
+      re_pattern: '(name: "FencedFrames",\n *)base_feature: "none",'
+      replace: '\1base_feature: "FencedFramesRuntime",'
+
   # These plaster override the `base::Feature` value for the blink runtime
   # features. Keep them in alphabetical order.
   - description: 'Ship the interest-group ad-targeting API disabled.'
@@ -98,6 +108,11 @@ substitutions:
   - description: 'Ship the Protected Audience ad auction API disabled.'
     set_blink_runtime_enabled_feature_state:
       feature_name: Fledge
+      value: disabled
+
+  - description: 'Ship the fenced frames API disabled.'
+    set_blink_runtime_enabled_feature_state:
+      feature_name: FencedFrames
       value: disabled
 
   - description: "Ship the Language Detection API's base feature disabled."


### PR DESCRIPTION
 disables the Fenced Frames API at the Blink renderer level.

**What changed:**

- `renderer/brave_content_renderer_client.cc` — calls `EnableFencedFrames(false)` at renderer startup, same pattern as `EnableFledge(false)`

- `rewrite/...runtime_enabled_features.json5.yaml` — two new plaster rules:
  1. Gives `FencedFrames` a backing `base::Feature` (`kFencedFramesRuntime`) — upstream declares `base_feature: "none"`, meaning no feature flag exists to force its state
  2. Sets that feature to `disabled` so the runtime flag is synced off at startup

- `patches/...runtime_enabled_features.json5.patch` — updated patch reflects the new `base_feature` + `base_feature_status: "disabled"` in the upstream JSON5

- `browser/test/disabled_features/fenced_frame_browsertest.cc` (new) — browser test confirming `<fencedframe>` element can be created without crashing the tab

**Why:** Upstream `FencedFrames` had `base_feature: "none"`, so disabling `kFencedFrames` (browser-side) wasn't enough to suppress the renderer-side runtime flag. PR adds a generated backing feature (`kFencedFramesRuntime`) so the disabled state can be enforced end-to-end.

Repro: https://trustsig.eu/blog/slack-devenv-remote-debugging-port/