### PR TITLE
Answer open tab search asynchronously when there are no tabs

### DIFF
--- a/browser/history_embeddings/open_tab_search.cc
+++ b/browser/history_embeddings/open_tab_search.cc
@@ -17,6 +17,7 @@
 #include "base/functional/bind.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/cancelable_task_tracker.h"
+#include "base/task/sequenced_task_runner.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/browser_window/public/global_browser_collection.h"
@@ -160,7 +161,9 @@ void SearchOpenTabsByContent(Profile* profile,
   // tracked-browser HTTP(S) tabs, so non-normal windows, other profiles and
   // incognito don't reach here.
   if (tabs.empty()) {
-    std::move(callback).Run({});
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE,
+        base::BindOnce(std::move(callback), std::vector<OpenTabInfo>()));
     return;
   }
   // Sequence the read-from-`tabs` (for URLs) before the move-of-`tabs` into

--- a/browser/history_embeddings/open_tab_search_browsertest.cc
+++ b/browser/history_embeddings/open_tab_search_browsertest.cc
@@ -123,6 +123,19 @@ class OpenTabSearchBrowserTest : public InProcessBrowserTest {
   content::ContentMockCertVerifier mock_cert_verifier_;
 };
 
+// With no tracked HTTP(S) tabs there is nothing to rank, and the result still
+// arrives asynchronously.
+IN_PROC_BROWSER_TEST_F(OpenTabSearchBrowserTest, NoTabsAnswersAsynchronously) {
+  ai_chat::FakeHistoryEmbeddingsSearch fake;
+
+  base::test::TestFuture<std::vector<OpenTabInfo>> future;
+  SearchOpenTabsByContent(profile(), history_service(), &fake, "query",
+                          future.GetCallback(), &tracker_);
+
+  EXPECT_FALSE(future.IsReady());
+  EXPECT_TRUE(future.Take().empty());
+}
+
 // Results follow the scored-row order (best first), and open tabs whose URL
 // isn't among the scored rows are dropped.
 IN_PROC_BROWSER_TEST_F(OpenTabSearchBrowserTest, RanksAndDropsUnmatchedTabs) {


### PR DESCRIPTION
`SearchOpenTabsByContent()` ran its callback inline when the profile had no
tracked HTTP(S) tabs, and posted it on every other path. Callers could not tell
which they would get, so the callback could re-enter them.

The empty result is now posted, matching every other exit. `ARCH-060` in
`docs/best-practices/architecture.md` asks for exactly this: a callback must be
consistently synchronous or consistently asynchronous, never both.
