### PR TITLE
Force youtube to desktop when dekstop site is required

### DIFF
--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -208,6 +208,9 @@ var package = Package(
           "Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/YoutubeQualityScript.js"
         ),
         .copy(
+          "Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/YoutubeDesktopCookieScript.js"
+        ),
+        .copy(
           "Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/BraveLeoScript.js"
         ),
         .copy(

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -491,6 +491,7 @@ public class BrowserViewController: UIViewController {
     Preferences.Shields.blockAdsAndTrackingLevelRaw.observe(from: self)
     Preferences.Privacy.screenTimeEnabled.observe(from: self)
     Preferences.Translate.translateEnabled.observe(from: self)
+    Preferences.General.preferYouTubeDesktopSite.observe(from: self)
 
     // Observe some Chromium prefs
     prefsChangeRegistrar.addObserver(forPath: BraveRewardsDisabledByPolicyPrefName) {
@@ -3070,6 +3071,12 @@ extension BrowserViewController: PreferencesObserver {
         screenTimeViewController?.suppressUsageRecording = true
         screenTimeViewController = nil
       }
+    case Preferences.General.preferYouTubeDesktopSite.key:
+      let enabled = Preferences.General.preferYouTubeDesktopSite.value
+      tabManager.allTabs.forEach {
+        $0.browserData?.setScript(script: .youtubeDesktopCookie, enabled: enabled)
+      }
+      tabManager.reloadSelectedTab()
     case Preferences.Translate.translateEnabled.key:
       if let tab = tabManager.selectedTab {
         updateTranslateURLBar(tab: tab, state: .unavailable)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
@@ -293,6 +293,7 @@ class TabBrowserData: NSObject, TabObserver {
       .cookieBlocking: tab.profile.prefs.boolean(forPath: kBlockAllCookiesEnabled),
       .mediaBackgroundPlay: tab.profile.prefs.boolean(forPath: kMediaBackgroundingEnabled),
       .braveTranslate: Preferences.Translate.translateEnabled.value != false,
+      .youtubeDesktopCookie: Preferences.General.preferYouTubeDesktopSite.value,
     ]
 
     userScripts = Set(scriptPreferences.filter({ $0.value }).map({ $0.key }))

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/UserScriptManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/UserScriptManager.swift
@@ -125,6 +125,7 @@ class UserScriptManager {
     case cardanoProvider
     case searchResultAd
     case youtubeQuality
+    case youtubeDesktopCookie
     case braveLeoAIChat
     case braveTranslate
 
@@ -167,6 +168,8 @@ class UserScriptManager {
       case .youtubeQuality:
         return Preferences.UserScript.youtubeQuality.value
           ? YoutubeQualityScriptHandler.userScript : nil
+      case .youtubeDesktopCookie:
+        return loadScript(named: "YoutubeDesktopCookieScript")
       case .braveLeoAIChat:
         return Preferences.UserScript.leo.value ? BraveLeoScriptHandler.userScript : nil
       case .braveTranslate:

--- a/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
@@ -103,6 +103,12 @@ extension Preferences {
       default: false
     )
 
+    /// Whether to rewrite YouTube PREF cookies so the desktop site is used.
+    public static let preferYouTubeDesktopSite = Option<Bool>(
+      key: "general.youtube-desktop-site",
+      default: false
+    )
+
     /// Whether or not the pull-to-refresh control is added to web views
     static let enablePullToRefresh = Option<Bool>(
       key: "general.enable-pull-to-refresh",

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Display/MediaSettingsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Display/MediaSettingsView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct MediaSettingsView: View {
   @Bindable var enableBackgroundAudio: PrefBackedBoolean
   @ObservedObject var keepYouTubeInBrave = Preferences.General.keepYouTubeInBrave
+  @ObservedObject var preferYouTubeDesktopSite = Preferences.General.preferYouTubeDesktopSite
   @ObservedObject var filterListStorage = FilterListStorage.shared
 
   @State var youtubeRecommendationsBlocking = false
@@ -36,6 +37,15 @@ struct MediaSettingsView: View {
       Section(header: Text(Strings.Settings.youtube)) {
         Toggle(isOn: $keepYouTubeInBrave.value) {
           Text(Strings.Settings.openYouTubeInBrave)
+        }
+        .tint(Color(braveSystemName: .primitivePrimary40))
+        Toggle(isOn: $preferYouTubeDesktopSite.value) {
+          VStack(alignment: .leading) {
+            Text(Strings.Settings.preferYouTubeDesktopSiteTitle)
+            Text(Strings.Settings.preferYouTubeDesktopSiteDesc)
+              .font(.footnote)
+              .foregroundColor(.secondary)
+          }
         }
         .tint(Color(braveSystemName: .primitivePrimary40))
         NavigationLink(destination: QualitySettingsView(prefs: prefs)) {

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/YoutubeDesktopCookieScript.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/YoutubeDesktopCookieScript.js
@@ -1,0 +1,47 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Media setting: rewrite YouTube PREF so the site prefers desktop.
+// Gated by Settings → Media → Always use YouTube desktop site.
+
+(function () {
+  const host = location.hostname;
+  if (!/(^|\.)youtube\.com$/.test(host) || host === "music.youtube.com") {
+    return;
+  }
+
+  const desktopF6 = "40000000";
+  let pref = "";
+  for (const pair of document.cookie.split(";")) {
+    const trimmed = pair.trim();
+    if (trimmed.startsWith("PREF=")) {
+      pref = trimmed.slice(5);
+      break;
+    }
+  }
+
+  const map = {};
+  if (pref) {
+    for (const part of pref.split("&")) {
+      const eq = part.indexOf("=");
+      if (eq === -1) {
+        continue;
+      }
+      map[part.slice(0, eq)] = part.slice(eq + 1);
+    }
+  }
+
+  if (map.f6 === desktopF6) {
+    return;
+  }
+
+  map.f6 = desktopF6;
+  const newPref = Object.keys(map)
+    .map((key) => key + "=" + map[key])
+    .join("&");
+  document.cookie =
+    "PREF=" + newPref +
+    "; domain=.youtube.com; path=/; Secure; SameSite=Lax; max-age=31536000";
+})();

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -2275,6 +2275,25 @@ extension Strings {
         comment: "A toggle label which lets the user always open YouTube urls in Brave"
       )
 
+    public static let preferYouTubeDesktopSiteTitle =
+      NSLocalizedString(
+        "settings.preferYouTubeDesktopSiteTitle",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Always Use Youtube Desktop Site When Requested",
+        comment: "Title beside the toggle for opening YouTube on the desktop site instead of mobile"
+      )
+
+    public static let preferYouTubeDesktopSiteDesc =
+      NSLocalizedString(
+        "settings.preferYouTubeDesktopSiteDesc",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Opens YouTube's desktop site instead of the mobile site when Always Request Desktop Site is on in Settings, or Request Desktop Site is on for a tab",
+        comment: "Description beside the toggle for opening YouTube on the desktop site instead of mobile"
+      )
+
+
     public static let highestQualityPlayback =
       NSLocalizedString(
         "settings.highestQualityPlayback",


### PR DESCRIPTION
### Problem
Any m.youtube.com load (often from a Top Sites tile) writes YouTube persist cookies that lock later visits to the mobile site,
even with Always Request Desktop Site enabled.

### Solution
Rewrite m.youtube.com to www.youtube.com before the load and add app=desktop&persist_app=1 so YouTube cannot 302 back to mobile.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/58357

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
