### PR TITLE
[Desktop] Blink shape cache incorrectly shares results across font sizes  

### DIFF
--- a/browser/ui/views/profiles/brave_profile_picker_view_browsertest.cc
+++ b/browser/ui/views/profiles/brave_profile_picker_view_browsertest.cc
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "chrome/browser/browser_process.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/profiles/profile_attributes_entry.h"
+#include "chrome/browser/profiles/profile_attributes_storage.h"
+#include "chrome/browser/profiles/profile_manager.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/profiles/profile_picker.h"
+#include "chrome/browser/ui/profiles/profile_ui_test_utils.h"
+#include "chrome/browser/ui/views/profiles/profile_picker_test_base.h"
+#include "chrome/common/chrome_isolated_world_ids.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "url/gurl.h"
+
+namespace {
+
+// Keep this at NGShapeCache's 30-code-unit limit so it remains cacheable while
+// still overflowing the profile name input.
+constexpr char16_t kLongProfileName[] =
+    u"WideProfileNameWideProfileName";
+
+// The profile card is rendered after profiles-list-changed. Wait for each DOM
+// element with MutationObserver, following Chromium's pattern in
+// content/browser/service_worker/service_worker_internals_ui_browsertest.cc.
+constexpr char kShowNameTooltipScript[] = R"(
+  (async () => {
+    const waitForElement = (root, selector) => {
+      const element = root.querySelector(selector);
+      if (element) {
+        return Promise.resolve(element);
+      }
+
+      return new Promise(resolve => {
+        const observer = new MutationObserver(() => {
+          const element = root.querySelector(selector);
+          if (element) {
+            observer.disconnect();
+            resolve(element);
+          }
+        });
+        observer.observe(root, {childList: true, subtree: true});
+      });
+    };
+
+    const getShadowRoot = element => {
+      if (!element.shadowRoot) {
+        throw new Error(`Missing shadow root for ${element.localName}`);
+      }
+      return element.shadowRoot;
+    };
+
+    const app = await waitForElement(document, 'profile-picker-app');
+    const mainView =
+        await waitForElement(getShadowRoot(app), '#mainView');
+    const card =
+        await waitForElement(getShadowRoot(mainView), 'profile-card');
+
+    const cardRoot = getShadowRoot(card);
+    const [nameInput, tooltip] = await Promise.all([
+      waitForElement(cardRoot, '#nameInput'),
+      waitForElement(cardRoot, '#tooltip'),
+    ]);
+    await document.fonts.ready;
+
+    const [input, tooltipElement] = await Promise.all([
+      waitForElement(getShadowRoot(nameInput), '#input'),
+      waitForElement(getShadowRoot(tooltip), '#tooltip'),
+    ]);
+    await new Promise(resolve => requestAnimationFrame(resolve));
+
+    const diagnostic = () => JSON.stringify({
+      name: input.value,
+      scrollWidth: input.scrollWidth,
+      offsetWidth: input.offsetWidth,
+      tooltipHidden: tooltipElement.hidden,
+    });
+
+    if (input.scrollWidth <= input.offsetWidth) {
+      return `Profile name is not truncated: ${diagnostic()}`;
+    }
+
+    nameInput.dispatchEvent(new MouseEvent('mouseenter'));
+    if (tooltipElement.hidden) {
+      return `Tooltip stayed hidden after mouseenter: ${diagnostic()}`;
+    }
+    return true;
+  })()
+)";
+
+class BraveProfilePickerViewBrowserTest : public ProfilePickerTestBase {};
+
+// The shape cache key must distinguish exact font sizes because HarfBuzz uses
+// that size even when nearby sizes share SimpleFontData and its NGShapeCache.
+IN_PROC_BROWSER_TEST_F(BraveProfilePickerViewBrowserTest,
+                       ShowsTooltipForTruncatedProfileName) {
+  ProfileManager* const profile_manager = g_browser_process->profile_manager();
+  ASSERT_NE(profile_manager, nullptr);
+  ProfileAttributesEntry* const entry =
+      profile_manager->GetProfileAttributesStorage()
+          .GetProfileAttributesWithPath(browser()->GetProfile()->GetPath());
+  ASSERT_NE(entry, nullptr);
+  entry->SetLocalProfileName(kLongProfileName, /*is_default_name=*/false);
+
+  ProfilePicker::Show(ProfilePicker::Params::FromEntryPoint(
+      ProfilePicker::EntryPoint::kProfileMenuManageProfiles));
+  profiles::testing::WaitForPickerUrl(GURL{"chrome://profile-picker"});
+
+  content::WebContents* const contents = web_contents();
+  ASSERT_NE(contents, nullptr);
+  EXPECT_EQ(true, content::EvalJs(contents, kShowNameTooltipScript,
+                                  content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,
+                                  ISOLATED_WORLD_ID_BRAVE_INTERNAL));
+}
+
+}  // namespace

