### PR TITLE
Fixed wrong tab group's hover card position in vertical tab

### DIFF
--- a/browser/ui/views/tabs/brave_tab_group_header.cc
+++ b/browser/ui/views/tabs/brave_tab_group_header.cc
@@ -23,6 +23,7 @@
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/gfx/color_utils.h"
 #include "ui/views/background.h"
+#include "ui/views/bubble/bubble_border.h"
 #include "ui/views/bubble/bubble_dialog_delegate_view.h"
 #include "ui/views/controls/label.h"
 #include "ui/views/widget/widget.h"
@@ -170,6 +171,14 @@ TabNestingInfo BraveTabGroupHeader::GetTabNestingInfo() const {
   return {
       .tree_height = tab_slot_controller_->GetTreeHeight(*tree_tab_node()),
       .level = tab_slot_controller_->GetTreeTabNode(*tree_tab_node())->level()};
+}
+
+views::BubbleBorder::Arrow BraveTabGroupHeader::GetAnchorPosition() const {
+  if (ShouldShowVerticalTabs()) {
+    return views::BubbleBorder::Arrow::LEFT_TOP;
+  }
+
+  return TabGroupHeader::GetAnchorPosition();
 }
 
 BEGIN_METADATA(BraveTabGroupHeader)

--- a/browser/ui/views/tabs/brave_tab_group_header.h
+++ b/browser/ui/views/tabs/brave_tab_group_header.h
@@ -10,6 +10,7 @@
 
 #include "chrome/browser/ui/views/tabs/tab_group_header.h"
 #include "chrome/browser/ui/views/tabs/tab_strip_layout_types.h"
+#include "ui/views/bubble/bubble_border.h"
 
 namespace tab_groups {
 class TabGroupId;
@@ -30,6 +31,7 @@ class BraveTabGroupHeader : public TabGroupHeader {
   int GetDesiredWidth() const override;
   void Layout(PassKey) override;
   TabNestingInfo GetTabNestingInfo() const override;
+  views::BubbleBorder::Arrow GetAnchorPosition() const override;
 
  private:
   bool ShouldShowVerticalTabs() const;

--- a/browser/ui/views/tabs/brave_tab_group_header_unittest.cc
+++ b/browser/ui/views/tabs/brave_tab_group_header_unittest.cc
@@ -25,6 +25,7 @@
 #include "components/tab_groups/tab_group_visual_data.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "ui/views/bubble/bubble_border.h"
 #include "ui/views/view.h"
 #include "ui/views/widget/widget.h"
 
@@ -134,4 +135,29 @@ TEST_F(BraveTabGroupHeaderTest, TitleChipClipPathClearedInVerticalTabs) {
   SetGroupTitle(u"A very long tab group title that needs lots of space");
 
   EXPECT_TRUE(title_chip()->clip_path().isEmpty());
+}
+
+// BraveTabGroupHeader::GetAnchorPosition() must return LEFT_TOP in vertical
+// tab mode so the hover card appears to the right of the tab strip, and must
+// delegate to TabGroupHeader::GetAnchorPosition() (TOP_LEFT) in horizontal
+// mode.
+TEST_F(BraveTabGroupHeaderTest, GetAnchorPositionReflectsTabOrientation) {
+  TestingProfile profile;
+
+  testing::NiceMock<MockBrowserWindowInterfaceWithVerticalTabController>
+      mock_browser_window(profile.GetPrefs());
+  EXPECT_CALL(*tab_slot_controller_, GetBrowserWindowInterface())
+      .WillRepeatedly(testing::Return(&mock_browser_window));
+
+  // Horizontal tabs: delegate to TabGroupHeader::GetAnchorPosition() which
+  // returns TOP_LEFT.
+  profile.GetPrefs()->SetBoolean(brave_tabs::kVerticalTabsEnabled, false);
+  EXPECT_EQ(views::BubbleBorder::Arrow::TOP_LEFT,
+            group_views_->header()->GetAnchorPosition());
+
+  // Vertical tabs: must return LEFT_TOP so the hover card appears to the
+  // right of the tab strip.
+  profile.GetPrefs()->SetBoolean(brave_tabs::kVerticalTabsEnabled, true);
+  EXPECT_EQ(views::BubbleBorder::Arrow::LEFT_TOP,
+            group_views_->header()->GetAnchorPosition());
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58592

<img width="400" alt="image" src="https://github.com/user-attachments/assets/f772f322-1451-4ba0-a22a-650a0479cc41" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
