### PR TITLE
[AI Chat]: Attach content tools when they become available

### DIFF
--- a/browser/ai_chat/web_mcp_browsertest.cc
+++ b/browser/ai_chat/web_mcp_browsertest.cc
@@ -5,6 +5,7 @@
 
 #include <set>
 #include <string>
+#include <string_view>
 
 #include "base/files/file_path.h"
 #include "base/path_service.h"
@@ -24,6 +25,9 @@
 #include "chrome/browser/ui/browser.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
+#include "content/public/browser/navigation_controller.h"
+#include "content/public/browser/navigation_entry.h"
+#include "content/public/browser/reload_type.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
 #include "content/public/test/content_mock_cert_verifier.h"
@@ -110,6 +114,52 @@ class WebMcpBrowserTest : public InProcessBrowserTest {
     return content::EvalJs(GetActiveWebContents(), "__webmcpReady");
   }
 
+  content::EvalJsResult GetPageToolCount() {
+    return content::EvalJs(
+        GetActiveWebContents(),
+        "(async () => (await document.modelContext.getTools()).length)()");
+  }
+
+  // Stashes each tool's AbortController so UnregisterPageTools() can
+  // unregister them later.
+  content::EvalJsResult RegisterPageTool(std::string_view name) {
+    return content::EvalJs(GetActiveWebContents(), content::JsReplace(R"JS(
+      (async () => {
+        window.__toolControllers = window.__toolControllers ?? [];
+        const controller = new AbortController();
+        window.__toolControllers.push(controller);
+        await document.modelContext.registerTool({
+          name: $1,
+          description: "A tool registered by the test",
+          execute: async () => "ok",
+        }, { signal: controller.signal });
+        return (await document.modelContext.getTools()).length;
+      })()
+    )JS",
+                                                                      name));
+  }
+
+  [[nodiscard]] bool UnregisterPageTools() {
+    return content::ExecJs(GetActiveWebContents(),
+                           "window.__toolControllers.forEach(c => c.abort())");
+  }
+
+  void ReloadActiveTab() {
+    auto* web_contents = GetActiveWebContents();
+    content::WaitForLoadStop(web_contents);
+    web_contents->GetController().Reload(content::ReloadType::NORMAL,
+                                         /*check_for_repost=*/false);
+    content::WaitForLoadStop(web_contents);
+  }
+
+  AssociatedContentManager* CreateConversationManager() {
+    auto* conversation =
+        AIChatServiceFactory::GetForBrowserContext(browser()->GetProfile())
+            ->CreateConversation();
+    EXPECT_TRUE(conversation);
+    return conversation->associated_content_manager();
+  }
+
   // Drives an empty new-generation-loop on the manager so it re-fetches the
   // current set of tools, then returns them.
   std::vector<base::WeakPtr<Tool>> RefreshAndGetTools(
@@ -160,12 +210,7 @@ IN_PROC_BROWSER_TEST_F(WebMcpBrowserTest,
   AssociatedContentDelegate* content = GetActiveContent();
   ASSERT_TRUE(content);
 
-  auto* ai_chat_service =
-      AIChatServiceFactory::GetForBrowserContext(browser()->GetProfile());
-  auto* conversation = ai_chat_service->CreateConversation();
-  ASSERT_TRUE(conversation);
-
-  auto* manager = conversation->associated_content_manager();
+  auto* manager = CreateConversationManager();
   manager->AddContent(content);
 
   // AddContent attaches content that exposes tools, but the detection probe is
@@ -213,12 +258,7 @@ IN_PROC_BROWSER_TEST_F(WebMcpBrowserTest,
   auto* content = GetActiveContent();
   ASSERT_TRUE(content);
 
-  auto* ai_chat_service =
-      AIChatServiceFactory::GetForBrowserContext(browser()->GetProfile());
-  auto* conversation = ai_chat_service->CreateConversation();
-  ASSERT_TRUE(conversation);
-
-  auto* manager = conversation->associated_content_manager();
+  auto* manager = CreateConversationManager();
   manager->AddContent(content);
 
   EXPECT_TRUE(RefreshAndGetTools(manager).empty());
@@ -228,11 +268,7 @@ IN_PROC_BROWSER_TEST_F(WebMcpBrowserTest,
 // page's tools and drop the old page's tools.
 IN_PROC_BROWSER_TEST_F(WebMcpBrowserTest,
                        AssociatedContentManager_RefreshesAcrossNavigations) {
-  auto* ai_chat_service =
-      AIChatServiceFactory::GetForBrowserContext(browser()->GetProfile());
-  auto* conversation = ai_chat_service->CreateConversation();
-  ASSERT_TRUE(conversation);
-  auto* manager = conversation->associated_content_manager();
+  auto* manager = CreateConversationManager();
 
   ASSERT_TRUE(ui_test_utils::NavigateToURL(
       browser(), https_server()->GetURL("a.com", kPageWithToolsPath)));
@@ -247,6 +283,140 @@ IN_PROC_BROWSER_TEST_F(WebMcpBrowserTest,
   ASSERT_TRUE(ui_test_utils::NavigateToURL(
       browser(), https_server()->GetURL("a.com", kPageWithoutToolsPath)));
   EXPECT_TRUE(RefreshAndGetTools(manager).empty());
+}
+
+// Late-registered tools attach the content via the `toolchange` notification.
+IN_PROC_BROWSER_TEST_F(WebMcpBrowserTest,
+                       AssociatedContentManager_AttachesOnLateRegistration) {
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), https_server()->GetURL("a.com", kPageWithoutToolsPath)));
+
+  auto* content = GetActiveContent();
+  ASSERT_TRUE(content);
+
+  auto* manager = CreateConversationManager();
+  manager->AddContent(content);
+  ASSERT_FALSE(content->tools_attached());
+
+  ASSERT_EQ(1, RegisterPageTool("late_tool"));
+
+  ASSERT_TRUE(base::test::RunUntil([&] { return content->tools_attached(); }));
+  EXPECT_EQ(1u, RefreshAndGetTools(manager).size());
+}
+
+// Unregistering all of the page's tools detaches the staged content again.
+IN_PROC_BROWSER_TEST_F(WebMcpBrowserTest,
+                       AssociatedContentManager_DetachesOnUnregistration) {
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), https_server()->GetURL("a.com", kPageWithoutToolsPath)));
+
+  auto* content = GetActiveContent();
+  ASSERT_TRUE(content);
+
+  auto* manager = CreateConversationManager();
+  manager->AddContent(content);
+  ASSERT_FALSE(content->tools_attached());
+
+  ASSERT_EQ(1, RegisterPageTool("tool_one"));
+  ASSERT_EQ(2, RegisterPageTool("tool_two"));
+  ASSERT_TRUE(base::test::RunUntil([&] { return content->tools_attached(); }));
+
+  ASSERT_TRUE(UnregisterPageTools());
+  // Confirm the page saw the unregistration, so a failure below is
+  // browser-side.
+  ASSERT_EQ(0, GetPageToolCount());
+
+  ASSERT_TRUE(base::test::RunUntil([&] { return !content->tools_attached(); }));
+  EXPECT_TRUE(RefreshAndGetTools(manager).empty());
+}
+
+// A reload re-establishes the subscription, so late-registered tools still
+// attach the content.
+IN_PROC_BROWSER_TEST_F(
+    WebMcpBrowserTest,
+    AssociatedContentManager_AttachesOnRegistrationAfterReload) {
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), https_server()->GetURL("a.com", kPageWithoutToolsPath)));
+
+  auto* manager = CreateConversationManager();
+  auto* content = GetActiveContent();
+  ASSERT_TRUE(content);
+  manager->AddContent(content);
+  ASSERT_FALSE(content->tools_attached());
+
+  ReloadActiveTab();
+  ASSERT_FALSE(content->tools_attached());
+
+  ASSERT_EQ(1, RegisterPageTool("late_tool"));
+
+  ASSERT_TRUE(base::test::RunUntil([&] { return content->tools_attached(); }));
+  EXPECT_EQ(1u, RefreshAndGetTools(manager).size());
+}
+
+// A reload keeps the content associated: the live delegate keeps its uuid, so
+// the page's re-registered tools re-attach without the frontend re-attaching.
+IN_PROC_BROWSER_TEST_F(WebMcpBrowserTest,
+                       AssociatedContentManager_ReloadKeepsAssociation) {
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), https_server()->GetURL("a.com", kPageWithToolsPath)));
+  ASSERT_EQ(2, WaitForPageToolCount());
+
+  auto* manager = CreateConversationManager();
+  auto* content = GetActiveContent();
+  ASSERT_TRUE(content);
+  manager->AddContent(content);
+  ASSERT_TRUE(base::test::RunUntil([&] { return content->tools_attached(); }));
+
+  auto associated = manager->GetAssociatedContent();
+  ASSERT_EQ(1u, associated.size());
+  const std::string uuid_before = associated[0]->uuid;
+
+  ReloadActiveTab();
+  ASSERT_EQ(2, WaitForPageToolCount());
+
+  associated = manager->GetAssociatedContent();
+  ASSERT_EQ(1u, associated.size());
+  EXPECT_EQ(uuid_before, associated[0]->uuid);
+  EXPECT_EQ("WebMCP test", associated[0]->title);
+  ASSERT_TRUE(base::test::RunUntil([&] { return content->tools_attached(); }));
+  EXPECT_EQ(2u, RefreshAndGetTools(manager).size());
+}
+
+// A renderer-initiated reload is a converted reload, so the entry gets a new
+// UniqueID, which the delegate must track as the frontend's content_id.
+IN_PROC_BROWSER_TEST_F(
+    WebMcpBrowserTest,
+    AssociatedContentManager_LocationReloadKeepsAssociation) {
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), https_server()->GetURL("a.com", kPageWithToolsPath)));
+  ASSERT_EQ(2, WaitForPageToolCount());
+
+  auto* manager = CreateConversationManager();
+  auto* content = GetActiveContent();
+  ASSERT_TRUE(content);
+  manager->AddContent(content);
+  ASSERT_TRUE(base::test::RunUntil([&] { return content->tools_attached(); }));
+
+  auto associated = manager->GetAssociatedContent();
+  ASSERT_EQ(1u, associated.size());
+  const std::string uuid_before = associated[0]->uuid;
+
+  auto* web_contents = GetActiveWebContents();
+  content::WaitForLoadStop(web_contents);
+  ASSERT_TRUE(content::ExecJs(web_contents, "location.reload()"));
+  content::WaitForLoadStop(web_contents);
+  ASSERT_EQ(2, WaitForPageToolCount());
+
+  associated = manager->GetAssociatedContent();
+  ASSERT_EQ(1u, associated.size());
+  EXPECT_EQ(uuid_before, associated[0]->uuid);
+  EXPECT_EQ("WebMCP test", associated[0]->title);
+  EXPECT_EQ(
+      web_contents->GetController().GetLastCommittedEntry()->GetUniqueID(),
+      associated[0]->content_id);
+
+  ASSERT_TRUE(base::test::RunUntil([&] { return content->tools_attached(); }));
+  EXPECT_EQ(2u, RefreshAndGetTools(manager).size());
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/content/browser/associated_web_contents_content.cc
+++ b/components/ai_chat/content/browser/associated_web_contents_content.cc
@@ -15,6 +15,7 @@
 
 #include "base/barrier_callback.h"
 #include "base/check_deref.h"
