### PR TITLE
[Android] Fix crash in BraveRewardsNativeWorker init before browser startup

### DIFF
--- a/browser/brave_rewards/android/brave_rewards_native_worker.cc
+++ b/browser/brave_rewards/android/brave_rewards_native_worker.cc
@@ -26,6 +26,7 @@
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "brave/components/brave_rewards/core/rewards_util.h"
 #include "chrome/android/chrome_jni_headers/BraveRewardsNativeWorker_jni.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/profiles/profile_manager.h"
 #include "components/prefs/pref_service.h"
@@ -997,16 +998,16 @@ void BraveRewardsNativeWorker::RecordPanelTrigger(JNIEnv* env) {
 static void JNI_BraveRewardsNativeWorker_Init(
     JNIEnv* env,
     const base::android::JavaRef<jobject>& jcaller) {
-  // Profile may be null when the process is started by AlarmManager for a
-  // retention notification before the browser is fully initialized. In this
-  // case we skip creating the native object, which leaves the Java native
-  // pointer at 0 and causes getInstance() to reset the singleton so it can
-  // be re-created on the next call.
-  Profile* profile = ProfileManager::GetActiveUserProfile();
-  if (!profile) {
+  // The process can be started by AlarmManager just to deliver a retention
+  // notification broadcast: the native library is loaded, but full browser
+  // startup hasn't run, so there is no browser process to get a profile from.
+  // Skipping the native object leaves the Java native pointer at 0, which makes
+  // getInstance() reset the singleton so it can be re-created on the next call.
+  if (!g_browser_process || !g_browser_process->profile_manager()) {
     return;
   }
-  new BraveRewardsNativeWorker(env, jcaller, *profile);
+  new BraveRewardsNativeWorker(env, jcaller,
+                               *ProfileManager::GetActiveUserProfile());
 }
 
 }  // namespace android


### PR DESCRIPTION
An AlarmManager retention notification broadcast can start the process on its own: the native library is loaded, but full browser startup hasn't run, so g_browser_process is still null. RetentionNotificationPublisher calls BraveRewardsNativeWorker.getInstance(), and native init then crashes dereferencing g_browser_process inside ProfileManager::GetActiveUserProfile().

Resolves: https://github.com/brave/brave-browser/issues/58575


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
