### PR TITLE
Fix libyuv SME crash on CPUs without SVE

### DIFF
--- a/patches/third_party-libyuv-BUILD.gn.patch
+++ b/patches/third_party-libyuv-BUILD.gn.patch
@@ -1,0 +1,13 @@
+diff --git a/third_party/libyuv/BUILD.gn b/third_party/libyuv/BUILD.gn
+index d3fbd33e2559b9012922d3c078d360adb1fea317..53d56fded3bcbde5461c2688b11163c44527da61 100644
+--- a/third_party/libyuv/BUILD.gn
++++ b/third_party/libyuv/BUILD.gn
+@@ -267,7 +267,7 @@ if (libyuv_use_sme) {
+     use_libcxx_modules = false
+ 
+     # SME is an Armv9-A feature.
+-    cflags = [ "-march=armv9-a+i8mm+sme" ]
++    cflags = [ "-march=armv9-a+i8mm+sme+nosve" ]
+   }
+ }
+ 


### PR DESCRIPTION
- Resolves https://github.com/brave/brave-browser/issues/58716

## Summary

Compile bundled libyuv SME routines with non-streaming SVE explicitly disabled.
`-march=armv9-a` enables SVE/SVE2, which lets Clang emit `cntd` before
`smstart` in locally-streaming functions. Apple Silicon under Asahi Linux
exposes SME without SVE, so those runtime-selected routines trap with `SIGILL`.

## Test plan

- Built `row_sme.cc`, `rotate_sme.cc`, and `scale_sme.cc` with Clang 22 and the
  corrected flags on affected Apple Silicon hardware.
- Confirmed the unpatched `I444ToARGBRow_SME` path traps with status 132.
- Confirmed the patched path exits successfully and its 3,840-pixel output
  matches `I444ToARGBRow_C` byte-for-byte.
- Confirmed the patch applies cleanly to Chromium 153.0.8010.18's pinned
  libyuv revision (`26e56be0f984af3dae4d0c0ab7a0bac8ac20e1b0`).
- Ran `git diff --check` and Brave's patch-header convention checks.

AI assistance: OpenAI Codex helped diagnose the crash and prepare this patch;
the generated code was compiled and executed on the affected hardware.
