### PR TITLE
[iptc] Remove mime type check in the download flow

### DIFF
--- a/browser/download/brave_download_manager_delegate.cc
+++ b/browser/download/brave_download_manager_delegate.cc
@@ -50,8 +50,10 @@ bool BraveDownloadManagerDelegate::IsDownloadReadyForCompletion(
   // types rely on upstream flow.
   // TODO(https://github.com/brave/brave-browser/issues/5238): PNG formats needs
   // more investigation whether FBMD is present or not. So, tackling only jpeg.
-  const std::string mime_type = item->GetMimeType();
-  if (mime_type != "image/jpeg") {
+  const base::FilePath path = item->GetTargetFilePath();
+  const bool is_jpeg_ext = path.MatchesExtension(FILE_PATH_LITERAL(".jpg")) ||
+                           path.MatchesExtension(FILE_PATH_LITERAL(".jpeg"));
+  if (!is_jpeg_ext) {
     return ChromeDownloadManagerDelegate::IsDownloadReadyForCompletion(
         item, std::move(internal_complete_callback));
   }

--- a/browser/download/brave_download_manager_delegate.cc
+++ b/browser/download/brave_download_manager_delegate.cc
@@ -46,10 +46,9 @@ bool BraveDownloadManagerDelegate::IsDownloadReadyForCompletion(
         item, std::move(internal_complete_callback));
   }
 
-  // IPTC metadata stripping only available for jpeg types. So, for non
-  // types rely on upstream flow.
-  // TODO(https://github.com/brave/brave-browser/issues/5238): PNG formats needs
-  // more investigation whether FBMD is present or not. So, tackling only jpeg.
+  // IPTC metadata stripping only available for jpeg.
+  // TODO(https://github.com/brave/brave-browser/issues/5238): PNG needs
+  // more investigation whether FBMD is present or not.
   const base::FilePath path = item->GetTargetFilePath();
   const bool is_jpeg_ext = path.MatchesExtension(FILE_PATH_LITERAL(".jpg")) ||
                            path.MatchesExtension(FILE_PATH_LITERAL(".jpeg"));

--- a/browser/download/brave_download_manager_delegate_browsertest.cc
+++ b/browser/download/brave_download_manager_delegate_browsertest.cc
@@ -221,21 +221,17 @@ class BraveDownloadManagerDelegateBrowserTestBase : public PlatformBrowserTest {
         << "File should always finish downloading";
   }
 
-  void DownloadAndExpectIptcStripping(const ImageTestFile& file) {
+  void DownloadAndExpectIptcStripping(const ImageTestFile& file,
+                                      bool should_strip) {
     base::test::TestFuture<void> iptc_metadata_stripper_future;
     GetDownloadManagerDelegate()->SetOnImageMetadataStrippedCallback(
         iptc_metadata_stripper_future.GetCallback());
     DownloadURL(embedded_test_server()->GetURL(UrlPath(file)));
-    EXPECT_TRUE(iptc_metadata_stripper_future.Wait());
-    AssertFileWasDownloaded(file);
-  }
-
-  void DownloadAndExpectNoIptcStripping(const ImageTestFile& file) {
-    base::test::TestFuture<void> iptc_metadata_stripper_future;
-    GetDownloadManagerDelegate()->SetOnImageMetadataStrippedCallback(
-        iptc_metadata_stripper_future.GetCallback());
-    DownloadURL(embedded_test_server()->GetURL(UrlPath(file)));
-    EXPECT_FALSE(iptc_metadata_stripper_future.IsReady());
+    if (should_strip) {
+      EXPECT_TRUE(iptc_metadata_stripper_future.Wait());
+    } else {
+      EXPECT_FALSE(iptc_metadata_stripper_future.IsReady());
+    }
     AssertFileWasDownloaded(file);
   }
 
@@ -289,7 +285,8 @@ class BraveDownloadManagerDelegateFeatureDisabledBrowserTest
 IN_PROC_BROWSER_TEST_F(
     BraveDownloadManagerDelegateBrowserTest,
     NON_ANDROID_TEST(RemovesFbmdMetadataFromDownloadedJpegImage)) {
-  DownloadAndExpectIptcStripping(kRealJpegImageAndJpegMimeFile);
+  DownloadAndExpectIptcStripping(kRealJpegImageAndJpegMimeFile,
+                                 /*should_strip=*/true);
 
   base::ScopedAllowBlockingForTesting allow_blocking;
   std::string downloaded_contents;
@@ -311,7 +308,8 @@ IN_PROC_BROWSER_TEST_F(
 IN_PROC_BROWSER_TEST_F(
     BraveDownloadManagerDelegateBrowserTest,
     NON_ANDROID_TEST(InvokesStrippingForJpegExtWithNonJpegMime)) {
-  DownloadAndExpectIptcStripping(kJpegExtAndOctetMimeFile);
+  DownloadAndExpectIptcStripping(kJpegExtAndOctetMimeFile,
+                                 /*should_strip=*/true);
 
   download::DownloadItem* const item = GetCompletedDownload();
   ASSERT_TRUE(item);
@@ -322,7 +320,8 @@ IN_PROC_BROWSER_TEST_F(
 IN_PROC_BROWSER_TEST_F(
     BraveDownloadManagerDelegateBrowserTest,
     NON_ANDROID_TEST(DoesNotInvokeStrippingForNonJpegExtWithJpegMime)) {
-  DownloadAndExpectNoIptcStripping(kPngExtAndJpegMimeFile);
+  DownloadAndExpectIptcStripping(kPngExtAndJpegMimeFile,
+                                 /*should_strip=*/false);
 
   download::DownloadItem* const item = GetCompletedDownload();
   ASSERT_TRUE(item);
@@ -333,28 +332,13 @@ IN_PROC_BROWSER_TEST_F(
 IN_PROC_BROWSER_TEST_F(
     BraveDownloadManagerDelegateBrowserTest,
     NON_ANDROID_TEST(DoesNotStripMetadataFromNonImageDownload)) {
-  base::test::TestFuture<void> iptc_metadata_stripper_future;
-  GetDownloadManagerDelegate()->SetOnImageMetadataStrippedCallback(
-      iptc_metadata_stripper_future.GetCallback());
-
-  DownloadURL(embedded_test_server()->GetURL(UrlPath(kTxtExtAndPlainMimeFile)));
-
-  // Target path is not .jpg/.jpeg, so IPTC stripping is skipped.
-  EXPECT_FALSE(iptc_metadata_stripper_future.IsReady());
-
-  // Ensure the file was still downloaded regardless.
-  AssertFileWasDownloaded(kTxtExtAndPlainMimeFile);
+  DownloadAndExpectIptcStripping(kTxtExtAndPlainMimeFile,
+                                 /*should_strip=*/false);
 }
 
 IN_PROC_BROWSER_TEST_F(
     BraveDownloadManagerDelegateFeatureDisabledBrowserTest,
     NON_ANDROID_TEST(DoesNotStripMetadataWhenFeatureDisabled)) {
-  base::test::TestFuture<void> iptc_metadata_stripper_future;
-  GetDownloadManagerDelegate()->SetOnImageMetadataStrippedCallback(
-      iptc_metadata_stripper_future.GetCallback());
-
-  DownloadURL(embedded_test_server()->GetURL(UrlPath(kJpegExtAndJpegMimeFile)));
-
-  EXPECT_FALSE(iptc_metadata_stripper_future.IsReady());
-  AssertFileWasDownloaded(kJpegExtAndJpegMimeFile);
+  DownloadAndExpectIptcStripping(kJpegExtAndJpegMimeFile,
+                                 /*should_strip=*/false);
 }

--- a/browser/download/brave_download_manager_delegate_browsertest.cc
+++ b/browser/download/brave_download_manager_delegate_browsertest.cc
@@ -18,6 +18,7 @@
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/path_service.h"
+#include "base/strings/strcat.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/test_future.h"
 #include "base/threading/thread_restrictions.h"
@@ -43,11 +44,35 @@
 
 namespace {
 
-constexpr char kJpegImageFileName[] = "test.jpeg";
-constexpr char kTextFileName[] = "test.txt";
-// Real JPEG fixture in //brave/test/data/image_metadata_stripper that contains
+struct ImageTestFile {
+  std::string_view file_name;
+  std::string_view mime_type;
+};
+
+const ImageTestFile kJpegExtAndJpegMimeFile{.file_name = "test.jpeg",
+                                            .mime_type = "image/jpeg"};
+
+const ImageTestFile kTxtExtAndPlainMimeFile{.file_name = "test.txt",
+                                            .mime_type = "text/plain"};
+
+// .jpeg with a non-image MIME type.
+const ImageTestFile kJpegExtAndOctetMimeFile{
+    .file_name = "octet_stream.jpeg",
+    .mime_type = "application/octet-stream"};
+
+// Non-jpeg extension with an image/jpeg Content-Type.
+const ImageTestFile kPngExtAndJpegMimeFile{.file_name = "jpeg_mime.png",
+                                           .mime_type = "image/jpeg"};
+
+// "Real" JPEG image in //brave/test/data/image_metadata_stripper that contains
 // a Facebook FBMD record inside its IPTC metadata.
-constexpr char kFbmdJpegImageFileName[] = "fbmd_test_image.jpg";
+const ImageTestFile kRealJpegImageAndJpegMimeFile{
+    .file_name = "fbmd_test_image.jpg",
+    .mime_type = "image/jpeg"};
+
+std::string UrlPath(const ImageTestFile& file) {
+  return base::StrCat({"/", file.file_name});
+}
 
 // The ASCII marker that begins the Facebook FBMD IPTC record. The stripper
 // zeroes the whole record (including this marker), so its absence in the
@@ -65,31 +90,37 @@ bool ContainsFbmd(std::string_view data) {
 constexpr std::string_view kFakeJpegContents = "\xff\xd8\xff\xe0-not-a-jpeg-";
 constexpr std::string_view kTextFileContents = "not-an-image";
 
+// Serves the test files in the response.
 std::unique_ptr<net::test_server::HttpResponse> HandleDownloadRequest(
     const std::string& fbmd_jpeg_contents,
     const net::test_server::HttpRequest& request) {
-  std::string mime_type;
+  const ImageTestFile* test_file = nullptr;
   std::string_view contents;
-  if (request.relative_url == std::string("/") + kJpegImageFileName) {
-    mime_type = "image/jpeg";
+  if (request.relative_url == UrlPath(kJpegExtAndJpegMimeFile)) {
+    test_file = &kJpegExtAndJpegMimeFile;
     contents = kFakeJpegContents;
-  } else if (request.relative_url ==
-             std::string("/") + kFbmdJpegImageFileName) {
-    mime_type = "image/jpeg";
+  } else if (request.relative_url == UrlPath(kRealJpegImageAndJpegMimeFile)) {
+    test_file = &kRealJpegImageAndJpegMimeFile;
     contents = fbmd_jpeg_contents;
-  } else if (request.relative_url == std::string("/") + kTextFileName) {
-    mime_type = "text/plain";
+  } else if (request.relative_url == UrlPath(kTxtExtAndPlainMimeFile)) {
+    test_file = &kTxtExtAndPlainMimeFile;
     contents = kTextFileContents;
+  } else if (request.relative_url == UrlPath(kJpegExtAndOctetMimeFile)) {
+    test_file = &kJpegExtAndOctetMimeFile;
+    contents = kTextFileContents;
+  } else if (request.relative_url == UrlPath(kPngExtAndJpegMimeFile)) {
+    test_file = &kPngExtAndJpegMimeFile;
+    contents = kFakeJpegContents;
   } else {
     return nullptr;
   }
 
   auto response = std::make_unique<net::test_server::BasicHttpResponse>();
   response->set_code(net::HTTP_OK);
-  response->set_content_type(mime_type);
+  response->set_content_type(test_file->mime_type);
   response->AddCustomHeader(
       "Content-Disposition",
-      "attachment; filename=\"" + request.relative_url.substr(1) + "\"");
+      base::StrCat({"attachment; filename=\"", test_file->file_name, "\""}));
   response->set_content(std::string(contents));
   return response;
 }
@@ -145,7 +176,7 @@ class BraveDownloadManagerDelegateBrowserTestBase : public PlatformBrowserTest {
       const base::FilePath fbmd_path =
           base::PathService::CheckedGet(base::DIR_SRC_TEST_DATA_ROOT)
               .AppendASCII("brave/test/data/image_metadata_stripper")
-              .AppendASCII(kFbmdJpegImageFileName);
+              .AppendASCII(kRealJpegImageAndJpegMimeFile.file_name);
       ASSERT_TRUE(base::ReadFileToString(fbmd_path, &fbmd_jpeg_contents_));
     }
     // Sanity check the fixture actually carries an FBMD record to strip.
@@ -183,10 +214,37 @@ class BraveDownloadManagerDelegateBrowserTestBase : public PlatformBrowserTest {
     observer.WaitForFinished();
   }
 
-  void AssertFileWasDownloaded(std::string_view file_name) {
+  void AssertFileWasDownloaded(const ImageTestFile& file) {
     base::ScopedAllowBlockingForTesting allow_blocking;
-    ASSERT_TRUE(base::PathExists(downloads_directory().AppendASCII(file_name)))
+    ASSERT_TRUE(
+        base::PathExists(downloads_directory().AppendASCII(file.file_name)))
         << "File should always finish downloading";
+  }
+
+  void DownloadAndExpectIptcStripping(const ImageTestFile& file) {
+    base::test::TestFuture<void> iptc_metadata_stripper_future;
+    GetDownloadManagerDelegate()->SetOnImageMetadataStrippedCallback(
+        iptc_metadata_stripper_future.GetCallback());
+    DownloadURL(embedded_test_server()->GetURL(UrlPath(file)));
+    EXPECT_TRUE(iptc_metadata_stripper_future.Wait());
+    AssertFileWasDownloaded(file);
+  }
+
+  void DownloadAndExpectNoIptcStripping(const ImageTestFile& file) {
+    base::test::TestFuture<void> iptc_metadata_stripper_future;
+    GetDownloadManagerDelegate()->SetOnImageMetadataStrippedCallback(
+        iptc_metadata_stripper_future.GetCallback());
+    DownloadURL(embedded_test_server()->GetURL(UrlPath(file)));
+    EXPECT_FALSE(iptc_metadata_stripper_future.IsReady());
+    AssertFileWasDownloaded(file);
+  }
+
+  download::DownloadItem* GetCompletedDownload() {
+    content::DownloadManager::DownloadVector downloads;
+    chrome_test_utils::GetProfile(this)->GetDownloadManager()->GetAllDownloads(
+        &downloads);
+    EXPECT_EQ(1u, downloads.size());
+    return downloads.empty() ? nullptr : downloads[0];
   }
 
  protected:
@@ -231,23 +289,14 @@ class BraveDownloadManagerDelegateFeatureDisabledBrowserTest
 IN_PROC_BROWSER_TEST_F(
     BraveDownloadManagerDelegateBrowserTest,
     NON_ANDROID_TEST(RemovesFbmdMetadataFromDownloadedJpegImage)) {
-  base::test::TestFuture<void> iptc_metadata_stripper_future;
-  GetDownloadManagerDelegate()->SetOnImageMetadataStrippedCallback(
-      iptc_metadata_stripper_future.GetCallback());
-
-  DownloadURL(embedded_test_server()->GetURL(std::string("/") +
-                                             kFbmdJpegImageFileName));
-
-  // RemoveIptcMetadata() ran for the download, and the download still made it
-  // to disk afterwards.
-  EXPECT_TRUE(iptc_metadata_stripper_future.Wait());
-  AssertFileWasDownloaded(kFbmdJpegImageFileName);
+  DownloadAndExpectIptcStripping(kRealJpegImageAndJpegMimeFile);
 
   base::ScopedAllowBlockingForTesting allow_blocking;
   std::string downloaded_contents;
-  ASSERT_TRUE(base::ReadFileToString(
-      downloads_directory().AppendASCII(kFbmdJpegImageFileName),
-      &downloaded_contents));
+  ASSERT_TRUE(
+      base::ReadFileToString(downloads_directory().AppendASCII(
+                                 kRealJpegImageAndJpegMimeFile.file_name),
+                             &downloaded_contents));
 
   // Same before/after invariants as StripsFbmdFromTestImage in
   // jpeg_iptc_metadata_stripper_unittest.cc: the source carried an FBMD record,
@@ -261,19 +310,40 @@ IN_PROC_BROWSER_TEST_F(
 
 IN_PROC_BROWSER_TEST_F(
     BraveDownloadManagerDelegateBrowserTest,
+    NON_ANDROID_TEST(InvokesStrippingForJpegExtWithNonJpegMime)) {
+  DownloadAndExpectIptcStripping(kJpegExtAndOctetMimeFile);
+
+  download::DownloadItem* const item = GetCompletedDownload();
+  ASSERT_TRUE(item);
+  EXPECT_TRUE(
+      item->GetTargetFilePath().MatchesExtension(FILE_PATH_LITERAL(".jpeg")));
+}
+
+IN_PROC_BROWSER_TEST_F(
+    BraveDownloadManagerDelegateBrowserTest,
+    NON_ANDROID_TEST(DoesNotInvokeStrippingForNonJpegExtWithJpegMime)) {
+  DownloadAndExpectNoIptcStripping(kPngExtAndJpegMimeFile);
+
+  download::DownloadItem* const item = GetCompletedDownload();
+  ASSERT_TRUE(item);
+  EXPECT_TRUE(
+      item->GetTargetFilePath().MatchesExtension(FILE_PATH_LITERAL(".png")));
+}
+
+IN_PROC_BROWSER_TEST_F(
+    BraveDownloadManagerDelegateBrowserTest,
     NON_ANDROID_TEST(DoesNotStripMetadataFromNonImageDownload)) {
   base::test::TestFuture<void> iptc_metadata_stripper_future;
   GetDownloadManagerDelegate()->SetOnImageMetadataStrippedCallback(
       iptc_metadata_stripper_future.GetCallback());
 
-  DownloadURL(embedded_test_server()->GetURL(std::string("/") + kTextFileName));
+  DownloadURL(embedded_test_server()->GetURL(UrlPath(kTxtExtAndPlainMimeFile)));
 
-  // Ensure the callback inside the iptc_metadata_stripper_future was never
-  // fired as the file's MIME type didn't correspond to image.
+  // Target path is not .jpg/.jpeg, so IPTC stripping is skipped.
   EXPECT_FALSE(iptc_metadata_stripper_future.IsReady());
 
   // Ensure the file was still downloaded regardless.
-  AssertFileWasDownloaded(kTextFileName);
+  AssertFileWasDownloaded(kTxtExtAndPlainMimeFile);
 }
 
 IN_PROC_BROWSER_TEST_F(
@@ -283,9 +353,8 @@ IN_PROC_BROWSER_TEST_F(
   GetDownloadManagerDelegate()->SetOnImageMetadataStrippedCallback(
       iptc_metadata_stripper_future.GetCallback());
 
-  DownloadURL(
-      embedded_test_server()->GetURL(std::string("/") + kJpegImageFileName));
+  DownloadURL(embedded_test_server()->GetURL(UrlPath(kJpegExtAndJpegMimeFile)));
 
   EXPECT_FALSE(iptc_metadata_stripper_future.IsReady());
-  AssertFileWasDownloaded(kJpegImageFileName);
+  AssertFileWasDownloaded(kJpegExtAndJpegMimeFile);
 }


### PR DESCRIPTION
This change removes using the mime type as a proxy to know if the downloaded file is a jpeg. Mime type could be spoofed. Instead, it relies on the upstream's `GetTargetFilePath` to check the file extension on jpeg. 

This change adds new tests and a minor test refactoring. 

### Fix verification of the hackerone report

https://github.com/user-attachments/assets/6505b62e-170c-4386-a54f-1db6ed025e8a

### General manual testing

https://github.com/user-attachments/assets/575ad29f-b584-475f-97b1-822b402cc514

Resolves https://github.com/brave/brave-browser/issues/58647


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->


<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
