### PR TITLE
Fix EdgeRevealWatcherTest leak

### DIFF
--- a/browser/ui/views/frame/edge_reveal/edge_reveal_watcher_unittest.cc
+++ b/browser/ui/views/frame/edge_reveal/edge_reveal_watcher_unittest.cc
@@ -75,17 +75,23 @@ class EdgeRevealWatcherTest : public views::test::WidgetTest {
     return widget;
   }
 
-  std::unique_ptr<views::Widget> CreateBubbleAnchoredTo(views::View* anchor) {
-    auto delegate = std::make_unique<views::BubbleDialogDelegate>(
+  // Client owns both the delegate and the widget. `delegate` is declared first
+  // so it outlives `widget` (required by BubbleDialogDelegate::CreateBubble).
+  struct AnchoredBubble {
+    std::unique_ptr<views::BubbleDialogDelegate> delegate;
+    std::unique_ptr<views::Widget> widget;
+  };
+
+  AnchoredBubble CreateBubbleAnchoredTo(views::View* anchor) {
+    AnchoredBubble bubble;
+    bubble.delegate = std::make_unique<views::BubbleDialogDelegate>(
         views::BubbleAnchor(anchor), views::BubbleBorder::TOP_LEFT);
-    delegate->SetContentsView(std::make_unique<views::View>());
-    delegate->set_close_on_deactivate(false);
-    std::unique_ptr<views::Widget> bubble_widget(
-        views::BubbleDialogDelegate::CreateBubbleDeprecated(
-            std::move(delegate),
-            views::Widget::InitParams::CLIENT_OWNS_WIDGET));
-    bubble_widget->Show();
-    return bubble_widget;
+    bubble.delegate->SetContentsView(std::make_unique<views::View>());
+    bubble.delegate->set_close_on_deactivate(false);
+    bubble.widget =
+        views::BubbleDialogDelegate::CreateBubble(bubble.delegate.get());
+    bubble.widget->Show();
+    return bubble;
   }
 
   void CloseHostWidget() {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/internal/issues/1871

`../testing/xvfb.py pnpm test brave_unit_tests Static --filter="EdgeRevealWatcherTest.BubbleAnchoredInEdgeSetsAnchoredBubble`
before:
```
...
[  PASSED  ] 1 test.

=================================================================
==99065==ERROR: LeakSanitizer: detected memory leaks

Indirect leak of 1096 byte(s) in 1 object(s) allocated from:
    #0 0x561759ba23e1 in operator new(unsigned long) (/mnt/wsl/PHYSICALDRIVE1p4/mikhail/work/brave-browser/src/out/Static/brave_unit_tests+0x15fb93e1) (BuildId: 7e1cbd2d0ddc9983)
    #1 0x56175d66a264 in make_unique<views::BubbleDialogDelegate, views::BubbleAnchor, views::BubbleBorder::Arrow, 0> third_party/libc++/src/include/__memory/unique_ptr.h:708:26
    #2 0x56175d66a264 in EdgeRevealWatcherTest::CreateBubbleAnchoredTo(views::View*) brave/browser/ui/views/frame/edge_reveal/edge_reveal_watcher_unittest.cc:79:21
    #3 0x56175d6698f2 in EdgeRevealWatcherTest_BubbleAnchoredInEdgeSetsAnchoredBubble_Test::TestBody() brave/browser/ui/views/frame/edge_reveal/edge_reveal_watcher_unittest.cc:133:17
```

after:
```
[1/1] EdgeRevealWatcherTest.BubbleAnchoredInEdgeSetsAnchoredBubble (45 ms)
SUCCESS: all tests passed.
Tests took 1 seconds.
(II) Server terminated successfully (0). Closing log file.
```

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
