### PR TITLE
[Refactor] Removed browser view's ContentsBackground

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -158,23 +158,6 @@ bool IsUnsupportedCommand(int command_id, Browser* browser) {
              browser->GetType() == BrowserWindowInterface::Type::TYPE_POPUP);
 }
 
-// A view that paints a background under the content area of the browser view so
-// that the web content area can be displayed with rounded corners and a shadow.
-class ContentsBackground : public views::View {
-  METADATA_HEADER(ContentsBackground, views::View)
- public:
-  ContentsBackground() {
-    SetBackground(views::CreateSolidBackground(kColorToolbar));
-    SetEnabled(false);
-
-    // Prevent to eat any events that goes to web contents because web contents
-    // could be behind this background.
-    SetCanProcessEventsWithinSubtree(false);
-  }
-};
-BEGIN_METADATA(ContentsBackground)
-END_METADATA
-
 }  // namespace
 
 // static
@@ -357,11 +340,6 @@ BraveBrowserView::BraveBrowserView(Browser* browser) : BrowserView(browser) {
   tab_strip_placement_ = std::make_unique<TabStripPlacementCoordinator>(
       base::PassKey<BraveBrowserView>(), browser,
       horizontal_tab_strip_region_view_);
-
-  // Need this background view always as we have contents margin/rounded corners
-  // when split view is active regardless of rounded corners feature.
-  contents_background_view_ =
-      AddChildViewAt(std::make_unique<ContentsBackground>(), 0);
 
   compact_horizontal_tabs_.Init(
       brave_tabs::kCompactHorizontalTabs, g_browser_process->local_state(),
@@ -840,8 +818,6 @@ void BraveBrowserView::AddedToWidget() {
       std::make_unique<BrowserWindowMouseEventHandler>(this);
 
   // we must call all new views once BraveBrowserView is added to widget
-
-  GetBrowserViewLayout()->set_contents_background(contents_background_view_);
   GetBrowserViewLayout()->set_sidebar_container(sidebar_container_view_);
 
   if (vertical_tab_strip_host_view_) {

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -224,6 +224,10 @@ class BraveBrowserView : public BrowserView,
     return vertical_tab_strip_host_view_;
   }
 
+  views::View* main_background_region_for_testing() const {
+    return main_background_region_;
+  }
+
 #if BUILDFLAG(ENABLE_EXTENSIONS)
   // Returns the PWA Shields toolbar button, if it exists. Note that this
   // returns valid pointer only when it's web app browser.
@@ -269,8 +273,6 @@ class BraveBrowserView : public BrowserView,
                            ShowVerticalTabOnMouseOverTest);
   FRIEND_TEST_ALL_PREFIXES(SplitViewWithRoundedCornersTest,
                            TabFullscreenStateTest);
-  FRIEND_TEST_ALL_PREFIXES(BraveBrowserViewWithRoundedCornersTest,
-                           ContentsBackgroundEventHandleTest);
   FRIEND_TEST_ALL_PREFIXES(sidebar::SidebarBrowserWithSplitViewTest,
                            ShowSidebarOnMouseOverTest);
 
@@ -355,7 +357,6 @@ class BraveBrowserView : public BrowserView,
   bool show_active_contents_domain_ = false;
   raw_ptr<BraveHelpBubbleHostView> brave_help_bubble_host_view_ = nullptr;
   raw_ptr<SidebarContainerView> sidebar_container_view_ = nullptr;
-  raw_ptr<views::View> contents_background_view_ = nullptr;
   raw_ptr<views::View> vertical_tab_strip_host_view_ = nullptr;
   raw_ptr<BraveVerticalTabStripContainerView>
       vertical_tab_strip_container_view_ = nullptr;

--- a/browser/ui/views/frame/brave_browser_view_browsertest.cc
+++ b/browser/ui/views/frame/brave_browser_view_browsertest.cc
@@ -755,14 +755,23 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,
 }
 
 IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,
-                       ContentsBackgroundEventHandleTest) {
-  EXPECT_TRUE(brave_browser_view()->contents_background_view_);
+                       MainBackgroundRegionEventHandleTest) {
+  RunScheduledLayouts();
 
-  EXPECT_TRUE(
-      brave_browser_view()->contents_background_view_->bounds().Contains(
-          brave_browser_view()->contents_container()->bounds()))
-      << "Expected contents_background_view_ bounds ("
-      << brave_browser_view()->contents_background_view_->bounds().ToString()
+  auto* main_background_region =
+      brave_browser_view()->main_background_region_for_testing();
+  // main_background_region is only forced visible when rounded corners are
+  // in effect.
+  EXPECT_EQ(IsRoundedCornersEnabled(), main_background_region->GetVisible());
+
+  if (!main_background_region->GetVisible()) {
+    GTEST_SKIP();
+  }
+
+  EXPECT_TRUE(main_background_region->bounds().Contains(
+      brave_browser_view()->contents_container()->bounds()))
+      << "Expected main_background_region bounds ("
+      << main_background_region->bounds().ToString()
       << ") to contain contents_container bounds ("
       << brave_browser_view()->contents_container()->bounds().ToString() << ")";
 
@@ -770,10 +779,10 @@ IN_PROC_BROWSER_TEST_P(BraveBrowserViewWithRoundedCornersTest,
       browser()->tab_strip_model()->GetActiveWebContents();
   gfx::Point screen_point = web_contents->GetContainerBounds().CenterPoint();
 
-  // Check contents background is not event handler for web contents region
+  // Check main background region is not event handler for web contents region
   // point.
   views::View::ConvertPointFromScreen(browser_view(), &screen_point);
-  EXPECT_NE(brave_browser_view()->contents_background_view_,
+  EXPECT_NE(main_background_region,
             browser_view()->GetEventHandlerForPoint(screen_point));
 }
 

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
@@ -191,17 +191,19 @@ BraveBrowserViewTabbedLayoutImpl::CalculateProposedLayout(
     layout.AddChild(views().focus_mode_title_bar, title_bar_bounds);
   }
 
+  // Upstream only makes |main_background_region| visible when the panel opens
+  // because the contents area has margins around it. We need it to always be
+  // visible when rounded corners are enabled.
+  if (delegate().ShouldUseBraveWebViewRoundedCornersForContents()) {
+    if (auto* main_background_layout =
+            layout.GetLayoutFor(views().main_background_region)) {
+      main_background_layout->visibility = true;
+    }
+  }
+
   // Retrieve contents container proposed bounds.
   auto* contents_layout = layout.GetLayoutFor(views().multi_contents_view);
   CHECK(contents_layout);
-
-  // Handle contents background - contents background should be laid out before
-  // other views like sidebar or vertical tab strip in order to cover the entire
-  // contents area that contains sidebar. Otherwise, we would have hole between
-  // contents background and sidebar when using rounded corners.
-  if (views().contents_background && contents_layout) {
-    layout.AddChild(views().contents_background, contents_layout->bounds);
-  }
 
   // Apply vertical tab strip insets for contents container BEFORE laying out
   // sidebar, so the sidebar is positioned adjacent to (not underneath) the

--- a/chromium_src/chrome/browser/ui/views/frame/layout/browser_view_layout.h
+++ b/chromium_src/chrome/browser/ui/views/frame/layout/browser_view_layout.h
@@ -20,25 +20,21 @@ class SidebarContainerView;
 // Add new members to BrowserViewLayoutViews for Brave specific layout changes.
 #define top_container_separator                           \
   top_container_separator;                                \
-  raw_ptr<views::View> contents_background = nullptr;     \
   raw_ptr<views::View> vertical_tab_strip_host = nullptr; \
   raw_ptr<views::View> focus_mode_title_bar = nullptr;    \
   raw_ptr<SidebarContainerView> sidebar_container
 
 // Add setters for the new members to BrowserViewLayout.
-#define set_side_panel_animation_content                                   \
-  set_contents_background(views::View* contents_background) {              \
-    views_.contents_background = contents_background;                      \
-  }                                                                        \
-  void set_vertical_tab_strip_host(views::View* vertical_tab_strip_host) { \
-    views_.vertical_tab_strip_host = vertical_tab_strip_host;              \
-  }                                                                        \
-  void set_focus_mode_title_bar(views::View* focus_mode_title_bar) {       \
-    views_.focus_mode_title_bar = focus_mode_title_bar;                    \
-  }                                                                        \
-  void set_sidebar_container(SidebarContainerView* sidebar_container) {    \
-    views_.sidebar_container = sidebar_container;                          \
-  }                                                                        \
+#define set_side_panel_animation_content                                \
+  set_vertical_tab_strip_host(views::View* vertical_tab_strip_host) {   \
+    views_.vertical_tab_strip_host = vertical_tab_strip_host;           \
+  }                                                                     \
+  void set_focus_mode_title_bar(views::View* focus_mode_title_bar) {    \
+    views_.focus_mode_title_bar = focus_mode_title_bar;                 \
+  }                                                                     \
+  void set_sidebar_container(SidebarContainerView* sidebar_container) { \
+    views_.sidebar_container = sidebar_container;                       \
+  }                                                                     \
   void set_side_panel_animation_content
 
 #include <chrome/browser/ui/views/frame/layout/browser_view_layout.h>  // IWYU pragma: export


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves - no issue. simple refactor

Removes Brave's custom ContentsBackground view and layout wiring in favor of upstream's existing main_background_region_ (MainBackgroundRegionView), which serves the same purpose — painting behind the contents area so margins/rounded corners don't expose a gap.

Brave's BraveBrowserViewTabbedLayoutImpl::CalculateProposedLayout now forces main_background_region visible whenever rounded corners are in effect (ShouldUseBraveWebViewRoundedCornersForContents()), instead of maintaining a parallel Brave-only view for the same job. This drops a chunk of duplicated view/layout code with no behavior change for users.

TEST=BraveBrowserViewWithRoundedCornersTest.MainBackgroundRegionEventHandleTest

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
