### PR TITLE
[iOS] Include keyboard height in web view obscured insets

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Keyboard.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Keyboard.swift
@@ -13,6 +13,9 @@ extension BrowserViewController: KeyboardHelperDelegate {
     keyboardWillShowWithState state: KeyboardState
   ) {
     keyboardState = state
+    if #available(iOS 26.0, *) {
+      updateWebViewObscuredInsets()
+    }
     // Only collapse the url bar take control of the toolbar if the reason why the keyboard will
     // show is because the active web content presented it.
     let isKeyboardActiveForWebContent =
@@ -55,6 +58,9 @@ extension BrowserViewController: KeyboardHelperDelegate {
     keyboardWillHideWithState state: KeyboardState
   ) {
     keyboardState = nil
+    if #available(iOS 26.0, *) {
+      updateWebViewObscuredInsets()
+    }
     isBrowserContentKeyboardActive = false
     // Always reset things after orientation change that may change bottom bar
     if isUsingBottomBar, !toolbarVisibilityViewModel.isEnabled {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -743,10 +743,6 @@ public class BrowserViewController: UIViewController {
     obscuredInsets.top = toolbarInsets.top
     obscuredInsets.bottom = toolbarInsets.bottom
 
-    // Setting obscuredInsets actually includes a side-effect of setting the web views contentInset
-    webViewProxy.obscuredInsets = obscuredInsets
-
-    // But we still need to update the scroll indicator insets manually
     var scrollIndicatorInsets = UIEdgeInsets(
       top: max(0, toolbarInsets.top - view.safeAreaInsets.top),
       left: 0,
@@ -757,15 +753,21 @@ public class BrowserViewController: UIViewController {
     if let keyboardState, case let keyboardHeight = keyboardState.intersectionHeightForView(view),
       keyboardHeight > 0
     {
-      var contentInsets = webViewProxy.scrollView?.contentInset ?? .zero
-      contentInsets.bottom = keyboardHeight + toolbarInsets.bottom
-      webViewProxy.scrollView?.contentInset = contentInsets
+      // The keyboard must be included in the obscured insets themselves. WKWebView derives and
+      // re-asserts the scroll view's contentInset from obscuredContentInsets, so adjusting the
+      // scroll view's contentInset manually would be overwritten by the web process.
+      obscuredInsets.bottom = max(obscuredInsets.bottom, keyboardHeight)
       if isUsingBottomBar {
         scrollIndicatorInsets.bottom = 0
       } else {
         scrollIndicatorInsets.bottom -= toolbarInsets.bottom
       }
     }
+
+    // Setting obscuredInsets actually includes a side-effect of setting the web views contentInset
+    webViewProxy.obscuredInsets = obscuredInsets
+
+    // But we still need to update the scroll indicator insets manually
     webViewProxy.scrollView?.scrollIndicatorInsets = scrollIndicatorInsets
   }
 


### PR DESCRIPTION
Fixes a bug on `ask.brave.com` where the software keyboard would occlude the input box