--- a/patches/third_party-blink-renderer-core-layout-inline-inline_node.cc.patch
+++ b/patches/third_party-blink-renderer-core-layout-inline-inline_node.cc.patch
@@ -1,0 +1,14 @@
+diff --git a/third_party/blink/renderer/core/layout/inline/inline_node.cc b/third_party/blink/renderer/core/layout/inline/inline_node.cc
+index ac96b2a2e7d8af063db17d118a32a60dda644fc1..44eac7910548cae45e758de73f3fa0327e78146a 100644
+--- a/third_party/blink/renderer/core/layout/inline/inline_node.cc
++++ b/third_party/blink/renderer/core/layout/inline/inline_node.cc
+@@ -173,7 +173,8 @@ class ReusingTextShaper final {
+       return font.PrimaryFont()->GetShapeCache().GetOrCreate(
+           ShapeCacheKey(shaper_.GetText(), start_item.StartOffset(), end_offset,
+                         locale ? locale->LocaleString() : g_null_atom,
+-                        font.GetFontFeatures(), start_item.Direction()),
++                        font.GetFontFeatures(), start_item.Direction(),
++                        font.GetFontDescription().SpecifiedSize()),
+           ShapeFunc);
+     }
+     return ShapeFunc().shape_result;

--- a/patches/third_party-blink-renderer-platform-fonts-shaping-ng_shape_cache.h.patch
+++ b/patches/third_party-blink-renderer-platform-fonts-shaping-ng_shape_cache.h.patch
@@ -1,0 +1,44 @@
+diff --git a/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache.h b/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache.h
+index fe4c1ca98aedc3eba9df9c598f7b546703bef05e..00259944a15d40f65971400105d2b1a2e7d376e2 100644
+--- a/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache.h
++++ b/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache.h
+@@ -79,12 +79,14 @@ struct ShapeCacheKey {
+                 unsigned end_offset,
+                 const AtomicString& locale,
+                 base::span<const FontFeatureRange> font_features,
+-                TextDirection direction)
++                TextDirection direction,
++                float specified_size)
+       : text_(text),
+         start_offset_(start_offset),
+         end_offset_(end_offset),
+         locale_(locale),
+         font_features_(font_features),
++        specified_size_(specified_size),
+         direction_(direction) {
+     DCHECK_NE(text_, g_empty_string);
+   }
+@@ -100,6 +102,7 @@ struct ShapeCacheKey {
+     AddIntToHash(hash, locale_ ? blink::GetHash(locale_) : 0);
+     AddIntToHash(
+         hash, StringHasher::HashMemory32(base::as_byte_span(font_features_)));
++    AddFloatToHash(hash, specified_size_);
+     AddIntToHash(hash, static_cast<unsigned>(direction_));
+     return hash;
+   }
+@@ -108,6 +111,7 @@ struct ShapeCacheKey {
+     return text_ == other.text_ && start_offset_ == other.start_offset_ &&
+            end_offset_ == other.end_offset_ && locale_ == other.locale_ &&
+            font_features_ == other.font_features_ &&
++           specified_size_ == other.specified_size_ &&
+            direction_ == other.direction_;
+   }
+ 
+@@ -119,6 +123,7 @@ struct ShapeCacheKey {
+   unsigned end_offset_ = 0u;
+   AtomicString locale_;
+   Vector<FontFeatureRange, 1> font_features_;
++  float specified_size_ = 0;
+   TextDirection direction_ = TextDirection::kLtr;
+ };
+ 

