### PR TITLE
[iOS] Show one-time confirmation alert for QuickView links

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -179,6 +179,26 @@ extension BrowserViewController: TabManagerDelegate {
           self.tabManager.configureTab(tab, request: request, flushToDisk: false, zombie: true)
           self.tabManager.saveTab(tab, saveOrder: true)
           self.tabManager.selectTab(tab)
+        },
+        onShowConfirmationAlert: { [weak self] in
+          let alert = UIAlertController(
+            title: Strings.quickViewConfirmationAlertTitle,
+            message: Strings.quickViewConfirmationAlertMessage,
+            preferredStyle: .alert
+          )
+          alert.addAction(
+            .init(title: Strings.quickViewConfirmationAlertKeepButtonTitle, style: .default)
+          )
+          alert.addAction(
+            .init(
+              title: Strings.quickViewConfirmationAlertTurnOffButtonTitle,
+              style: .cancel,
+              handler: { _ in
+                Preferences.General.openLinkInQuickViewMode.value = false
+              }
+            )
+          )
+          self?.present(alert, animated: true)
         }
       )
       if let sheet = quickViewController.sheetPresentationController {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
@@ -41,6 +41,7 @@ class QuickViewController: UIViewController {
   private let onOpenInNewTab: ((URLRequest, Bool) -> Void)?
   private let onOpenInNewWindow: ((URL, Bool) -> Void)?
   private let onAttachTab: ((any TabState) -> Void)?
+  private let onShowConfirmationAlert: (() -> Void)?
 
   private var preKeyboardToolbarState: ToolbarVisibilityViewModel.ToolbarState?
   private var toolbarHeightConstraint: Constraint?
@@ -64,7 +65,8 @@ class QuickViewController: UIViewController {
     historyAPI: BraveHistoryAPI,
     onOpenInNewTab: ((URLRequest, Bool) -> Void)?,
     onOpenInNewWindow: ((URL, Bool) -> Void)?,
-    onAttachTab: ((any TabState) -> Void)?
+    onAttachTab: ((any TabState) -> Void)?,
+    onShowConfirmationAlert: (() -> Void)?
   ) {
     self.url = url
     self.profile = profile
@@ -78,12 +80,21 @@ class QuickViewController: UIViewController {
     self.onOpenInNewTab = onOpenInNewTab
     self.onOpenInNewWindow = onOpenInNewWindow
     self.onAttachTab = onAttachTab
+    self.onShowConfirmationAlert = onShowConfirmationAlert
     super.init(nibName: nil, bundle: nil)
     modalPresentationStyle = .pageSheet
   }
 
   @available(*, unavailable)
   required init?(coder aDecoder: NSCoder) { fatalError() }
+
+  override func viewDidDisappear(_ animated: Bool) {
+    super.viewDidDisappear(animated)
+    if !Preferences.General.openLinkInQuickViewModeConfirmationShown.value {
+      Preferences.General.openLinkInQuickViewModeConfirmationShown.value = true
+      onShowConfirmationAlert?()
+    }
+  }
 
   override func viewDidAppear(_ animated: Bool) {
     super.viewDidAppear(animated)

--- a/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
@@ -146,6 +146,11 @@ extension Preferences {
       key: "general.open-link-in-quickview-mode",
       default: true
     )
+    /// Whether or not brave has shown a prompt to users to confirm later continue opening links in QuickView
+    public static let openLinkInQuickViewModeConfirmationShown: Option<Bool> = .init(
+      key: "general.open-link-in-quickview-mode-confirmation-shown",
+      default: false
+    )
     /// Whether or not the crash reporting alert has been shown at least once
     public static let crashReportingOptInShown: Option<Bool> = .init(
       key: "general.crash-reporting-opt-in-shown",

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -9264,4 +9264,36 @@ extension Strings {
     comment:
       "Accessibility text for an icon button which will exit QuickView mode and open the current page in a regular tab."
   )
+
+  public static let quickViewConfirmationAlertTitle = NSLocalizedString(
+    "quickview.confirmation.alert.title",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Keep opening links in QuickView?",
+    comment:
+      "Title of the alert shown the first time a user closes QuickView, asking if they want to keep using it for future links."
+  )
+  public static let quickViewConfirmationAlertMessage = NSLocalizedString(
+    "quickview.confirmation.alert.message",
+    tableName: "BraveShared",
+    bundle: .module,
+    value:
+      "QuickView lets you preview links without leaving your page. You can turn this off anytime in Settings.",
+    comment:
+      "Message of the alert shown the first time a user closes QuickView, explaining the feature and where to change it."
+  )
+  public static let quickViewConfirmationAlertKeepButtonTitle = NSLocalizedString(
+    "quickview.confirmation.alert.keep.button.title",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Keep using QuickView",
+    comment: "Button title to keep opening links in QuickView after the confirmation alert."
+  )
+  public static let quickViewConfirmationAlertTurnOffButtonTitle = NSLocalizedString(
+    "quickview.confirmation.alert.turnOff.button.title",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Turn off",
+    comment: "Button title to stop opening links in QuickView after the confirmation alert."
+  )
 }

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -9269,7 +9269,7 @@ extension Strings {
     "quickview.confirmation.alert.title",
     tableName: "BraveShared",
     bundle: .module,
-    value: "Keep opening links in QuickView?",
+    value: "Keep opening conversation links in Quick View?",
     comment:
       "Title of the alert shown the first time a user closes QuickView, asking if they want to keep using it for future links."
   )


### PR DESCRIPTION
Ask the user once, after their first QuickView dismissal, whether to keep opening Ask Brave/Search links in QuickView or switch to regular tabs. The choice remains changeable in settings.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58591

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
