### PR TITLE
[Android][Bottom Bar] Fix for menu and tab switcher buttons visibility

### DIFF
--- a/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
+++ b/android/java/org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl.java
@@ -1495,6 +1495,13 @@ public abstract class BraveToolbarLayoutImpl extends ToolbarLayout
 
     public void onBottomControlsVisibilityChanged(boolean isVisible) {
         mIsBottomControlsVisible = isVisible;
+        // The tab switcher and menu buttons are only Brave's to move between the top toolbar and
+        // the bottom while Brave's own bottom controls carry them. Upstream's bottom bar carries
+        // them instead, and ToolbarPhone hides the top ones for it, so showing them back here -
+        // which this does whenever the omnibox takes focus - would leave a second pair on top.
+        if (BottomToolbarConfiguration.isAndroidBottomBarEnabled()) {
+            return;
+        }
         if (BraveReflectionUtil.equalTypes(this.getClass(), ToolbarPhone.class)
                 && getMenuButtonCoordinator() != null) {
             getMenuButtonCoordinator().setVisibility(!isVisible);

--- a/android/javatests/org/chromium/chrome/browser/toolbar/BraveBottomBarToolbarTest.java
+++ b/android/javatests/org/chromium/chrome/browser/toolbar/BraveBottomBarToolbarTest.java
@@ -1,0 +1,93 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.toolbar;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import android.view.View;
+
+import androidx.test.filters.MediumTest;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.chromium.base.ThreadUtils;
+import org.chromium.base.test.util.Batch;
+import org.chromium.base.test.util.CommandLineFlags;
+import org.chromium.base.test.util.Features.EnableFeatures;
+import org.chromium.base.test.util.Restriction;
+import org.chromium.chrome.R;
+import org.chromium.chrome.browser.flags.ChromeFeatureList;
+import org.chromium.chrome.browser.flags.ChromeSwitches;
+import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
+import org.chromium.chrome.test.ChromeTabbedActivityTestRule;
+import org.chromium.chrome.test.util.OmniboxTestUtils;
+import org.chromium.ui.base.DeviceFormFactor;
+
+/** Tests for the top toolbar while upstream's bottom bar carries Brave's button set. */
+@RunWith(ChromeJUnit4ClassRunner.class)
+@CommandLineFlags.Add({ChromeSwitches.DISABLE_FIRST_RUN_EXPERIENCE})
+@Batch(Batch.PER_CLASS)
+@EnableFeatures(ChromeFeatureList.ANDROID_BOTTOM_BAR)
+@Restriction(DeviceFormFactor.PHONE)
+public class BraveBottomBarToolbarTest {
+    @Rule
+    public ChromeTabbedActivityTestRule mActivityTestRule = new ChromeTabbedActivityTestRule();
+
+    private OmniboxTestUtils mOmnibox;
+
+    @Before
+    public void setUp() {
+        mActivityTestRule.startMainActivityOnBlankPage();
+        mOmnibox = new OmniboxTestUtils(mActivityTestRule.getActivity());
+    }
+
+    /**
+     * The bottom bar carries the tab switcher and the app menu, so ToolbarPhone hides the top
+     * toolbar's own. Brave's bottom controls are off in that configuration and must leave them
+     * alone - their visibility handling used to put both back on every omnibox focus change, which
+     * left a second tab switcher and app menu on top once the omnibox had been dismissed.
+     */
+    @Test
+    @MediumTest
+    public void testTopToolbarButtonsStayHiddenAcrossOmniboxFocus() {
+        assertTopToolbarButtonsHidden("before focusing the omnibox");
+
+        mOmnibox.requestFocus();
+        // Dismisses the omnibox the way the back button does.
+        mOmnibox.clearFocus();
+
+        assertTopToolbarButtonsHidden("after dismissing the omnibox");
+    }
+
+    private void assertTopToolbarButtonsHidden(String when) {
+        ThreadUtils.runOnUiThreadBlocking(
+                () -> {
+                    View toolbar = mActivityTestRule.getActivity().findViewById(R.id.toolbar);
+                    assertNotNull("The top toolbar is missing.", toolbar);
+
+                    // Looked up on the toolbar rather than on the activity: the bottom bar holds a
+                    // tab switcher button under the same id.
+                    View tabSwitcherButton = toolbar.findViewById(R.id.tab_switcher_button);
+                    assertNotNull(
+                            "The top toolbar tab switcher button is missing.", tabSwitcherButton);
+                    assertEquals(
+                            "The top toolbar tab switcher button is shown " + when + ".",
+                            View.GONE,
+                            tabSwitcherButton.getVisibility());
+
+                    View menuButton = toolbar.findViewById(R.id.menu_button_wrapper);
+                    assertNotNull("The top toolbar menu button is missing.", menuButton);
+                    assertEquals(
+                            "The top toolbar menu button is shown " + when + ".",
+                            View.GONE,
+                            menuButton.getVisibility());
+                });
+    }
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1669,6 +1669,7 @@ if (is_android) {
       "//brave/android/javatests/org/chromium/chrome/browser/settings/BraveTabsAndTabGroupsSettingsTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/settings/search/BraveAutofillOptionsSearchIndexTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/sync/BraveManageSyncSettingsTest.java",
+      "//brave/android/javatests/org/chromium/chrome/browser/toolbar/BraveBottomBarToolbarTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/toolbar/BraveToolbarManagerTest.java",
     ]
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/58605

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