+#include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
 #include "base/memory/weak_ptr.h"
@@ -51,6 +52,7 @@
 #include "pdf/buildflags.h"
 #include "services/service_manager/public/cpp/interface_provider.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
+#include "third_party/blink/public/common/features.h"
 #include "third_party/blink/public/common/permissions/permission_utils.h"
 
 #if BUILDFLAG(ENABLE_PDF)
@@ -148,6 +150,7 @@ void AssociatedWebContentsContent::NavigationEntryCommitted(
   // alone.
   // Note: This doesn't treat navigations to the same URL as a reload as
   // they have a different content_id.
+  const bool is_reload = pending_navigation_is_reload_;
   const bool is_same_page_reload =
       pending_navigation_is_reload_ && !is_same_document_navigation_ &&
       load_details.previous_main_frame_url ==
@@ -161,6 +164,17 @@ void AssociatedWebContentsContent::NavigationEntryCommitted(
     OnNewPage(pending_navigation_id_);
   }
   previous_page_title_ = load_details.entry->GetTitle();
+
+  // A new document means a new PageContentExtractor, so any subscription we had
+  // died with the old RenderFrame. A non-reload navigation runs OnNewPage
+  // above, which archives this content and gets the new document attached (and
+  // so subscribed) afresh, so only reloads need re-subscribing here.
+  // |content_tools_listener_| is never passively unbound, so it records whether
+  // a conversation ever attached this content.
+  if (is_reload && !is_same_document_navigation_ &&
+      content_tools_listener_.is_bound()) {
+    SubscribeToContentToolChanges();
+  }
 }
 
 void AssociatedWebContentsContent::TitleWasSet(
@@ -407,6 +421,33 @@ void AssociatedWebContentsContent::OnContentToolsFetched(
     }
   }
   std::move(callback).Run(std::move(tools));