--- a/patches/third_party-blink-renderer-platform-fonts-shaping-ng_shape_cache_test.cc.patch
+++ b/patches/third_party-blink-renderer-platform-fonts-shaping-ng_shape_cache_test.cc.patch
@@ -1,0 +1,23 @@
+diff --git a/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache_test.cc b/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache_test.cc
+index eb5987ebac862df7f639590f692536f3183c0739..627fa0d4c0edfbceca84f6997d86312431685eab 100644
+--- a/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache_test.cc
++++ b/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache_test.cc
+@@ -33,7 +33,8 @@ TEST_F(NGShapeCacheTest, AddEntriesAndCacheHits) {
+ 
+   auto CreateKey = [](const String& text,
+                       TextDirection direction) -> ShapeCacheKey {
+-    return ShapeCacheKey(text, 0, text.length(), g_null_atom, {}, direction);
++    return ShapeCacheKey(text, 0, text.length(), g_null_atom, {}, direction,
++                         100.f);
+   };
+ 
+   // Adding an entry is successful.
+@@ -80,7 +81,7 @@ TEST_F(NGShapeCacheTest, FontPerformanceMetrics) {
+ 
+   auto CreateKey = [](const String& text) -> ShapeCacheKey {
+     return ShapeCacheKey(text, 0, text.length(), g_null_atom, {},
+-                         TextDirection::kLtr);
++                         TextDirection::kLtr, 100.f);
+   };
+ 
+   // First access: Miss

--- a/rewrite/third_party/blink/renderer/core/layout/inline/inline_node.cc.yaml
+++ b/rewrite/third_party/blink/renderer/core/layout/inline/inline_node.cc.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Pass `FontDescription::SpecifiedSize()` to ShapeCacheKey.
+
+      The cache belongs to `SimpleFontData`, which can serve nearby font sizes.
+      Pass the current font's size so the key matches the shaping input.
+    regex:
+      pattern: 'font.GetFontFeatures(), start_item.Direction())'
+      replace: |-
+        font.GetFontFeatures(), start_item.Direction(),
+                                font.GetFontDescription().SpecifiedSize())

--- a/rewrite/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache.h.yaml
+++ b/rewrite/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache.h.yaml
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Add `specified_size` to ShapeCacheKey.
+
+      `SimpleFontData` can serve nearby font sizes. Include the size used for
+      shaping so their cached `ShapeResult`s cannot share a key.
+    regex:
+      pattern: 'TextDirection direction)'
+      replace: |-
+        TextDirection direction,
+                        float specified_size)
+
+  - description: 'Store the exact font size in ShapeCacheKey.'
+    regex:
+      pattern: 'font_features_(font_features),'
+      replace: |-
+        font_features_(font_features),
+                specified_size_(specified_size),
+
+  - description: 'Hash the exact font size in ShapeCacheKey.'
+    regex:
+      pattern: 'AddIntToHash(hash, static_cast<unsigned>(direction_));'
+      replace: |-
+        AddFloatToHash(hash, specified_size_);
+            AddIntToHash(hash, static_cast<unsigned>(direction_));
+
+  - description: 'Compare the exact font size in ShapeCacheKey.'
+    regex:
+      pattern: 'font_features_ == other.font_features_ &&'
+      replace: |-
+        font_features_ == other.font_features_ &&
+                   specified_size_ == other.specified_size_ &&
+
+  - description: 'Declare the exact font size in ShapeCacheKey.'
+    regex:
+      pattern: 'TextDirection direction_ = TextDirection::kLtr;'
+      replace: |-
+        float specified_size_ = 0;
+          TextDirection direction_ = TextDirection::kLtr;

