### PR TITLE
Update shift+right click override to check for canvas

### DIFF
--- a/browser/renderer_context_menu/force_context_menu_on_shift_right_click_browsertest.cc
+++ b/browser/renderer_context_menu/force_context_menu_on_shift_right_click_browsertest.cc
@@ -1,0 +1,158 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <string_view>
+
+#include "base/test/scoped_feature_list.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/context_menu_interceptor.h"
+#include "third_party/blink/public/common/context_menu_data/untrustworthy_context_menu_params.h"
+#include "third_party/blink/public/common/features.h"
+#include "third_party/blink/public/common/input/web_input_event.h"
+#include "third_party/blink/public/common/input/web_mouse_event.h"
+#include "third_party/blink/public/mojom/context_menu/context_menu.mojom-shared.h"
+#include "ui/gfx/geometry/point.h"
+
+namespace {
+
+// Mirrors the shape of a real canvas app: the canvas is covered by a
+// transparent overlay that takes the input, so the contextmenu target is the
+// overlay and not the canvas. Tinkercad's is a `div.hud`. "opaque" covers a
+// second canvas the way ordinary page content covers a decorative background
+// canvas, and "plain" is off on its own with no canvas underneath.
+constexpr char kTestPage[] = R"(data:text/html,
+    <html><body style="margin:0">
+      <div style="position:relative;width:200px;height:200px">
+        <canvas width="200" height="200"
+                style="position:absolute;inset:0"></canvas>
+        <div id="overlay" style="position:absolute;inset:0"></div>
+      </div>
+      <div style="position:relative;width:200px;height:200px">
+        <canvas width="200" height="200"
+                style="position:absolute;inset:0"></canvas>
+        <div id="opaque"
+             style="position:absolute;inset:0;background:#fff"></div>
+      </div>
+      <div id="plain" style="width:200px;height:200px"></div>
+      <script>
+        for (const c of document.querySelectorAll('canvas')) {
+          c.getContext('2d');
+        }
+        document.addEventListener('contextmenu', e => e.preventDefault());
+      </script>
+    </body></html>)";
+
+// A bare canvas on a page that does not block the context menu.
+constexpr char kUnblockedTestPage[] = R"(data:text/html,
+    <html><body style="margin:0">
+      <canvas id="canvas" width="200" height="200"></canvas>
+      <script>
+        document.getElementById('canvas').getContext('2d');
+      </script>
+    </body></html>)";
+
+}  // namespace
+
+class ForceContextMenuOnShiftRightClickBrowserTest
+    : public InProcessBrowserTest {
+ public:
+  ForceContextMenuOnShiftRightClickBrowserTest() {
+    scoped_feature_list_.InitAndEnableFeature(
+        blink::features::kForceContextMenuOnShiftRightClick);
+  }
+
+ protected:
+  content::WebContents* web_contents() {
+    return browser()->tab_strip_model()->GetActiveWebContents();
+  }
+
+  void ShiftRightClickOn(std::string_view id) {
+    const gfx::PointF center =
+        content::GetCenterCoordinatesOfElementWithId(web_contents(), id);
+    content::SimulateMouseClickAt(web_contents(),
+                                  blink::WebInputEvent::kShiftKey,
+                                  blink::WebMouseEvent::Button::kRight,
+                                  gfx::Point(center.x(), center.y()));
+  }
+
+ private:
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
+
+// Shift + Right Click still overrides preventDefault() away from a canvas.
+IN_PROC_BROWSER_TEST_F(ForceContextMenuOnShiftRightClickBrowserTest,
+                       OverridesPreventDefaultOffCanvas) {
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), GURL(kTestPage)));
+
+  content::ContextMenuInterceptor interceptor(
+      web_contents()->GetPrimaryMainFrame(),
+      content::ContextMenuInterceptor::ShowBehavior::kPreventShow);
+  ShiftRightClickOn("plain");
+  interceptor.Wait();
+
+  EXPECT_EQ(blink::mojom::ContextMenuDataMediaType::kNone,
+            interceptor.get_params().media_type);
+}
+
+// A canvas under a transparent overlay is still a canvas, so preventDefault()
+// is honored. See https://github.com/brave/brave-browser/issues/56333.
+IN_PROC_BROWSER_TEST_F(ForceContextMenuOnShiftRightClickBrowserTest,
+                       HonorsPreventDefaultOnCanvasUnderOverlay) {
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), GURL(kTestPage)));
+
+  content::ContextMenuInterceptor interceptor(
+      web_contents()->GetPrimaryMainFrame(),
+      content::ContextMenuInterceptor::ShowBehavior::kPreventShow);
+  ShiftRightClickOn("overlay");
+
+  // A menu for the overlay would arrive before this one, and would carry
+  // kCanvas because ContextMenuController penetrates to the canvas too. So the
+  // media type of the first menu we see says whether the click was honored.
+  ShiftRightClickOn("plain");
+  interceptor.Wait();
+
+  EXPECT_EQ(blink::mojom::ContextMenuDataMediaType::kNone,
+            interceptor.get_params().media_type);
+}
+
+// Opaque content between the cursor and a canvas means the click didn't land
+// on an app surface, so the override still applies.
+IN_PROC_BROWSER_TEST_F(ForceContextMenuOnShiftRightClickBrowserTest,
+                       OverridesPreventDefaultOnCanvasUnderOpaqueContent) {
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), GURL(kTestPage)));
+
+  content::ContextMenuInterceptor interceptor(
+      web_contents()->GetPrimaryMainFrame(),
+      content::ContextMenuInterceptor::ShowBehavior::kPreventShow);
+  ShiftRightClickOn("opaque");
+  interceptor.Wait();
+
+  EXPECT_EQ(blink::mojom::ContextMenuDataMediaType::kNone,
+            interceptor.get_params().media_type);
+}
+
+// The carve-out only applies to the preventDefault() override: a canvas that
+// doesn't block the context menu still gets one.
+IN_PROC_BROWSER_TEST_F(ForceContextMenuOnShiftRightClickBrowserTest,
+                       ShowsMenuOnCanvasWithoutPreventDefault) {
+  ASSERT_TRUE(
+      ui_test_utils::NavigateToURL(browser(), GURL(kUnblockedTestPage)));
+
+  content::ContextMenuInterceptor interceptor(
+      web_contents()->GetPrimaryMainFrame(),
+      content::ContextMenuInterceptor::ShowBehavior::kPreventShow);
+  ShiftRightClickOn("canvas");
+  interceptor.Wait();
+
+  EXPECT_EQ(blink::mojom::ContextMenuDataMediaType::kCanvas,
+            interceptor.get_params().media_type);
+}

