### PR TITLE
[ads] Hide "Sponsored sites" toggle when unavailable

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.test.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.test.tsx
@@ -7,11 +7,13 @@ import * as React from 'react'
 import { render, screen } from '@testing-library/react'
 import { createStateStore } from '$web-common/state_store'
 import { TopSitesContext } from '../../context/top_sites_context'
+import { RewardsContext } from '../../context/rewards_context'
 import {
   sponsoredSiteLearnMoreURL,
   TopSitesListKind,
   TopSitesState,
 } from '../../state/top_sites_store'
+import { RewardsState } from '../../state/rewards_store'
 import { TopSitesPanel } from './top_sites_panel'
 
 // The default $web-common/locale mock (see components/test/testSetup.ts)
@@ -56,15 +58,40 @@ function createStore(
   })
 }
 
+function createRewardsStore(state: Partial<RewardsState>) {
+  return createStateStore<RewardsState>({
+    initialized: true,
+    rewardsFeatureEnabled: true,
+    showRewardsWidget: false,
+    rewardsEnabled: false,
+    rewardsExternalWallet: null,
+    rewardsBalance: null,
+    rewardsExchangeRate: 0,
+    rewardsAdsViewed: null,
+    minEarningsPreviousMonth: 0,
+    payoutStatus: {},
+    tosUpdateRequired: false,
+    actions: {
+      setShowRewardsWidget() {},
+      recordNewTabOnboardingClick() {},
+    },
+    ...state,
+  })
+}
+
 function renderPanel(
   state: Partial<TopSitesState>,
   actions: Partial<TopSitesState['actions']> = {},
+  rewardsState: Partial<RewardsState> = {},
 ) {
   const store = createStore(state, actions)
+  const rewardsStore = createRewardsStore(rewardsState)
   render(
-    <TopSitesContext.Provider value={store}>
-      <TopSitesPanel />
-    </TopSitesContext.Provider>,
+    <RewardsContext.Provider value={rewardsStore}>
+      <TopSitesContext.Provider value={store}>
+        <TopSitesPanel />
+      </TopSitesContext.Provider>
+    </RewardsContext.Provider>,
   )
 }
 
@@ -81,6 +108,31 @@ describe('TopSitesPanel', () => {
     expect(
       screen.getByText('NEW_TAB_SHOW_SPONSORED_SITES_LABEL'),
     ).toBeInTheDocument()
+  })
+
+  it('should not render the sponsored sites toggle when an external wallet is connected', () => {
+    renderPanel(
+      { showTopSites: true },
+      {},
+      {
+        rewardsExternalWallet: {
+          provider: 'uphold',
+          authenticated: true,
+          name: '',
+          url: '',
+        },
+      },
+    )
+    expect(
+      screen.queryByText('NEW_TAB_SHOW_SPONSORED_SITES_LABEL'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not render the sponsored sites toggle when the rewards feature is disabled', () => {
+    renderPanel({ showTopSites: true }, {}, { rewardsFeatureEnabled: false })
+    expect(
+      screen.queryByText('NEW_TAB_SHOW_SPONSORED_SITES_LABEL'),
+    ).not.toBeInTheDocument()
   })
 
   it('should render the sponsored sites description with a learn more link', () => {

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.tsx
@@ -15,6 +15,7 @@ import {
   useTopSitesState,
   useTopSitesActions,
 } from '../../context/top_sites_context'
+import { useRewardsState } from '../../context/rewards_context'
 import { getString } from '../../lib/strings'
 import { SettingsPanel } from './settings_panel'
 import { formatString } from '$web-common/formatString'
@@ -29,6 +30,8 @@ export function TopSitesPanel() {
   const showTopSites = useTopSitesState((s) => s.showTopSites)
   const showSponsoredSites = useTopSitesState((s) => s.showSponsoredSites)
   const listKind = useTopSitesState((s) => s.topSitesListKind)
+  const rewardsFeatureEnabled = useRewardsState((s) => s.rewardsFeatureEnabled)
+  const rewardsExternalWallet = useRewardsState((s) => s.rewardsExternalWallet)
 
   function renderSelectedMarker(kind: TopSitesListKind) {
     if (kind === listKind) {
@@ -58,7 +61,7 @@ export function TopSitesPanel() {
           {getString(S.NEW_TAB_SHOW_TOP_SITES_LABEL)}
         </span>
       </Toggle>
-      {showTopSites && (
+      {showTopSites && rewardsFeatureEnabled && !rewardsExternalWallet && (
         <Toggle
           className='toggle-row'
           size='small'


### PR DESCRIPTION
The Top Sites settings panel showed a “Sponsored sites” toggle even if sponsored sites could never actually appear: when the user has an external Rewards wallet connected and on Brave Origin. The toggle now only shows when sponsored sites are actually available matching how the “Show new tab page ads” toggle already behaves on Brave Origin.

## Test plan

Make sure that "Show sponsored sites" toggle is:
* hidden when user has external Rewards wallet connected.
* hidden for Brave Origin browser

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58696
- Resolves https://github.com/brave/brave-browser/issues/58692

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