--- a/rewrite/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache_test.cc.yaml
+++ b/rewrite/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache_test.cc.yaml
@@ -1,0 +1,23 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Pass the Ahem font size to the directional ShapeCacheKey test helper.
+
+      The cache is created for a 100px Ahem font, so the helper must state the
+      exact font size now required by ShapeCacheKey.
+    regex:
+      pattern:
+        'return ShapeCacheKey(text, 0, text.length(), g_null_atom, {},
+        direction);'
+      replace: |-
+        return ShapeCacheKey(text, 0, text.length(), g_null_atom, {}, direction,
+                                 100.f);
+
+  - description: 'Pass the Ahem font size to the LTR ShapeCacheKey test helper.'
+    regex:
+      pattern: 'TextDirection::kLtr);'
+      replace: 'TextDirection::kLtr, 100.f);'

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -148,6 +148,7 @@ test("brave_unit_tests") {
     "//brave/components/ntp_background_images/browser/test/ntp_sponsored_source_test_util.h",
     "//brave/components/webcompat/content/test/webcompat_exceptions_unittest.cc",
     "//brave/third_party/blink/renderer/brave_font_whitelist_unittest.cc",
+    "//brave/third_party/blink/renderer/shape_cache_key_unittest.cc",
     "//brave/third_party/libaddressinput/chromium/chrome_metadata_source_unittest.cc",
     "//brave/vendor/brave_base/random_unittest.cc",
     "//components/domain_reliability/test_util.cc",
@@ -1445,6 +1446,10 @@ test("brave_browser_tests") {
       "//chrome/browser/ui/web_applications",
       "//ui/base/clipboard:clipboard_test_support",
     ]
+
+    if (enable_dice_support) {
+      sources += [ "//brave/browser/ui/views/profiles/brave_profile_picker_view_browsertest.cc" ]
+    }
 
     if (enable_brave_rewards) {
       sources += [ "//brave/browser/ui/views/brave_actions/brave_actions_container_browsertest.cc" ]

--- a/third_party/blink/renderer/shape_cache_key_unittest.cc
+++ b/third_party/blink/renderer/shape_cache_key_unittest.cc
@@ -15,7 +15,7 @@ namespace {
 ShapeCacheKey CreateShapeCacheKey(float specified_size) {
   const String text("A");
   return ShapeCacheKey(text, 0, text.length(), g_null_atom, {},
-                       TextDirection::kLtr);
+                       TextDirection::kLtr, specified_size);
 }
 
 TEST(ShapeCacheKeyTest, SpecifiedSizeAffectsEquality) {

--- a/third_party/blink/renderer/shape_cache_key_unittest.cc
+++ b/third_party/blink/renderer/shape_cache_key_unittest.cc
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache.h"
+#include "third_party/blink/renderer/platform/text/text_direction.h"
+#include "third_party/blink/renderer/platform/wtf/text/atomic_string.h"
+#include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
+
+namespace blink {
+namespace {
+
+ShapeCacheKey CreateShapeCacheKey(float specified_size) {
+  const String text("A");
+  return ShapeCacheKey(text, 0, text.length(), g_null_atom, {},
+                       TextDirection::kLtr);
+}
+
+TEST(ShapeCacheKeyTest, SpecifiedSizeAffectsEquality) {
+  const ShapeCacheKey size_12 = CreateShapeCacheKey(12.f);
+  const ShapeCacheKey size_12_0003 = CreateShapeCacheKey(12.0003f);
+
+  EXPECT_FALSE(size_12 == size_12_0003);
+}
+
+}  // namespace
+}  // namespace blink


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58616.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

## Summary


Blink’s [font cache key reduces font-size precision to two decimal places](https://chromium.googlesource.com/chromium/src/+/8753e81e049e9b56771f9f7900edeec425b120ca/third_party/blink/renderer/platform/fonts/font_description.cc#271), so [nearby specified sizes can share](https://chromium.googlesource.com/chromium/src/+/8753e81e049e9b56771f9f7900edeec425b120ca/third_party/blink/renderer/platform/fonts/font_platform_data_cache.cc#56) the same [`SimpleFontData`](https://chromium.googlesource.com/chromium/src/+/8753e81e049e9b56771f9f7900edeec425b120ca/third_party/blink/renderer/platform/fonts/font_data_cache.cc#61). HarfBuzz still shapes text using the exact [`FontDescription::SpecifiedSize()`](https://chromium.googlesource.com/chromium/src/+/8753e81e049e9b56771f9f7900edeec425b120ca/third_party/blink/renderer/platform/fonts/shaping/harfbuzz_shaper.cc#1035).

Because [`ShapeCacheKey`](https://chromium.googlesource.com/chromium/src/+/8753e81e049e9b56771f9f7900edeec425b120ca/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache.h#72) did not include that exact size, it could [reuse a `ShapeResult` produced for a different size](https://chromium.googlesource.com/chromium/src/+/8753e81e049e9b56771f9f7900edeec425b120ca/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache.h#223). Different behavior is exhibited in the different build configs:
* Debug builds detect the mismatch with an [`NGShapeCache` `DCHECK`](https://chromium.googlesource.com/chromium/src/+/8753e81e049e9b56771f9f7900edeec425b120ca/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache.h#246); 
* Release builds can [silently reuse the incorrect result](https://chromium.googlesource.com/chromium/src/+/8753e81e049e9b56771f9f7900edeec425b120ca/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache.h#249).

This PR adds the exact specified font size to the shape-cache key, hash, and equality comparison.

## Changes

### Commit 1

**Add tests to demonstrate Blink shape cache font size bug**

- require cache keys to distinguish nearby exact font sizes
- reproduce the shape-cache DCHECK through a truncated Profile Picker name

Note: by design, these tests will fail 🔴. Subsequent commits will include the exact font size in the cache key, turning these tests from red to green.

If you `git checkout` at Commit 1 running these tests will fail (making sure to run `pnpm run apply_patches` as necessary of course):

`pnpm run test brave_browser_tests Debug --filter=BraveProfilePickerViewBrowserTest.ShowsTooltipForTruncatedProfileName`
`pnpm run test brave_unit_tests Debug --use_remoteexec=true --filter=ShapeCacheKeyTest.\*`

### Commit 2

**Key Blink shape cache by exact font size**

- key cached results by `FontDescription::SpecifiedSize()`
- require every `ShapeCacheKey` caller to pass `specified_size`

After this Commit 2, the tests above pass 🟢.

## Screenshots

Note: captures taken from a debug build - as mentioned, the renderer crash only occurs in Debug due to the [`NGShapeCache` `DCHECK`](https://chromium.googlesource.com/chromium/src/+/8753e81e049e9b56771f9f7900edeec425b120ca/third_party/blink/renderer/platform/fonts/shaping/ng_shape_cache.h#246) that does not run in Release.


Before:

[https://github.com/user-attachments/assets/cb3ebcb7-d487-4ba4-97a8-e1f3613b299d](https://github.com/user-attachments/assets/cb3ebcb7-d487-4ba4-97a8-e1f3613b299d)

After:

[https://github.com/user-attachments/assets/7dc6746d-5158-467e-9051-916f0863a904](https://github.com/user-attachments/assets/7dc6746d-5158-467e-9051-916f0863a904)

## Notes

I appreciate it's suboptimal to make largely patch/plaster based PRs. If there's a more preferable means of fixing this, please just let me know.
