### PR TITLE
[plaster] Use `insert_into_list` for existing plaster

### DIFF
--- a/rewrite/chrome/browser/ui/android/bottombar/BUILD.gn.yaml
+++ b/rewrite/chrome/browser/ui/android/bottombar/BUILD.gn.yaml
@@ -9,6 +9,7 @@ substitutions:
 
       BottomBarCoordinator constructs BraveBottomBarButtonManager, so a target of
       its own would have to be depended on by the component it depends on.
-    add_sources:
+    insert_into_list:
       target: java
-      sources: //brave/browser/ui/android/bottombar/java/src/org/chromium/chrome/browser/ui/bottombar/BraveBottomBarButtonManager.java
+      list_name: sources
+      values: //brave/browser/ui/android/bottombar/java/src/org/chromium/chrome/browser/ui/bottombar/BraveBottomBarButtonManager.java


### PR DESCRIPTION
There was a already a plaster in place making use of `add_to_sources`.
This change migrates that plaster too.

Bug: https://github.com/brave/brave-browser/issues/58378