+}
+
+void AssociatedWebContentsContent::OnAssociatedWithConversation() {
+  SubscribeToContentToolChanges();
+}
+
+void AssociatedWebContentsContent::OnContentToolsChanged() {
+  NotifyContentToolsChanged();
+}
+
+void AssociatedWebContentsContent::SubscribeToContentToolChanges() {
+  if (!base::FeatureList::IsEnabled(blink::features::kWebMCP)) {
+    return;
+  }
+
+  content::RenderFrameHost* rfh = web_contents()->GetPrimaryMainFrame();
+  if (!rfh || !rfh->IsRenderFrameLive()) {
+    return;
+  }
+
+  content_tools_extractor_.reset();
+  rfh->GetRemoteInterfaces()->GetInterface(
+      content_tools_extractor_.BindNewPipeAndPassReceiver());
+
+  content_tools_listener_.reset();
+  content_tools_extractor_->SetContentToolsListener(
+      content_tools_listener_.BindNewPipeAndPassRemote());
 }
 
 bool AssociatedWebContentsContent::HasOpenAIChatPermission() const {

--- a/components/ai_chat/content/browser/associated_web_contents_content.h
+++ b/components/ai_chat/content/browser/associated_web_contents_content.h
@@ -138,6 +138,7 @@ class AssociatedWebContentsContent : public content::WebContentsObserver,
   // mojom::ContentToolsListener
   void OnContentToolsChanged() override;
 
+  // Never unbound, as the content may be attached to several conversations.
   void SubscribeToContentToolChanges();
 
   // Called when an event of significance occurs that, if the page is a

--- a/components/ai_chat/content/browser/associated_web_contents_content.h
+++ b/components/ai_chat/content/browser/associated_web_contents_content.h
@@ -27,6 +27,7 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "content/public/browser/web_contents_user_data.h"
+#include "mojo/public/cpp/bindings/receiver.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "pdf/buildflags.h"
 #include "third_party/blink/public/mojom/content_extraction/ai_page_content.mojom.h"
@@ -46,7 +47,8 @@ class AIChatMetrics;
 
 // Provides context to an AI Chat conversation in the form of the Tab's content
 class AssociatedWebContentsContent : public content::WebContentsObserver,
-                                     public AssociatedContentDriver {
+                                     public AssociatedContentDriver,
+                                     public mojom::ContentToolsListener {
  public:
   // Delegate to extract print preview content
   class PrintPreviewExtractionDelegate {
@@ -130,6 +132,14 @@ class AssociatedWebContentsContent : public content::WebContentsObserver,
   void OnNewPage(int64_t navigation_id) override;
   void GetContentTools(GetContentToolsCallback callback) override;
 
+  // ai_chat::AssociatedContentDelegate
+  void OnAssociatedWithConversation() override;
+
+  // mojom::ContentToolsListener
+  void OnContentToolsChanged() override;
+
+  void SubscribeToContentToolChanges();
+
   // Called when an event of significance occurs that, if the page is a
   // same-document navigation, should result in that previous navigation
   // being considered as a new page.
@@ -196,6 +206,9 @@ class AssociatedWebContentsContent : public content::WebContentsObserver,
   std::unique_ptr<PageContentFetcherDelegate> page_content_fetcher_delegate_;
 
   std::unique_ptr<FullScreenshotter> full_screenshotter_;
+
+  mojo::Remote<mojom::PageContentExtractor> content_tools_extractor_;
+  mojo::Receiver<mojom::ContentToolsListener> content_tools_listener_{this};
 
   base::WeakPtrFactory<AssociatedWebContentsContent> weak_ptr_factory_{this};
 };

--- a/components/ai_chat/core/browser/associated_content_delegate.cc
+++ b/components/ai_chat/core/browser/associated_content_delegate.cc
@@ -101,4 +101,8 @@ void AssociatedContentDelegate::RemoveObserver(Observer* observer) {
   observers_.RemoveObserver(observer);
 }
 
+void AssociatedContentDelegate::NotifyContentToolsChanged() {
+  observers_.Notify(&Observer::OnContentToolsChanged, this);
+}
+
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/associated_content_delegate.h
+++ b/components/ai_chat/core/browser/associated_content_delegate.h
@@ -67,6 +67,7 @@ class AssociatedContentDelegate {
     virtual void OnNewPage(AssociatedContentDelegate* delegate) {}
     virtual void OnTitleChanged(AssociatedContentDelegate* delegate) {}
     virtual void OnToolsAttachedChanged(AssociatedContentDelegate* delegate) {}
+    virtual void OnContentToolsChanged(AssociatedContentDelegate* delegate) {}
   };
 
   AssociatedContentDelegate();
@@ -93,6 +94,10 @@ class AssociatedContentDelegate {
   using GetContentToolsCallback =
       base::OnceCallback<void(std::vector<std::unique_ptr<Tool>>)>;
   virtual void GetContentTools(GetContentToolsCallback callback);
+
+  // Called by AssociatedContentManager when this content is attached to a
+  // conversation.
+  virtual void OnAssociatedWithConversation() {}
 
   base::WeakPtr<AssociatedContentDelegate> GetWeakPtr() {
     return weak_ptr_factory_.GetWeakPtr();
@@ -126,6 +131,8 @@ class AssociatedContentDelegate {
  protected:
   // Content has navigated
   virtual void OnNewPage(int64_t navigation_id);
+
+  void NotifyContentToolsChanged();
 
   void set_uuid(std::string uuid) { uuid_ = std::move(uuid); }
   void NotifyNewPage();

--- a/components/ai_chat/core/browser/associated_content_manager.cc
+++ b/components/ai_chat/core/browser/associated_content_manager.cc
@@ -31,7 +31,7 @@ namespace ai_chat {
 
 namespace {
 constexpr size_t kMaxToolsPerContent = 30;
-}
+}  // namespace
 
 AssociatedContentManager::AssociatedContentManager(
     ConversationHandler* conversation)
@@ -152,11 +152,13 @@ void AssociatedContentManager::AddContent(AssociatedContentDelegate* delegate,
     content_delegates_.push_back(delegate);
     content_observations_.AddObservation(delegate);
 
+    // Let the content start watching for tool changes now that there's a
+    // conversation to report them to.
+    delegate->OnAssociatedWithConversation();
+
     // Discover whether this content exposes tools so it can be attached and
     // surfaced in the tools pill without waiting for a generation loop.
-    delegate->GetContentTools(
-        base::BindOnce(&AssociatedContentManager::OnContentToolsDetected,
-                       weak_ptr_factory_.GetWeakPtr(), delegate->GetWeakPtr()));
+    DetectContentTools(delegate);
   }
 
   if (notify_updated) {
@@ -183,6 +185,7 @@ void AssociatedContentManager::RemoveContent(
     // anymore.
     content_observations_.RemoveObservation(delegate);
     content_delegates_.erase(it);
+    tools_attachment_overridden_.erase(delegate->uuid());
   }
 
   // If this is owned content, delete it.
@@ -214,6 +217,9 @@ void AssociatedContentManager::RemoveContent(std::string_view content_uuid,
 void AssociatedContentManager::SetToolsAttached(std::string_view content_uuid,
                                                 bool tools_attached) {
   DVLOG(1) << __func__;
+
+  // Record even when it matches the current state, so auto-updates stop.
+  tools_attachment_overridden_.insert(std::string(content_uuid));
 
   auto it = std::ranges::find_if(content_delegates_,
                                  [&content_uuid](const auto& delegate) {
@@ -254,11 +260,16 @@ void AssociatedContentManager::GetToolInfos(std::string_view content_uuid,
       std::move(callback)));
 }
 
+void AssociatedContentManager::DetectContentTools(
+    AssociatedContentDelegate* delegate) {
+  delegate->GetContentTools(
+      base::BindOnce(&AssociatedContentManager::OnContentToolsDetected,
+                     weak_ptr_factory_.GetWeakPtr(), delegate->GetWeakPtr()));
+}
+
 void AssociatedContentManager::OnContentToolsDetected(
     base::WeakPtr<AssociatedContentDelegate> delegate,
     std::vector<std::unique_ptr<Tool>> tools) {
-  // Attach content when it exposes any tools, detach it otherwise. The user
-  // can subsequently override this via SetToolsAttached.
   if (!delegate) {
     return;
   }
@@ -267,6 +278,20 @@ void AssociatedContentManager::OnContentToolsDetected(
     return;
   }
   delegate->set_tools_attached(tools_attached);
+}
+
+bool AssociatedContentManager::IsEligibleForAutoToolsUpdate(
+    const std::string& uuid) const {
+  return !content_uuid_to_conversation_turns_.contains(uuid) &&
+         !tools_attachment_overridden_.contains(uuid);
+}
+
+void AssociatedContentManager::OnContentToolsChanged(
+    AssociatedContentDelegate* delegate) {
+  if (!IsEligibleForAutoToolsUpdate(delegate->uuid())) {
+    return;
+  }
+  DetectContentTools(delegate);
 }
 
 void AssociatedContentManager::ClearContent() {
@@ -603,6 +628,7 @@ void AssociatedContentManager::DetachContent() {
   content_observations_.RemoveAllObservations();
   content_delegates_.clear();
   owned_content_.clear();
+  tools_attachment_overridden_.clear();
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/associated_content_manager.cc
+++ b/components/ai_chat/core/browser/associated_content_manager.cc
@@ -281,9 +281,9 @@ void AssociatedContentManager::OnContentToolsDetected(
 }
 
 bool AssociatedContentManager::IsEligibleForAutoToolsUpdate(
-    const std::string& uuid) const {
-  return !content_uuid_to_conversation_turns_.contains(uuid) &&
-         !tools_attachment_overridden_.contains(uuid);
+    const std::string& content_uuid) const {
+  return !content_uuid_to_conversation_turns_.contains(content_uuid) &&
+         !tools_attachment_overridden_.contains(content_uuid);
 }
 
 void AssociatedContentManager::OnContentToolsChanged(

--- a/components/ai_chat/core/browser/associated_content_manager.h
+++ b/components/ai_chat/core/browser/associated_content_manager.h
@@ -146,13 +146,19 @@ class AssociatedContentManager : public ToolProvider,
  private:
   void DetachContent();
 
-  // Attaches |delegate| if it exposes tools, detaching it otherwise.
+  // Fetches the tools |delegate| exposes, updating its tools_attached state via
+  // OnContentToolsDetected().
   void DetectContentTools(AssociatedContentDelegate* delegate);
+
+  // Attaches |delegate| when the tools it exposes are non-empty (and detaches
+  // it otherwise), so its tools are surfaced (via the tools pill) before any
+  // generation occurs. Invoked with the result of GetContentTools().
   void OnContentToolsDetected(base::WeakPtr<AssociatedContentDelegate> delegate,
                               std::vector<std::unique_ptr<Tool>> tools);
 
-  // Whether |uuid| is staged and the user hasn't overridden its attachment.
-  bool IsEligibleForAutoToolsUpdate(const std::string& uuid) const;
+  // Whether |content_uuid| is staged and the user hasn't overridden its
+  // attachment.
+  bool IsEligibleForAutoToolsUpdate(const std::string& content_uuid) const;
 
   raw_ptr<ConversationHandler> conversation_;
 

--- a/components/ai_chat/core/browser/associated_content_manager.h
+++ b/components/ai_chat/core/browser/associated_content_manager.h
@@ -13,6 +13,7 @@
 #include <string_view>
 #include <vector>
 
+#include "base/containers/flat_set.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/one_shot_event.h"
@@ -136,6 +137,7 @@ class AssociatedContentManager : public ToolProvider,
   void OnDestroyed(AssociatedContentDelegate* delegate) override;
   void OnTitleChanged(AssociatedContentDelegate* delegate) override;
   void OnToolsAttachedChanged(AssociatedContentDelegate* delegate) override;
+  void OnContentToolsChanged(AssociatedContentDelegate* delegate) override;
 
   std::vector<AssociatedContentDelegate*> GetContentDelegatesForTesting() {
     return content_delegates_;
@@ -144,17 +146,22 @@ class AssociatedContentManager : public ToolProvider,
  private:
   void DetachContent();
 
-  // Attaches |delegate| when the tools it exposes are non-empty (and detaches
-  // it otherwise), so its tools are surfaced (via the tools pill) before any
-  // generation occurs. Invoked with the result of GetContentTools().
+  // Attaches |delegate| if it exposes tools, detaching it otherwise.
+  void DetectContentTools(AssociatedContentDelegate* delegate);
   void OnContentToolsDetected(base::WeakPtr<AssociatedContentDelegate> delegate,
                               std::vector<std::unique_ptr<Tool>> tools);
+
+  // Whether |uuid| is staged and the user hasn't overridden its attachment.
+  bool IsEligibleForAutoToolsUpdate(const std::string& uuid) const;
 
   raw_ptr<ConversationHandler> conversation_;
 
   std::vector<std::unique_ptr<Tool>> tools_;
   std::vector<AssociatedContentDelegate*> content_delegates_;
   base::flat_map<std::string, std::string> content_uuid_to_conversation_turns_;
+
+  // uuids whose tools attachment the user explicitly set.
+  base::flat_set<std::string> tools_attachment_overridden_;
 
   // Used for ownership - still stored in the above array.
   // This includes:

--- a/components/ai_chat/core/browser/associated_content_manager_unittest.cc
+++ b/components/ai_chat/core/browser/associated_content_manager_unittest.cc
@@ -11,7 +11,9 @@
 
 #include "base/files/scoped_temp_dir.h"
 #include "base/functional/callback_helpers.h"
+#include "base/task/sequenced_task_runner.h"
 #include "base/test/bind.h"
+#include "base/test/run_until.h"
 #include "base/test/task_environment.h"
 #include "base/test/test_future.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_credential_manager.h"
@@ -766,6 +768,176 @@ TEST_F(AssociatedContentManagerUnitTest, SurfacesToolsBeingDetached) {
 
   ASSERT_EQ(1u, conversation_->associated_content.size());
   EXPECT_FALSE(conversation_->associated_content[0]->tools_attached);
+}
+
+namespace {
+
+// Counts how many times the manager probes the page's tools.
+class FakePageTools {
+ public:
+  FakePageTools(NiceMock<MockAssociatedContent>& content, bool has_tools)
+      : has_tools_(has_tools) {
+    // Real content fetches tools from a renderer, so reply asynchronously.
+    // Replying inline would re-enter the delegate's observer list while it is
+    // still notifying OnContentToolsChanged().
+    ON_CALL(content, GetContentTools)
+        .WillByDefault(
+            [this](
+                AssociatedContentDelegate::GetContentToolsCallback callback) {
+              ++probe_count_;
+              std::vector<std::unique_ptr<Tool>> tools;
+              if (has_tools_) {
+                tools.push_back(std::make_unique<NiceMock<MockTool>>("a_tool"));
+              }
+              base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+                  FROM_HERE,
+                  base::BindOnce(std::move(callback), std::move(tools)));
+            });
+  }
+
+  void set_has_tools(bool has_tools) { has_tools_ = has_tools; }
+  int probe_count() const { return probe_count_; }
+
+ private:
+  bool has_tools_;
+  int probe_count_ = 0;
+};
+
+}  // namespace
+
+TEST_F(AssociatedContentManagerUnitTest,
+       AddContent_TellsContentItWasAssociatedWithAConversation) {
+  // Content only watches for tool changes once a conversation is listening for
+  // them, so attaching must notify it.
+  NiceMock<MockAssociatedContent> content;
+  FakePageTools page_tools(content, /*has_tools=*/false);
+
+  auto* manager = conversation_handler_->associated_content_manager();
+  EXPECT_CALL(content, OnAssociatedWithConversation());
+  manager->AddContent(&content);
+  testing::Mock::VerifyAndClearExpectations(&content);
+
+  // Re-attaching after a detach notifies again, so the content can re-subscribe
+  // to whatever document it is now showing.
+  manager->RemoveContent(&content);
+  EXPECT_CALL(content, OnAssociatedWithConversation());
+  manager->AddContent(&content);
+}
+
+TEST_F(AssociatedContentManagerUnitTest,
+       OnContentToolsChanged_AttachesStagedContentWhenToolsAppear) {
+  NiceMock<MockAssociatedContent> content;
+  FakePageTools page_tools(content, /*has_tools=*/false);
+
+  auto* manager = conversation_handler_->associated_content_manager();
+  manager->AddContent(&content);
+  ASSERT_FALSE(content.tools_attached());
+  ASSERT_EQ(1, page_tools.probe_count());
+
+  page_tools.set_has_tools(true);
+  content.NotifyContentToolsChanged();
+
+  ASSERT_TRUE(base::test::RunUntil([&] { return content.tools_attached(); }));
+  auto associated = manager->GetAssociatedContent();
+  ASSERT_EQ(1u, associated.size());
+  EXPECT_TRUE(associated[0]->tools_attached);
+}
+
+TEST_F(AssociatedContentManagerUnitTest,
+       OnContentToolsChanged_DetachesStagedContentWhenToolsDisappear) {
+  NiceMock<MockAssociatedContent> content;
+  FakePageTools page_tools(content, /*has_tools=*/true);
+
+  auto* manager = conversation_handler_->associated_content_manager();
+  manager->AddContent(&content);
+  ASSERT_TRUE(base::test::RunUntil([&] { return content.tools_attached(); }));
+
+  page_tools.set_has_tools(false);
+  content.NotifyContentToolsChanged();
+
+  ASSERT_TRUE(base::test::RunUntil([&] { return !content.tools_attached(); }));
+  auto associated = manager->GetAssociatedContent();
+  ASSERT_EQ(1u, associated.size());
+  EXPECT_FALSE(associated[0]->tools_attached);
+}
+
+TEST_F(AssociatedContentManagerUnitTest,
+       OnContentToolsChanged_IgnoresContentAssociatedWithTurn) {
+  // Associated content is no longer staged, so changes are ignored.
+  NiceMock<MockAssociatedContent> content;
+  FakePageTools page_tools(content, /*has_tools=*/false);
+
+  auto* manager = conversation_handler_->associated_content_manager();
+  manager->AddContent(&content);
+  ASSERT_FALSE(content.tools_attached());
+  ASSERT_EQ(1, page_tools.probe_count());
+
+  auto turn = mojom::ConversationTurn::New(
+      "test-turn-uuid", std::nullopt /* thread_uuid */,
+      mojom::CharacterType::HUMAN, mojom::ActionType::QUERY,
+      "Test human message", std::nullopt, std::nullopt, std::nullopt,
+      base::Time::Now(), std::nullopt, std::nullopt, nullptr /* skill */, false,
+      std::nullopt, nullptr,
+      std::vector<std::string>{} /* child_thread_uuids */);
+  manager->AssociateUnsentContentWithTurn(turn);
+
+  page_tools.set_has_tools(true);
+  content.NotifyContentToolsChanged();
+
+  // Drive a change we do expect to be probed, so the ignored one has had its
+  // chance to run.
+  NiceMock<MockAssociatedContent> other_content;
+  FakePageTools other_page_tools(other_content, /*has_tools=*/true);
+  manager->AddContent(&other_content);
+  ASSERT_TRUE(
+      base::test::RunUntil([&] { return other_content.tools_attached(); }));
+
+  EXPECT_EQ(1, page_tools.probe_count());
+  EXPECT_FALSE(content.tools_attached());
+}
+
+TEST_F(AssociatedContentManagerUnitTest,
+       OnContentToolsChanged_IgnoresUserOverriddenContent) {
+  NiceMock<MockAssociatedContent> content;
+  FakePageTools page_tools(content, /*has_tools=*/false);
+
+  auto* manager = conversation_handler_->associated_content_manager();
+  manager->AddContent(&content);
+  ASSERT_FALSE(content.tools_attached());
+  ASSERT_EQ(1, page_tools.probe_count());
+
+  manager->SetToolsAttached(content.uuid(), /*tools_attached=*/false);
+
+  page_tools.set_has_tools(true);
+  content.NotifyContentToolsChanged();
+
+  // Drive a change we do expect to be probed, so the ignored one has had its
+  // chance to run.
+  NiceMock<MockAssociatedContent> other_content;
+  FakePageTools other_page_tools(other_content, /*has_tools=*/true);
+  manager->AddContent(&other_content);
+  ASSERT_TRUE(
+      base::test::RunUntil([&] { return other_content.tools_attached(); }));
+
+  EXPECT_EQ(1, page_tools.probe_count());
+  EXPECT_FALSE(content.tools_attached());
+}
+
+TEST_F(AssociatedContentManagerUnitTest,
+       OnContentToolsChanged_ReprobesForEachChange) {
+  NiceMock<MockAssociatedContent> content;
+  FakePageTools page_tools(content, /*has_tools=*/true);
+
+  auto* manager = conversation_handler_->associated_content_manager();
+  manager->AddContent(&content);
+  ASSERT_EQ(1, page_tools.probe_count());
+
+  content.NotifyContentToolsChanged();
+  content.NotifyContentToolsChanged();
+  content.NotifyContentToolsChanged();
+
+  ASSERT_TRUE(
+      base::test::RunUntil([&] { return page_tools.probe_count() == 4; }));
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/test/mock_associated_content.h
+++ b/components/ai_chat/core/browser/test/mock_associated_content.h
@@ -32,6 +32,9 @@ class MockAssociatedContent : public AssociatedContentDelegate {
 
   void SetTitle(std::u16string title);
 
+  // Simulates the page registering or unregistering a tool.
+  using AssociatedContentDelegate::NotifyContentToolsChanged;
+
   // AssociatedContentDelegate:
   void GetContent(GetPageContentCallback callback) override;
   void OnNewPage(int64_t navigation_id) override;
@@ -46,6 +49,7 @@ class MockAssociatedContent : public AssociatedContentDelegate {
               (mojom::ConversationHandler::GetScreenshotsCallback),
               (override));
   MOCK_METHOD(void, GetContentTools, (GetContentToolsCallback), (override));
+  MOCK_METHOD(void, OnAssociatedWithConversation, (), (override));
 
   base::WeakPtr<AssociatedContentDelegate> GetWeakPtr() {
     return weak_ptr_factory_.GetWeakPtr();


### PR DESCRIPTION
Previously, we would only check for tools at attach time. Now when we receive a tool change notification we attach them unless we have an explicit user intention.

<!-- Add brave-browser issue below that this PR will resolve -->
- Series https://github.com/brave/brave-browser/issues/55232

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
