### PR TITLE
[iOS] Wait until application is active to enable crash report helper

### DIFF
--- a/ios/app/brave_core_main.mm
+++ b/ios/app/brave_core_main.mm
@@ -116,6 +116,11 @@ const BraveCoreLogSeverity BraveCoreLogSeverityVerbose =
              object:nil];
     [[NSNotificationCenter defaultCenter]
         addObserver:self
+           selector:@selector(onAppDidBecomeActive:)
+               name:UIApplicationDidBecomeActiveNotification
+             object:nil];
+    [[NSNotificationCenter defaultCenter]
+        addObserver:self
            selector:@selector(onAppWillTerminate:)
                name:UIApplicationWillTerminateNotification
              object:nil];
@@ -194,8 +199,7 @@ const BraveCoreLogSeverity BraveCoreLogSeverityVerbose =
 
     _adblockService = [[AdblockService alloc] initWithComponentUpdater:cus];
 
-    // Applies the persisted crash reporting consent as soon as local state is
-    // available, and keeps it in sync with the pref for the rest of the
+    // Keeps crash helper enabled in sync with the pref for the rest of the
     // process lifetime (e.g. when changed from Settings).
     PrefService* localState = GetApplicationContext()->GetLocalState();
     _localStatePrefChangeRegistrar.Init(localState);
@@ -207,8 +211,6 @@ const BraveCoreLogSeverity BraveCoreLogSeverityVerbose =
                   metrics::prefs::kMetricsReportingEnabled));
             },
             localState));
-    crash_helper::SetEnabled(
-        localState->GetBoolean(metrics::prefs::kMetricsReportingEnabled));
   }
   return self;
 }
@@ -233,13 +235,20 @@ const BraveCoreLogSeverity BraveCoreLogSeverityVerbose =
   }
 }
 
+- (void)onAppDidBecomeActive:(NSNotification*)notification {
+  // We need to wait until the application is active to actual set this value
+  // or it wont be written to the app group prefs.
+  crash_helper::SetEnabled(GetApplicationContext()->GetLocalState()->GetBoolean(
+      metrics::prefs::kMetricsReportingEnabled));
+  // This is a no-op if reports are already uploading
+  crash_helper::UploadCrashReports();
+}
+
 - (void)onAppEnterForeground:(NSNotification*)notification {
   auto* context = GetApplicationContext();
   if (context) {
     context->OnAppEnterForeground();
   }
-  // This is a no-op if reporst are already uploading
-  crash_helper::UploadCrashReports();
 }
 
 - (void)onAppWillTerminate:(NSNotification*)notification {


### PR DESCRIPTION
The crash helper has active applications state checks which means the consent saved in the group container prefs is not updated unless nor are crash reports uploaded automatically. This change updates where the crash helper methods are invoked to wait until the app is active.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58577

### Test
Beta/Nightly channel only as it is what channel enables crash reporting by default without onboarding/enabling via settings:
- Install a build older than 1.95 and complete the onboarding
- Install a new 1.95+ build that includes this change
- Open brave://crashes, it should NOT say that crash reporting is disabled at the top
- Open Settings, enable developer options, scroll all the day down and tap "CRASH!", crash the app
- Upon relaunch refresh the brave://crashes tab
- Verify the crash is marked as uploaded
