### PR TITLE
Fix `pnpm run sync`

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -101,7 +101,7 @@ hooks = [
     'pattern': '.',
     # Required for download_cryptography below. Specifically, newer versions of
     # pip are required for obtaining binary wheels on Arm64 macOS.
-    'action': ['python3', '-m', 'pip', '-q', '--disable-pip-version-check', 'install', '-U', '--no-warn-script-location', 'pip'],
+    'action': ['python3', '-m', 'ensurepip', '--upgrade'],
   },
   {
     'name': 'download_cryptography',


### PR DESCRIPTION
The `pnpm run sync` step of the brave-core build failed with the following error:

```
> gclient runhooks
Updating depot_tools...
Running hooks:  87% (124/141) update_pip
________ running 'python3 -m pip -q --disable-pip-version-check install -U --no-warn-script-location pip' in 'C:\work\brave-browser\src/brave'
C:\Users\Anton\AppData\Local\vpython-root.0\store\uv_venv-psdcsdeopc12tc6kci3c5qv2t0\contents\Scripts\python3.exe: No module named pip
Error: Command 'python3 -m pip -q --disable-pip-version-check install -U --no-warn-script-location pip' returned non-zero exit status 1 in C:\work\brave-browser\src/brave
C:\Users\Anton\AppData\Local\vpython-root.0\store\uv_venv-psdcsdeopc12tc6kci3c5qv2t0\contents\Scripts\python3.exe: No module named pip

null
null
[ELIFECYCLE] Command failed with exit code 1.
```