--- a/browser/renderer_context_menu/force_context_menu_on_shift_right_click_browsertest.cc
+++ b/browser/renderer_context_menu/force_context_menu_on_shift_right_click_browsertest.cc
@@ -40,7 +40,7 @@ constexpr char kTestPage[] = R"(data:text/html,
         <canvas width="200" height="200"
                 style="position:absolute;inset:0"></canvas>
         <div id="opaque"
-             style="position:absolute;inset:0;background:#fff"></div>
+             style="position:absolute;inset:0;background:white"></div>
       </div>
       <div id="plain" style="width:200px;height:200px"></div>
       <script>
@@ -76,6 +76,17 @@ class ForceContextMenuOnShiftRightClickBrowserTest
   }
 
   void ShiftRightClickOn(std::string_view id) {
+    // GetCenterCoordinatesOfElementWithId() CHECK-fails on a missing element,
+    // which reads as a browser crash rather than a test failure. A truncated
+    // test page is the likely cause, so say so.
+    if (!content::EvalJs(
+             web_contents(),
+             content::JsReplace("!!document.getElementById($1)", id))
+             .ExtractBool()) {
+      ADD_FAILURE() << "no #" << id << " on the page; is it truncated?";
+      return;
+    }
+
     const gfx::PointF center =
         content::GetCenterCoordinatesOfElementWithId(web_contents(), id);
     content::SimulateMouseClickAt(web_contents(),

--- a/browser/renderer_context_menu/force_context_menu_on_shift_right_click_browsertest.cc
+++ b/browser/renderer_context_menu/force_context_menu_on_shift_right_click_browsertest.cc
@@ -15,12 +15,15 @@
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/context_menu_interceptor.h"
+#include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/blink/public/common/context_menu_data/untrustworthy_context_menu_params.h"
 #include "third_party/blink/public/common/features.h"
 #include "third_party/blink/public/common/input/web_input_event.h"
 #include "third_party/blink/public/common/input/web_mouse_event.h"
 #include "third_party/blink/public/mojom/context_menu/context_menu.mojom-shared.h"
 #include "ui/gfx/geometry/point.h"
+#include "ui/gfx/geometry/point_f.h"
+#include "url/gurl.h"
 
 namespace {
 
@@ -31,18 +34,18 @@ namespace {
 // canvas, and "plain" is off on its own with no canvas underneath.
 constexpr char kTestPage[] = R"(data:text/html,
     <html><body style="margin:0">
-      <div style="position:relative;width:200px;height:200px">
-        <canvas width="200" height="200"
+      <div style="position:relative;width:100px;height:100px">
+        <canvas width="100" height="100"
                 style="position:absolute;inset:0"></canvas>
         <div id="overlay" style="position:absolute;inset:0"></div>
       </div>
-      <div style="position:relative;width:200px;height:200px">
-        <canvas width="200" height="200"
+      <div style="position:relative;width:100px;height:100px">
+        <canvas width="100" height="100"
                 style="position:absolute;inset:0"></canvas>
         <div id="opaque"
              style="position:absolute;inset:0;background:white"></div>
       </div>
-      <div id="plain" style="width:200px;height:200px"></div>
+      <div id="plain" style="width:100px;height:100px"></div>
       <script>
         for (const c of document.querySelectorAll('canvas')) {
           c.getContext('2d');
@@ -75,7 +78,7 @@ class ForceContextMenuOnShiftRightClickBrowserTest
     return browser()->tab_strip_model()->GetActiveWebContents();
   }
 
-  void ShiftRightClickOn(std::string_view id) {
+  gfx::Point ShiftRightClickOn(std::string_view id) {
     // GetCenterCoordinatesOfElementWithId() CHECK-fails on a missing element,
     // which reads as a browser crash rather than a test failure. A truncated
     // test page is the likely cause, so say so.
@@ -84,15 +87,27 @@ class ForceContextMenuOnShiftRightClickBrowserTest
              content::JsReplace("!!document.getElementById($1)", id))
              .ExtractBool()) {
       ADD_FAILURE() << "no #" << id << " on the page; is it truncated?";
-      return;
+      return gfx::Point();
     }
 
     const gfx::PointF center =
         content::GetCenterCoordinatesOfElementWithId(web_contents(), id);
+    const gfx::Point point(center.x(), center.y());
     content::SimulateMouseClickAt(web_contents(),
                                   blink::WebInputEvent::kShiftKey,
-                                  blink::WebMouseEvent::Button::kRight,
-                                  gfx::Point(center.x(), center.y()));
+                                  blink::WebMouseEvent::Button::kRight, point);
+    return point;
+  }
+
+  // media_type can't identify which element a menu came from on a page with a
+  // document-level contextmenu listener: that listener makes
+  // ContextMenuController::GetContextMenuNodeWithImageContents() treat image
+  // selection as blocked and report kNone even for a hit that penetrates to a
+  // canvas. Where the menu was raised is the signal that still works.
+  static void ExpectMenuRaisedAt(const gfx::Point& expected,
+                                 content::ContextMenuInterceptor& interceptor) {
+    const auto params = interceptor.get_params();
+    EXPECT_EQ(expected, gfx::Point(params.x, params.y));
   }
 
  private:
@@ -107,11 +122,10 @@ IN_PROC_BROWSER_TEST_F(ForceContextMenuOnShiftRightClickBrowserTest,
   content::ContextMenuInterceptor interceptor(
       web_contents()->GetPrimaryMainFrame(),
       content::ContextMenuInterceptor::ShowBehavior::kPreventShow);
-  ShiftRightClickOn("plain");
+  const gfx::Point plain = ShiftRightClickOn("plain");
   interceptor.Wait();
 
-  EXPECT_EQ(blink::mojom::ContextMenuDataMediaType::kNone,
-            interceptor.get_params().media_type);
+  ExpectMenuRaisedAt(plain, interceptor);
 }
 
 // A canvas under a transparent overlay is still a canvas, so preventDefault()
@@ -125,14 +139,13 @@ IN_PROC_BROWSER_TEST_F(ForceContextMenuOnShiftRightClickBrowserTest,
       content::ContextMenuInterceptor::ShowBehavior::kPreventShow);
   ShiftRightClickOn("overlay");
 
-  // A menu for the overlay would arrive before this one, and would carry
-  // kCanvas because ContextMenuController penetrates to the canvas too. So the
-  // media type of the first menu we see says whether the click was honored.
-  ShiftRightClickOn("plain");
+  // The overlay click must raise nothing, so the menu we wait for is the one
+  // from #plain. If the override leaked through, the overlay's menu arrives
+  // first and this sees its position instead.
+  const gfx::Point plain = ShiftRightClickOn("plain");
   interceptor.Wait();
 
-  EXPECT_EQ(blink::mojom::ContextMenuDataMediaType::kNone,
-            interceptor.get_params().media_type);
+  ExpectMenuRaisedAt(plain, interceptor);
 }
 
 // Opaque content between the cursor and a canvas means the click didn't land
@@ -144,11 +157,10 @@ IN_PROC_BROWSER_TEST_F(ForceContextMenuOnShiftRightClickBrowserTest,
   content::ContextMenuInterceptor interceptor(
       web_contents()->GetPrimaryMainFrame(),
       content::ContextMenuInterceptor::ShowBehavior::kPreventShow);
-  ShiftRightClickOn("opaque");
+  const gfx::Point opaque = ShiftRightClickOn("opaque");
   interceptor.Wait();
 
-  EXPECT_EQ(blink::mojom::ContextMenuDataMediaType::kNone,
-            interceptor.get_params().media_type);
+  ExpectMenuRaisedAt(opaque, interceptor);
 }
 
 // The carve-out only applies to the preventDefault() override: a canvas that

--- a/chromium_src/third_party/blink/renderer/core/dom/events/event_dispatcher.cc
+++ b/chromium_src/third_party/blink/renderer/core/dom/events/event_dispatcher.cc
@@ -4,6 +4,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "base/feature_list.h"
+#include "build/build_config.h"
 #include "third_party/blink/public/common/features.h"
 #include "third_party/blink/renderer/core/dom/document.h"
 #include "third_party/blink/renderer/core/dom/events/event.h"

--- a/chromium_src/third_party/blink/renderer/core/dom/events/event_dispatcher.cc
+++ b/chromium_src/third_party/blink/renderer/core/dom/events/event_dispatcher.cc
@@ -5,12 +5,64 @@
 
 #include "base/feature_list.h"
 #include "third_party/blink/public/common/features.h"
+#include "third_party/blink/renderer/core/dom/document.h"
 #include "third_party/blink/renderer/core/dom/events/event.h"
+#include "third_party/blink/renderer/core/dom/events/event_target.h"
+#include "third_party/blink/renderer/core/dom/node.h"
 #include "third_party/blink/renderer/core/event_type_names.h"
 #include "third_party/blink/renderer/core/events/mouse_event.h"
+#include "third_party/blink/renderer/core/frame/local_frame.h"
+#include "third_party/blink/renderer/core/html/canvas/html_canvas_element.h"
+#include "third_party/blink/renderer/core/input/event_handler.h"
+#include "third_party/blink/renderer/core/layout/geometry/physical_rect.h"
+#include "third_party/blink/renderer/core/layout/hit_test_location.h"
+#include "third_party/blink/renderer/core/layout/hit_test_request.h"
+#include "third_party/blink/renderer/core/layout/hit_test_result.h"
+#include "third_party/blink/renderer/core/layout/layout_box.h"
+#include "third_party/blink/renderer/platform/geometry/physical_offset.h"
 
 namespace blink {
 namespace {
+
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)
+// Canvas apps such as games and 3D editors call preventDefault() on contextmenu
+// to bind Shift + Right Click to their own input handling, so the override
+// isn't wanted there. The canvas usually isn't the event target: apps overlay
+// it with a transparent element that takes the input, so look at everything
+// under the cursor rather than at the target's ancestors. Stop at opaque
+// content, the way
+// ContextMenuController::GetContextMenuNodeWithImageContents() does, so that a
+// decorative canvas behind an ordinary page doesn't count.
+// See https://github.com/brave/brave-browser/issues/56333.
+bool IsOverCanvas(MouseEvent* event) {
+  EventTarget* target = event->RawTarget();
+  Node* target_node = target ? target->ToNode() : nullptr;
+  LocalFrame* frame =
+      target_node ? target_node->GetDocument().GetFrame() : nullptr;
+  if (!frame) {
+    return false;
+  }
+
+  HitTestLocation location(
+      PhysicalOffset::FromPointFRound(event->AbsoluteLocation()));
+  HitTestResult result = frame->GetEventHandler().HitTestResultAtLocation(
+      location, HitTestRequest::kReadOnly | HitTestRequest::kPenetratingList |
+                    HitTestRequest::kListBased);
+
+  const PhysicalRect point_rect =
+      HitTestLocation::RectForPoint(result.PointInInnerNodeFrame());
+  for (const auto& node : result.ListBasedTestResult()) {
+    if (IsA<HTMLCanvasElement>(node.Get())) {
+      return true;
+    }
+    const LayoutBox* box = node->GetLayoutBox();
+    if (box && box->BackgroundIsKnownToBeOpaqueInRect(point_rect)) {
+      return false;
+    }
+  }
+  return false;
+}
+#endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)
 
 // Function to determine if contextmenu event should bypass preventDefault so
 // that users can always open context menu by holding Shift key. This method is
@@ -27,7 +79,8 @@ bool ShouldBypassDefaultPreventedForContextMenu(Event* event) {
     return false;
   }
   if (auto* context_mouse_event = DynamicTo<MouseEvent>(event)) {
-    return context_mouse_event->shiftKey();
+    return context_mouse_event->shiftKey() &&
+           !IsOverCanvas(context_mouse_event);
   }
   return false;
 #else

--- a/chromium_src/third_party/blink/renderer/core/dom/events/event_dispatcher.cc
+++ b/chromium_src/third_party/blink/renderer/core/dom/events/event_dispatcher.cc
@@ -14,7 +14,6 @@
 #include "third_party/blink/renderer/core/frame/local_frame.h"
 #include "third_party/blink/renderer/core/html/canvas/html_canvas_element.h"
 #include "third_party/blink/renderer/core/input/event_handler.h"
-#include "third_party/blink/renderer/core/layout/geometry/physical_rect.h"
 #include "third_party/blink/renderer/core/layout/hit_test_location.h"
 #include "third_party/blink/renderer/core/layout/hit_test_request.h"
 #include "third_party/blink/renderer/core/layout/hit_test_result.h"
@@ -30,9 +29,9 @@ namespace {
 // isn't wanted there. The canvas usually isn't the event target: apps overlay
 // it with a transparent element that takes the input, so look at everything
 // under the cursor rather than at the target's ancestors. Stop at opaque
-// content, the way
-// ContextMenuController::GetContextMenuNodeWithImageContents() does, so that a
-// decorative canvas behind an ordinary page doesn't count.
+// content, as ContextMenuController::GetContextMenuNodeWithImageContents()
+// does when it penetrates to an image, so that a decorative canvas behind an
+// ordinary page doesn't count.
 // See https://github.com/brave/brave-browser/issues/56333.
 bool IsOverCanvas(MouseEvent* event) {
   EventTarget* target = event->RawTarget();
@@ -49,14 +48,18 @@ bool IsOverCanvas(MouseEvent* event) {
       location, HitTestRequest::kReadOnly | HitTestRequest::kPenetratingList |
                     HitTestRequest::kListBased);
 
-  const PhysicalRect point_rect =
-      HitTestLocation::RectForPoint(result.PointInInnerNodeFrame());
   for (const auto& node : result.ListBasedTestResult()) {
     if (IsA<HTMLCanvasElement>(node.Get())) {
       return true;
     }
+    // The hit test already places the cursor inside this box, so asking
+    // whether the box is opaque across its whole area answers the question
+    // without having to map the cursor into the box's coordinates. Erring
+    // toward "not opaque" keeps looking for a canvas, which is the side that
+    // leaves a page's own binding alone.
     const LayoutBox* box = node->GetLayoutBox();
-    if (box && box->BackgroundIsKnownToBeOpaqueInRect(point_rect)) {
+    if (box &&
+        box->BackgroundIsKnownToBeOpaqueInRect(box->PhysicalBorderBoxRect())) {
       return false;
     }
   }

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1381,6 +1381,10 @@ test("brave_browser_tests") {
     ]
   }
 
+  if (is_win || is_linux || is_mac) {
+    sources += [ "//brave/browser/renderer_context_menu/force_context_menu_on_shift_right_click_browsertest.cc" ]
+  }
+
   if (is_linux) {
     sources +=
         [ "//brave/browser/ui/views/brave_views_delegate_linux_browsertest.cc" ]


### PR DESCRIPTION
## Description
This helps prevent situations where the right click handler was intentionally prevented for a game or a 3D experience.

Fixes https://github.com/brave/brave-browser/issues/56333

## Test plan
1. Make sure the happy path test plan in https://github.com/brave/brave-browser/issues/54790 still works
2. Let's test a case with 3D. Visit https://tinkercad.com
3. Login - you need to create an account.
4. One logged in, click the create button in the top right and click `3D design`
    <img width="260" height="135" alt="image" src="https://github.com/user-attachments/assets/03a827d2-2ce7-45fc-89f2-0438441b6a73" />
5. You should see a 3D plane
6. When holding shift + using right click and dragging, the window should move like this
    <img width="1233" height="1026" alt="tinkercad" src="https://github.com/user-attachments/assets/19ed3081-6d71-4248-85a4-359cc65f8741" />
7. The context menu should NOT show up
