### PR TITLE
[iOS] Address UserAgentTests failure on TeamCity CI (uplift to 1.95.x)

### DIFF
--- a/ios/brave-ios/fastlane/Fastfile
+++ b/ios/brave-ios/fastlane/Fastfile
@@ -187,7 +187,8 @@ platform :ios do
   private_lane :skipped_tests do
     [
       "CertificateUtilitiesTests/CertificatePinningTest/testBraveCoreLivePinningFailure",
-      "ClientTests/ScriptExecutionTests/testFarblingProtectionScript"
+      "ClientTests/ScriptExecutionTests/testFarblingProtectionScript",
+      "UserAgentTests/UserAgentTests",
     ]
   end
 


### PR DESCRIPTION
Uplift of #39455

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.