### PR TITLE
feat(ci): close PRs with incomplete template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -136,6 +136,10 @@ android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java
 /.github/CODEOWNERS @brave/codeowners
 /.github/PULL_REQUEST_TEMPLATE.md @bsclifton
 
+# PR template auto-close bot (auto-closes external PRs, needs security review)
+/.github/workflows/check-prs.yml @brave/devops-team @brave/sec-team
+/script/check_pr_template.py @brave/sec-team
+
 # Semgrep configuration
 /.semgrepignore @thypon
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,24 +19,16 @@
 (1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
 -->
 
-<!--
 ## Checklist:
 
-- Review design docs
-  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
-  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
-  [Core principles](https://www.chromium.org/developers/core-principles/)
-- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
-- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
-- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
-  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
-- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
-- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
-- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
-- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
-- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
-- Checked the PR locally:
-  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
-  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
-- Run `git rebase master` (if needed)
--->
+- [ ] Reviewed the relevant design docs: [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md), [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md), [Core principles](https://www.chromium.org/developers/core-principles/)
+- [ ] Tests are included or updated: unit tests as much as possible (including edge cases), plus browser tests covering high level functionality ([wiki](https://www.chromium.org/developers/testing/))
+- [ ] Classes/methods have comments explaining what they are/do (the "why" is often more important than the "what"), and any relevant docs are updated
+- [ ] Security or other review requested if applicable (third-party libraries, rust code, etc): [security/privacy review](https://github.com/brave/brave-browser/wiki/Security-reviews), [other review](https://github.com/brave/reviews/issues/new/choose), [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md)
+- [ ] A [ticket](https://github.com/brave/brave-browser/issues) exists for this change and GitHub [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) are used in the PR description above
+- [ ] A good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html) is written
+- [ ] Review feedback and "fixup" commits are squashed before merge, so that history is a record of what happened in the repo
+- [ ] Appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) are added to the associated issue
+- [ ] Checked the PR locally: `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` ([wiki](https://github.com/brave/brave-browser/wiki/Tests)), `pnpm run presubmit` ([wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks)), `pnpm run gn_check`
+- [ ] Ran `git rebase master` (if needed)
+- [ ] I did not use AI/LLM tooling to create this PR, or I have disclosed the AI tooling/model used below and verified its output

--- a/.github/workflows/check-prs.yml
+++ b/.github/workflows/check-prs.yml
@@ -1,0 +1,139 @@
+name: Check pull requests
+
+on:
+  # `pull_request_target` has a write token, so this workflow must only ever
+  # run trusted base-branch code. It must never checkout or execute pull
+  # request head code.
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+concurrency:
+  group: "check-pr-${{ github.event.pull_request.number }}"
+  cancel-in-progress: true
+
+jobs:
+  check-prs:
+    # Only pull requests from forks (all Brave automation pushes same-repo
+    # branches) submitted by authors who are not Brave org members or repo
+    # collaborators are subject to this check.
+    if: >-
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      !contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      DRY_RUN: 'false'
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_TEMPLATE_URL: ${{ github.server_url }}/${{ github.repository }}/blob/master/.github/PULL_REQUEST_TEMPLATE.md
+    steps:
+      - name: Verify no checkout
+        run: |
+          if git -C "${GITHUB_WORKSPACE:?}" rev-parse --is-inside-work-tree &>/dev/null
+          then
+            echo "Refusing to run after a repository checkout in ${GITHUB_WORKSPACE}." >&2
+            exit 1
+          fi
+
+      - name: Write pull request body
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          mkdir -p "${RUNNER_TEMP:?}/check-prs"
+          printf "%s" "${PR_BODY}" >"${RUNNER_TEMP}/check-prs/body"
+
+      - name: Fetch pull request template
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY:?}/contents/.github/PULL_REQUEST_TEMPLATE.md?ref=master" \
+            --jq ".content" |
+            base64 --decode >"${RUNNER_TEMP:?}/check-prs/template"
+
+      - name: Fetch template checker
+        run: |
+          gh api "repos/${GITHUB_REPOSITORY:?}/contents/script/check_pr_template.py?ref=master" \
+            --jq ".content" |
+            base64 --decode >"${RUNNER_TEMP:?}/check-prs/check_pr_template.py"
+
+      - name: Check pull request template
+        id: template
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          complete_template="$(
+            python3 "${RUNNER_TEMP:?}/check-prs/check_pr_template.py" pull-request \
+              "${RUNNER_TEMP}/check-prs/body" \
+              "${RUNNER_TEMP}/check-prs/template" \
+              "${PR_TITLE}" \
+              "${GITHUB_REPOSITORY:?}"
+          )"
+          case "${complete_template}" in
+            true | false) ;;
+            *)
+              echo "Unexpected template completion result: ${complete_template}" >&2
+              exit 1
+              ;;
+          esac
+          echo "complete_template=${complete_template}" >>"${GITHUB_OUTPUT:?}"
+
+      - name: Find incomplete template comment
+        id: comments
+        if: >-
+          github.event.pull_request.state != 'closed' &&
+          steps.template.outputs.complete_template == 'false'
+        run: |
+          comment_ids="$(
+            gh api --paginate "repos/${GITHUB_REPOSITORY:?}/issues/${PR_NUMBER:?}/comments" \
+              --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("<!-- incomplete-pr-template -->"))) | .id'
+          )"
+          if [[ -n "${comment_ids}" ]]
+          then
+            echo "has_incomplete_template_comment=true" >>"${GITHUB_OUTPUT:?}"
+          else
+            echo "has_incomplete_template_comment=false" >>"${GITHUB_OUTPUT:?}"
+          fi
+
+      - name: Comment on incomplete pull request
+        if: >-
+          github.event.pull_request.state != 'closed' &&
+          steps.template.outputs.complete_template == 'false' &&
+          steps.comments.outputs.has_incomplete_template_comment != 'true' &&
+          env.DRY_RUN != 'true'
+        run: |
+          gh api --method POST "repos/${GITHUB_REPOSITORY:?}/issues/${PR_NUMBER:?}/comments" \
+            --raw-field body="$(
+              cat <<COMMENT
+          <!-- incomplete-pr-template -->
+          Thanks for your pull request. This has been closed because it appears to be missing the pull request template, perhaps because this was written by an AI not a human. We require humans to read and fill in these templates.
+
+          Please edit this pull request to fill in the current [pull request template](${PR_TEMPLATE_URL:?}). Once the template is complete, ask a Brave maintainer to reopen this pull request. **Do not open a new pull request for this.**
+          COMMENT
+            )"
+
+      - name: Close incomplete pull request
+        if: >-
+          github.event.pull_request.state != 'closed' &&
+          steps.template.outputs.complete_template == 'false' &&
+          env.DRY_RUN != 'true'
+        run: |
+          gh api --method PATCH "repos/${GITHUB_REPOSITORY:?}/pulls/${PR_NUMBER:?}" \
+            -f state=closed
+
+      - name: Dry run result
+        if: >-
+          github.event.pull_request.state != 'closed' &&
+          steps.template.outputs.complete_template == 'false' &&
+          env.DRY_RUN == 'true'
+        run: |
+          echo "DRY_RUN: would comment on and close pull request ${PR_NUMBER} for an incomplete template."

