### PR TITLE
[ads] Hide "Sponsored sites" toggle when unavailable (uplift to 1.96.x)

### DIFF
--- a/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.test.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.test.tsx
@@ -7,11 +7,13 @@ import * as React from 'react'
 import { render, screen } from '@testing-library/react'
 import { createStateStore } from '$web-common/state_store'
 import { TopSitesContext } from '../../context/top_sites_context'
+import { RewardsContext } from '../../context/rewards_context'
 import {
   sponsoredSiteLearnMoreURL,
   TopSitesListKind,
   TopSitesState,
 } from '../../state/top_sites_store'
+import { RewardsState } from '../../state/rewards_store'
 import { TopSitesPanel } from './top_sites_panel'
 
 // The default $web-common/locale mock (see components/test/testSetup.ts)
@@ -56,15 +58,40 @@ function createStore(
   })
 }
 
+function createRewardsStore(state: Partial<RewardsState>) {
+  return createStateStore<RewardsState>({
+    initialized: true,
+    rewardsFeatureEnabled: true,
+    showRewardsWidget: false,
+    rewardsEnabled: false,
+    rewardsExternalWallet: null,
+    rewardsBalance: null,
+    rewardsExchangeRate: 0,
+    rewardsAdsViewed: null,
+    minEarningsPreviousMonth: 0,
+    payoutStatus: {},
+    tosUpdateRequired: false,
+    actions: {
+      setShowRewardsWidget() {},
+      recordNewTabOnboardingClick() {},
+    },
+    ...state,
+  })
+}
+
 function renderPanel(
   state: Partial<TopSitesState>,
   actions: Partial<TopSitesState['actions']> = {},
+  rewardsState: Partial<RewardsState> = {},
 ) {
   const store = createStore(state, actions)
+  const rewardsStore = createRewardsStore(rewardsState)
   render(
-    <TopSitesContext.Provider value={store}>
-      <TopSitesPanel />
-    </TopSitesContext.Provider>,
+    <RewardsContext.Provider value={rewardsStore}>
+      <TopSitesContext.Provider value={store}>
+        <TopSitesPanel />
+      </TopSitesContext.Provider>
+    </RewardsContext.Provider>,
   )
 }
 
@@ -81,6 +108,31 @@ describe('TopSitesPanel', () => {
     expect(
       screen.getByText('NEW_TAB_SHOW_SPONSORED_SITES_LABEL'),
     ).toBeInTheDocument()
+  })
+
+  it('should not render the sponsored sites toggle when an external wallet is connected', () => {
+    renderPanel(
+      { showTopSites: true },
+      {},
+      {
+        rewardsExternalWallet: {
+          provider: 'uphold',
+          authenticated: true,
+          name: '',
+          url: '',
+        },
+      },
+    )
+    expect(
+      screen.queryByText('NEW_TAB_SHOW_SPONSORED_SITES_LABEL'),
+    ).not.toBeInTheDocument()
+  })
+
+  it('should not render the sponsored sites toggle when the rewards feature is disabled', () => {
+    renderPanel({ showTopSites: true }, {}, { rewardsFeatureEnabled: false })
+    expect(
+      screen.queryByText('NEW_TAB_SHOW_SPONSORED_SITES_LABEL'),
+    ).not.toBeInTheDocument()
   })
 
   it('should render the sponsored sites description with a learn more link', () => {

--- a/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.tsx
+++ b/browser/resources/brave_new_tab_page_refresh/components/settings/top_sites_panel.tsx
@@ -15,6 +15,7 @@ import {
   useTopSitesState,
   useTopSitesActions,
 } from '../../context/top_sites_context'
+import { useRewardsState } from '../../context/rewards_context'
 import { getString } from '../../lib/strings'
 import { SettingsPanel } from './settings_panel'
 import { formatString } from '$web-common/formatString'
@@ -29,6 +30,8 @@ export function TopSitesPanel() {
   const showTopSites = useTopSitesState((s) => s.showTopSites)
   const showSponsoredSites = useTopSitesState((s) => s.showSponsoredSites)
   const listKind = useTopSitesState((s) => s.topSitesListKind)
+  const rewardsFeatureEnabled = useRewardsState((s) => s.rewardsFeatureEnabled)
+  const rewardsExternalWallet = useRewardsState((s) => s.rewardsExternalWallet)
 
   function renderSelectedMarker(kind: TopSitesListKind) {
     if (kind === listKind) {
@@ -58,7 +61,7 @@ export function TopSitesPanel() {
           {getString(S.NEW_TAB_SHOW_TOP_SITES_LABEL)}
         </span>
       </Toggle>
-      {showTopSites && (
+      {showTopSites && rewardsFeatureEnabled && !rewardsExternalWallet && (
         <Toggle
           className='toggle-row'
           size='small'


### PR DESCRIPTION
Uplift of #39616
Resolves https://github.com/brave/brave-browser/issues/58696
Resolves https://github.com/brave/brave-browser/issues/58692

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.