### PR TITLE
Account: introduce `FlowBase` to own the per-flow plumbing

### DIFF
--- a/components/brave_account/BUILD.gn
+++ b/components/brave_account/BUILD.gn
@@ -19,12 +19,15 @@ source_set("brave_account") {
     "flows/cancel_verification.h",
     "flows/change_password.cc",
     "flows/change_password.h",
+    "flows/flow_base.cc",
+    "flows/flow_base.h",
     "flows/get_service_token.cc",
     "flows/get_service_token.h",
     "flows/log_out.cc",
     "flows/log_out.h",
     "flows/login.cc",
     "flows/login.h",
+    "flows/make_request.h",
     "flows/register.cc",
     "flows/register.h",
     "flows/resend_verification_email.cc",
@@ -136,6 +139,7 @@ source_set("unit_tests") {
     "brave_account_service_unittest.cc",
     "flows/cancel_verification_unittest.cc",
     "flows/change_password_unittest.cc",
+    "flows/flow_base_unittest.cc",
     "flows/get_service_token_unittest.cc",
     "flows/log_out_unittest.cc",
     "flows/login_unittest.cc",
@@ -144,7 +148,6 @@ source_set("unit_tests") {
     "flows/reset_password_unittest.cc",
     "flows/update_email_unittest.cc",
     "prefs_unittest.cc",
-    "state_base_unittest.cc",
   ]
 
   deps = [

--- a/components/brave_account/flows/cancel_verification.cc
+++ b/components/brave_account/flows/cancel_verification.cc
@@ -10,8 +10,9 @@
 #include "base/check.h"
 #include "brave/components/brave_account/endpoint_client/with_headers.h"
 #include "brave/components/brave_account/endpoints/verify_delete.h"
-#include "brave/components/brave_account/state_base.h"
+#include "brave/components/brave_account/flows/make_request.h"
 #include "brave/components/brave_account/state_internal.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
 
 namespace brave_account {
 
@@ -20,7 +21,11 @@ using endpoint_client::WithHeaders;
 using endpoints::VerifyDelete;
 using internal::MakeRequest;
 
-CancelVerification::CancelVerification(StateBase& state) : state_(state) {}
+CancelVerification::CancelVerification(
+    AccountStatePrefs& account_state_prefs,
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    const os_crypt_async::Encryptor& encryptor)
+    : FlowBase(account_state_prefs, std::move(url_loader_factory), encryptor) {}
 
 CancelVerification::~CancelVerification() = default;
 
@@ -32,21 +37,21 @@ void CancelVerification::operator()(mojom::VerificationIntentPtr intent) {
           mojom::LoggedOutVerificationIntent::kRegistration) {
     // Best-effort notification to the server, since server side will clean up
     // verification tokens automatically (currently after 30 minutes).
-    // Not adopted into the state's in-flight bag:
+    // Not adopted into the flow's in-flight bag:
     // best-effort with no callback that touches state.
     if (const auto verification_token =
-            state_->GetDecryptedVerificationToken(std::move(intent));
+            GetDecryptedVerificationToken(std::move(intent));
         !verification_token.empty()) {
       auto request = MakeRequest<WithHeaders<VerifyDelete::Request>>();
       SetBearerToken(request, verification_token);
 
-      state_->SendUnownedRequest<VerifyDelete>(std::move(request));
+      SendUnownedRequest<VerifyDelete>(std::move(request));
     }
   }
 
   // LoggedOutWithVerification ==> LoggedOut (no state swap), or
   // LoggedInWithVerification ==> LoggedIn (no state swap).
-  state_->account_state_prefs_->ClearVerification();
+  account_state_prefs_->ClearVerification();
 }
 
 }  // namespace brave_account

--- a/components/brave_account/flows/cancel_verification.h
+++ b/components/brave_account/flows/cancel_verification.h
@@ -6,27 +6,42 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ACCOUNT_FLOWS_CANCEL_VERIFICATION_H_
 #define BRAVE_COMPONENTS_BRAVE_ACCOUNT_FLOWS_CANCEL_VERIFICATION_H_
 
-#include "base/memory/raw_ref.h"
+#include "base/memory/scoped_refptr.h"
+#include "brave/components/brave_account/brave_account_state_prefs.h"
+#include "brave/components/brave_account/flows/flow_base.h"
 #include "brave/components/brave_account/mojom/brave_account.mojom.h"
+
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
+
+namespace os_crypt_async {
+class Encryptor;
+}  // namespace os_crypt_async
 
 namespace brave_account {
 
-class StateBase;
-
 // Owns the verification cancellation of the `mojom::Authentication` surface.
-// Like `ResendVerificationEmail`, this one is held by `StateBase` itself, since
-// `CancelVerification()` is valid in both the logged-out and logged-in states:
-// `StateBase` holds a `CancelVerification` member and forwards the single mojom
-// `CancelVerification` method to `operator()()` here, which best-effort
-// notifies one backend endpoint before dropping the verification slot:
+// Like `ResendVerificationEmail`, and unlike the other flow helpers, this one
+// is duplicated across both states, since `CancelVerification()` is valid in
+// both the logged-out and logged-in states: `LoggedOutState` and
+// `LoggedInState` each hold their own `CancelVerification` member and forward
+// their `CancelVerification` override to `operator()()` here, which
+// best-effort notifies one backend endpoint before dropping the verification
+// slot:
 //
 //   operator()() -> /v2/verify/delete
 //
-// The request is sent through the owning state's `StateBase` helpers, so its
-// lifetime is tied to that state (see `StateBase::SendUnownedRequest`).
-class CancelVerification {
+// The request is deliberately unowned: it is fire-and-forget, so it is not
+// parked in `in_flight_` and outlives this flow rather than being cancelled by
+// `~FlowBase` (see `FlowBase::SendUnownedRequest`). That is safe because its
+// response callback is a no-op that touches no state.
+class CancelVerification : public FlowBase {
  public:
-  explicit CancelVerification(StateBase& state);
+  CancelVerification(
+      AccountStatePrefs& account_state_prefs,
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+      const os_crypt_async::Encryptor& encryptor);
 
   CancelVerification(const CancelVerification&) = delete;
   CancelVerification& operator=(const CancelVerification&) = delete;
@@ -34,9 +49,6 @@ class CancelVerification {
   ~CancelVerification();
 
   void operator()(mojom::VerificationIntentPtr intent);
-
- private:
-  const raw_ref<StateBase> state_;
 };
 
 }  // namespace brave_account

--- a/components/brave_account/flows/change_password.cc
+++ b/components/brave_account/flows/change_password.cc
@@ -13,9 +13,10 @@
 #include "base/types/expected.h"
 #include "brave/components/brave_account/brave_account_utils.h"
 #include "brave/components/brave_account/endpoint_client/with_headers.h"
+#include "brave/components/brave_account/flows/make_request.h"
 #include "brave/components/brave_account/mojom/change_password.mojom.h"
-#include "brave/components/brave_account/state_base.h"
 #include "brave/components/brave_account/state_internal.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
 
 namespace brave_account {
 
@@ -25,7 +26,11 @@ using internal::MakeClientError;
 using internal::MakeRequest;
 using internal::MakeServerError;
 
-ChangePassword::ChangePassword(StateBase& state) : state_(state) {}
+ChangePassword::ChangePassword(
+    AccountStatePrefs& account_state_prefs,
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    const os_crypt_async::Encryptor& encryptor)
+    : FlowBase(account_state_prefs, std::move(url_loader_factory), encryptor) {}
 
 ChangePassword::~ChangePassword() = default;
 
@@ -35,7 +40,7 @@ void ChangePassword::Step1(
   CHECK(!email.empty());
 
   auto authentication_token =
-      state_->GetDecryptedAuthenticationToken<mojom::ChangePasswordError>();
+      GetDecryptedAuthenticationToken<mojom::ChangePasswordError>();
   if (!authentication_token.has_value()) {
     return std::move(callback).Run(
         base::unexpected(std::move(authentication_token).error()));
@@ -50,7 +55,7 @@ void ChangePassword::Step1(
   request.body.locale = "";
   request.body.service = kServiceToString.at(mojom::Service::kAccounts);
 
-  state_->SendStateOwnedRequest<endpoints::VerifyInit>(
+  SendFlowOwnedRequest<endpoints::VerifyInit>(
       std::move(request),
       base::BindOnce(&ChangePassword::OnStep1, weak_factory_.GetWeakPtr(),
                      std::move(callback)));
@@ -62,7 +67,7 @@ void ChangePassword::Step2(
   CHECK(!code.empty());
 
   auto verification_token =
-      state_->GetDecryptedVerificationToken<mojom::ChangePasswordError>(
+      GetDecryptedVerificationToken<mojom::ChangePasswordError>(
           mojom::VerificationIntent::NewLoggedInIntent(
               mojom::LoggedInVerificationIntent::kChangePassword));
   if (!verification_token.has_value()) {
@@ -74,7 +79,7 @@ void ChangePassword::Step2(
   SetBearerToken(request, *verification_token);
   request.body.code = code;
 
-  state_->SendStateOwnedRequest<endpoints::VerifyComplete>(
+  SendFlowOwnedRequest<endpoints::VerifyComplete>(
       std::move(request),
       base::BindOnce(&ChangePassword::OnStep2, weak_factory_.GetWeakPtr(),
                      std::move(callback)));
@@ -86,7 +91,7 @@ void ChangePassword::Step3(
   CHECK(!blinded_message.empty());
 
   auto verification_token =
-      state_->GetDecryptedVerificationToken<mojom::ChangePasswordError>(
+      GetDecryptedVerificationToken<mojom::ChangePasswordError>(
           mojom::VerificationIntent::NewLoggedInIntent(
               mojom::LoggedInVerificationIntent::kChangePassword));
   if (!verification_token.has_value()) {
@@ -101,7 +106,7 @@ void ChangePassword::Step3(
       kServiceToString.at(mojom::Service::kAccounts);
   request.body.serialize_response = true;
 
-  state_->SendStateOwnedRequest<endpoints::PasswordInit>(
+  SendFlowOwnedRequest<endpoints::PasswordInit>(
       std::move(request),
       base::BindOnce(&ChangePassword::OnStep3, weak_factory_.GetWeakPtr(),
                      std::move(callback)));
@@ -113,7 +118,7 @@ void ChangePassword::Step4(
   CHECK(!serialized_record.empty());
 
   auto verification_token =
-      state_->GetDecryptedVerificationToken<mojom::ChangePasswordError>(
+      GetDecryptedVerificationToken<mojom::ChangePasswordError>(
           mojom::VerificationIntent::NewLoggedInIntent(
               mojom::LoggedInVerificationIntent::kChangePassword));
   if (!verification_token.has_value()) {
@@ -126,7 +131,7 @@ void ChangePassword::Step4(
   SetBearerToken(request, *verification_token);
   request.body.serialized_record = serialized_record;
 
-  state_->SendStateOwnedRequest<endpoints::PasswordFinalize>(
+  SendFlowOwnedRequest<endpoints::PasswordFinalize>(
       std::move(request),
       base::BindOnce(&ChangePassword::OnStep4, weak_factory_.GetWeakPtr(),
                      std::move(callback)));
@@ -169,7 +174,7 @@ void ChangePassword::OnStep1(
             }
 
             if (encrypted_verification_token =
-                    state_->Encrypt(success_body.verification_token);
+                    Encrypt(success_body.verification_token);
                 encrypted_verification_token.empty()) {
               return base::unexpected(
                   MakeClientError<mojom::ChangePasswordError>(
@@ -188,7 +193,7 @@ void ChangePassword::OnStep1(
 
   if (success) {
     CHECK(!encrypted_verification_token.empty());
-    state_->account_state_prefs_->AddVerification(
+    account_state_prefs_->AddVerification(
         encrypted_verification_token,
         mojom::VerificationIntent::NewLoggedInIntent(
             mojom::LoggedInVerificationIntent::kChangePassword));
@@ -244,7 +249,7 @@ void ChangePassword::OnStep2(
 
   if (success) {
     CHECK(!email.empty());
-    state_->account_state_prefs_->SetVerificationVerifiedEmail(email);
+    account_state_prefs_->SetVerificationVerifiedEmail(email);
   }
 }
 
@@ -326,7 +331,7 @@ void ChangePassword::OnStep4(
   std::move(callback).Run(std::move(result));
 
   if (success) {
-    state_->account_state_prefs_->ClearVerification();
+    account_state_prefs_->ClearVerification();
   }
 }
 

--- a/components/brave_account/flows/change_password.cc
+++ b/components/brave_account/flows/change_password.cc
@@ -185,7 +185,7 @@ void ChangePassword::OnStep1(
             return mojom::ChangePasswordStep1Result::New();
           });
 
-  // See `StateBase`'s class comment on ordering.
+  // See `FlowBase`'s class comment on ordering.
   // LoggedIn ==> LoggedInWithVerification (no state swap): attaches a
   // verification slot to the existing logged-in state.
   const bool success = result.has_value();
@@ -241,7 +241,7 @@ void ChangePassword::OnStep2(
             return mojom::ChangePasswordStep2Result::New();
           });
 
-  // See `StateBase`'s class comment on ordering.
+  // See `FlowBase`'s class comment on ordering.
   // LoggedInWithVerification ==> LoggedInWithVerification (no state swap):
   // records the verified email.
   const bool success = result.has_value();
@@ -324,7 +324,7 @@ void ChangePassword::OnStep4(
             return mojom::ChangePasswordStep4Result::New();
           });
 
-  // See `StateBase`'s class comment on ordering.
+  // See `FlowBase`'s class comment on ordering.
   // LoggedInWithVerification ==> LoggedIn (no state swap): drops the
   // verification slot.
   const bool success = result.has_value();

--- a/components/brave_account/flows/change_password.h
+++ b/components/brave_account/flows/change_password.h
@@ -8,17 +8,25 @@
 
 #include <string>
 
-#include "base/memory/raw_ref.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
+#include "brave/components/brave_account/brave_account_state_prefs.h"
 #include "brave/components/brave_account/endpoints/password_finalize.h"
 #include "brave/components/brave_account/endpoints/password_init.h"
 #include "brave/components/brave_account/endpoints/verify_complete.h"
 #include "brave/components/brave_account/endpoints/verify_init.h"
+#include "brave/components/brave_account/flows/flow_base.h"
 #include "brave/components/brave_account/mojom/brave_account.mojom.h"
 
-namespace brave_account {
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
 
-class StateBase;
+namespace os_crypt_async {
+class Encryptor;
+}  // namespace os_crypt_async
+
+namespace brave_account {
 
 // Owns the password-change half of the logged-in `mojom::Authentication`
 // surface. `LoggedInState` holds a `ChangePassword` member and forwards the
@@ -30,11 +38,14 @@ class StateBase;
 //   Step3 -> /v2/accounts/password/init
 //   Step4 -> /v2/accounts/password/finalize
 //
-// Requests are sent through the owning state's `StateBase` helpers, so their
-// lifetime is tied to that state (see `StateBase::SendStateOwnedRequest`).
-class ChangePassword {
+// Requests are sent through the inherited `FlowBase` helpers, so their
+// lifetime is tied to this flow (see `FlowBase::SendFlowOwnedRequest`).
+class ChangePassword : public FlowBase {
  public:
-  explicit ChangePassword(StateBase& state);
+  ChangePassword(
+      AccountStatePrefs& account_state_prefs,
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+      const os_crypt_async::Encryptor& encryptor);
 
   ChangePassword(const ChangePassword&) = delete;
   ChangePassword& operator=(const ChangePassword&) = delete;
@@ -65,8 +76,6 @@ class ChangePassword {
 
   void OnStep4(mojom::Authentication::ChangePasswordStep4Callback callback,
                endpoints::PasswordFinalize::Response response);
-
-  const raw_ref<StateBase> state_;
 
   base::WeakPtrFactory<ChangePassword> weak_factory_{this};
 };

--- a/components/brave_account/flows/flow_base.cc
+++ b/components/brave_account/flows/flow_base.cc
@@ -1,0 +1,40 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_account/flows/flow_base.h"
+
+#include <utility>
+
+#include "base/check.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+
+namespace brave_account {
+
+FlowBase::FlowBase(
+    AccountStatePrefs& account_state_prefs,
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    const os_crypt_async::Encryptor& encryptor)
+    : account_state_prefs_(account_state_prefs),
+      url_loader_factory_(std::move(url_loader_factory)),
+      encryption_(encryptor) {
+  CHECK(url_loader_factory_);
+}
+
+FlowBase::~FlowBase() = default;
+
+std::string FlowBase::Encrypt(const std::string& plain_text) const {
+  return encryption_.Encrypt(plain_text);
+}
+
+std::string FlowBase::Decrypt(const std::string& base64) const {
+  return encryption_.Decrypt(base64);
+}
+
+void FlowBase::RemoveRequestHandle(
+    std::list<endpoint_client::RequestHandle>::iterator slot) {
+  in_flight_.erase(slot);
+}
+
+}  // namespace brave_account

--- a/components/brave_account/flows/flow_base.h
+++ b/components/brave_account/flows/flow_base.h
@@ -1,0 +1,181 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ACCOUNT_FLOWS_FLOW_BASE_H_
+#define BRAVE_COMPONENTS_BRAVE_ACCOUNT_FLOWS_FLOW_BASE_H_
+
+#include <list>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+#include "base/check.h"
+#include "base/functional/bind.h"
+#include "base/functional/callback.h"
+#include "base/memory/raw_ref.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/types/expected.h"
+#include "brave/components/brave_account/brave_account_encryption.h"
+#include "brave/components/brave_account/brave_account_state_prefs.h"
+#include "brave/components/brave_account/endpoint_client/client.h"
+#include "brave/components/brave_account/endpoint_client/request_handle.h"
+#include "brave/components/brave_account/mojom/brave_account.mojom.h"
+#include "brave/components/brave_account/state_internal.h"
+
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
+
+namespace os_crypt_async {
+class Encryptor;
+}  // namespace os_crypt_async
+
+namespace brave_account {
+
+// Shared plumbing for the `mojom::Authentication` flow helpers. Each flow
+// (`Login`, `LogOut`, `Register`, ...) derives `FlowBase` and reaches the
+// crypto, prefs, and request-sending helpers below by inheritance.
+//
+// Request lifetime: flow-owned requests are parked in `in_flight_` and
+// cancelled by `~FlowBase`. A flow is a member of its owning state, so the
+// chain is: `BraveAccountService::EnsureState()` replaces a state -> the old
+// state is destroyed -> its flows are destroyed -> their pending requests are
+// cancelled.
+//
+// Cancelling does not un-queue an already-posted response task, so every
+// callback that task would run must be bound through a `WeakPtr` to be
+// dropped. `SendFlowOwnedRequest()` binds the slot-erase through
+// `weak_factory_` here; the user callback it is given must be bound through
+// the derived flow's own `weak_factory_`. Each class needs its own factory,
+// since `base::WeakPtr` cannot downcast to bind a `&Derived::On...` method.
+//
+// Rules for flow implementers:
+//
+//   - State-mutating pref writes must be the *last* thing a method does -
+//     this applies to every method that writes, including each `On*` response
+//     handler. A pref write re-enters
+//     `BraveAccountService::OnAccountStateChanged()` synchronously; if it
+//     changes which `mojom::AccountState` alternative is active,
+//     `BraveAccountService::EnsureState()` migrates the receivers via
+//     `StateBase::TakeReceivers()` and destroys the outgoing state - and with
+//     it this flow.
+//   - Callback-bearing methods must invoke `callback` *before* the pref write;
+//     otherwise the response sender held by `callback` becomes invalid when
+//     receivers unbind (see `mojo::Receiver::Unbind()` in receiver.h). The
+//     rule applies uniformly even for same-alternative writes - the
+//     `Authentication` response and `AuthenticationObserver` notifications are
+//     on separate pipes, so their relative arrival order at the renderer was
+//     never guaranteed in the first place.
+class FlowBase {
+ public:
+  FlowBase(const FlowBase&) = delete;
+  FlowBase& operator=(const FlowBase&) = delete;
+
+ protected:
+  FlowBase(AccountStatePrefs& account_state_prefs,
+           scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+           const os_crypt_async::Encryptor& encryptor);
+
+  ~FlowBase();
+
+  std::string Encrypt(const std::string& plain_text) const;
+  std::string Decrypt(const std::string& base64) const;
+
+  template <typename Error = void>
+  auto GetDecryptedVerificationToken(
+      mojom::VerificationIntentPtr intent) const {
+    if constexpr (std::is_void_v<Error>) {
+      return Decrypt(
+          account_state_prefs_->GetVerificationToken(std::move(intent)));
+    } else {
+      using Expected =
+          base::expected<std::string, decltype(Error::NewClientError(nullptr))>;
+
+      const auto encrypted_verification_token =
+          account_state_prefs_->GetVerificationToken(std::move(intent));
+      if (encrypted_verification_token.empty()) {
+        return Expected(internal::MakeCalledInWrongStateError<Error>());
+      }
+
+      auto verification_token = Decrypt(encrypted_verification_token);
+      if (verification_token.empty()) {
+        return Expected(
+            internal::MakeVerificationTokenDecryptionFailedError<Error>());
+      }
+
+      return Expected(std::move(verification_token));
+    }
+  }
+
+  template <typename Error = void>
+  auto GetDecryptedAuthenticationToken() const {
+    const auto encrypted_authentication_token =
+        account_state_prefs_->GetAuthenticationToken();
+    CHECK(!encrypted_authentication_token.empty());
+
+    auto authentication_token = Decrypt(encrypted_authentication_token);
+    if constexpr (std::is_void_v<Error>) {
+      return authentication_token;
+    } else {
+      using Expected =
+          base::expected<std::string, decltype(Error::NewClientError(nullptr))>;
+
+      if (authentication_token.empty()) {
+        return Expected(
+            internal::MakeAuthenticationTokenDecryptionFailedError<Error>());
+      }
+
+      return Expected(std::move(authentication_token));
+    }
+  }
+
+  // Caller-owned: the returned handle cancels the request when destroyed.
+  // Use when the request's lifetime is tied to something other than
+  // `~FlowBase` (e.g. replaced by the next scheduled attempt).
+  template <typename Endpoint, typename Request, typename Response>
+  [[nodiscard]] endpoint_client::RequestHandle SendCallerOwnedRequest(
+      Request request,
+      base::OnceCallback<void(Response)> callback) {
+    return endpoint_client::Client<Endpoint>::template Send<
+        endpoint_client::RequestCancelability::kCancelable>(
+        url_loader_factory_, std::move(request), std::move(callback));
+  }
+
+  // Flow-owned: the handle is parked in `in_flight_` and cancelled by
+  // `~FlowBase`. The default for response-driven flows.
+  template <typename Endpoint, typename Request, typename Response>
+  void SendFlowOwnedRequest(Request request,
+                            base::OnceCallback<void(Response)> callback) {
+    auto slot = in_flight_.emplace(in_flight_.end());
+    *slot = SendCallerOwnedRequest<Endpoint>(
+        std::move(request),
+        std::move(callback).Then(base::BindOnce(
+            &FlowBase::RemoveRequestHandle, weak_factory_.GetWeakPtr(), slot)));
+  }
+
+  // Unowned: fire-and-forget, no callback, not cancelable. Use only for
+  // best-effort notifications whose response is intentionally ignored.
+  template <typename Endpoint, typename Request>
+  void SendUnownedRequest(Request request) {
+    endpoint_client::Client<Endpoint>::Send(
+        url_loader_factory_, std::move(request),
+        base::BindOnce([](typename Endpoint::Response) {}));
+  }
+
+  const raw_ref<AccountStatePrefs> account_state_prefs_;
+
+ private:
+  void RemoveRequestHandle(
+      std::list<endpoint_client::RequestHandle>::iterator slot);
+
+  const scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
+  const BraveAccountEncryption encryption_;
+  std::list<endpoint_client::RequestHandle> in_flight_;
+  base::WeakPtrFactory<FlowBase> weak_factory_{this};
+};
+
+}  // namespace brave_account
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ACCOUNT_FLOWS_FLOW_BASE_H_

--- a/components/brave_account/flows/flow_base.h
+++ b/components/brave_account/flows/flow_base.h
@@ -16,6 +16,7 @@
 #include "base/functional/callback.h"
 #include "base/memory/raw_ref.h"
 #include "base/memory/scoped_refptr.h"
+#include "base/memory/weak_ptr.h"
 #include "base/types/expected.h"
 #include "brave/components/brave_account/brave_account_encryption.h"
 #include "brave/components/brave_account/brave_account_state_prefs.h"
@@ -35,8 +36,9 @@ class Encryptor;
 namespace brave_account {
 
 // Shared plumbing for the `mojom::Authentication` flow helpers. Each flow
-// (`Login`, `LogOut`, `Register`, ...) derives `FlowBase` and reaches the
-// crypto, prefs, and request-sending helpers below by inheritance.
+// (`Login`, `LogOut`, `Register`, ...) derives `FlowBase` and reaches
+// `Encrypt()`/`Decrypt()`, `GetDecrypted*Token()`, `account_state_prefs_`, and
+// the `Send*Request()` helpers by inheritance.
 //
 // Request lifetime: flow-owned requests are parked in `in_flight_` and
 // cancelled by `~FlowBase`. A flow is a member of its owning state, so the

--- a/components/brave_account/flows/flow_base_unittest.cc
+++ b/components/brave_account/flows/flow_base_unittest.cc
@@ -3,12 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "brave/components/brave_account/state_base.h"
+#include "brave/components/brave_account/flows/flow_base.h"
 
 #include <memory>
 #include <utility>
 
-#include "base/functional/callback_helpers.h"
 #include "base/location.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/run_loop.h"
@@ -42,29 +41,27 @@ struct TestEndpoint {
   static GURL URL() { return GURL("https://example.com/api/query"); }
 };
 
-class TestState : public StateBase {
+class TestFlow : public FlowBase {
  public:
-  TestState(AccountStatePrefs& account_state_prefs,
-            scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-            const os_crypt_async::Encryptor& encryptor,
-            AddObserverCallback add_observer)
-      : StateBase(account_state_prefs,
-                  std::move(url_loader_factory),
-                  encryptor,
-                  std::move(add_observer)) {}
+  TestFlow(AccountStatePrefs& account_state_prefs,
+           scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+           const os_crypt_async::Encryptor& encryptor)
+      : FlowBase(account_state_prefs,
+                 std::move(url_loader_factory),
+                 encryptor) {}
 
-  using StateBase::SendStateOwnedRequest;
+  using FlowBase::SendFlowOwnedRequest;
 };
 
-class StateBaseTest : public testing::Test {
+class FlowBaseTest : public testing::Test {
  protected:
   void SetUp() override {
     prefs::RegisterPrefs(pref_service_.registry());
     account_state_prefs_ = std::make_unique<AccountStatePrefs>(pref_service_);
     encryptor_ = os_crypt_async::GetTestEncryptorForTesting();
-    state_ = std::make_unique<TestState>(
+    flow_ = std::make_unique<TestFlow>(
         *account_state_prefs_, test_url_loader_factory_.GetSafeWeakWrapper(),
-        *encryptor_, base::DoNothing());
+        *encryptor_);
   }
 
   base::test::TaskEnvironment task_environment_;
@@ -72,7 +69,7 @@ class StateBaseTest : public testing::Test {
   std::unique_ptr<AccountStatePrefs> account_state_prefs_;
   network::TestURLLoaderFactory test_url_loader_factory_;
   scoped_refptr<os_crypt_async::Encryptor> encryptor_;
-  std::unique_ptr<TestState> state_;
+  std::unique_ptr<TestFlow> flow_;
 };
 
 }  // namespace
@@ -80,25 +77,25 @@ class StateBaseTest : public testing::Test {
 // Happy path: the user callback fires with the response.
 // Smoke test that the `.Then(RemoveRequestHandle)` continuation doesn't
 // break delivery.
-TEST_F(StateBaseTest, StateOwnedRequest_DeliversResponse) {
+TEST_F(FlowBaseTest, FlowOwnedRequest_DeliversResponse) {
   endpoint_client::MockResponseFor<TestEndpoint>(test_url_loader_factory_,
                                                  TestEndpoint::Response{
                                                      .net_error = net::OK,
                                                  });
   base::test::TestFuture<TestEndpoint::Response> future;
-  state_->SendStateOwnedRequest<TestEndpoint>(TestEndpoint::Request(),
-                                              future.GetCallback());
+  flow_->SendFlowOwnedRequest<TestEndpoint>(TestEndpoint::Request(),
+                                            future.GetCallback());
   EXPECT_TRUE(future.Wait());
 }
 
-// `~StateBase` must cancel still-pending state-owned requests:
-// no response is registered, so the loader hangs until the state is
+// `~FlowBase` must cancel still-pending flow-owned requests:
+// no response is registered, so the loader hangs until the flow is
 // destroyed, and the user callback must never run.
-TEST_F(StateBaseTest, StateOwnedRequest_DestructionCancelsPendingRequest) {
+TEST_F(FlowBaseTest, FlowOwnedRequest_DestructionCancelsPendingRequest) {
   base::test::TestFuture<TestEndpoint::Response> future;
-  state_->SendStateOwnedRequest<TestEndpoint>(TestEndpoint::Request(),
-                                              future.GetCallback());
-  state_.reset();
+  flow_->SendFlowOwnedRequest<TestEndpoint>(TestEndpoint::Request(),
+                                            future.GetCallback());
+  flow_.reset();
   base::RunLoop run_loop;
   base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
       FROM_HERE, run_loop.QuitClosure());

--- a/components/brave_account/flows/get_service_token.cc
+++ b/components/brave_account/flows/get_service_token.cc
@@ -13,9 +13,10 @@
 #include "base/types/expected.h"
 #include "brave/components/brave_account/brave_account_utils.h"
 #include "brave/components/brave_account/endpoint_client/with_headers.h"
+#include "brave/components/brave_account/flows/make_request.h"
 #include "brave/components/brave_account/mojom/get_service_token.mojom.h"
-#include "brave/components/brave_account/state_base.h"
 #include "brave/components/brave_account/state_internal.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
 
 namespace brave_account {
 
@@ -26,7 +27,11 @@ using internal::MakeClientError;
 using internal::MakeRequest;
 using internal::MakeServerError;
 
-GetServiceToken::GetServiceToken(StateBase& state) : state_(state) {}
+GetServiceToken::GetServiceToken(
+    AccountStatePrefs& account_state_prefs,
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    const os_crypt_async::Encryptor& encryptor)
+    : FlowBase(account_state_prefs, std::move(url_loader_factory), encryptor) {}
 
 GetServiceToken::~GetServiceToken() = default;
 
@@ -35,15 +40,15 @@ void GetServiceToken::operator()(
     mojom::Authentication::GetServiceTokenCallback callback) {
   CHECK(service != mojom::Service::kAccounts);
   std::string service_name(kServiceToString.at(service));
-  if (auto service_token = state_->Decrypt(
-          state_->account_state_prefs_->GetCachedServiceToken(service_name));
+  if (auto service_token =
+          Decrypt(account_state_prefs_->GetCachedServiceToken(service_name));
       !service_token.empty()) {
     return std::move(callback).Run(
         mojom::GetServiceTokenResult::New(std::move(service_token)));
   }
 
   auto authentication_token =
-      state_->GetDecryptedAuthenticationToken<mojom::GetServiceTokenError>();
+      GetDecryptedAuthenticationToken<mojom::GetServiceTokenError>();
   if (!authentication_token.has_value()) {
     return std::move(callback).Run(
         base::unexpected(std::move(authentication_token).error()));
@@ -53,7 +58,7 @@ void GetServiceToken::operator()(
   SetBearerToken(request, *authentication_token);
   request.body.service = service_name;
 
-  state_->SendStateOwnedRequest<ServiceToken>(
+  SendFlowOwnedRequest<ServiceToken>(
       std::move(request),
       base::BindOnce(&GetServiceToken::OnResponse, weak_factory_.GetWeakPtr(),
                      std::move(service_name), std::move(callback)));
@@ -92,8 +97,7 @@ void GetServiceToken::OnResponse(
                       mojom::GetServiceTokenServerErrorCode::kInvalidResponse));
             }
 
-            auto encrypted_service_token =
-                state_->Encrypt(success_body.auth_token);
+            auto encrypted_service_token = Encrypt(success_body.auth_token);
             if (encrypted_service_token.empty()) {
               return base::unexpected(
                   MakeClientError<mojom::GetServiceTokenError>(
@@ -101,7 +105,7 @@ void GetServiceToken::OnResponse(
                           kServiceTokenEncryptionFailed));
             }
 
-            state_->account_state_prefs_->CacheServiceToken(
+            account_state_prefs_->CacheServiceToken(
                 service_name, std::move(encrypted_service_token));
 
             return mojom::GetServiceTokenResult::New(

--- a/components/brave_account/flows/get_service_token.h
+++ b/components/brave_account/flows/get_service_token.h
@@ -8,14 +8,22 @@
 
 #include <string>
 
-#include "base/memory/raw_ref.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
+#include "brave/components/brave_account/brave_account_state_prefs.h"
 #include "brave/components/brave_account/endpoints/service_token.h"
+#include "brave/components/brave_account/flows/flow_base.h"
 #include "brave/components/brave_account/mojom/brave_account.mojom.h"
 
-namespace brave_account {
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
 
-class StateBase;
+namespace os_crypt_async {
+class Encryptor;
+}  // namespace os_crypt_async
+
+namespace brave_account {
 
 // Owns the service-token half of the logged-in `mojom::Authentication`
 // surface. `LoggedInState` holds a `GetServiceToken` member and forwards the
@@ -25,11 +33,14 @@ class StateBase;
 //
 //   operator()() -> /v2/auth/service_token
 //
-// Requests are sent through the owning state's `StateBase` helpers, so their
-// lifetime is tied to that state (see `StateBase::SendStateOwnedRequest`).
-class GetServiceToken {
+// Requests are sent through the inherited `FlowBase` helpers, so their
+// lifetime is tied to this flow (see `FlowBase::SendFlowOwnedRequest`).
+class GetServiceToken : public FlowBase {
  public:
-  explicit GetServiceToken(StateBase& state);
+  GetServiceToken(
+      AccountStatePrefs& account_state_prefs,
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+      const os_crypt_async::Encryptor& encryptor);
 
   GetServiceToken(const GetServiceToken&) = delete;
   GetServiceToken& operator=(const GetServiceToken&) = delete;
@@ -43,8 +54,6 @@ class GetServiceToken {
   void OnResponse(const std::string& service_name,
                   mojom::Authentication::GetServiceTokenCallback callback,
                   endpoints::ServiceToken::Response response);
-
-  const raw_ref<StateBase> state_;
 
   base::WeakPtrFactory<GetServiceToken> weak_factory_{this};
 };

--- a/components/brave_account/flows/log_out.cc
+++ b/components/brave_account/flows/log_out.cc
@@ -41,7 +41,7 @@ void LogOut::operator()() {
     SendUnownedRequest<AuthLogout>(std::move(request));
   }
 
-  // See `StateBase`'s class comment on ordering.
+  // See `FlowBase`'s class comment on ordering.
   // LoggedIn ==> LoggedOut (state swap).
   account_state_prefs_->SetLoggedOut();
 }

--- a/components/brave_account/flows/log_out.cc
+++ b/components/brave_account/flows/log_out.cc
@@ -9,8 +9,9 @@
 
 #include "brave/components/brave_account/endpoint_client/with_headers.h"
 #include "brave/components/brave_account/endpoints/auth_logout.h"
-#include "brave/components/brave_account/state_base.h"
+#include "brave/components/brave_account/flows/make_request.h"
 #include "brave/components/brave_account/state_internal.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
 
 namespace brave_account {
 
@@ -19,27 +20,30 @@ using endpoint_client::WithHeaders;
 using endpoints::AuthLogout;
 using internal::MakeRequest;
 
-LogOut::LogOut(StateBase& state) : state_(state) {}
+LogOut::LogOut(
+    AccountStatePrefs& account_state_prefs,
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    const os_crypt_async::Encryptor& encryptor)
+    : FlowBase(account_state_prefs, std::move(url_loader_factory), encryptor) {}
 
 LogOut::~LogOut() = default;
 
 void LogOut::operator()() {
   // Best-effort notification to the server, since server side will clean up
   // authentication tokens automatically (currently in 6 months of inactivity).
-  // Not adopted into the state's in-flight bag:
+  // Not adopted into the flow's in-flight bag:
   // best-effort with no callback that touches state.
-  if (const auto authentication_token =
-          state_->GetDecryptedAuthenticationToken();
+  if (const auto authentication_token = GetDecryptedAuthenticationToken();
       !authentication_token.empty()) {
     auto request = MakeRequest<WithHeaders<AuthLogout::Request>>();
     SetBearerToken(request, authentication_token);
 
-    state_->SendUnownedRequest<AuthLogout>(std::move(request));
+    SendUnownedRequest<AuthLogout>(std::move(request));
   }
 
   // See `StateBase`'s class comment on ordering.
   // LoggedIn ==> LoggedOut (state swap).
-  state_->account_state_prefs_->SetLoggedOut();
+  account_state_prefs_->SetLoggedOut();
 }
 
 }  // namespace brave_account

--- a/components/brave_account/flows/log_out.h
+++ b/components/brave_account/flows/log_out.h
@@ -6,11 +6,19 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ACCOUNT_FLOWS_LOG_OUT_H_
 #define BRAVE_COMPONENTS_BRAVE_ACCOUNT_FLOWS_LOG_OUT_H_
 
-#include "base/memory/raw_ref.h"
+#include "base/memory/scoped_refptr.h"
+#include "brave/components/brave_account/brave_account_state_prefs.h"
+#include "brave/components/brave_account/flows/flow_base.h"
+
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
+
+namespace os_crypt_async {
+class Encryptor;
+}  // namespace os_crypt_async
 
 namespace brave_account {
-
-class StateBase;
 
 // Owns the log-out of the logged-in `mojom::Authentication` surface.
 // `LoggedInState` holds a `LogOut` member and forwards the single mojom
@@ -19,11 +27,15 @@ class StateBase;
 //
 //   operator()() -> /v2/auth/logout
 //
-// The request is sent through the owning state's `StateBase` helpers, so its
-// lifetime is tied to that state (see `StateBase::SendUnownedRequest`).
-class LogOut {
+// The request is deliberately unowned: it is fire-and-forget, so it is not
+// parked in `in_flight_` and outlives this flow rather than being cancelled by
+// `~FlowBase` (see `FlowBase::SendUnownedRequest`). That is safe because its
+// response callback is a no-op that touches no state.
+class LogOut : public FlowBase {
  public:
-  explicit LogOut(StateBase& state);
+  LogOut(AccountStatePrefs& account_state_prefs,
+         scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+         const os_crypt_async::Encryptor& encryptor);
 
   LogOut(const LogOut&) = delete;
   LogOut& operator=(const LogOut&) = delete;
@@ -31,9 +43,6 @@ class LogOut {
   ~LogOut();
 
   void operator()();
-
- private:
-  const raw_ref<StateBase> state_;
 };
 
 }  // namespace brave_account

--- a/components/brave_account/flows/login.cc
+++ b/components/brave_account/flows/login.cc
@@ -13,9 +13,10 @@
 #include "base/types/expected.h"
 #include "brave/components/brave_account/brave_account_utils.h"
 #include "brave/components/brave_account/endpoint_client/with_headers.h"
+#include "brave/components/brave_account/flows/make_request.h"
 #include "brave/components/brave_account/mojom/login.mojom.h"
-#include "brave/components/brave_account/state_base.h"
 #include "brave/components/brave_account/state_internal.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
 
 namespace brave_account {
 
@@ -25,7 +26,10 @@ using internal::MakeClientError;
 using internal::MakeRequest;
 using internal::MakeServerError;
 
-Login::Login(StateBase& state) : state_(state) {}
+Login::Login(AccountStatePrefs& account_state_prefs,
+             scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+             const os_crypt_async::Encryptor& encryptor)
+    : FlowBase(account_state_prefs, std::move(url_loader_factory), encryptor) {}
 
 Login::~Login() = default;
 
@@ -42,7 +46,7 @@ void Login::Step1(mojom::Service initiating_service,
       kServiceToString.at(initiating_service);
   request.body.serialized_ke1 = serialized_ke1;
 
-  state_->SendStateOwnedRequest<endpoints::LoginInit>(
+  SendFlowOwnedRequest<endpoints::LoginInit>(
       std::move(request),
       base::BindOnce(&Login::OnStep1, weak_factory_.GetWeakPtr(),
                      std::move(callback)));
@@ -54,7 +58,7 @@ void Login::Step2(const std::string& encrypted_login_token,
   CHECK(!encrypted_login_token.empty());
   CHECK(!client_mac.empty());
 
-  const std::string login_token = state_->Decrypt(encrypted_login_token);
+  const std::string login_token = Decrypt(encrypted_login_token);
   if (login_token.empty()) {
     return std::move(callback).Run(
         base::unexpected(MakeClientError<mojom::LoginError>(
@@ -65,7 +69,7 @@ void Login::Step2(const std::string& encrypted_login_token,
   SetBearerToken(request, login_token);
   request.body.client_mac = client_mac;
 
-  state_->SendStateOwnedRequest<endpoints::LoginFinalize>(
+  SendFlowOwnedRequest<endpoints::LoginFinalize>(
       std::move(request),
       base::BindOnce(&Login::OnStep2, weak_factory_.GetWeakPtr(),
                      std::move(callback)));
@@ -102,7 +106,7 @@ void Login::OnStep1(mojom::Authentication::LoginStep1Callback callback,
             }
 
             std::string encrypted_login_token =
-                state_->Encrypt(success_body.login_token);
+                Encrypt(success_body.login_token);
             if (encrypted_login_token.empty()) {
               return base::unexpected(MakeClientError<mojom::LoginError>(
                   mojom::LoginClientErrorCode::kLoginTokenEncryptionFailed));
@@ -149,7 +153,7 @@ void Login::OnStep2(mojom::Authentication::LoginStep2Callback callback,
             }
 
             if (encrypted_authentication_token =
-                    state_->Encrypt(success_body.auth_token);
+                    Encrypt(success_body.auth_token);
                 encrypted_authentication_token.empty()) {
               return base::unexpected(MakeClientError<mojom::LoginError>(
                   mojom::LoginClientErrorCode::
@@ -169,8 +173,7 @@ void Login::OnStep2(mojom::Authentication::LoginStep2Callback callback,
   if (success) {
     CHECK(!email.empty());
     CHECK(!encrypted_authentication_token.empty());
-    state_->account_state_prefs_->SetLoggedIn(email,
-                                              encrypted_authentication_token);
+    account_state_prefs_->SetLoggedIn(email, encrypted_authentication_token);
   }
 }
 

--- a/components/brave_account/flows/login.cc
+++ b/components/brave_account/flows/login.cc
@@ -165,7 +165,7 @@ void Login::OnStep2(mojom::Authentication::LoginStep2Callback callback,
             return mojom::LoginStep2Result::New();
           });
 
-  // See `StateBase`'s class comment on ordering.
+  // See `FlowBase`'s class comment on ordering.
   // LoggedOut ==> LoggedIn (state swap).
   const bool success = result.has_value();
   std::move(callback).Run(std::move(result));

--- a/components/brave_account/flows/login.h
+++ b/components/brave_account/flows/login.h
@@ -8,15 +8,23 @@
 
 #include <string>
 
-#include "base/memory/raw_ref.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
+#include "brave/components/brave_account/brave_account_state_prefs.h"
 #include "brave/components/brave_account/endpoints/login_finalize.h"
 #include "brave/components/brave_account/endpoints/login_init.h"
+#include "brave/components/brave_account/flows/flow_base.h"
 #include "brave/components/brave_account/mojom/brave_account.mojom.h"
 
-namespace brave_account {
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
 
-class StateBase;
+namespace os_crypt_async {
+class Encryptor;
+}  // namespace os_crypt_async
+
+namespace brave_account {
 
 // Owns the login half of the logged-out `mojom::Authentication` surface.
 // `LoggedOutState` holds a `Login` member and forwards the two mojom
@@ -26,11 +34,13 @@ class StateBase;
 //   Step1 -> /v2/auth/login/init
 //   Step2 -> /v2/auth/login/finalize
 //
-// Requests are sent through the owning state's `StateBase` helpers, so their
-// lifetime is tied to that state (see `StateBase::SendStateOwnedRequest`).
-class Login {
+// Requests are sent through the inherited `FlowBase` helpers, so their
+// lifetime is tied to this flow (see `FlowBase::SendFlowOwnedRequest`).
+class Login : public FlowBase {
  public:
-  explicit Login(StateBase& state);
+  Login(AccountStatePrefs& account_state_prefs,
+        scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+        const os_crypt_async::Encryptor& encryptor);
 
   Login(const Login&) = delete;
   Login& operator=(const Login&) = delete;
@@ -52,8 +62,6 @@ class Login {
 
   void OnStep2(mojom::Authentication::LoginStep2Callback callback,
                endpoints::LoginFinalize::Response response);
-
-  const raw_ref<StateBase> state_;
 
   base::WeakPtrFactory<Login> weak_factory_{this};
 };

--- a/components/brave_account/flows/make_request.h
+++ b/components/brave_account/flows/make_request.h
@@ -1,0 +1,51 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ACCOUNT_FLOWS_MAKE_REQUEST_H_
+#define BRAVE_COMPONENTS_BRAVE_ACCOUNT_FLOWS_MAKE_REQUEST_H_
+
+#include "net/traffic_annotation/network_traffic_annotation.h"
+
+namespace brave_account::internal {
+
+inline constexpr net::NetworkTrafficAnnotationTag kTrafficAnnotation =
+    net::DefineNetworkTrafficAnnotation("brave_account_endpoints",
+                                        R"(
+  semantics {
+    sender: "Brave Account client"
+    description:
+      "Implements the creation or sign-in process for a Brave Account."
+    trigger:
+      "User attempts to create or sign in to a Brave Account from settings."
+    user_data: {
+      type: EMAIL
+    }
+    data:
+      "Blinded cryptographic message for secure password setup "
+      "and account email address."
+      "Verification token for account activation and "
+      "serialized cryptographic record for account finalization."
+    destination: OTHER
+    destination_other: "Brave Account service"
+  }
+  policy {
+    cookies_allowed: NO
+    policy_exception_justification:
+      "These requests are essential for Brave Account creation and sign-in "
+      "and cannot be disabled by policy."
+  }
+)");
+
+template <typename Request>
+auto MakeRequest() {
+  Request request;
+  request.network_traffic_annotation_tag =
+      net::MutableNetworkTrafficAnnotationTag(kTrafficAnnotation);
+  return request;
+}
+
+}  // namespace brave_account::internal
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ACCOUNT_FLOWS_MAKE_REQUEST_H_

--- a/components/brave_account/flows/register.cc
+++ b/components/brave_account/flows/register.cc
@@ -13,9 +13,10 @@
 #include "base/types/expected.h"
 #include "brave/components/brave_account/brave_account_utils.h"
 #include "brave/components/brave_account/endpoint_client/with_headers.h"
+#include "brave/components/brave_account/flows/make_request.h"
 #include "brave/components/brave_account/mojom/register.mojom.h"
-#include "brave/components/brave_account/state_base.h"
 #include "brave/components/brave_account/state_internal.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
 
 namespace brave_account {
 
@@ -25,7 +26,11 @@ using internal::MakeClientError;
 using internal::MakeRequest;
 using internal::MakeServerError;
 
-Register::Register(StateBase& state) : state_(state) {}
+Register::Register(
+    AccountStatePrefs& account_state_prefs,
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    const os_crypt_async::Encryptor& encryptor)
+    : FlowBase(account_state_prefs, std::move(url_loader_factory), encryptor) {}
 
 Register::~Register() = default;
 
@@ -43,7 +48,7 @@ void Register::Step1(mojom::Service initiating_service,
   request.body.new_account_email = email;
   request.body.serialize_response = true;
 
-  state_->SendStateOwnedRequest<endpoints::PasswordInit>(
+  SendFlowOwnedRequest<endpoints::PasswordInit>(
       std::move(request),
       base::BindOnce(&Register::OnStep1, weak_factory_.GetWeakPtr(),
                      std::move(callback)));
@@ -55,8 +60,7 @@ void Register::Step2(const std::string& encrypted_verification_token,
   CHECK(!encrypted_verification_token.empty());
   CHECK(!serialized_record.empty());
 
-  const std::string verification_token =
-      state_->Decrypt(encrypted_verification_token);
+  const std::string verification_token = Decrypt(encrypted_verification_token);
   if (verification_token.empty()) {
     return std::move(callback).Run(base::unexpected(MakeClientError<
                                                     mojom::RegisterError>(
@@ -68,7 +72,7 @@ void Register::Step2(const std::string& encrypted_verification_token,
   SetBearerToken(request, verification_token);
   request.body.serialized_record = serialized_record;
 
-  state_->SendStateOwnedRequest<endpoints::PasswordFinalize>(
+  SendFlowOwnedRequest<endpoints::PasswordFinalize>(
       std::move(request),
       base::BindOnce(&Register::OnStep2, weak_factory_.GetWeakPtr(),
                      std::move(callback), encrypted_verification_token));
@@ -78,10 +82,9 @@ void Register::Step3(const std::string& code,
                      mojom::Authentication::RegisterStep3Callback callback) {
   CHECK(!code.empty());
 
-  auto verification_token =
-      state_->GetDecryptedVerificationToken<mojom::RegisterError>(
-          mojom::VerificationIntent::NewLoggedOutIntent(
-              mojom::LoggedOutVerificationIntent::kRegistration));
+  auto verification_token = GetDecryptedVerificationToken<mojom::RegisterError>(
+      mojom::VerificationIntent::NewLoggedOutIntent(
+          mojom::LoggedOutVerificationIntent::kRegistration));
   if (!verification_token.has_value()) {
     return std::move(callback).Run(
         base::unexpected(std::move(verification_token).error()));
@@ -91,7 +94,7 @@ void Register::Step3(const std::string& code,
   SetBearerToken(request, *verification_token);
   request.body.code = code;
 
-  state_->SendStateOwnedRequest<endpoints::VerifyComplete>(
+  SendFlowOwnedRequest<endpoints::VerifyComplete>(
       std::move(request),
       base::BindOnce(&Register::OnStep3, weak_factory_.GetWeakPtr(),
                      std::move(callback)));
@@ -130,7 +133,7 @@ void Register::OnStep1(mojom::Authentication::RegisterStep1Callback callback,
             }
 
             std::string encrypted_verification_token =
-                state_->Encrypt(*success_body.verification_token);
+                Encrypt(*success_body.verification_token);
             if (encrypted_verification_token.empty()) {
               return base::unexpected(MakeClientError<mojom::RegisterError>(
                   mojom::RegisterClientErrorCode::
@@ -179,7 +182,7 @@ void Register::OnStep2(mojom::Authentication::RegisterStep2Callback callback,
   std::move(callback).Run(std::move(result));
 
   if (success) {
-    state_->account_state_prefs_->AddVerification(
+    account_state_prefs_->AddVerification(
         encrypted_verification_token,
         mojom::VerificationIntent::NewLoggedOutIntent(
             mojom::LoggedOutVerificationIntent::kRegistration));
@@ -222,7 +225,7 @@ void Register::OnStep3(mojom::Authentication::RegisterStep3Callback callback,
             }
 
             if (encrypted_authentication_token =
-                    state_->Encrypt(success_body.auth_token.GetString());
+                    Encrypt(success_body.auth_token.GetString());
                 encrypted_authentication_token.empty()) {
               return base::unexpected(MakeClientError<mojom::RegisterError>(
                   mojom::RegisterClientErrorCode::
@@ -242,8 +245,7 @@ void Register::OnStep3(mojom::Authentication::RegisterStep3Callback callback,
   if (success) {
     CHECK(!email.empty());
     CHECK(!encrypted_authentication_token.empty());
-    state_->account_state_prefs_->SetLoggedIn(email,
-                                              encrypted_authentication_token);
+    account_state_prefs_->SetLoggedIn(email, encrypted_authentication_token);
   }
 }
 

--- a/components/brave_account/flows/register.cc
+++ b/components/brave_account/flows/register.cc
@@ -176,7 +176,7 @@ void Register::OnStep2(mojom::Authentication::RegisterStep2Callback callback,
             return mojom::RegisterStep2Result::New();
           });
 
-  // See `StateBase`'s class comment on ordering.
+  // See `FlowBase`'s class comment on ordering.
   // LoggedOut ==> LoggedOutWithVerification (no state swap).
   const bool success = result.has_value();
   std::move(callback).Run(std::move(result));
@@ -237,7 +237,7 @@ void Register::OnStep3(mojom::Authentication::RegisterStep3Callback callback,
             return mojom::RegisterStep3Result::New();
           });
 
-  // See `StateBase`'s class comment on ordering.
+  // See `FlowBase`'s class comment on ordering.
   // LoggedOutWithVerification ==> LoggedIn (state swap).
   const bool success = result.has_value();
   std::move(callback).Run(std::move(result));

--- a/components/brave_account/flows/register.h
+++ b/components/brave_account/flows/register.h
@@ -8,16 +8,24 @@
 
 #include <string>
 
-#include "base/memory/raw_ref.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
+#include "brave/components/brave_account/brave_account_state_prefs.h"
 #include "brave/components/brave_account/endpoints/password_finalize.h"
 #include "brave/components/brave_account/endpoints/password_init.h"
 #include "brave/components/brave_account/endpoints/verify_complete.h"
+#include "brave/components/brave_account/flows/flow_base.h"
 #include "brave/components/brave_account/mojom/brave_account.mojom.h"
 
-namespace brave_account {
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
 
-class StateBase;
+namespace os_crypt_async {
+class Encryptor;
+}  // namespace os_crypt_async
+
+namespace brave_account {
 
 // Owns the registration half of the logged-out `mojom::Authentication`
 // surface. `LoggedOutState` holds a `Register` member and forwards the
@@ -28,11 +36,13 @@ class StateBase;
 //   Step2 -> /v2/accounts/password/finalize
 //   Step3 -> /v2/verify/complete
 //
-// Requests are sent through the owning state's `StateBase` helpers, so their
-// lifetime is tied to that state (see `StateBase::SendStateOwnedRequest`).
-class Register {
+// Requests are sent through the inherited `FlowBase` helpers, so their
+// lifetime is tied to this flow (see `FlowBase::SendFlowOwnedRequest`).
+class Register : public FlowBase {
  public:
-  explicit Register(StateBase& state);
+  Register(AccountStatePrefs& account_state_prefs,
+           scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+           const os_crypt_async::Encryptor& encryptor);
 
   Register(const Register&) = delete;
   Register& operator=(const Register&) = delete;
@@ -61,8 +71,6 @@ class Register {
 
   void OnStep3(mojom::Authentication::RegisterStep3Callback callback,
                endpoints::VerifyComplete::Response response);
-
-  const raw_ref<StateBase> state_;
 
   base::WeakPtrFactory<Register> weak_factory_{this};
 };

--- a/components/brave_account/flows/resend_verification_email.cc
+++ b/components/brave_account/flows/resend_verification_email.cc
@@ -12,10 +12,11 @@
 #include "base/types/expected.h"
 #include "brave/components/brave_account/brave_account_service_constants.h"
 #include "brave/components/brave_account/endpoint_client/with_headers.h"
+#include "brave/components/brave_account/flows/make_request.h"
 #include "brave/components/brave_account/mojom/resend_verification_email.mojom.h"
-#include "brave/components/brave_account/state_base.h"
 #include "brave/components/brave_account/state_internal.h"
 #include "net/http/http_status_code.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
 
 namespace brave_account {
 
@@ -25,8 +26,11 @@ using endpoints::VerifyResend;
 using internal::MakeRequest;
 using internal::MakeServerError;
 
-ResendVerificationEmail::ResendVerificationEmail(StateBase& state)
-    : state_(state) {}
+ResendVerificationEmail::ResendVerificationEmail(
+    AccountStatePrefs& account_state_prefs,
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    const os_crypt_async::Encryptor& encryptor)
+    : FlowBase(account_state_prefs, std::move(url_loader_factory), encryptor) {}
 
 ResendVerificationEmail::~ResendVerificationEmail() = default;
 
@@ -34,9 +38,8 @@ void ResendVerificationEmail::operator()(
     mojom::VerificationIntentPtr intent,
     mojom::Authentication::ResendVerificationEmailCallback callback) {
   auto verification_token =
-      state_
-          ->GetDecryptedVerificationToken<mojom::ResendVerificationEmailError>(
-              std::move(intent));
+      GetDecryptedVerificationToken<mojom::ResendVerificationEmailError>(
+          std::move(intent));
   if (!verification_token.has_value()) {
     return std::move(callback).Run(
         base::unexpected(std::move(verification_token).error()));
@@ -49,7 +52,7 @@ void ResendVerificationEmail::operator()(
   request.body.locale = "";
   request.timeout_duration = kVerifyResendTimeout;
 
-  state_->SendStateOwnedRequest<VerifyResend>(
+  SendFlowOwnedRequest<VerifyResend>(
       std::move(request),
       base::BindOnce(&ResendVerificationEmail::OnResponse,
                      weak_factory_.GetWeakPtr(), std::move(callback)));

--- a/components/brave_account/flows/resend_verification_email.h
+++ b/components/brave_account/flows/resend_verification_email.h
@@ -6,29 +6,41 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ACCOUNT_FLOWS_RESEND_VERIFICATION_EMAIL_H_
 #define BRAVE_COMPONENTS_BRAVE_ACCOUNT_FLOWS_RESEND_VERIFICATION_EMAIL_H_
 
-#include "base/memory/raw_ref.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
+#include "brave/components/brave_account/brave_account_state_prefs.h"
 #include "brave/components/brave_account/endpoints/verify_resend.h"
+#include "brave/components/brave_account/flows/flow_base.h"
 #include "brave/components/brave_account/mojom/brave_account.mojom.h"
+
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
+
+namespace os_crypt_async {
+class Encryptor;
+}  // namespace os_crypt_async
 
 namespace brave_account {
 
-class StateBase;
-
 // Owns the verification-email resend of the `mojom::Authentication` surface.
-// Unlike the other flow helpers, this one is held by `StateBase` itself, since
-// `ResendVerificationEmail()` is valid in both the logged-out and logged-in
-// states: `StateBase` holds a `ResendVerificationEmail` member and forwards
-// the single mojom `ResendVerificationEmail` method to `operator()()` here,
+// Like `CancelVerification`, and unlike the other flow helpers, this one is
+// duplicated across both states, since `ResendVerificationEmail()` is valid in
+// both the logged-out and logged-in states: `LoggedOutState` and
+// `LoggedInState` each hold their own `ResendVerificationEmail` member and
+// forward their `ResendVerificationEmail` override to `operator()()` here,
 // which maps onto one backend endpoint:
 //
 //   operator()() -> /v2/verify/resend
 //
-// Requests are sent through the owning state's `StateBase` helpers, so their
-// lifetime is tied to that state (see `StateBase::SendStateOwnedRequest`).
-class ResendVerificationEmail {
+// Requests are sent through the inherited `FlowBase` helpers, so their
+// lifetime is tied to this flow (see `FlowBase::SendFlowOwnedRequest`).
+class ResendVerificationEmail : public FlowBase {
  public:
-  explicit ResendVerificationEmail(StateBase& state);
+  ResendVerificationEmail(
+      AccountStatePrefs& account_state_prefs,
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+      const os_crypt_async::Encryptor& encryptor);
 
   ResendVerificationEmail(const ResendVerificationEmail&) = delete;
   ResendVerificationEmail& operator=(const ResendVerificationEmail&) = delete;
@@ -43,8 +55,6 @@ class ResendVerificationEmail {
   void OnResponse(
       mojom::Authentication::ResendVerificationEmailCallback callback,
       endpoints::VerifyResend::Response response);
-
-  const raw_ref<StateBase> state_;
 
   base::WeakPtrFactory<ResendVerificationEmail> weak_factory_{this};
 };

--- a/components/brave_account/flows/reset_password.cc
+++ b/components/brave_account/flows/reset_password.cc
@@ -13,9 +13,10 @@
 #include "base/types/expected.h"
 #include "brave/components/brave_account/brave_account_utils.h"
 #include "brave/components/brave_account/endpoint_client/with_headers.h"
+#include "brave/components/brave_account/flows/make_request.h"
 #include "brave/components/brave_account/mojom/reset_password.mojom.h"
-#include "brave/components/brave_account/state_base.h"
 #include "brave/components/brave_account/state_internal.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
 
 namespace brave_account {
 
@@ -25,7 +26,11 @@ using internal::MakeClientError;
 using internal::MakeRequest;
 using internal::MakeServerError;
 
-ResetPassword::ResetPassword(StateBase& state) : state_(state) {}
+ResetPassword::ResetPassword(
+    AccountStatePrefs& account_state_prefs,
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    const os_crypt_async::Encryptor& encryptor)
+    : FlowBase(account_state_prefs, std::move(url_loader_factory), encryptor) {}
 
 ResetPassword::~ResetPassword() = default;
 
@@ -42,7 +47,7 @@ void ResetPassword::Step1(
   request.body.locale = "";
   request.body.service = kServiceToString.at(mojom::Service::kAccounts);
 
-  state_->SendStateOwnedRequest<endpoints::VerifyInit>(
+  SendFlowOwnedRequest<endpoints::VerifyInit>(
       std::move(request),
       base::BindOnce(&ResetPassword::OnStep1, weak_factory_.GetWeakPtr(),
                      std::move(callback)));
@@ -54,7 +59,7 @@ void ResetPassword::Step2(
   CHECK(!code.empty());
 
   auto verification_token =
-      state_->GetDecryptedVerificationToken<mojom::ResetPasswordError>(
+      GetDecryptedVerificationToken<mojom::ResetPasswordError>(
           mojom::VerificationIntent::NewLoggedOutIntent(
               mojom::LoggedOutVerificationIntent::kResetPassword));
   if (!verification_token.has_value()) {
@@ -66,7 +71,7 @@ void ResetPassword::Step2(
   SetBearerToken(request, *verification_token);
   request.body.code = code;
 
-  state_->SendStateOwnedRequest<endpoints::VerifyComplete>(
+  SendFlowOwnedRequest<endpoints::VerifyComplete>(
       std::move(request),
       base::BindOnce(&ResetPassword::OnStep2, weak_factory_.GetWeakPtr(),
                      std::move(callback)));
@@ -78,7 +83,7 @@ void ResetPassword::Step3(
   CHECK(!blinded_message.empty());
 
   auto verification_token =
-      state_->GetDecryptedVerificationToken<mojom::ResetPasswordError>(
+      GetDecryptedVerificationToken<mojom::ResetPasswordError>(
           mojom::VerificationIntent::NewLoggedOutIntent(
               mojom::LoggedOutVerificationIntent::kResetPassword));
   if (!verification_token.has_value()) {
@@ -93,7 +98,7 @@ void ResetPassword::Step3(
       kServiceToString.at(mojom::Service::kAccounts);
   request.body.serialize_response = true;
 
-  state_->SendStateOwnedRequest<endpoints::PasswordInit>(
+  SendFlowOwnedRequest<endpoints::PasswordInit>(
       std::move(request),
       base::BindOnce(&ResetPassword::OnStep3, weak_factory_.GetWeakPtr(),
                      std::move(callback)));
@@ -107,7 +112,7 @@ void ResetPassword::Step4(
   CHECK(!email.empty());
 
   auto verification_token =
-      state_->GetDecryptedVerificationToken<mojom::ResetPasswordError>(
+      GetDecryptedVerificationToken<mojom::ResetPasswordError>(
           mojom::VerificationIntent::NewLoggedOutIntent(
               mojom::LoggedOutVerificationIntent::kResetPassword));
   if (!verification_token.has_value()) {
@@ -120,7 +125,7 @@ void ResetPassword::Step4(
   SetBearerToken(request, *verification_token);
   request.body.serialized_record = serialized_record;
 
-  state_->SendStateOwnedRequest<endpoints::PasswordFinalize>(
+  SendFlowOwnedRequest<endpoints::PasswordFinalize>(
       std::move(request),
       base::BindOnce(&ResetPassword::OnStep4, weak_factory_.GetWeakPtr(),
                      std::move(callback), email));
@@ -161,7 +166,7 @@ void ResetPassword::OnStep1(
             }
 
             if (encrypted_verification_token =
-                    state_->Encrypt(success_body.verification_token);
+                    Encrypt(success_body.verification_token);
                 encrypted_verification_token.empty()) {
               return base::unexpected(
                   MakeClientError<mojom::ResetPasswordError>(
@@ -179,7 +184,7 @@ void ResetPassword::OnStep1(
 
   if (success) {
     CHECK(!encrypted_verification_token.empty());
-    state_->account_state_prefs_->AddVerification(
+    account_state_prefs_->AddVerification(
         encrypted_verification_token,
         mojom::VerificationIntent::NewLoggedOutIntent(
             mojom::LoggedOutVerificationIntent::kResetPassword));
@@ -233,7 +238,7 @@ void ResetPassword::OnStep2(
 
   if (success) {
     CHECK(!email.empty());
-    state_->account_state_prefs_->SetVerificationVerifiedEmail(email);
+    account_state_prefs_->SetVerificationVerifiedEmail(email);
   }
 }
 
@@ -313,7 +318,7 @@ void ResetPassword::OnStep4(
             }
 
             if (encrypted_authentication_token =
-                    state_->Encrypt(success_body.auth_token.GetString());
+                    Encrypt(success_body.auth_token.GetString());
                 encrypted_authentication_token.empty()) {
               return base::unexpected(
                   MakeClientError<mojom::ResetPasswordError>(
@@ -331,8 +336,7 @@ void ResetPassword::OnStep4(
 
   if (success) {
     CHECK(!encrypted_authentication_token.empty());
-    state_->account_state_prefs_->SetLoggedIn(email,
-                                              encrypted_authentication_token);
+    account_state_prefs_->SetLoggedIn(email, encrypted_authentication_token);
   }
 }
 

--- a/components/brave_account/flows/reset_password.cc
+++ b/components/brave_account/flows/reset_password.cc
@@ -177,7 +177,7 @@ void ResetPassword::OnStep1(
             return mojom::ResetPasswordStep1Result::New();
           });
 
-  // See `StateBase`'s class comment on ordering.
+  // See `FlowBase`'s class comment on ordering.
   // LoggedOut ==> LoggedOutWithVerification (no state swap).
   const bool success = result.has_value();
   std::move(callback).Run(std::move(result));
@@ -230,7 +230,7 @@ void ResetPassword::OnStep2(
             return mojom::ResetPasswordStep2Result::New();
           });
 
-  // See `StateBase`'s class comment on ordering.
+  // See `FlowBase`'s class comment on ordering.
   // LoggedOutWithVerification ==> LoggedOutWithVerification (no state swap):
   // records the verified email.
   const bool success = result.has_value();
@@ -329,7 +329,7 @@ void ResetPassword::OnStep4(
             return mojom::ResetPasswordStep4Result::New();
           });
 
-  // See `StateBase`'s class comment on ordering.
+  // See `FlowBase`'s class comment on ordering.
   // LoggedOutWithVerification ==> LoggedIn (state swap).
   const bool success = result.has_value();
   std::move(callback).Run(std::move(result));

--- a/components/brave_account/flows/reset_password.h
+++ b/components/brave_account/flows/reset_password.h
@@ -8,17 +8,25 @@
 
 #include <string>
 
-#include "base/memory/raw_ref.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
+#include "brave/components/brave_account/brave_account_state_prefs.h"
 #include "brave/components/brave_account/endpoints/password_finalize.h"
 #include "brave/components/brave_account/endpoints/password_init.h"
 #include "brave/components/brave_account/endpoints/verify_complete.h"
 #include "brave/components/brave_account/endpoints/verify_init.h"
+#include "brave/components/brave_account/flows/flow_base.h"
 #include "brave/components/brave_account/mojom/brave_account.mojom.h"
 
-namespace brave_account {
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
 
-class StateBase;
+namespace os_crypt_async {
+class Encryptor;
+}  // namespace os_crypt_async
+
+namespace brave_account {
 
 // Owns the password-reset half of the logged-out `mojom::Authentication`
 // surface. `LoggedOutState` holds a `ResetPassword` member and forwards the
@@ -30,11 +38,14 @@ class StateBase;
 //   Step3 -> /v2/accounts/password/init
 //   Step4 -> /v2/accounts/password/finalize
 //
-// Requests are sent through the owning state's `StateBase` helpers, so their
-// lifetime is tied to that state (see `StateBase::SendStateOwnedRequest`).
-class ResetPassword {
+// Requests are sent through the inherited `FlowBase` helpers, so their
+// lifetime is tied to this flow (see `FlowBase::SendFlowOwnedRequest`).
+class ResetPassword : public FlowBase {
  public:
-  explicit ResetPassword(StateBase& state);
+  ResetPassword(
+      AccountStatePrefs& account_state_prefs,
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+      const os_crypt_async::Encryptor& encryptor);
 
   ResetPassword(const ResetPassword&) = delete;
   ResetPassword& operator=(const ResetPassword&) = delete;
@@ -67,8 +78,6 @@ class ResetPassword {
   void OnStep4(mojom::Authentication::ResetPasswordStep4Callback callback,
                const std::string& email,
                endpoints::PasswordFinalize::Response response);
-
-  const raw_ref<StateBase> state_;
 
   base::WeakPtrFactory<ResetPassword> weak_factory_{this};
 };

--- a/components/brave_account/flows/update_email.cc
+++ b/components/brave_account/flows/update_email.cc
@@ -11,8 +11,9 @@
 #include "base/location.h"
 #include "brave/components/brave_account/brave_account_service_constants.h"
 #include "brave/components/brave_account/endpoint_client/with_headers.h"
-#include "brave/components/brave_account/state_base.h"
+#include "brave/components/brave_account/flows/make_request.h"
 #include "brave/components/brave_account/state_internal.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
 
 namespace brave_account {
 
@@ -22,7 +23,11 @@ using endpoint_client::WithHeaders;
 using endpoints::AuthValidate;
 using internal::MakeRequest;
 
-UpdateEmail::UpdateEmail(StateBase& state) : state_(state) {
+UpdateEmail::UpdateEmail(
+    AccountStatePrefs& account_state_prefs,
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    const os_crypt_async::Encryptor& encryptor)
+    : FlowBase(account_state_prefs, std::move(url_loader_factory), encryptor) {
   ScheduleRequest();
 }
 
@@ -38,7 +43,7 @@ void UpdateEmail::ScheduleRequest(base::TimeDelta delay,
 void UpdateEmail::SendRequest(RequestHandle current_request) {
   current_request.reset();
 
-  const auto authentication_token = state_->GetDecryptedAuthenticationToken();
+  const auto authentication_token = GetDecryptedAuthenticationToken();
   if (authentication_token.empty()) {
     return;
   }
@@ -46,11 +51,11 @@ void UpdateEmail::SendRequest(RequestHandle current_request) {
   auto request = MakeRequest<WithHeaders<AuthValidate::Request>>();
   SetBearerToken(request, authentication_token);
 
-  // Not adopted into the state's in-flight bag:
+  // Not adopted into the flow's in-flight bag:
   // the request handle is passed forward into the next scheduled
   // `SendRequest`, which resets it (cancelling any still-pending previous
   // attempt) before issuing the new one.
-  current_request = state_->SendCallerOwnedRequest<AuthValidate>(
+  current_request = SendCallerOwnedRequest<AuthValidate>(
       std::move(request),
       base::BindOnce(&UpdateEmail::OnResponse, weak_factory_.GetWeakPtr()));
 
@@ -67,14 +72,14 @@ void UpdateEmail::OnResponse(AuthValidate::Response response) {
                                    : "";
 
   if (!email.empty()) {
-    state_->account_state_prefs_->UpdateEmail(email);
+    account_state_prefs_->UpdateEmail(email);
   } else if (response.status_code >= 400 && response.status_code < 500) {
     // Force logged-out (and stop polling) to prevent presenting invalid state
     // to the user and issuing invalid requests.
     //
     // See `StateBase`'s class comment on ordering.
     // LoggedIn ==> LoggedOut (state swap).
-    return state_->account_state_prefs_->SetLoggedOut();
+    return account_state_prefs_->SetLoggedOut();
   }
 
   // Replace watchdog timer with the normal cadence.

--- a/components/brave_account/flows/update_email.cc
+++ b/components/brave_account/flows/update_email.cc
@@ -77,7 +77,7 @@ void UpdateEmail::OnResponse(AuthValidate::Response response) {
     // Force logged-out (and stop polling) to prevent presenting invalid state
     // to the user and issuing invalid requests.
     //
-    // See `StateBase`'s class comment on ordering.
+    // See `FlowBase`'s class comment on ordering.
     // LoggedIn ==> LoggedOut (state swap).
     return account_state_prefs_->SetLoggedOut();
   }

--- a/components/brave_account/flows/update_email.h
+++ b/components/brave_account/flows/update_email.h
@@ -7,16 +7,24 @@
 #define BRAVE_COMPONENTS_BRAVE_ACCOUNT_FLOWS_UPDATE_EMAIL_H_
 
 #include "base/check_is_test.h"
-#include "base/memory/raw_ref.h"
+#include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/time/time.h"
 #include "base/timer/timer.h"
+#include "brave/components/brave_account/brave_account_state_prefs.h"
 #include "brave/components/brave_account/endpoint_client/request_handle.h"
 #include "brave/components/brave_account/endpoints/auth_validate.h"
+#include "brave/components/brave_account/flows/flow_base.h"
+
+namespace network {
+class SharedURLLoaderFactory;
+}  // namespace network
+
+namespace os_crypt_async {
+class Encryptor;
+}  // namespace os_crypt_async
 
 namespace brave_account {
-
-class StateBase;
 
 // Owns the periodic email refresh of the logged-in `mojom::Authentication`
 // surface. Unlike the other flow helpers, this one is not driven by a mojom
@@ -29,10 +37,12 @@ class StateBase;
 // (and stops polling). Each poll is a caller-owned request whose handle is
 // passed forward into the next scheduled poll, which cancels any still-pending
 // previous attempt before issuing the new one (see
-// `StateBase::SendCallerOwnedRequest`).
-class UpdateEmail {
+// `FlowBase::SendCallerOwnedRequest`).
+class UpdateEmail : public FlowBase {
  public:
-  explicit UpdateEmail(StateBase& state);
+  UpdateEmail(AccountStatePrefs& account_state_prefs,
+              scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+              const os_crypt_async::Encryptor& encryptor);
 
   UpdateEmail(const UpdateEmail&) = delete;
   UpdateEmail& operator=(const UpdateEmail&) = delete;
@@ -51,8 +61,6 @@ class UpdateEmail {
   void SendRequest(endpoint_client::RequestHandle current_request);
 
   void OnResponse(endpoints::AuthValidate::Response response);
-
-  const raw_ref<StateBase> state_;
 
   base::OneShotTimer timer_;
   base::WeakPtrFactory<UpdateEmail> weak_factory_{this};

--- a/components/brave_account/logged_in_state.cc
+++ b/components/brave_account/logged_in_state.cc
@@ -16,12 +16,23 @@ LoggedInState::LoggedInState(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     const os_crypt_async::Encryptor& encryptor,
     AddObserverCallback add_observer)
-    : StateBase(account_state_prefs,
-                std::move(url_loader_factory),
-                encryptor,
-                std::move(add_observer)) {}
+    : StateBase(std::move(add_observer)),
+      cancel_verification_(account_state_prefs, url_loader_factory, encryptor),
+      change_password_(account_state_prefs, url_loader_factory, encryptor),
+      get_service_token_(account_state_prefs, url_loader_factory, encryptor),
+      log_out_(account_state_prefs, url_loader_factory, encryptor),
+      resend_verification_email_(account_state_prefs,
+                                 url_loader_factory,
+                                 encryptor),
+      update_email_(account_state_prefs,
+                    std::move(url_loader_factory),
+                    encryptor) {}
 
 LoggedInState::~LoggedInState() = default;
+
+void LoggedInState::CancelVerification(mojom::VerificationIntentPtr intent) {
+  cancel_verification_(std::move(intent));
+}
 
 void LoggedInState::ChangePasswordStep1(const std::string& email,
                                         ChangePasswordStep1Callback callback) {
@@ -43,13 +54,19 @@ void LoggedInState::ChangePasswordStep4(const std::string& serialized_record,
   change_password_.Step4(serialized_record, std::move(callback));
 }
 
+void LoggedInState::GetServiceToken(mojom::Service service,
+                                    GetServiceTokenCallback callback) {
+  get_service_token_(service, std::move(callback));
+}
+
 void LoggedInState::LogOut() {
   log_out_();
 }
 
-void LoggedInState::GetServiceToken(mojom::Service service,
-                                    GetServiceTokenCallback callback) {
-  get_service_token_(service, std::move(callback));
+void LoggedInState::ResendVerificationEmail(
+    mojom::VerificationIntentPtr intent,
+    ResendVerificationEmailCallback callback) {
+  resend_verification_email_(std::move(intent), std::move(callback));
 }
 
 }  // namespace brave_account

--- a/components/brave_account/logged_in_state.h
+++ b/components/brave_account/logged_in_state.h
@@ -12,9 +12,11 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/timer/timer.h"
 #include "brave/components/brave_account/brave_account_state_prefs.h"
+#include "brave/components/brave_account/flows/cancel_verification.h"
 #include "brave/components/brave_account/flows/change_password.h"
 #include "brave/components/brave_account/flows/get_service_token.h"
 #include "brave/components/brave_account/flows/log_out.h"
+#include "brave/components/brave_account/flows/resend_verification_email.h"
 #include "brave/components/brave_account/flows/update_email.h"
 #include "brave/components/brave_account/mojom/brave_account.mojom.h"
 #include "brave/components/brave_account/state_base.h"
@@ -31,8 +33,9 @@ namespace brave_account {
 // `log_out_`, `change_password_`, and `get_service_token_` helpers. The
 // `update_email_` helper additionally drives itself, periodically refreshing
 // the stored email in the background. `ResendVerificationEmail()` and
-// `CancelVerification()` are fully handled by `StateBase` for both states. All
-// other methods inherit `StateBase`'s wrong-state default.
+// `CancelVerification()` are valid in both states, so this state owns its own
+// `resend_verification_email_` and `cancel_verification_` helpers. All other
+// methods inherit `StateBase`'s wrong-state default.
 class LoggedInState : public StateBase {
  public:
   LoggedInState(
@@ -52,6 +55,8 @@ class LoggedInState : public StateBase {
   }
 
  private:
+  void CancelVerification(mojom::VerificationIntentPtr intent) override;
+
   void ChangePasswordStep1(const std::string& email,
                            ChangePasswordStep1Callback callback) override;
 
@@ -64,15 +69,21 @@ class LoggedInState : public StateBase {
   void ChangePasswordStep4(const std::string& serialized_record,
                            ChangePasswordStep4Callback callback) override;
 
-  void LogOut() override;
-
   void GetServiceToken(mojom::Service service,
                        GetServiceTokenCallback callback) override;
 
-  ChangePassword change_password_{*this};
-  class GetServiceToken get_service_token_{*this};
-  class LogOut log_out_{*this};
-  UpdateEmail update_email_{*this};
+  void LogOut() override;
+
+  void ResendVerificationEmail(
+      mojom::VerificationIntentPtr intent,
+      ResendVerificationEmailCallback callback) override;
+
+  class CancelVerification cancel_verification_;
+  ChangePassword change_password_;
+  class GetServiceToken get_service_token_;
+  class LogOut log_out_;
+  class ResendVerificationEmail resend_verification_email_;
+  UpdateEmail update_email_;
 };
 
 }  // namespace brave_account

--- a/components/brave_account/logged_out_state.cc
+++ b/components/brave_account/logged_out_state.cc
@@ -16,12 +16,22 @@ LoggedOutState::LoggedOutState(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     const os_crypt_async::Encryptor& encryptor,
     AddObserverCallback add_observer)
-    : StateBase(account_state_prefs,
-                std::move(url_loader_factory),
-                encryptor,
-                std::move(add_observer)) {}
+    : StateBase(std::move(add_observer)),
+      cancel_verification_(account_state_prefs, url_loader_factory, encryptor),
+      login_(account_state_prefs, url_loader_factory, encryptor),
+      register_(account_state_prefs, url_loader_factory, encryptor),
+      resend_verification_email_(account_state_prefs,
+                                 url_loader_factory,
+                                 encryptor),
+      reset_password_(account_state_prefs,
+                      std::move(url_loader_factory),
+                      encryptor) {}
 
 LoggedOutState::~LoggedOutState() = default;
+
+void LoggedOutState::CancelVerification(mojom::VerificationIntentPtr intent) {
+  cancel_verification_(std::move(intent));
+}
 
 void LoggedOutState::LoginStep1(mojom::Service initiating_service,
                                 const std::string& email,
@@ -55,6 +65,12 @@ void LoggedOutState::RegisterStep2(
 void LoggedOutState::RegisterStep3(const std::string& code,
                                    RegisterStep3Callback callback) {
   register_.Step3(code, std::move(callback));
+}
+
+void LoggedOutState::ResendVerificationEmail(
+    mojom::VerificationIntentPtr intent,
+    ResendVerificationEmailCallback callback) {
+  resend_verification_email_(std::move(intent), std::move(callback));
 }
 
 void LoggedOutState::ResetPasswordStep1(const std::string& email,

--- a/components/brave_account/logged_out_state.h
+++ b/components/brave_account/logged_out_state.h
@@ -10,8 +10,10 @@
 
 #include "base/memory/scoped_refptr.h"
 #include "brave/components/brave_account/brave_account_state_prefs.h"
+#include "brave/components/brave_account/flows/cancel_verification.h"
 #include "brave/components/brave_account/flows/login.h"
 #include "brave/components/brave_account/flows/register.h"
+#include "brave/components/brave_account/flows/resend_verification_email.h"
 #include "brave/components/brave_account/flows/reset_password.h"
 #include "brave/components/brave_account/mojom/brave_account.mojom.h"
 #include "brave/components/brave_account/state_base.h"
@@ -26,9 +28,9 @@ namespace brave_account {
 // `mojom::Authentication` surface available before login:
 // the login, registration, and password-reset steps,
 // which are delegated to the `login_`, `register_`, and
-// `reset_password_` helpers.
-// `ResendVerificationEmail()` and `CancelVerification()` are fully
-// handled by `StateBase` for both states.
+// `reset_password_` helpers. `ResendVerificationEmail()` and
+// `CancelVerification()` are valid in both states, so this state owns its own
+// `resend_verification_email_` and `cancel_verification_` helpers.
 // All other methods inherit `StateBase`'s wrong-state default.
 class LoggedOutState : public StateBase {
  public:
@@ -44,6 +46,8 @@ class LoggedOutState : public StateBase {
   ~LoggedOutState() override;
 
  private:
+  void CancelVerification(mojom::VerificationIntentPtr intent) override;
+
   void LoginStep1(mojom::Service initiating_service,
                   const std::string& email,
                   const std::string& serialized_ke1,
@@ -65,6 +69,10 @@ class LoggedOutState : public StateBase {
   void RegisterStep3(const std::string& code,
                      RegisterStep3Callback callback) override;
 
+  void ResendVerificationEmail(
+      mojom::VerificationIntentPtr intent,
+      ResendVerificationEmailCallback callback) override;
+
   void ResetPasswordStep1(const std::string& email,
                           ResetPasswordStep1Callback callback) override;
 
@@ -78,9 +86,11 @@ class LoggedOutState : public StateBase {
                           const std::string& email,
                           ResetPasswordStep4Callback callback) override;
 
-  Login login_{*this};
-  Register register_{*this};
-  ResetPassword reset_password_{*this};
+  class CancelVerification cancel_verification_;
+  Login login_;
+  Register register_;
+  class ResendVerificationEmail resend_verification_email_;
+  ResetPassword reset_password_;
 };
 
 }  // namespace brave_account

--- a/components/brave_account/state_base.cc
+++ b/components/brave_account/state_base.cc
@@ -8,7 +8,6 @@
 #include <utility>
 
 #include "base/check.h"
-#include "brave/components/brave_account/brave_account_encryption.h"
 #include "brave/components/brave_account/mojom/change_password.mojom.h"
 #include "brave/components/brave_account/mojom/login.mojom.h"
 #include "brave/components/brave_account/mojom/register.mojom.h"
@@ -29,98 +28,16 @@ StateBase::TakeReceivers() {
   return receivers_.TakeReceivers();
 }
 
-StateBase::StateBase(
-    AccountStatePrefs& account_state_prefs,
-    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-    const os_crypt_async::Encryptor& encryptor,
-    AddObserverCallback add_observer)
-    : account_state_prefs_(account_state_prefs),
-      url_loader_factory_(std::move(url_loader_factory)),
-      encryption_(encryptor),
-      add_observer_(std::move(add_observer)) {
-  CHECK(url_loader_factory_);
+StateBase::StateBase(AddObserverCallback add_observer)
+    : add_observer_(std::move(add_observer)) {
   CHECK(add_observer_);
 }
 
 StateBase::~StateBase() = default;
 
-std::string StateBase::Encrypt(const std::string& plain_text) const {
-  return encryption_.Encrypt(plain_text);
-}
-
-std::string StateBase::Decrypt(const std::string& base64) const {
-  return encryption_.Decrypt(base64);
-}
-
 void StateBase::AddObserver(
     mojo::PendingRemote<mojom::AuthenticationObserver> observer) {
   add_observer_.Run(std::move(observer));
-}
-
-void StateBase::RegisterStep1(mojom::Service initiating_service,
-                              const std::string& email,
-                              const std::string& blinded_message,
-                              RegisterStep1Callback callback) {
-  std::move(callback).Run(MakeCalledInWrongStateError<mojom::RegisterError>());
-}
-
-void StateBase::RegisterStep2(const std::string& encrypted_verification_token,
-                              const std::string& serialized_record,
-                              RegisterStep2Callback callback) {
-  std::move(callback).Run(MakeCalledInWrongStateError<mojom::RegisterError>());
-}
-
-void StateBase::RegisterStep3(const std::string& code,
-                              RegisterStep3Callback callback) {
-  std::move(callback).Run(MakeCalledInWrongStateError<mojom::RegisterError>());
-}
-
-void StateBase::ResendVerificationEmail(
-    mojom::VerificationIntentPtr intent,
-    ResendVerificationEmailCallback callback) {
-  resend_verification_email_(std::move(intent), std::move(callback));
-}
-
-void StateBase::CancelVerification(mojom::VerificationIntentPtr intent) {
-  cancel_verification_(std::move(intent));
-}
-
-void StateBase::ResetPasswordStep1(const std::string& email,
-                                   ResetPasswordStep1Callback callback) {
-  std::move(callback).Run(
-      MakeCalledInWrongStateError<mojom::ResetPasswordError>());
-}
-
-void StateBase::ResetPasswordStep2(const std::string& code,
-                                   ResetPasswordStep2Callback callback) {
-  std::move(callback).Run(
-      MakeCalledInWrongStateError<mojom::ResetPasswordError>());
-}
-
-void StateBase::ResetPasswordStep3(const std::string& blinded_message,
-                                   ResetPasswordStep3Callback callback) {
-  std::move(callback).Run(
-      MakeCalledInWrongStateError<mojom::ResetPasswordError>());
-}
-
-void StateBase::ResetPasswordStep4(const std::string& serialized_record,
-                                   const std::string& email,
-                                   ResetPasswordStep4Callback callback) {
-  std::move(callback).Run(
-      MakeCalledInWrongStateError<mojom::ResetPasswordError>());
-}
-
-void StateBase::LoginStep1(mojom::Service initiating_service,
-                           const std::string& email,
-                           const std::string& serialized_ke1,
-                           LoginStep1Callback callback) {
-  std::move(callback).Run(MakeCalledInWrongStateError<mojom::LoginError>());
-}
-
-void StateBase::LoginStep2(const std::string& encrypted_login_token,
-                           const std::string& client_mac,
-                           LoginStep2Callback callback) {
-  std::move(callback).Run(MakeCalledInWrongStateError<mojom::LoginError>());
 }
 
 void StateBase::ChangePasswordStep1(const std::string& email,
@@ -147,17 +64,68 @@ void StateBase::ChangePasswordStep4(const std::string& serialized_record,
       MakeCalledInWrongStateError<mojom::ChangePasswordError>());
 }
 
-void StateBase::LogOut() {}
-
 void StateBase::GetServiceToken(mojom::Service,
                                 GetServiceTokenCallback callback) {
   std::move(callback).Run(
       MakeCalledInWrongStateError<mojom::GetServiceTokenError>());
 }
 
-void StateBase::RemoveRequestHandle(
-    std::list<endpoint_client::RequestHandle>::iterator slot) {
-  in_flight_.erase(slot);
+void StateBase::LogOut() {}
+
+void StateBase::LoginStep1(mojom::Service initiating_service,
+                           const std::string& email,
+                           const std::string& serialized_ke1,
+                           LoginStep1Callback callback) {
+  std::move(callback).Run(MakeCalledInWrongStateError<mojom::LoginError>());
+}
+
+void StateBase::LoginStep2(const std::string& encrypted_login_token,
+                           const std::string& client_mac,
+                           LoginStep2Callback callback) {
+  std::move(callback).Run(MakeCalledInWrongStateError<mojom::LoginError>());
+}
+
+void StateBase::RegisterStep1(mojom::Service initiating_service,
+                              const std::string& email,
+                              const std::string& blinded_message,
+                              RegisterStep1Callback callback) {
+  std::move(callback).Run(MakeCalledInWrongStateError<mojom::RegisterError>());
+}
+
+void StateBase::RegisterStep2(const std::string& encrypted_verification_token,
+                              const std::string& serialized_record,
+                              RegisterStep2Callback callback) {
+  std::move(callback).Run(MakeCalledInWrongStateError<mojom::RegisterError>());
+}
+
+void StateBase::RegisterStep3(const std::string& code,
+                              RegisterStep3Callback callback) {
+  std::move(callback).Run(MakeCalledInWrongStateError<mojom::RegisterError>());
+}
+
+void StateBase::ResetPasswordStep1(const std::string& email,
+                                   ResetPasswordStep1Callback callback) {
+  std::move(callback).Run(
+      MakeCalledInWrongStateError<mojom::ResetPasswordError>());
+}
+
+void StateBase::ResetPasswordStep2(const std::string& code,
+                                   ResetPasswordStep2Callback callback) {
+  std::move(callback).Run(
+      MakeCalledInWrongStateError<mojom::ResetPasswordError>());
+}
+
+void StateBase::ResetPasswordStep3(const std::string& blinded_message,
+                                   ResetPasswordStep3Callback callback) {
+  std::move(callback).Run(
+      MakeCalledInWrongStateError<mojom::ResetPasswordError>());
+}
+
+void StateBase::ResetPasswordStep4(const std::string& serialized_record,
+                                   const std::string& email,
+                                   ResetPasswordStep4Callback callback) {
+  std::move(callback).Run(
+      MakeCalledInWrongStateError<mojom::ResetPasswordError>());
 }
 
 }  // namespace brave_account

--- a/components/brave_account/state_base.h
+++ b/components/brave_account/state_base.h
@@ -6,37 +6,14 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ACCOUNT_STATE_BASE_H_
 #define BRAVE_COMPONENTS_BRAVE_ACCOUNT_STATE_BASE_H_
 
-#include <list>
 #include <string>
-#include <type_traits>
-#include <utility>
 #include <vector>
 
-#include "base/check.h"
-#include "base/functional/bind.h"
 #include "base/functional/callback.h"
-#include "base/memory/raw_ref.h"
-#include "base/memory/scoped_refptr.h"
-#include "base/types/expected.h"
-#include "brave/components/brave_account/brave_account_encryption.h"
-#include "brave/components/brave_account/brave_account_state_prefs.h"
-#include "brave/components/brave_account/endpoint_client/client.h"
-#include "brave/components/brave_account/endpoint_client/request_handle.h"
-#include "brave/components/brave_account/flows/cancel_verification.h"
-#include "brave/components/brave_account/flows/resend_verification_email.h"
 #include "brave/components/brave_account/mojom/brave_account.mojom.h"
-#include "brave/components/brave_account/state_internal.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver_set.h"
-
-namespace network {
-class SharedURLLoaderFactory;
-}  // namespace network
-
-namespace os_crypt_async {
-class Encryptor;
-}  // namespace os_crypt_async
 
 namespace brave_account {
 
@@ -44,33 +21,16 @@ namespace brave_account {
 // only the methods valid in their state; the rest inherit the default
 // wrong-state response (client error with `kCalledInWrongState`).
 //
+// The `mojom::Authentication` methods that carry real logic are implemented by
+// flow helpers (`Login`, `LogOut`, `Register`, ...), each a member of the state
+// whose overrides it serves.
+//
 // `AddObserver()` is the one method that is not state-scoped; `StateBase`
 // forwards it to the service via `AddObserverCallback` so observer
 // subscriptions outlive any single state.
 //
-// Rules for state method implementers:
-//
-//   - State-mutating pref writes must be the *last* thing a method does. A
-//     pref write re-enters `OnAccountStateChanged()` synchronously, and
-//     `EnsureState()` unbinds this state's receivers via `TakeReceivers()`
-//     (and, when the write crosses variant alternatives, destroys `this`).
-//   - Callback-bearing methods must invoke `callback` *before* the pref
-//     write; otherwise the response sender held by `callback` becomes
-//     invalid when receivers unbind (see `mojo::Receiver::Unbind()` in
-//     receiver.h). The rule applies uniformly even for same-alternative
-//     writes - the `Authentication` response and `AuthenticationObserver`
-//     notifications are on separate pipes, so their relative arrival order
-//     at the renderer was never guaranteed in the first place.
-//   - Response callbacks bound through `SendStateOwnedRequest()` must use
-//     `weak_factory_.GetWeakPtr()`. `~StateBase` cancels `in_flight_`
-//     loaders via `DeleteSoon()`, which is not synchronous: a response
-//     already queued on the response task runner can still fire the
-//     callback after this state has been replaced. The `WeakPtr` drops it.
-//
-// Two `WeakPtr` factories are involved: the derived state's `weak_factory_`
-// invalidates the user callback, and `StateBase::weak_factory_` invalidates
-// the internal slot-erase bind. Both are declared last so they destruct
-// first.
+// The rules that govern pref writes, callback ordering, and response-callback
+// `WeakPtr`s live on `FlowBase`, since the flows are what implement them.
 class StateBase : public mojom::Authentication {
  public:
   StateBase(const StateBase&) = delete;
@@ -84,125 +44,39 @@ class StateBase : public mojom::Authentication {
   using AddObserverCallback = base::RepeatingCallback<void(
       mojo::PendingRemote<mojom::AuthenticationObserver>)>;
 
-  StateBase(AccountStatePrefs& account_state_prefs,
-            scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-            const os_crypt_async::Encryptor& encryptor,
-            AddObserverCallback add_observer);
+  explicit StateBase(AddObserverCallback add_observer);
 
   ~StateBase() override;
 
-  std::string Encrypt(const std::string& plain_text) const;
-  std::string Decrypt(const std::string& base64) const;
-
-  template <typename Error = void>
-  auto GetDecryptedVerificationToken(
-      mojom::VerificationIntentPtr intent) const {
-    if constexpr (std::is_void_v<Error>) {
-      return Decrypt(
-          account_state_prefs_->GetVerificationToken(std::move(intent)));
-    } else {
-      using Expected =
-          base::expected<std::string, decltype(Error::NewClientError(nullptr))>;
-
-      const auto encrypted_verification_token =
-          account_state_prefs_->GetVerificationToken(std::move(intent));
-      if (encrypted_verification_token.empty()) {
-        return Expected(internal::MakeCalledInWrongStateError<Error>());
-      }
-
-      auto verification_token = Decrypt(encrypted_verification_token);
-      if (verification_token.empty()) {
-        return Expected(
-            internal::MakeVerificationTokenDecryptionFailedError<Error>());
-      }
-
-      return Expected(std::move(verification_token));
-    }
-  }
-
-  template <typename Error = void>
-  auto GetDecryptedAuthenticationToken() const {
-    const auto encrypted_authentication_token =
-        account_state_prefs_->GetAuthenticationToken();
-    CHECK(!encrypted_authentication_token.empty());
-
-    auto authentication_token = Decrypt(encrypted_authentication_token);
-    if constexpr (std::is_void_v<Error>) {
-      return authentication_token;
-    } else {
-      using Expected =
-          base::expected<std::string, decltype(Error::NewClientError(nullptr))>;
-
-      if (authentication_token.empty()) {
-        return Expected(
-            internal::MakeAuthenticationTokenDecryptionFailedError<Error>());
-      }
-
-      return Expected(std::move(authentication_token));
-    }
-  }
-
-  // Caller-owned: the returned handle cancels the request when destroyed.
-  // Use when the request's lifetime is tied to something other than
-  // `~StateBase` (e.g. replaced by the next scheduled attempt).
-  template <typename Endpoint, typename Request, typename Response>
-  [[nodiscard]] endpoint_client::RequestHandle SendCallerOwnedRequest(
-      Request request,
-      base::OnceCallback<void(Response)> callback) {
-    return endpoint_client::Client<Endpoint>::template Send<
-        endpoint_client::RequestCancelability::kCancelable>(
-        url_loader_factory_, std::move(request), std::move(callback));
-  }
-
-  // State-owned: the handle is parked in `in_flight_` and cancelled by
-  // `~StateBase`. The default for response-driven flows.
-  template <typename Endpoint, typename Request, typename Response>
-  void SendStateOwnedRequest(Request request,
-                             base::OnceCallback<void(Response)> callback) {
-    auto slot = in_flight_.emplace(in_flight_.end());
-    *slot = SendCallerOwnedRequest<Endpoint>(
-        std::move(request), std::move(callback).Then(base::BindOnce(
-                                &StateBase::RemoveRequestHandle,
-                                weak_factory_.GetWeakPtr(), slot)));
-  }
-
-  // Unowned: fire-and-forget, no callback, not cancelable. Use only for
-  // best-effort notifications whose response is intentionally ignored.
-  template <typename Endpoint, typename Request>
-  void SendUnownedRequest(Request request) {
-    endpoint_client::Client<Endpoint>::Send(
-        url_loader_factory_, std::move(request),
-        base::BindOnce([](typename Endpoint::Response) {}));
-  }
-
  private:
-  // Flow helpers, each owned by one state and implementing that state's
-  // flow overrides on its owner's behalf: `Login`, `Register`, and
-  // `ResetPassword` owned by `LoggedOutState` (the `LoginStep*`, `Register*`,
-  // and `ResetPassword*` overrides), `ChangePassword`, `GetServiceToken`, and
-  // `LogOut` owned by `LoggedInState` (the `ChangePassword*`,
-  // `GetServiceToken`, and `LogOut` overrides). `CancelVerification` and
-  // `ResendVerificationEmail` are the exceptions: they are owned by `StateBase`
-  // itself (see `cancel_verification_` and `resend_verification_email_` below),
-  // because their overrides are valid in both states. `UpdateEmail`, owned by
-  // `LoggedInState`, implements no mojom override at all: it drives itself,
-  // polling in the background to refresh the stored email. They are friended on
-  // `StateBase` (not on the owning state) because the plumbing they borrow
-  // through their back-reference - request lifetime (`in_flight_`,
-  // `SendStateOwnedRequest()`, `SendCallerOwnedRequest()`), crypto, and
-  // `account_state_prefs_` - is bound to `StateBase` and can't move out.
-  friend class CancelVerification;
-  friend class ChangePassword;
-  friend class GetServiceToken;
-  friend class Login;
-  friend class LogOut;
-  friend class Register;
-  friend class ResendVerificationEmail;
-  friend class ResetPassword;
-  friend class UpdateEmail;
-
   void AddObserver(
       mojo::PendingRemote<mojom::AuthenticationObserver> observer) final;
+
+  void ChangePasswordStep1(const std::string& email,
+                           ChangePasswordStep1Callback callback) override;
+
+  void ChangePasswordStep2(const std::string& code,
+                           ChangePasswordStep2Callback callback) override;
+
+  void ChangePasswordStep3(const std::string& blinded_message,
+                           ChangePasswordStep3Callback callback) override;
+
+  void ChangePasswordStep4(const std::string& serialized_record,
+                           ChangePasswordStep4Callback callback) override;
+
+  void GetServiceToken(mojom::Service service,
+                       GetServiceTokenCallback callback) override;
+
+  void LogOut() override;
+
+  void LoginStep1(mojom::Service initiating_service,
+                  const std::string& email,
+                  const std::string& serialized_ke1,
+                  LoginStep1Callback callback) override;
+
+  void LoginStep2(const std::string& encrypted_login_token,
+                  const std::string& client_mac,
+                  LoginStep2Callback callback) override;
 
   void RegisterStep1(mojom::Service initiating_service,
                      const std::string& email,
@@ -215,12 +89,6 @@ class StateBase : public mojom::Authentication {
 
   void RegisterStep3(const std::string& code,
                      RegisterStep3Callback callback) override;
-
-  void ResendVerificationEmail(
-      mojom::VerificationIntentPtr intent,
-      ResendVerificationEmailCallback callback) override;
-
-  void CancelVerification(mojom::VerificationIntentPtr intent) override;
 
   void ResetPasswordStep1(const std::string& email,
                           ResetPasswordStep1Callback callback) override;
@@ -235,47 +103,8 @@ class StateBase : public mojom::Authentication {
                           const std::string& email,
                           ResetPasswordStep4Callback callback) override;
 
-  void LoginStep1(mojom::Service initiating_service,
-                  const std::string& email,
-                  const std::string& serialized_ke1,
-                  LoginStep1Callback callback) override;
-
-  void LoginStep2(const std::string& encrypted_login_token,
-                  const std::string& client_mac,
-                  LoginStep2Callback callback) override;
-
-  void ChangePasswordStep1(const std::string& email,
-                           ChangePasswordStep1Callback callback) override;
-
-  void ChangePasswordStep2(const std::string& code,
-                           ChangePasswordStep2Callback callback) override;
-
-  void ChangePasswordStep3(const std::string& blinded_message,
-                           ChangePasswordStep3Callback callback) override;
-
-  void ChangePasswordStep4(const std::string& serialized_record,
-                           ChangePasswordStep4Callback callback) override;
-
-  void LogOut() override;
-
-  void GetServiceToken(mojom::Service service,
-                       GetServiceTokenCallback callback) override;
-
-  void RemoveRequestHandle(
-      std::list<endpoint_client::RequestHandle>::iterator slot);
-
- protected:
-  const raw_ref<AccountStatePrefs> account_state_prefs_;
-
- private:
-  const scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
-  const BraveAccountEncryption encryption_;
   const AddObserverCallback add_observer_;
   mojo::ReceiverSet<mojom::Authentication> receivers_;
-  std::list<endpoint_client::RequestHandle> in_flight_;
-  class CancelVerification cancel_verification_{*this};
-  class ResendVerificationEmail resend_verification_email_{*this};
-  base::WeakPtrFactory<StateBase> weak_factory_{this};
 };
 
 }  // namespace brave_account

--- a/components/brave_account/state_internal.h
+++ b/components/brave_account/state_internal.h
@@ -13,45 +13,8 @@
 #include "base/types/expected.h"
 #include "brave/components/brave_account/endpoints/error_body.h"
 #include "brave/components/brave_account/mojom/brave_account.mojom.h"
-#include "net/traffic_annotation/network_traffic_annotation.h"
 
 namespace brave_account::internal {
-
-inline constexpr net::NetworkTrafficAnnotationTag kTrafficAnnotation =
-    net::DefineNetworkTrafficAnnotation("brave_account_endpoints",
-                                        R"(
-  semantics {
-    sender: "Brave Account client"
-    description:
-      "Implements the creation or sign-in process for a Brave Account."
-    trigger:
-      "User attempts to create or sign in to a Brave Account from settings."
-    user_data: {
-      type: EMAIL
-    }
-    data:
-      "Blinded cryptographic message for secure password setup "
-      "and account email address."
-      "Verification token for account activation and "
-      "serialized cryptographic record for account finalization."
-    destination: OTHER
-    destination_other: "Brave Account service"
-  }
-  policy {
-    cookies_allowed: NO
-    policy_exception_justification:
-      "These requests are essential for Brave Account creation and sign-in "
-      "and cannot be disabled by policy."
-  }
-)");
-
-template <typename Request>
-auto MakeRequest() {
-  Request request;
-  request.network_traffic_annotation_tag =
-      net::MutableNetworkTrafficAnnotationTag(kTrafficAnnotation);
-  return request;
-}
 
 template <typename Error>
 using ClientErrorOf = typename std::remove_cvref_t<


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/56361

Continues organizing `BraveAccountService`'s internals **per-flow** instead of **per-state**. The flow helpers already existed as separate objects, but each still reached back into its owning state through a `raw_ref<StateBase>` to borrow request-sending, crypto, and prefs access — which required nine `friend class` declarations on `StateBase`.

`FlowBase` now owns that plumbing, and flows inherit it instead of pointing back at a state:
- `FlowBase` owns request lifetime (`in_flight_`, `Send*Request()`), crypto (`Encrypt`/`Decrypt`, `GetDecrypted*Token`), and `account_state_prefs_`
- `StateBase` is now purely the `mojom::Authentication` surface

Also included:
- `SendStateOwnedRequest()` → `SendFlowOwnedRequest()` — the in-flight bag lives on the flow now
- `kTrafficAnnotation` + `MakeRequest()` → `flows/make_request.h`, as both are flows-only
- `state_base_unittest.cc` → `flows/flow_base_unittest.cc`

Pure refactor, no behavior change.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
