### PR TITLE
Cherry-pick fix from M155 to fix regression w/ omnibox

### DIFF
--- a/patches/components-omnibox-browser-base_search_provider.cc.patch
+++ b/patches/components-omnibox-browser-base_search_provider.cc.patch
@@ -1,0 +1,46 @@
+diff --git a/components/omnibox/browser/base_search_provider.cc b/components/omnibox/browser/base_search_provider.cc
+index 1407be3d414c61c6353842feea297d16755d76e8..e018dced4ab43c161c5b847735a618be02153035 100644
+--- a/components/omnibox/browser/base_search_provider.cc
++++ b/components/omnibox/browser/base_search_provider.cc
+@@ -56,6 +56,25 @@ bool MatchTypeAndContentsAreEqual(const AutocompleteMatch& lhs,
+   return lhs.contents == rhs.contents && lhs.type == rhs.type;
+ }
+ 
++// Ensure an image returned by the the search suggestion API (`image_url`) is
++// valid for a given search engine (`template_url`).
++//
++// Images for an entity in the search suggestion are expected to be coming from
++// the same domain as the search engine. The hosting for those images could be
++// on a dedicated subdomain (img.domain.com), so this compares registrable
++// domains rather than origins. Private registries are included so that engines
++// sharing a hosting suffix are still treated as separate sites.
++bool CanFetchSuggestionImage(const GURL& image_url,
++                             const TemplateURL& template_url,
++                             const SearchTermsData& search_terms_data) {
++  if (!image_url.is_valid() || !image_url.SchemeIs(url::kHttpsScheme)) {
++    return false;
++  }
++  return net::registry_controlled_domains::SameDomainOrHost(
++      image_url, template_url.GenerateSearchURL(search_terms_data),
++      net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES);
++}
++
+ std::u16string GetMatchContentsForOnDeviceTailSuggestion(
+     const std::u16string& input_text,
+     const std::u16string& sanitized_suggestion) {
+@@ -148,6 +167,15 @@ AutocompleteMatch BaseSearchProvider::CreateSearchSuggestion(
+     }
+     match.answer_template = suggestion.answer_template();
+     match.answer_type = suggestion.answer_type();
++   } else {
++    // Non-Google engines can also provide an entity image, but only ones they
++    // hosted on the same domain. Answers (template, type) aren't handled as
++    // they are Google-only.
++    const GURL image_url(suggestion.entity_info().image_url());
++    if (CanFetchSuggestionImage(image_url, *template_url, search_terms_data)) {
++      match.image_dominant_color = suggestion.entity_info().dominant_color();
++      match.image_url = image_url;
++    }
+   }
+   match.entity_id = suggestion.entity_info().entity_id();
+   match.website_uri = suggestion.entity_info().website_uri();

--- a/patches/components-omnibox-browser-base_search_provider_unittest.cc.patch
+++ b/patches/components-omnibox-browser-base_search_provider_unittest.cc.patch
@@ -1,0 +1,78 @@
+diff --git a/components/omnibox/browser/base_search_provider_unittest.cc b/components/omnibox/browser/base_search_provider_unittest.cc
+index c4353bc209f957d96eeac95f70b43a5876430276..fd4701a8c0427d5a7d354cffcaf861ade52f5686 100644
+--- a/components/omnibox/browser/base_search_provider_unittest.cc
++++ b/components/omnibox/browser/base_search_provider_unittest.cc
+@@ -868,3 +868,73 @@ TEST_F(BaseSearchProviderTest, AnswerAndImageOnlyPopulatedForGoogle) {
+               map.begin()->second.image_url.spec());
+   }
+ }
++
++TEST_F(BaseSearchProviderTest, EntityImageMustBeHostedBySearchEngine) {
++  // A search engine may supply an entity image that it hosts itself: while it
++  // is in use it already observes what is typed into the omnibox, so fetching
++  // such an image tells it nothing new. Naming a host it does not control is a
++  // different matter, and stays blocked.
++  struct {
++    const char* search_url;
++    const char* image_url;
++    bool expected_allowed;
++  } kCases[] = {
++      // Images are commonly served from a dedicated subdomain, so the
++      // comparison is by registrable domain rather than by origin.
++      {"https://search.brave.com/search?q={searchTerms}",
++       "https://imgs.search.brave.com/a.png", true},
++      {"https://search.brave.com/search?q={searchTerms}",
++       "https://search.brave.com/a.png", true},
++      // A different site, however it is dressed up.
++      {"https://search.brave.com/search?q={searchTerms}",
++       "https://evil.com/a.png", false},
++      {"https://search.brave.com/search?q={searchTerms}",
++       "https://brave.com.evil.com/a.png", false},
++      // Not https. Requests like the second one are the reason for the check.
++      {"https://search.brave.com/search?q={searchTerms}",
++       "http://search.brave.com/a.png", false},
++      {"https://search.brave.com/search?q={searchTerms}",
++       "http://192.168.0.1/a.png", false},
++      {"https://search.brave.com/search?q={searchTerms}", "not a url", false},
++      {"https://search.brave.com/search?q={searchTerms}", "", false},
++  };
++
++  for (const auto& test_case : kCases) {
++    SCOPED_TRACE(test_case.image_url);
++
++    omnibox::EntityInfo entity_info;
++    entity_info.set_image_url(test_case.image_url);
++    entity_info.set_dominant_color("#ffffff");
++
++    std::u16string query = u"weather";
++    SearchSuggestionParser::SuggestResult result(
++        query, AutocompleteMatchType::SEARCH_SUGGEST, omnibox::TYPE_QUERY,
++        /*subtypes=*/{}, /*from_keyword=*/false,
++        /*navigational_intent=*/omnibox::NAV_INTENT_NONE,
++        /*relevance=*/1300, /*relevance_from_server=*/true,
++        /*input_text=*/query);
++    result.SetEntityInfo(entity_info);
++
++    TemplateURLData data;
++    data.SetURL(test_case.search_url);
++    auto turl = std::make_unique<TemplateURL>(data);
++
++    TestBaseSearchProvider::MatchMap map;
++    provider_->AddMatchToMap(
++        result, AutocompleteInput(), turl.get(),
++        client_->GetTemplateURLService()->search_terms_data(),
++        TemplateURLRef::NO_SUGGESTION_CHOSEN, false, false, &map);
++    ASSERT_EQ(1U, map.size());
++    const AutocompleteMatch& match = map.begin()->second;
++
++    EXPECT_EQ(test_case.expected_allowed, !match.image_url.is_empty());
++    if (test_case.expected_allowed) {
++      EXPECT_EQ(test_case.image_url, match.image_url.spec());
++      EXPECT_EQ("#ffffff", match.image_dominant_color);
++    } else {
++      EXPECT_TRUE(match.image_dominant_color.empty());
++    }
++    // Answers remain Google-only.
++    EXPECT_FALSE(match.answer_template.has_value());
++  }
++}


### PR DESCRIPTION
Unintentionally caused upstream by https://chromium-review.googlesource.com/c/chromium/src/+/8262150 Fixed upstream with https://chromium-review.googlesource.com/c/chromium/src/+/8310777

Fixes https://github.com/brave/brave-browser/issues/58717
