### PR TITLE
[iOS] Add topsites mode preference and one-time setup

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
@@ -241,6 +241,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       }
     }
 
+    if Preferences.NewTabPage.topsitesMode.value == nil {
+      Preferences.NewTabPage.topsitesMode.value =
+        Favorite.hasFavorites ? TopsitesMode.favourite : TopsitesMode.mostVisited
+    }
+
     if isFirstLaunch {
       let currentDate = Date()
       Preferences.DAU.installationDate.value = currentDate

--- a/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
@@ -27,6 +27,11 @@ enum BackgroundMediaType: Int, CaseIterable {
   }
 }
 
+public enum TopsitesMode: Int {
+  case mostVisited
+  case favourite
+}
+
 extension Preferences {
   public enum AutoCloseTabsOption: Int, CaseIterable {
     case manually
@@ -340,6 +345,12 @@ extension Preferences {
     /// Tells the app whether we should show Favourites in new tab page view controller
     public static let showNewTabFavourites =
       Option<Bool>(key: "newtabpage.show-newtab-favourites", default: true)
+
+    /// Mode to display NTP tiles in NTP
+    public static let topsitesMode = Option<TopsitesMode?>(
+      key: "newtabpage.topsites-mode",
+      default: nil
+    )
   }
 
   final public class AdblockDebug {


### PR DESCRIPTION
New iOS NTP tile mode (Most Visited vs Favourites) needs a persisted preference. Default is nil until first resolved: existing users with favourites keep .favourite, everyone else starts on .mostVisited.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
