### PR TITLE
Account: name emitted WASM by module id instead of content hash

### DIFF
--- a/build/webpack/webpack.config.ts
+++ b/build/webpack/webpack.config.ts
@@ -66,6 +66,13 @@ export function createWebpackConfig(
     path: path.resolve(options.output_dir), // Must be absolute path
     filename: '[name].bundle.js',
     chunkFilename: '[name].chunk.js',
+    // Not webpack's default [hash]: that hashes the WASM bytes, which differ
+    // between the x64 and arm64 builds. A macOS universal (fat) app merges
+    // both architectures' binaries but can only ship one resources.pak, so a
+    // per-build name is unresolvable for whichever arch didn't produce it.
+    // [id] comes from NamedModuleIdsPlugin (see deterministic-output.ts) and
+    // is stable across architectures.
+    webassemblyModuleFilename: '[id].module.wasm',
     publicPath: '/',
   }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58576

Setting `webassemblyModuleFilename: '[id].module.wasm'` makes both the emitted filename and the runtime URL derive from the module id instead of a content hash of the WASM bytes.

The id here is `./brave/components/brave_account/resources/opaque_ke/bundler/pkg/index_bg.wasm`, which webpack's `prepareId` (`.../webpack/lib/TemplatedPathPlugin.js`) sanitizes to `_brave_components_brave_account_resources_opaque_ke_bundler_pkg_index_bg_wasm.module.wasm`. Verbose, but path-derived and therefore identical across the x64 and arm64 builds — which is the point, since the universal app ships only one arch's `resources.pak` and a per-build hashed name is unresolvable on the other arch.

Webpack still passes the hash as the third argument to `__webpack_require__.v` (that call site is generated independently of the filename template), but the generated runtime no longer references it:
```js
/******/ /* webpack/runtime/wasm loading */
/******/ (() => {
/******/ 	__webpack_require__.v = (exports, wasmModuleId, wasmModuleHash, importsObj) => {
/******/ 	
/******/ 		return (() => {
/******/ 			const { promise, resolve } = Promise.withResolvers();
/******/ 			const request = new XMLHttpRequest();
/******/ 			request.onload = () => (resolve({ arrayBuffer() { return request.response }}));
/******/ 			request.open("GET", __webpack_require__.p + "" + (wasmModuleId  + "").replace(/(^[.-]|[^a-zA-Z0-9_-])+/g, "_") + ".module.wasm");
/******/ 			request.responseType = "arraybuffer";
/******/ 			request.send();
/******/ 			return promise;
/******/ 		})()
/******/ 			.then((x) => (x.arrayBuffer()))
/******/ 			.then((bytes) => (WebAssembly.instantiate(bytes, importsObj)))
/******/ 			.then((res) => (Object.assign(exports, res.instance.exports)));
/******/ 	};
/******/ })();
```

`wasmModuleHash` appears only in the parameter list, the URL is built entirely from `wasmModuleId`. The `.replace(...)` comes from `prepareId`, which applies the same sanitization at build time (for the filename) and at runtime (for the URL), so the two always agree.

This does mean one arch loads the WASM the other arch built. That's harmless — the module targets `wasm32-unknown-unknown` and carries no host architecture.

`[name]` isn't an option: WASM module assets go through `TemplatedPathPlugin`'s module branch, which only registers `[id]` and `[hash]` (`nameReplacer` lives in the chunk branch). `[id]` is the only deterministic one.

Note this doesn't make the two builds byte-identical — the unused hash literal still differs, so the paks still differ. That remains https://github.com/brave/brave-browser/issues/57254.

### Test plan

Setup (all platforms): enable Brave Account, navigate to Settings, click/tap `Get Started`. The Brave Account WebUI must render the entry dialog, not a blank window.

**macOS — all three installers**
```
┌─────────────────────────────┬──────────────────────────────┐
│          Installer          │           Test on            │
├─────────────────────────────┼──────────────────────────────┤
│ Brave-Browser-arm64.dmg     │ Apple Silicon                │
├─────────────────────────────┼──────────────────────────────┤
│ Brave-Browser-x64.dmg       │ Intel                        │
├─────────────────────────────┼──────────────────────────────┤
│ Brave-Browser-universal.dmg │ both Apple Silicon and Intel │
└─────────────────────────────┴──────────────────────────────┘
```

Other platforms:
- Android
- iOS
- Linux
- Windows

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
