### PR TITLE
[Wallet]: Hide Input Number Spinners in Forms

### DIFF
--- a/components/brave_wallet_ui/components/desktop/popup-modals/shield_zcash_account/shield_zcash_account.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/shield_zcash_account/shield_zcash_account.tsx
@@ -4,7 +4,6 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 import * as React from 'react'
 import Icon from '@brave/leo/react/icon'
-import Input from '@brave/leo/react/input'
 import Button from '@brave/leo/react/button'
 
 // Slices
@@ -37,6 +36,7 @@ import {
   CollapseIcon,
 } from './shield_zcash_account.style'
 import { Column, Text, Row } from '../../../shared/style'
+import { NumberInput } from '../../../shared/number_input/number_input'
 
 const MIN_ACCOUNT_BIRTHDAY_BLOCK = 1687104
 
@@ -235,9 +235,8 @@ export const ShieldZCashAccountModal = (props: Props) => {
                 >
                   {getLocale(S.BRAVE_WALLET_SHIELDED_ACCOUNT_BIRTHDAY_BLOCK)}
                 </Text>
-                <Input
+                <NumberInput
                   size='small'
-                  type='number'
                   value={customBirthdayBlock}
                   onInput={(e) => setCustomBirthdayBlock(e.value)}
                   showErrors={invalidBirthdayBlock}

--- a/components/brave_wallet_ui/components/shared/add-custom-token-form/add-custom-token-form.tsx
+++ b/components/brave_wallet_ui/components/shared/add-custom-token-form/add-custom-token-form.tsx
@@ -33,6 +33,7 @@ import {
 import Tooltip from '../tooltip'
 import { FormErrorsList } from './form-errors-list'
 import { NetworksDropdown } from '../dropdowns/networks_dropdown'
+import { NumberInput } from '../number_input/number_input'
 
 // styles
 import {
@@ -404,16 +405,15 @@ export const AddCustomTokenForm = (props: Props) => {
             </Input>
           </FormColumn>
           <FormColumn>
-            <Input
+            <NumberInput
               value={decimals}
               onInput={handleTokenDecimalsChanged}
               disabled={isDecimalDisabled}
-              type='number'
             >
               <InputLabel>
                 {getLocale(S.BRAVE_WALLET_WATCH_LIST_TOKEN_DECIMALS)}
               </InputLabel>
-            </Input>
+            </NumberInput>
           </FormColumn>
         </FormRow>
 

--- a/components/brave_wallet_ui/components/shared/add-custom-token-form/add-nft-form.tsx
+++ b/components/brave_wallet_ui/components/shared/add-custom-token-form/add-nft-form.tsx
@@ -46,6 +46,7 @@ import { NetworksDropdown } from '../dropdowns/networks_dropdown'
 import { FormErrorsList } from './form-errors-list'
 import { NftIcon } from '../nft-icon/nft-icon'
 import { InfoIconTooltip } from '../info_icon_tooltip/info_icon_tooltip'
+import { NumberInput } from '../number_input/number_input'
 
 // styles
 import {
@@ -495,14 +496,13 @@ export const AddNftForm = (props: Props) => {
         {customAssetsNetwork
           && customAssetsNetwork?.coin !== BraveWallet.CoinType.SOL && (
             <FullWidthFormColumn>
-              <Input
+              <NumberInput
                 value={
                   customTokenID
                     ? new Amount(customTokenID).format(undefined, false)
                     : ''
                 }
                 onInput={handleTokenIDChanged}
-                type='number'
                 placeholder={getLocale(S.BRAVE_WALLET_EXEMPLI_GRATIA).replace(
                   '$1',
                   '1234',
@@ -520,7 +520,7 @@ export const AddNftForm = (props: Props) => {
                     text={getLocale(S.BRAVE_WALLET_WHAT_IS_AN_NFT_TOKEN_ID)}
                   />
                 </Row>
-              </Input>
+              </NumberInput>
             </FullWidthFormColumn>
           )}
 

--- a/components/brave_wallet_ui/components/shared/number_input/number_input.tsx
+++ b/components/brave_wallet_ui/components/shared/number_input/number_input.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import Input from '@brave/leo/react/input'
+
+// Leo Input keeps the native <input> in shadow DOM, so page-level CSS cannot
+// hide number spinners. Inject the rules into each host's shadow root instead.
+const HIDE_SPINNERS_STYLE_ID = 'hide-number-spinners'
+const HIDE_SPINNERS_CSS = `
+  .leo-input[type='number'] {
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+  .leo-input::-webkit-inner-spin-button,
+  .leo-input::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    appearance: none;
+    margin: 0;
+    display: none;
+  }
+`
+
+function hideNumberSpinners(host: HTMLElement | null) {
+  if (
+    !host?.shadowRoot
+    || host.shadowRoot.querySelector(`#${HIDE_SPINNERS_STYLE_ID}`)
+  ) {
+    return
+  }
+  const style = document.createElement('style')
+  style.id = HIDE_SPINNERS_STYLE_ID
+  style.textContent = HIDE_SPINNERS_CSS
+  host.shadowRoot.appendChild(style)
+}
+
+/**
+ * Props for {@link NumberInput}.
+ *
+ * Note: `type` is fixed to `'number'` internally. Consumers should not pass `type`.
+ */
+export type NumberInputProps = Omit<React.ComponentProps<typeof Input>, 'type'>
+
+// Wrap rather than use styled(Input).attrs(): styled-components v6's type
+// machinery explodes over leo Input's large prop type (TS2590). Cast on
+// createElement for the same reason (ref + spread also trips TS2590/TS2769).
+/**
+ * Leo `<input type="number">` without native spinner controls.
+ */
+export const NumberInput = (props: NumberInputProps) => {
+  const setRef = React.useCallback((node: HTMLElement | null) => {
+    hideNumberSpinners(node)
+  }, [])
+
+  return React.createElement(Input, {
+    ...props,
+    type: 'number',
+    ref: setRef,
+  } as any)
+}
+
+export default NumberInput


### PR DESCRIPTION
## Description 

- Add a reusable `NumberInput` Leo wrapper that hides native number spinners by injecting CSS into the component’s shadow root (page-level styles can’t reach the inner input).
- Use it for wallet number fields that previously used Leo `Input` with `type='number'`: custom token decimals, NFT token ID, and Zcash account birthday block.

## Test plan
- [ ] Open **Add custom token** and confirm the decimals field has no up/down spinner and still accepts only numeric input
- [ ] Open **Add NFT** (non-Solana network) and confirm the token ID field has no spinner and still works
- [ ] Open **Shield Zcash account** advanced birthday block input and confirm no spinner; validation still works

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/58567>

<img width="528" height="603" alt="Screenshot 49" src="https://github.com/user-attachments/assets/430f073b-efd9-444d-9b3b-994ac7605bae" />

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
