### PR TITLE
[AI Chat]: Notify when content tools are attached or detached

### DIFF
--- a/components/ai_chat/core/browser/associated_content_delegate.cc
+++ b/components/ai_chat/core/browser/associated_content_delegate.cc
@@ -76,9 +76,7 @@ void AssociatedContentDelegate::set_tools_attached(bool tools_attached) {
   }
   tools_attached_ = tools_attached;
 
-  for (auto& observer : observers_) {
-    observer.OnToolsAttachedChanged(this);
-  }
+  observers_.Notify(&Observer::OnToolsAttachedChanged, this);
 }
 
 void AssociatedContentDelegate::NotifyNewPage() {

--- a/components/ai_chat/core/browser/associated_content_delegate.cc
+++ b/components/ai_chat/core/browser/associated_content_delegate.cc
@@ -70,6 +70,17 @@ void AssociatedContentDelegate::GetContentTools(
   std::move(callback).Run({});
 }
 
+void AssociatedContentDelegate::set_tools_attached(bool tools_attached) {
+  if (tools_attached_ == tools_attached) {
+    return;
+  }
+  tools_attached_ = tools_attached;
+
+  for (auto& observer : observers_) {
+    observer.OnToolsAttachedChanged(this);
+  }
+}
+
 void AssociatedContentDelegate::NotifyNewPage() {
   for (auto& observer : observers_) {
     observer.OnNewPage(this);

--- a/components/ai_chat/core/browser/associated_content_delegate.h
+++ b/components/ai_chat/core/browser/associated_content_delegate.h
@@ -66,6 +66,7 @@ class AssociatedContentDelegate {
     virtual void OnRequestArchive(AssociatedContentDelegate* delegate) {}
     virtual void OnNewPage(AssociatedContentDelegate* delegate) {}
     virtual void OnTitleChanged(AssociatedContentDelegate* delegate) {}
+    virtual void OnToolsAttachedChanged(AssociatedContentDelegate* delegate) {}
   };
 
   AssociatedContentDelegate();
@@ -113,9 +114,8 @@ class AssociatedContentDelegate {
   // not persisted. Content is attached when it is first found to expose tools,
   // and can subsequently be overridden by the user.
   bool tools_attached() const { return tools_attached_; }
-  void set_tools_attached(bool tools_attached) {
-    tools_attached_ = tools_attached;
-  }
+  // Notifies observers when the value changes.
+  void set_tools_attached(bool tools_attached);
 
   // Get current cache of content, if available. Do not perform any fresh
   // fetch for the content.

--- a/components/ai_chat/core/browser/associated_content_manager.cc
+++ b/components/ai_chat/core/browser/associated_content_manager.cc
@@ -225,7 +225,6 @@ void AssociatedContentManager::SetToolsAttached(std::string_view content_uuid,
   }
 
   (*it)->set_tools_attached(tools_attached);
-  conversation_->OnAssociatedContentUpdated();
 }
 
 void AssociatedContentManager::GetToolInfos(std::string_view content_uuid,
@@ -268,7 +267,6 @@ void AssociatedContentManager::OnContentToolsDetected(
     return;
   }
   delegate->set_tools_attached(tools_attached);
-  conversation_->OnAssociatedContentUpdated();
 }
 
 void AssociatedContentManager::ClearContent() {
@@ -547,6 +545,11 @@ void AssociatedContentManager::OnTitleChanged(
     AssociatedContentDelegate* delegate) {
   DVLOG(1) << __func__;
 
+  conversation_->OnAssociatedContentUpdated();
+}
+
+void AssociatedContentManager::OnToolsAttachedChanged(
+    AssociatedContentDelegate* delegate) {
   conversation_->OnAssociatedContentUpdated();
 }
 

--- a/components/ai_chat/core/browser/associated_content_manager.h
+++ b/components/ai_chat/core/browser/associated_content_manager.h
@@ -135,6 +135,7 @@ class AssociatedContentManager : public ToolProvider,
   void OnRequestArchive(AssociatedContentDelegate* delegate) override;
   void OnDestroyed(AssociatedContentDelegate* delegate) override;
   void OnTitleChanged(AssociatedContentDelegate* delegate) override;
+  void OnToolsAttachedChanged(AssociatedContentDelegate* delegate) override;
 
   std::vector<AssociatedContentDelegate*> GetContentDelegatesForTesting() {
     return content_delegates_;

--- a/components/ai_chat/core/browser/associated_content_manager_unittest.cc
+++ b/components/ai_chat/core/browser/associated_content_manager_unittest.cc
@@ -735,4 +735,35 @@ TEST_F(AssociatedContentManagerUnitTest,
             mojom::ContentType::VideoTranscript);
 }
 
+// Content is attached before it can offer tools: a workspace only registers
+// them once its hidden page has loaded, long after it was attached.
+TEST_F(AssociatedContentManagerUnitTest, SurfacesToolsAttachedAfterTheFact) {
+  NiceMock<MockAssociatedContent> associated_content;
+  associated_content.SetUrl(GURL("https://example.com"));
+  conversation_handler_->associated_content_manager()->AddContent(
+      &associated_content);
+
+  ASSERT_EQ(1u, conversation_->associated_content.size());
+  ASSERT_FALSE(conversation_->associated_content[0]->tools_attached);
+
+  associated_content.set_tools_attached(true);
+
+  ASSERT_EQ(1u, conversation_->associated_content.size());
+  EXPECT_TRUE(conversation_->associated_content[0]->tools_attached);
+}
+
+TEST_F(AssociatedContentManagerUnitTest, SurfacesToolsBeingDetached) {
+  NiceMock<MockAssociatedContent> associated_content;
+  associated_content.SetUrl(GURL("https://example.com"));
+  conversation_handler_->associated_content_manager()->AddContent(
+      &associated_content);
+  associated_content.set_tools_attached(true);
+  ASSERT_TRUE(conversation_->associated_content[0]->tools_attached);
+
+  associated_content.set_tools_attached(false);
+
+  ASSERT_EQ(1u, conversation_->associated_content.size());
+  EXPECT_FALSE(conversation_->associated_content[0]->tools_attached);
+}
+
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/associated_content_manager_unittest.cc
+++ b/components/ai_chat/core/browser/associated_content_manager_unittest.cc
@@ -758,6 +758,8 @@ TEST_F(AssociatedContentManagerUnitTest, SurfacesToolsBeingDetached) {
   conversation_handler_->associated_content_manager()->AddContent(
       &associated_content);
   associated_content.set_tools_attached(true);
+
+  ASSERT_EQ(1u, conversation_->associated_content.size());
   ASSERT_TRUE(conversation_->associated_content[0]->tools_attached);
 
   associated_content.set_tools_attached(false);


### PR DESCRIPTION
This is useful for rehydrating workspaces because the tools aren't added until the page commits.

<!-- Add brave-browser issue below that this PR will resolve -->
- Series https://github.com/brave/brave-browser/issues/55232

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
