### PR TITLE
[plaster] Cancel global `git` config for reproducible patches

### DIFF
--- a/build/commands/lib/updatePatches.js
+++ b/build/commands/lib/updatePatches.js
@@ -138,10 +138,18 @@ async function writePatchFiles(
       '--ignore-space-at-eol',
       old,
     ]
+    // Cancelling global git settings to make sure we get reproducible output
+    // across machines, as there are certain diff tools that can mangle the
+    // diffs.
     const patchContents = await util.runAsync('git', singleDiffArgs, {
       cwd: gitRepoPath,
       verbose: false,
-      env: { ...process.env, GIT_ATTR_NOSYSTEM: '1' },
+      env: {
+        ...process.env,
+        GIT_ATTR_NOSYSTEM: '1',
+        GIT_CONFIG_GLOBAL: '/dev/null',
+        GIT_CONFIG_NOSYSTEM: '1',
+      },
     })
 
     if (isPlasterManaged) {

--- a/build/commands/lib/updatePatches.test.js
+++ b/build/commands/lib/updatePatches.test.js
@@ -166,6 +166,13 @@ describe('updatePatches diff pins', function () {
       .find((args) => args.includes('diff') && args.includes('--full-index'))
   }
 
+  // The options object (including `env`) for that same call.
+  function findSingleDiffCallOptions(spy) {
+    return spy.mock.calls.find(
+      ([, args]) => args.includes('diff') && args.includes('--full-index'),
+    )[2]
+  }
+
   test('pins diff.algorithm and core.attributesFile for a text file', async () => {
     const textPath = path.join(repoPath, 'source.cc')
     await fs.writeFile(textPath, 'line one\nline two\n')
@@ -181,6 +188,11 @@ describe('updatePatches diff pins', function () {
     expect(diffArgs.some((arg) => arg.startsWith('core.attributesFile='))).toBe(
       true,
     )
+
+    const diffOptions = findSingleDiffCallOptions(spy)
+    expect(diffOptions.env.GIT_ATTR_NOSYSTEM).toBe('1')
+    expect(diffOptions.env.GIT_CONFIG_GLOBAL).toBe('/dev/null')
+    expect(diffOptions.env.GIT_CONFIG_NOSYSTEM).toBe('1')
   })
 
   test('skips the attributesFile pin for a binary file, keeping it a binary diff', async () => {

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -359,6 +359,10 @@ class PatchinfoBuilder:
         # select a different one (e.g. `histogram`) than git's own default,
         # which would produce different hunks for the same change and fail
         # presubmit in CI.
+        #
+        # `GIT_CONFIG_GLOBAL` is repointed at an empty file instead of
+        # `~/.gitconfig`, and `GIT_CONFIG_NOSYSTEM` drops `/etc/gitconfig`. This
+        # is done to prevent certain user tools from mangling the diff.
         content = repository.chromium.run_git(
             '-c',
             f'core.attributesFile={PLASTER_GITATTRIBUTES_PATH}',
@@ -373,7 +377,10 @@ class PatchinfoBuilder:
             self.source,
             no_trim=True,
             env={
-                **os.environ, 'GIT_ATTR_NOSYSTEM': '1'
+                **os.environ,
+                'GIT_ATTR_NOSYSTEM': '1',
+                'GIT_CONFIG_GLOBAL': '/dev/null',
+                'GIT_CONFIG_NOSYSTEM': '1',
             })
         return self.patch.save_if_changed(new_content=content, dry_run=dry_run)
 

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -202,8 +202,10 @@ class PlasterTest(unittest.TestCase):
             ('-c',
              f'core.attributesFile={plaster.PLASTER_GITATTRIBUTES_PATH}'),
             pinned_options)
-        self.assertEqual(
-            diff_calls[0].kwargs.get('env', {}).get('GIT_ATTR_NOSYSTEM'), '1')
+        diff_env = diff_calls[0].kwargs.get('env', {})
+        self.assertEqual(diff_env.get('GIT_ATTR_NOSYSTEM'), '1')
+        self.assertEqual(diff_env.get('GIT_CONFIG_GLOBAL'), '/dev/null')
+        self.assertEqual(diff_env.get('GIT_CONFIG_NOSYSTEM'), '1')
 
     def test_checksum_hashes_raw_bytes_without_newline_normalization(self):
         # The checksum must be over the file's raw bytes so it matches


### PR DESCRIPTION
This PR cancels the use of global git config files when generating
patches, in order to keep the output of our tools reproducible across
machines. This was noticed by a user who had `difftastic` set as the
diff tool in his computer.

Bug: https://github.com/brave/brave-browser/issues/58307