--- a/script/check_pr_template.py
+++ b/script/check_pr_template.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Checks whether a pull request body preserves the pull request template.
+
+Python port of the `pull-request` mode of Homebrew's check_template.rb
+(Homebrew/brew#22186). A pull request is considered complete when at least
+75% of the template's checkbox/heading items appear verbatim in the body
+(checkboxes count whether ticked or not) and the body discloses AI/LLM use.
+
+Usage: check_pr_template.py pull-request BODY TEMPLATE [TITLE REPOSITORY]
+Prints "true" or "false".
+"""
+
+import re
+import sys
+
+CHECKBOX_MARKER = re.compile(r'^- \[[ xX]\] ')
+NORMALISED_CHECKBOX = '- [ ] '
+HTML_COMMENT_LINE = re.compile(r'<!--.*-->')
+MARKDOWN_HEADING = re.compile(r'^#+ ')
+MARKDOWN_HORIZONTAL_LINE = re.compile(r'^-+$')
+AI_MENTION = re.compile(r'\b(?:AI|LLM)\b', re.IGNORECASE)
+REVERT_TITLE = re.compile(r'Revert ".+"')
+REQUIRED_TEMPLATE_PERCENTAGE = 75
+PERCENTAGE_SCALE = 100
+
+
+def normalised_lines(text):
+    lines = []
+    seen = set()
+    for line in text.splitlines():
+        line = CHECKBOX_MARKER.sub(NORMALISED_CHECKBOX, line.strip(), count=1)
+        if not line:
+            continue
+        if MARKDOWN_HORIZONTAL_LINE.fullmatch(line):
+            continue
+        if HTML_COMMENT_LINE.fullmatch(line):
+            continue
+        if line in seen:
+            continue
+        seen.add(line)
+        lines.append(line)
+    return lines
+
+
+def template_items(template):
+    return [
+        line for line in normalised_lines(template)
+        if line.startswith(NORMALISED_CHECKBOX) or MARKDOWN_HEADING.match(line)
+    ]
+
+
+def is_complete(body, template, title='', repository=''):
+    if repository and title:
+        if REVERT_TITLE.fullmatch(title):
+            if re.match(r'\s*Reverts ' + re.escape(repository) + r'#\d+\r?$',
+                        body):
+                return True
+
+    normalised_body = normalised_lines(body)
+    items = template_items(template)
+    present = sum(1 for item in items if item in normalised_body)
+    preserves_template = present * PERCENTAGE_SCALE >= len(
+        items) * REQUIRED_TEMPLATE_PERCENTAGE
+    discloses_ai = any(AI_MENTION.search(line) for line in normalised_body)
+    return preserves_template and discloses_ai
+
+
+def read_text(path):
+    with open(path, 'rb') as f:
+        return f.read().decode('utf-8', errors='replace')
+
+
+def main(argv):
+    if len(argv) < 4 or argv[1] != 'pull-request':
+        print(
+            'Usage: check_pr_template.py pull-request BODY TEMPLATE [TITLE REPOSITORY]',
+            file=sys.stderr)
+        return 1
+    body = read_text(argv[2])
+    template = read_text(argv[3])
+    title = argv[4] if len(argv) > 4 else ''
+    repository = argv[5] if len(argv) > 5 else ''
+    print(
+        'true' if is_complete(body, template, title, repository) else 'false')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/script/test/test_check_pr_template.py
+++ b/script/test/test_check_pr_template.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import io
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+dirname = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, os.path.join(dirname, '..'))
+
+import check_pr_template  # noqa: E402
+
+REPO = 'brave/brave-core'
+
+TEMPLATE = '''<!-- Add brave-browser issue below that this PR will resolve -->
+- Resolves
+
+<!-- CI-related labels comment block -->
+
+## Checklist:
+
+- [ ] Reviewed the relevant design docs
+- [ ] Tests are included or updated
+- [ ] Comments explaining the "why" and relevant docs updated
+- [ ] Security or other review requested if applicable
+- [ ] A ticket exists and auto-closing keywords are used
+- [ ] A good PR/commit description is written
+- [ ] Review feedback and "fixup" commits are squashed
+- [ ] Appropriate labels added to the associated issue
+- [ ] Checked the PR locally
+- [ ] Ran `git rebase master` (if needed)
+- [ ] I did not use AI to create this PR, or I have disclosed the AI tooling used
+'''
+
+
+def filled_body(ticked=False, count=11):
+    body = ['- Resolves', '', '## Checklist:', '']
+    for i in range(1, 12):
+        if i > count:
+            continue
+        marker = '- [x] ' if ticked else '- [ ] '
+        body.append(marker + TEMPLATE.splitlines()[6 + i][6:])
+    body.append('')
+    return '\n'.join(body) + '\n'
+
+
+class CheckPullRequestTemplateTest(unittest.TestCase):
+
+    def test_complete_when_template_preserved_and_ai_disclosed(self):
+        self.assertTrue(
+            check_pr_template.is_complete(filled_body(), TEMPLATE, '', ''))
+
+    def test_complete_when_checkboxes_ticked(self):
+        self.assertTrue(
+            check_pr_template.is_complete(filled_body(ticked=True), TEMPLATE,
+                                          '', ''))
+
+    def test_incomplete_when_body_stripped(self):
+        self.assertFalse(
+            check_pr_template.is_complete(
+                'Fixes a bug in the network stack.\n\n- Resolves brave/brave-browser#1\n',
+                TEMPLATE, '', ''))
+
+    def test_incomplete_when_body_empty(self):
+        self.assertFalse(check_pr_template.is_complete('', TEMPLATE, '', ''))
+
+    def test_incomplete_below_threshold_preservation(self):
+        # 8 of 12 items (7 checkboxes + '## Checklist:') = 67% < 75%, AI disclosed
+        body = filled_body(count=7) + 'Used an LLM to fix typos\n'
+        self.assertFalse(check_pr_template.is_complete(body, TEMPLATE, '', ''))
+
+    def test_complete_at_threshold_preservation(self):
+        # 9 of 12 items (8 checkboxes + '## Checklist:') = exactly 75%, AI disclosed
+        body = filled_body(count=8) + 'Used an LLM to fix typos\n'
+        self.assertTrue(check_pr_template.is_complete(body, TEMPLATE, '', ''))
+
+    def test_incomplete_when_ai_not_disclosed(self):
+        body = filled_body().replace(
+            '- [ ] I did not use AI to create this PR, or I have disclosed the AI tooling used\n',
+            '')
+        self.assertFalse(check_pr_template.is_complete(body, TEMPLATE, '', ''))
+
+    def test_ai_disclosed_anywhere_in_body(self):
+        body = filled_body(count=9).replace(
+            '- [ ] Reviewed the relevant design docs',
+            'Reviewed the relevant design docs (prompted an LLM for wording)')
+        self.assertTrue(check_pr_template.is_complete(body, TEMPLATE, '', ''))
+
+    def test_normalisation_drops_noise_lines(self):
+        body = (
+            '\r\n'
+            '---\n'
+            '<!-- a single line comment -->\n'
+            '## Checklist:\n'
+            '## Checklist:\n'
+            '- [X] Reviewed the relevant design docs\n'
+            '- [ ] Tests are included or updated\n'
+            '- [ ] Comments explaining the "why" and relevant docs updated\n'
+            '- [ ] Security or other review requested if applicable\n'
+            '- [ ] A ticket exists and auto-closing keywords are used\n'
+            '- [ ] A good PR/commit description is written\n'
+            '- [ ] Review feedback and "fixup" commits are squashed\n'
+            '- [ ] Appropriate labels added to the associated issue\n'
+            '- [ ] Checked the PR locally\n'
+            '- [ ] Ran `git rebase master` (if needed)\n'
+            '- [ ] I did not use AI to create this PR, or I have disclosed the AI tooling used\n'
+            '\n')
+        self.assertTrue(check_pr_template.is_complete(body, TEMPLATE, '', ''))
+
+    def test_template_items_include_headings_and_checkboxes_only(self):
+        self.assertEqual(12, len(check_pr_template.template_items(TEMPLATE)))
+
+    def test_revert_escape(self):
+        body = 'Reverts brave/brave-core#123\r\n'
+        self.assertTrue(
+            check_pr_template.is_complete(body, TEMPLATE,
+                                          'Revert "some change"', REPO))
+
+    def test_revert_escape_requires_matching_repository(self):
+        body = 'Reverts brave/brave-core#123\n'
+        self.assertFalse(
+            check_pr_template.is_complete(body, TEMPLATE,
+                                          'Revert "some change"',
+                                          'brave/brave-browser'))
+
+    def test_revert_escape_requires_revert_title(self):
+        body = 'Reverts brave/brave-core#123\n'
+        self.assertFalse(
+            check_pr_template.is_complete(body, TEMPLATE, 'Some change', REPO))
+
+    def test_cli_prints_true(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            body_path = os.path.join(tmp, 'body')
+            template_path = os.path.join(tmp, 'template')
+            with open(body_path, 'w', encoding='utf-8') as f:
+                f.write(filled_body())
+            with open(template_path, 'w', encoding='utf-8') as f:
+                f.write(TEMPLATE)
+            output = self.run_cli(body_path, template_path, 'Fix network bug',
+                                  REPO)
+            self.assertEqual('true', output)
+
+    def test_cli_prints_false(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            body_path = os.path.join(tmp, 'body')
+            template_path = os.path.join(tmp, 'template')
+            with open(body_path, 'w', encoding='utf-8') as f:
+                f.write('just a description\n')
+            with open(template_path, 'w', encoding='utf-8') as f:
+                f.write(TEMPLATE)
+            output = self.run_cli(body_path, template_path, 'Fix network bug',
+                                  REPO)
+            self.assertEqual('false', output)
+
+    def test_cli_handles_invalid_utf8_without_crashing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            body_path = os.path.join(tmp, 'body')
+            template_path = os.path.join(tmp, 'template')
+            with open(body_path, 'wb') as f:
+                f.write(b'\xff\xfe broken bytes\n')
+            with open(template_path, 'w', encoding='utf-8') as f:
+                f.write(TEMPLATE)
+            output = self.run_cli(body_path, template_path, 'Fix network bug',
+                                  REPO)
+            self.assertEqual('false', output)
+
+    def run_cli(self, body_path, template_path, title, repository):
+        argv = [
+            'check_pr_template.py', 'pull-request', body_path, template_path,
+            title, repository
+        ]
+        out = io.StringIO()
+        with redirect_stdout(out):
+            check_pr_template.main(argv)
+        return out.getvalue().strip()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Motivation

`brave-core` receives pull requests (an increasing share AI-generated) that strip or ignore the pull request template, and the current template is almost entirely HTML comments with a commented-out checklist — so nothing enforces it and nothing can verify a PR "filled it in". Maintainers bounce these back manually today.

This ports the proven Homebrew mechanism ([Homebrew/brew#22186](https://github.com/Homebrew/brew/pull/22186), workflow + checker synced via [Homebrew/.github](https://github.com/Homebrew/.github)); see [homebrew-core#301407](https://github.com/Homebrew/homebrew-core/pull/301407) for the flow on a real contributor PR.

Resolves brave/brave-browser#58547

## Changes

- **`.github/workflows/check-prs.yml`** — `pull_request_target` (`opened`/`edited`/`reopened`). Applies only to **fork PRs from non-Brave authors** (`head.repo.full_name != github.repository` and `author_association` not `MEMBER`/`OWNER`/`COLLABORATOR`). Brave org members, collaborators, and all same-repo automation (`update-dep`, `socket-fix`, `dependabot`, `renovate`, `sync-pr-from-fork` — all push same-repo branches) are exempt. Posts one deduplicated comment (marker `<!-- incomplete-pr-template -->`) and closes the PR. **No auto-reopen** — a maintainer reopens after the body is fixed. `DRY_RUN` env flag for observe-only rollout.
- **`script/check_pr_template.py`** — stdlib Python port of Homebrew's `check_template.rb`: lines normalized (checkbox state ignored, empty lines/horizontal rules/single-line comments/duplicates dropped), ≥75% of template checkbox/heading items must appear verbatim in the body, body must disclose AI/LLM use, `Revert "…"` PRs escaped. CLI: `pull-request BODY TEMPLATE [TITLE REPOSITORY]` → prints `true`/`false`.
- **`.github/PULL_REQUEST_TEMPLATE.md`** — checklist uncommented into 11 real `- [ ]` items (including an AI/LLM disclosure item); `- Resolves` and the CI-labels comment block unchanged.
- **`script/test/test_check_pr_template.py`** — 16 unittests (threshold boundaries 74%/75%, ticked vs unticked, normalization noise, revert escape, invalid UTF-8, CLI).

## Safety (mirrors upstream design)

- Workflow never checks out or executes PR head code (guarded by a "verify no checkout" step).
- PR body passed to the checker via env-var binding, never `${{ }}` shell interpolation.
- `permissions: {}` top-level; job requests only `contents: read`, `issues: write`, `pull-requests: write`.
- Checker + template are fetched from `master` at run time, so only trusted base-branch code runs under the write token.

## Verification

- Unit tests green locally and in the Ubuntu VM (Python 3.14).
- Python port cross-validated against the upstream Ruby checker on identical fixtures (incl. real new template) with identical `true`/`false` output.
- `actionlint` clean; shell-injection simulation with a hostile PR body confirms nothing is executed.

## Rollout suggestion

Land with `DRY_RUN: 'true'` to observe results, then flip to `'false'` to enforce. `/.github` is owned by @brave/devops-team per CODEOWNERS.
