### PR TITLE
Forgetful Browser cleanup fails for tabs opened within the 5s startup window

### DIFF
--- a/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.cc
+++ b/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.h"
 
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -183,6 +184,7 @@ void BraveEphemeralStorageServiceDelegate::CleanupFirstPartyStorageArea(
          base::FeatureList::IsEnabled(
              net::features::kThirdPartyStoragePartitioning));
 
+LOG(INFO) << "[SHRED] BraveEphemeralStorageServiceDelegate::CleanupFirstPartyStorageArea key:" << key.first << " : " << key.second;
   content::BrowsingDataRemover::DataType data_to_remove =
       (content::BrowsingDataRemover::DATA_TYPE_ON_STORAGE_PARTITION &
        chrome_browsing_data_remover::FILTERABLE_DATA_TYPES);
@@ -199,6 +201,76 @@ void BraveEphemeralStorageServiceDelegate::CleanupFirstPartyStorageArea(
   content::BrowsingDataRemover* remover = context_->GetBrowsingDataRemover();
   remover->RemoveWithFilter(base::Time(), base::Time::Max(), data_to_remove,
                             origin_type, std::move(filter_builder));
+}
+
+void BraveEphemeralStorageServiceDelegate::ReloadTabIfMatchingEphemeralDomain(
+    std::vector<std::pair<std::string, base::OnceClosure>>
+        ephemeral_domains) {
+  auto* profile = Profile::FromBrowserContext(context_);
+  CHECK(profile);
+
+//#if !BUILDFLAG(IS_ANDROID)
+  for (auto* browser : GetAllBrowserWindowInterfaces()) {
+    if (profile != browser->GetProfile()) {
+      continue;
+    }
+    auto* tab_strip = browser->GetTabStripModel();
+    if (!tab_strip) {
+      continue;
+    }
+    for (auto* tab : *tab_strip) {
+      if (!tab || !tab->GetContents()) {
+        continue;
+      }
+
+      content::WebContents* contents = tab->GetContents();
+      if (!contents) {
+        continue;
+      }
+
+      const auto tab_domain =
+          net::URLToEphemeralStorageDomain(contents->GetLastCommittedURL());
+      if (tab_domain.empty()) {
+        continue;
+      }
+
+      // Each domain's cleanup closure must be run exactly once, so only the
+      // first tab found for a given domain gets it; other tabs on the same
+      // domain are still reloaded, just without the closure.
+      auto domain_it = std::ranges::find(
+          ephemeral_domains, tab_domain,
+          &std::pair<std::string, base::OnceClosure>::first);
+      if (domain_it == ephemeral_domains.end()) {
+        continue;
+      }
+
+      if (auto* ephemeral_storage_tab_helper =
+              ephemeral_storage::EphemeralStorageTabHelper::FromWebContents(
+                  tab->GetContents())) {
+LOG(INFO) << "[SHRED] ReloadTabsMatchingFirstPartyStorageAreaFromNetwork url:" << contents->GetLastCommittedURL();
+        ephemeral_storage_tab_helper->ReloadBypassingCacheWhenReady(
+            std::move(domain_it->second));
+      }
+      //contents->GetController().SetNeedsReload();
+    }
+  }
+// #else
+//   for (TabModel* model : TabModelList::models()) {
+//     const size_t tab_count = model->GetTabCount();
+//     for (size_t index = 0; index < tab_count; index++) {
+//       auto* tab = static_cast<TabAndroid*>(model->GetTabAt(index));
+//       if (!tab || profile != tab->profile()) {
+//         continue;
+//       }
+//       content::WebContents* contents = tab->GetContents();
+//       if (!ShouldReloadTabFromNetwork(contents, key)) {
+//         continue;
+//       }
+//       contents->GetController().Reload(content::ReloadType::BYPASSING_CACHE,
+//                                        /*check_for_repost=*/true);
+//     }
+//   }
+// #endif
 }
 
 void BraveEphemeralStorageServiceDelegate::CleanupTLDBrowsingHistory(
@@ -227,7 +299,7 @@ void BraveEphemeralStorageServiceDelegate::OnApplicationBecameInactive() {
           brave_shields::features::kBraveShredFeature)) {
     return;
   }
-
+LOG(INFO) << "[SHRED] BraveEphemeralStorageServiceDelegate::OnApplicationBecameInactive";
   // Collect ephemeral domains from currently open tabs that have the "Shred on
   // App Close" mode enabled.
   const auto ephemeral_domains = GetEphemeralDomainsToCleanOnAppClose();
@@ -250,7 +322,7 @@ void BraveEphemeralStorageServiceDelegate::
   if (enforced_by_user) {
     brave_shields::RecordManualShredP3A(*g_browser_process->local_state());
   }
-
+LOG(INFO) << "[SHRED] PrepareTabsForFirstPartyStorageCleanup ephemeral_domains.size:" << ephemeral_domains.size();
   auto* profile = Profile::FromBrowserContext(context_);
   CHECK(profile);
 

--- a/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.cc
+++ b/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.cc
@@ -129,8 +129,6 @@ void ReloadBypassingCacheWhenReady(content::WebContents* contents) {
     return;
   }
 
-  LOG(INFO) << "[SHRED] ReloadTabsMatchingFirstPartyStorageAreaFromNetwork url:"
-            << contents->GetLastCommittedURL();
   ephemeral_storage_tab_helper->ReloadBypassingCacheWhenReady();
 }
 
@@ -221,7 +219,6 @@ void BraveEphemeralStorageServiceDelegate::CleanupFirstPartyStorageArea(
          base::FeatureList::IsEnabled(
              net::features::kThirdPartyStoragePartitioning));
 
-LOG(INFO) << "[SHRED] BraveEphemeralStorageServiceDelegate::CleanupFirstPartyStorageArea key:" << key.first << " : " << key.second;
   content::BrowsingDataRemover::DataType data_to_remove =
       (content::BrowsingDataRemover::DATA_TYPE_ON_STORAGE_PARTITION &
        chrome_browsing_data_remover::FILTERABLE_DATA_TYPES);
@@ -262,7 +259,6 @@ void BraveEphemeralStorageServiceDelegate::ReloadTabIfMatchingEphemeralDomain(co
 
       content::WebContents* contents = tab->GetContents();
       if (!contents) {
-        LOG(INFO) << "[SHRED] ReloadTabsMatchingFirstPartyStorageAreaFromNetwork #300";
         continue;
       }
 
@@ -284,7 +280,6 @@ void BraveEphemeralStorageServiceDelegate::ReloadTabIfMatchingEphemeralDomain(co
       }
       content::WebContents* contents = tab->GetContents();
       if (!contents) {
-        LOG(INFO) << "[SHRED] ReloadTabsMatchingFirstPartyStorageAreaFromNetwork #300";
         continue;
       }
 
@@ -325,7 +320,6 @@ void BraveEphemeralStorageServiceDelegate::OnApplicationBecameInactive() {
           brave_shields::features::kBraveShredFeature)) {
     return;
   }
-LOG(INFO) << "[SHRED] BraveEphemeralStorageServiceDelegate::OnApplicationBecameInactive";
   // Collect ephemeral domains from currently open tabs that have the "Shred on
   // App Close" mode enabled.
   const auto ephemeral_domains = GetEphemeralDomainsToCleanOnAppClose();
@@ -348,7 +342,6 @@ void BraveEphemeralStorageServiceDelegate::
   if (enforced_by_user) {
     brave_shields::RecordManualShredP3A(*g_browser_process->local_state());
   }
-LOG(INFO) << "[SHRED] PrepareTabsForFirstPartyStorageCleanup ephemeral_domains.size:" << ephemeral_domains.size();
   auto* profile = Profile::FromBrowserContext(context_);
   CHECK(profile);
 

--- a/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.cc
+++ b/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.cc
@@ -99,37 +99,43 @@ bool PrepareTabForFirstPartyStorageCleanup(
 
 class RemovalObserver : public content::BrowsingDataRemover::Observer {
  public:
-  ~RemovalObserver() override {
-    context_->GetBrowsingDataRemover()->RemoveObserver(this);
-  }
+  ~RemovalObserver() override { remover_->RemoveObserver(this); }
+
   static content::BrowsingDataRemover::Observer* Create(
-      content::BrowserContext* context, base::OnceClosure callback) {
+      content::BrowserContext* context,
+      base::OnceClosure callback) {
+    CHECK(context);
     return new RemovalObserver(context, std::move(callback));
   }
 
   void OnBrowsingDataRemoverDone(uint64_t failed_data_types) override {
     std::move(callback_).Run();
   }
+
  private:
-   RemovalObserver(content::BrowserContext* context, base::OnceClosure callback)
-      : context_(context),
+  RemovalObserver(content::BrowserContext* context, base::OnceClosure callback)
+      : remover_(context->GetBrowsingDataRemover()),
         callback_(std::move(callback).Then(
             base::BindOnce(&base::DeletePointer<RemovalObserver>, this))) {
-    context_->GetBrowsingDataRemover()->AddObserver(this);
+    CHECK(remover_);
+    remover_->AddObserver(this);
   }
 
-  raw_ptr<content::BrowserContext> context_ = nullptr;
-  base::OnceClosure callback_;  // Owns `this`.
+  raw_ptr<content::BrowsingDataRemover> remover_;
+  base::OnceClosure callback_;
 };
 
-void ReloadBypassingCacheWhenReady(content::WebContents* contents) {
+void ReloadBypassingCacheWhenReady(
+    content::WebContents* contents,
+    const std::string& cleaned_ephemeral_domain) {
   auto* ephemeral_storage_tab_helper =
       ephemeral_storage::EphemeralStorageTabHelper::FromWebContents(contents);
   if (!ephemeral_storage_tab_helper) {
     return;
   }
 
-  ephemeral_storage_tab_helper->ReloadBypassingCacheWhenReady();
+  ephemeral_storage_tab_helper->ReloadBypassingCacheWhenReady(
+      cleaned_ephemeral_domain);
 }
 
 }  // namespace
@@ -212,7 +218,8 @@ void BraveEphemeralStorageServiceDelegate::CleanupTLDEphemeralArea(
 }
 
 void BraveEphemeralStorageServiceDelegate::CleanupFirstPartyStorageArea(
-    const TLDEphemeralAreaKey& key, base::OnceClosure callback) {
+    const TLDEphemeralAreaKey& key,
+    base::OnceClosure callback) {
   DVLOG(1) << __func__ << " " << key.first << " " << key.second;
   DCHECK(base::FeatureList::IsEnabled(
              net::features::kBraveForgetFirstPartyStorage) ||
@@ -233,13 +240,19 @@ void BraveEphemeralStorageServiceDelegate::CleanupFirstPartyStorageArea(
   filter_builder->SetStoragePartitionConfig(key.second);
 
   content::BrowsingDataRemover* remover = context_->GetBrowsingDataRemover();
-  remover->RemoveWithFilterAndReply(
-      base::Time(), base::Time::Max(), data_to_remove, origin_type,
-      std::move(filter_builder),
-      RemovalObserver::Create(context_, std::move(callback)));
+  if (callback) {
+    remover->RemoveWithFilterAndReply(
+        base::Time(), base::Time::Max(), data_to_remove, origin_type,
+        std::move(filter_builder),
+        RemovalObserver::Create(context_, std::move(callback)));
+  } else {
+    remover->RemoveWithFilter(base::Time(), base::Time::Max(), data_to_remove,
+                              origin_type, std::move(filter_builder));
+  }
 }
 
-void BraveEphemeralStorageServiceDelegate::ReloadTabIfMatchingEphemeralDomain(const std::string& ephemeral_domain) {
+void BraveEphemeralStorageServiceDelegate::ReloadTabIfMatchingEphemeralDomain(
+    const std::string& ephemeral_domain) {
   auto* profile = Profile::FromBrowserContext(context_);
   CHECK(profile);
 
@@ -258,19 +271,15 @@ void BraveEphemeralStorageServiceDelegate::ReloadTabIfMatchingEphemeralDomain(co
       }
 
       content::WebContents* contents = tab->GetContents();
-      if (!contents) {
-        continue;
-      }
-
       if (ShouldSkipCleanupForURL(contents->GetLastCommittedURL(),
-                              {ephemeral_domain})) {
+                                  {ephemeral_domain})) {
         continue;
       }
 
-      ReloadBypassingCacheWhenReady(contents);
+      ReloadBypassingCacheWhenReady(contents, ephemeral_domain);
     }
   }
- #else
+#else
   for (TabModel* model : TabModelList::models()) {
     const size_t tab_count = model->GetTabCount();
     for (size_t index = 0; index < tab_count; index++) {
@@ -284,14 +293,14 @@ void BraveEphemeralStorageServiceDelegate::ReloadTabIfMatchingEphemeralDomain(co
       }
 
       if (ShouldSkipCleanupForURL(contents->GetLastCommittedURL(),
-                              {ephemeral_domain})) {
+                                  {ephemeral_domain})) {
         continue;
       }
 
-      ReloadBypassingCacheWhenReady(contents);
+      ReloadBypassingCacheWhenReady(contents, ephemeral_domain);
     }
   }
- #endif
+#endif
 }
 
 void BraveEphemeralStorageServiceDelegate::CleanupTLDBrowsingHistory(
@@ -489,7 +498,8 @@ bool BraveEphemeralStorageServiceDelegate::IsShredBrowsingHistoryEnabled() {
   return shields_settings_service_->IsShredBrowsingHistoryEnabled();
 }
 
-base::WeakPtr<EphemeralStorageServiceDelegate> BraveEphemeralStorageServiceDelegate::AsWeakPtr() {
+base::WeakPtr<EphemeralStorageServiceDelegate>
+BraveEphemeralStorageServiceDelegate::AsWeakPtr() {
   return weak_ptr_factory_.GetWeakPtr();
 }
 

--- a/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.cc
+++ b/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.cc
@@ -97,6 +97,43 @@ bool PrepareTabForFirstPartyStorageCleanup(
   return false;
 }
 
+class RemovalObserver : public content::BrowsingDataRemover::Observer {
+ public:
+  ~RemovalObserver() override {
+    context_->GetBrowsingDataRemover()->RemoveObserver(this);
+  }
+  static content::BrowsingDataRemover::Observer* Create(
+      content::BrowserContext* context, base::OnceClosure callback) {
+    return new RemovalObserver(context, std::move(callback));
+  }
+
+  void OnBrowsingDataRemoverDone(uint64_t failed_data_types) override {
+    std::move(callback_).Run();
+  }
+ private:
+   RemovalObserver(content::BrowserContext* context, base::OnceClosure callback)
+      : context_(context),
+        callback_(std::move(callback).Then(
+            base::BindOnce(&base::DeletePointer<RemovalObserver>, this))) {
+    context_->GetBrowsingDataRemover()->AddObserver(this);
+  }
+
+  raw_ptr<content::BrowserContext> context_ = nullptr;
+  base::OnceClosure callback_;  // Owns `this`.
+};
+
+void ReloadBypassingCacheWhenReady(content::WebContents* contents) {
+  auto* ephemeral_storage_tab_helper =
+      ephemeral_storage::EphemeralStorageTabHelper::FromWebContents(contents);
+  if (!ephemeral_storage_tab_helper) {
+    return;
+  }
+
+  LOG(INFO) << "[SHRED] ReloadTabsMatchingFirstPartyStorageAreaFromNetwork url:"
+            << contents->GetLastCommittedURL();
+  ephemeral_storage_tab_helper->ReloadBypassingCacheWhenReady();
+}
+
 }  // namespace
 
 namespace ephemeral_storage {
@@ -177,7 +214,7 @@ void BraveEphemeralStorageServiceDelegate::CleanupTLDEphemeralArea(
 }
 
 void BraveEphemeralStorageServiceDelegate::CleanupFirstPartyStorageArea(
-    const TLDEphemeralAreaKey& key) {
+    const TLDEphemeralAreaKey& key, base::OnceClosure callback) {
   DVLOG(1) << __func__ << " " << key.first << " " << key.second;
   DCHECK(base::FeatureList::IsEnabled(
              net::features::kBraveForgetFirstPartyStorage) ||
@@ -199,17 +236,17 @@ LOG(INFO) << "[SHRED] BraveEphemeralStorageServiceDelegate::CleanupFirstPartySto
   filter_builder->SetStoragePartitionConfig(key.second);
 
   content::BrowsingDataRemover* remover = context_->GetBrowsingDataRemover();
-  remover->RemoveWithFilter(base::Time(), base::Time::Max(), data_to_remove,
-                            origin_type, std::move(filter_builder));
+  remover->RemoveWithFilterAndReply(
+      base::Time(), base::Time::Max(), data_to_remove, origin_type,
+      std::move(filter_builder),
+      RemovalObserver::Create(context_, std::move(callback)));
 }
 
-void BraveEphemeralStorageServiceDelegate::ReloadTabIfMatchingEphemeralDomain(
-    std::vector<std::pair<std::string, base::OnceClosure>>
-        ephemeral_domains) {
+void BraveEphemeralStorageServiceDelegate::ReloadTabIfMatchingEphemeralDomain(const std::string& ephemeral_domain) {
   auto* profile = Profile::FromBrowserContext(context_);
   CHECK(profile);
 
-//#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID)
   for (auto* browser : GetAllBrowserWindowInterfaces()) {
     if (profile != browser->GetProfile()) {
       continue;
@@ -225,52 +262,41 @@ void BraveEphemeralStorageServiceDelegate::ReloadTabIfMatchingEphemeralDomain(
 
       content::WebContents* contents = tab->GetContents();
       if (!contents) {
+        LOG(INFO) << "[SHRED] ReloadTabsMatchingFirstPartyStorageAreaFromNetwork #300";
         continue;
       }
 
-      const auto tab_domain =
-          net::URLToEphemeralStorageDomain(contents->GetLastCommittedURL());
-      if (tab_domain.empty()) {
+      if (ShouldSkipCleanupForURL(contents->GetLastCommittedURL(),
+                              {ephemeral_domain})) {
         continue;
       }
 
-      // Each domain's cleanup closure must be run exactly once, so only the
-      // first tab found for a given domain gets it; other tabs on the same
-      // domain are still reloaded, just without the closure.
-      auto domain_it = std::ranges::find(
-          ephemeral_domains, tab_domain,
-          &std::pair<std::string, base::OnceClosure>::first);
-      if (domain_it == ephemeral_domains.end()) {
-        continue;
-      }
-
-      if (auto* ephemeral_storage_tab_helper =
-              ephemeral_storage::EphemeralStorageTabHelper::FromWebContents(
-                  tab->GetContents())) {
-LOG(INFO) << "[SHRED] ReloadTabsMatchingFirstPartyStorageAreaFromNetwork url:" << contents->GetLastCommittedURL();
-        ephemeral_storage_tab_helper->ReloadBypassingCacheWhenReady(
-            std::move(domain_it->second));
-      }
-      //contents->GetController().SetNeedsReload();
+      ReloadBypassingCacheWhenReady(contents);
     }
   }
-// #else
-//   for (TabModel* model : TabModelList::models()) {
-//     const size_t tab_count = model->GetTabCount();
-//     for (size_t index = 0; index < tab_count; index++) {
-//       auto* tab = static_cast<TabAndroid*>(model->GetTabAt(index));
-//       if (!tab || profile != tab->profile()) {
-//         continue;
-//       }
-//       content::WebContents* contents = tab->GetContents();
-//       if (!ShouldReloadTabFromNetwork(contents, key)) {
-//         continue;
-//       }
-//       contents->GetController().Reload(content::ReloadType::BYPASSING_CACHE,
-//                                        /*check_for_repost=*/true);
-//     }
-//   }
-// #endif
+ #else
+  for (TabModel* model : TabModelList::models()) {
+    const size_t tab_count = model->GetTabCount();
+    for (size_t index = 0; index < tab_count; index++) {
+      auto* tab = static_cast<TabAndroid*>(model->GetTabAt(index));
+      if (!tab || profile != tab->profile()) {
+        continue;
+      }
+      content::WebContents* contents = tab->GetContents();
+      if (!contents) {
+        LOG(INFO) << "[SHRED] ReloadTabsMatchingFirstPartyStorageAreaFromNetwork #300";
+        continue;
+      }
+
+      if (ShouldSkipCleanupForURL(contents->GetLastCommittedURL(),
+                              {ephemeral_domain})) {
+        continue;
+      }
+
+      ReloadBypassingCacheWhenReady(contents);
+    }
+  }
+ #endif
 }
 
 void BraveEphemeralStorageServiceDelegate::CleanupTLDBrowsingHistory(
@@ -468,6 +494,10 @@ BraveEphemeralStorageServiceDelegate::GetEphemeralDomainsToCleanOnAppClose() {
 
 bool BraveEphemeralStorageServiceDelegate::IsShredBrowsingHistoryEnabled() {
   return shields_settings_service_->IsShredBrowsingHistoryEnabled();
+}
+
+base::WeakPtr<EphemeralStorageServiceDelegate> BraveEphemeralStorageServiceDelegate::AsWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
 }
 
 }  // namespace ephemeral_storage

--- a/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.cc
+++ b/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.cc
@@ -13,12 +13,11 @@
 
 #include "base/check.h"
 #include "base/containers/flat_set.h"
-#include "base/functional/bind.h"
 #include "base/functional/callback_forward.h"
 #include "base/functional/callback_helpers.h"
 #include "base/logging.h"
-#include "base/memory/raw_ptr.h"
 #include "base/memory/scoped_refptr.h"
+#include "base/scoped_observation.h"
 #include "brave/browser/brave_shields/brave_shields_settings_service_factory.h"
 #include "brave/browser/ephemeral_storage/browsing_history_cleaner.h"
 #include "brave/browser/ephemeral_storage/ephemeral_storage_tab_helper.h"
@@ -97,9 +96,11 @@ bool PrepareTabForFirstPartyStorageCleanup(
   return false;
 }
 
+// Self-owned observer: destroys itself once the removal it observes is done.
 class RemovalObserver : public content::BrowsingDataRemover::Observer {
  public:
-  ~RemovalObserver() override { remover_->RemoveObserver(this); }
+  RemovalObserver(const RemovalObserver&) = delete;
+  RemovalObserver& operator=(const RemovalObserver&) = delete;
 
   static content::BrowsingDataRemover::Observer* Create(
       content::BrowserContext* context,
@@ -110,18 +111,22 @@ class RemovalObserver : public content::BrowsingDataRemover::Observer {
 
   void OnBrowsingDataRemoverDone(uint64_t failed_data_types) override {
     std::move(callback_).Run();
+    delete this;  // Matches the `new` in Create().
   }
 
  private:
   RemovalObserver(content::BrowserContext* context, base::OnceClosure callback)
-      : remover_(context->GetBrowsingDataRemover()),
-        callback_(std::move(callback).Then(
-            base::BindOnce(&base::DeletePointer<RemovalObserver>, this))) {
-    CHECK(remover_);
-    remover_->AddObserver(this);
+      : callback_(std::move(callback)) {
+    content::BrowsingDataRemover* remover = context->GetBrowsingDataRemover();
+    CHECK(remover);
+    observation_.Observe(remover);
   }
 
-  raw_ptr<content::BrowsingDataRemover> remover_;
+  ~RemovalObserver() override = default;
+
+  base::ScopedObservation<content::BrowsingDataRemover,
+                          content::BrowsingDataRemover::Observer>
+      observation_{this};
   base::OnceClosure callback_;
 };
 

--- a/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.cc
+++ b/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.cc
@@ -503,9 +503,4 @@ bool BraveEphemeralStorageServiceDelegate::IsShredBrowsingHistoryEnabled() {
   return shields_settings_service_->IsShredBrowsingHistoryEnabled();
 }
 
-base::WeakPtr<EphemeralStorageServiceDelegate>
-BraveEphemeralStorageServiceDelegate::AsWeakPtr() {
-  return weak_ptr_factory_.GetWeakPtr();
-}
-
 }  // namespace ephemeral_storage

--- a/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.h
+++ b/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.h
@@ -44,8 +44,10 @@ class BraveEphemeralStorageServiceDelegate
 
   // EphemeralStorageServiceDelegate:
   void CleanupTLDEphemeralArea(const TLDEphemeralAreaKey& key) override;
-  void CleanupFirstPartyStorageArea(const TLDEphemeralAreaKey& key, base::OnceClosure callback) override;
-  void ReloadTabIfMatchingEphemeralDomain(const std::string& ephemeral_domain) override;
+  void CleanupFirstPartyStorageArea(const TLDEphemeralAreaKey& key,
+                                    base::OnceClosure callback) override;
+  void ReloadTabIfMatchingEphemeralDomain(
+      const std::string& ephemeral_domain) override;
   void CleanupTLDBrowsingHistory(const TLDEphemeralAreaKey& key) override;
   void RegisterFirstWindowOpenedCallback(base::OnceClosure callback) override;
   void PrepareTabsForFirstPartyStorageCleanup(
@@ -74,7 +76,8 @@ class BraveEphemeralStorageServiceDelegate
   std::unique_ptr<ApplicationStateObserver> application_state_observer_;
   raw_ptr<brave_shields::BraveShieldsSettingsService>
       shields_settings_service_ = nullptr;
-  base::WeakPtrFactory<BraveEphemeralStorageServiceDelegate> weak_ptr_factory_{this};
+  base::WeakPtrFactory<BraveEphemeralStorageServiceDelegate> weak_ptr_factory_{
+      this};
 };
 
 }  // namespace ephemeral_storage

--- a/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.h
+++ b/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.h
@@ -45,6 +45,9 @@ class BraveEphemeralStorageServiceDelegate
   // EphemeralStorageServiceDelegate:
   void CleanupTLDEphemeralArea(const TLDEphemeralAreaKey& key) override;
   void CleanupFirstPartyStorageArea(const TLDEphemeralAreaKey& key) override;
+  void ReloadTabIfMatchingEphemeralDomain(
+      std::vector<std::pair<std::string, base::OnceClosure>>
+          ephemeral_domains) override;
   void CleanupTLDBrowsingHistory(const TLDEphemeralAreaKey& key) override;
   void RegisterFirstWindowOpenedCallback(base::OnceClosure callback) override;
   void PrepareTabsForFirstPartyStorageCleanup(

--- a/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.h
+++ b/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.h
@@ -44,10 +44,8 @@ class BraveEphemeralStorageServiceDelegate
 
   // EphemeralStorageServiceDelegate:
   void CleanupTLDEphemeralArea(const TLDEphemeralAreaKey& key) override;
-  void CleanupFirstPartyStorageArea(const TLDEphemeralAreaKey& key) override;
-  void ReloadTabIfMatchingEphemeralDomain(
-      std::vector<std::pair<std::string, base::OnceClosure>>
-          ephemeral_domains) override;
+  void CleanupFirstPartyStorageArea(const TLDEphemeralAreaKey& key, base::OnceClosure callback) override;
+  void ReloadTabIfMatchingEphemeralDomain(const std::string& ephemeral_domain) override;
   void CleanupTLDBrowsingHistory(const TLDEphemeralAreaKey& key) override;
   void RegisterFirstWindowOpenedCallback(base::OnceClosure callback) override;
   void PrepareTabsForFirstPartyStorageCleanup(
@@ -63,6 +61,7 @@ class BraveEphemeralStorageServiceDelegate
 #endif
 
   bool IsShredBrowsingHistoryEnabled() override;
+  base::WeakPtr<EphemeralStorageServiceDelegate> AsWeakPtr() override;
 
  private:
   std::vector<std::string> GetEphemeralDomainsToCleanOnAppClose();
@@ -75,6 +74,7 @@ class BraveEphemeralStorageServiceDelegate
   std::unique_ptr<ApplicationStateObserver> application_state_observer_;
   raw_ptr<brave_shields::BraveShieldsSettingsService>
       shields_settings_service_ = nullptr;
+  base::WeakPtrFactory<BraveEphemeralStorageServiceDelegate> weak_ptr_factory_{this};
 };
 
 }  // namespace ephemeral_storage

--- a/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.h
+++ b/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.h
@@ -63,7 +63,6 @@ class BraveEphemeralStorageServiceDelegate
 #endif
 
   bool IsShredBrowsingHistoryEnabled() override;
-  base::WeakPtr<EphemeralStorageServiceDelegate> AsWeakPtr() override;
 
  private:
   std::vector<std::string> GetEphemeralDomainsToCleanOnAppClose();

--- a/browser/ephemeral_storage/ephemeral_storage_auto_shred_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_auto_shred_browsertest.cc
@@ -8,6 +8,7 @@
 #include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
 #include "brave/components/brave_shields/core/browser/brave_shields_utils.h"
 #include "brave/components/brave_shields/core/common/features.h"
+#include "brave/components/ephemeral_storage/ephemeral_storage_service.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/test/base/chrome_test_utils.h"
@@ -76,11 +77,15 @@ IN_PROC_BROWSER_TEST_F(EphemeralStorageAutoShredBrowserTest,
 
   // Cookies SHOULD exist for a.com.
   EXPECT_EQ(3u, GetAllCookies().size());
+
+  // Simulate that the tabs were closed more than 30 seconds ago
+  ExpireFirstPartyStorageOrigins(true);
 }
 
 IN_PROC_BROWSER_TEST_F(EphemeralStorageAutoShredBrowserTest,
                        OnAppCloseShredAfterRestart) {
-  EXPECT_EQ(2u, WaitForCleanupAfterKeepAlive());
+  // Nothing to clean — everything was already cleared when the browser started
+  EXPECT_EQ(0u, WaitForCleanupAfterKeepAlive());
   EXPECT_EQ(1u, GetAllCookies().size());
 }
 
@@ -112,11 +117,14 @@ IN_PROC_BROWSER_TEST_F(EphemeralStorageAutoShredBrowserTest,
 
   // Cookies SHOULD exist for a.com, b.com, c.com.
   EXPECT_EQ(3u, GetAllCookies().size());
+
+  // Simulate that the tabs were closed more than 30 seconds ago
+  ExpireFirstPartyStorageOrigins(true);
 }
 
 IN_PROC_BROWSER_TEST_F(EphemeralStorageAutoShredBrowserTest,
                        OnAppCloseShredGlobalAfterRestart) {
-  EXPECT_EQ(2u, WaitForCleanupAfterKeepAlive());
+  EXPECT_EQ(0u, WaitForCleanupAfterKeepAlive());
   EXPECT_EQ(1u, GetAllCookies().size());
   // Make sure that only b.com has not been cleaned
   EXPECT_EQ("name=bcom",

--- a/browser/ephemeral_storage/ephemeral_storage_auto_shred_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_auto_shred_browsertest.cc
@@ -8,6 +8,7 @@
 #include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
 #include "brave/components/brave_shields/core/browser/brave_shields_utils.h"
 #include "brave/components/brave_shields/core/common/features.h"
+#include "brave/components/ephemeral_storage/ephemeral_storage_pref_names.h"
 #include "brave/components/ephemeral_storage/ephemeral_storage_service.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
@@ -16,10 +17,22 @@
 #include "components/content_settings/core/browser/cookie_settings.h"
 #include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "components/content_settings/core/common/content_settings.h"
+#include "components/prefs/pref_service.h"
 #include "content/public/test/browser_test.h"
+#include "content/public/test/test_utils.h"
 #include "net/base/features.h"
 
 namespace ephemeral_storage {
+
+namespace {
+
+size_t GetOriginsQueuedForCleanupCount(Profile* profile) {
+  return profile->GetPrefs()
+      ->GetList(kFirstPartyStorageOriginsToCleanup)
+      .size();
+}
+
+}  // namespace
 
 class EphemeralStorageAutoShredBrowserTest
     : public EphemeralStorageBrowserTest {
@@ -130,6 +143,66 @@ IN_PROC_BROWSER_TEST_F(EphemeralStorageAutoShredBrowserTest,
   EXPECT_EQ("name=bcom",
             content::GetCookies(browser()->GetProfile(),
                                 https_server_.GetURL("b.com", "/")));
+}
+
+// Closing a tab queues its shred behind the Ephemeral Storage keepalive. If the
+// browser quits before that keepalive elapses, the queued shred must survive
+// the restart: it either runs at the next start or stays queued until it is
+// due. Dropping it would leave the site's storage on disk forever.
+IN_PROC_BROWSER_TEST_F(EphemeralStorageAutoShredBrowserTest,
+                       PRE_PRE_ShredQueuedWithinKeepAliveSurvivesRestart) {
+  const GURL a_site_set_cookie_url(
+      "https://a.com/set-cookie?name=acom;path=/"
+      ";SameSite=None;Secure;Max-Age=600");
+
+  brave_shields_settings_->SetAutoShredMode(
+      brave_shields::mojom::AutoShredMode::LAST_TAB_CLOSED,
+      a_site_set_cookie_url);
+
+  // Cookies should NOT exist for a.com.
+  EXPECT_EQ(0u, GetAllCookies().size());
+
+  content::WebContents* a_tab = LoadURLInNewTab(a_site_set_cookie_url);
+  ASSERT_TRUE(a_tab);
+
+  // Cookies SHOULD exist for a.com.
+  EXPECT_EQ(1u, GetAllCookies().size());
+
+  // Close the a.com tab. The shred is deferred by the keepalive, so nothing is
+  // cleaned yet, but the area is queued in prefs with the current close time.
+  CloseWebContents(a_tab);
+  content::RunAllTasksUntilIdle();
+
+  EXPECT_EQ(1u, GetOriginsQueuedForCleanupCount(browser()->GetProfile()));
+  EXPECT_EQ(1u, GetAllCookies().size());
+
+  // The browser quits here, well within the keepalive, so the deferred cleanup
+  // timer never fires.
+}
+
+IN_PROC_BROWSER_TEST_F(EphemeralStorageAutoShredBrowserTest,
+                       PRE_ShredQueuedWithinKeepAliveSurvivesRestart) {
+  // Let the startup cleanup run. The close time is only seconds old, so the
+  // keepalive has not elapsed yet.
+  content::RunAllTasksUntilIdle();
+
+  const bool still_queued =
+      GetOriginsQueuedForCleanupCount(browser()->GetProfile()) == 1u;
+  const bool already_shredded = GetAllCookies().empty();
+  EXPECT_TRUE(still_queued || already_shredded)
+      << "the a.com shred queued before the restart was dropped without being "
+         "performed";
+
+  // Simulate the keepalive elapsing, so the next start must shred a.com.
+  ExpireFirstPartyStorageOrigins(false);
+}
+
+IN_PROC_BROWSER_TEST_F(EphemeralStorageAutoShredBrowserTest,
+                       ShredQueuedWithinKeepAliveSurvivesRestart) {
+  // The queued shred is now due and must have happened on this start.
+  content::RunAllTasksUntilIdle();
+  WaitForCleanupAfterKeepAlive();
+  EXPECT_EQ(0u, GetAllCookies().size());
 }
 
 }  // namespace ephemeral_storage

--- a/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
@@ -18,6 +18,7 @@
 #include "base/test/test_future.h"
 #include "base/time/time.h"
 #include "brave/browser/brave_shields/brave_shields_settings_service_factory.h"
+#include "brave/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.h"
 #include "brave/browser/ephemeral_storage/ephemeral_storage_service_factory.h"
 #include "brave/browser/ephemeral_storage/ephemeral_storage_tab_helper.h"
 #include "brave/components/brave_shields/core/browser/brave_shields_settings_service.h"
@@ -25,6 +26,7 @@
 #include "brave/components/brave_shields/core/common/brave_shield_constants.h"
 #include "brave/components/brave_shields/core/common/features.h"
 #include "brave/components/constants/brave_paths.h"
+#include "brave/components/ephemeral_storage/ephemeral_storage_pref_names.h"
 #include "brave/components/ephemeral_storage/ephemeral_storage_service.h"
 #include "chrome/browser/content_settings/cookie_settings_factory.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
@@ -51,8 +53,6 @@
 #include "net/test/embedded_test_server/request_handler_util.h"
 #include "services/network/public/cpp/network_switches.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
-#include "brave/components/ephemeral_storage/ephemeral_storage_pref_names.h"
-#include "brave/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.h"
 
 using content::RenderFrameHost;
 using content::WebContents;

--- a/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string_view>
 
+#include "base/json/values_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/path_service.h"
 #include "base/strings/escape.h"
@@ -35,6 +36,7 @@
 #include "components/content_settings/core/browser/cookie_settings.h"
 #include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "components/prefs/pref_service.h"
+#include "components/prefs/scoped_user_pref_update.h"
 #include "content/public/browser/browsing_data_remover.h"
 #include "content/public/browser/security_principal.h"
 #include "content/public/browser/storage_partition.h"
@@ -49,6 +51,8 @@
 #include "net/test/embedded_test_server/request_handler_util.h"
 #include "services/network/public/cpp/network_switches.h"
 #include "third_party/abseil-cpp/absl/strings/str_format.h"
+#include "brave/components/ephemeral_storage/ephemeral_storage_pref_names.h"
+#include "brave/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.h"
 
 using content::RenderFrameHost;
 using content::WebContents;
@@ -59,6 +63,8 @@ using net::test_server::HttpRequest;
 using net::test_server::HttpResponse;
 
 namespace {
+
+constexpr char kClosedAtKey[] = "t";
 
 const char* ToString(EphemeralStorageBrowserTest::StorageType storage_type) {
   switch (storage_type) {
@@ -374,11 +380,46 @@ void WaitForCleanup(Profile* profile) {
   remover->RemoveObserver(&data_remover_observer);
 }
 
+void EphemeralStorageBrowserTest::ExpireFirstPartyStorageOrigins(
+    bool stop_before_expiring,
+    Profile* profile) {
+  if (!profile) {
+    profile = browser()->GetProfile();
+  }
+
+  if (stop_before_expiring) {
+    auto* service =
+        EphemeralStorageServiceFactory::GetInstance()->GetForContext(profile);
+    auto* delegate =
+        static_cast<ephemeral_storage::BraveEphemeralStorageServiceDelegate*>(
+            service->delegate_.get());
+    static_cast<ephemeral_storage::ApplicationStateObserver::Observer*>(
+        delegate)
+        ->OnApplicationBecameInactive();
+    content::RunAllTasksUntilIdle();  // let tab Close() +
+                                      // TLDEphemeralLifetimeDestroyed run
+  }
+
+  ScopedListPrefUpdate pref_update(
+      profile->GetPrefs(),
+      ephemeral_storage::kFirstPartyStorageOriginsToCleanup);
+  for (auto& value : *pref_update) {
+    base::DictValue* dict = value.GetIfDict();
+    if (!dict) {
+      continue;
+    }
+LOG(ERROR) << "[SHRED] Expire dict:" << dict->DebugString();
+    // Set past last access time.
+    dict->Set(kClosedAtKey, base::TimeToValue(base::Time::Min()));
+  }
+}
+
 size_t EphemeralStorageBrowserTest::WaitForCleanupAfterKeepAlive(
     Profile* profile) {
   if (!profile) {
     profile = browser()->GetProfile();
   }
+
   const size_t fired_cnt = EphemeralStorageServiceFactory::GetInstance()
                                ->GetForContext(profile)
                                ->FireCleanupTimersForTesting();

--- a/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
@@ -408,7 +408,6 @@ void EphemeralStorageBrowserTest::ExpireFirstPartyStorageOrigins(
     if (!dict) {
       continue;
     }
-LOG(ERROR) << "[SHRED] Expire dict:" << dict->DebugString();
     // Set past last access time.
     dict->Set(kClosedAtKey, base::TimeToValue(base::Time::Min()));
   }

--- a/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
@@ -393,9 +393,7 @@ void EphemeralStorageBrowserTest::ExpireFirstPartyStorageOrigins(
     auto* delegate =
         static_cast<ephemeral_storage::BraveEphemeralStorageServiceDelegate*>(
             service->delegate_.get());
-    static_cast<ephemeral_storage::ApplicationStateObserver::Observer*>(
-        delegate)
-        ->OnApplicationBecameInactive();
+    delegate->OnApplicationBecameInactive();
     content::RunAllTasksUntilIdle();  // let tab Close() +
                                       // TLDEphemeralLifetimeDestroyed run
   }

--- a/browser/ephemeral_storage/ephemeral_storage_browsertest.h
+++ b/browser/ephemeral_storage/ephemeral_storage_browsertest.h
@@ -93,7 +93,8 @@ class EphemeralStorageBrowserTest : public InProcessBrowserTest {
                                                StorageType storage_type);
   void SetCookieInFrame(content::RenderFrameHost* host, std::string cookie);
   content::EvalJsResult GetCookiesInFrame(content::RenderFrameHost* host);
-  void ExpireFirstPartyStorageOrigins(bool stop_before_expiring, Profile* profile = nullptr);
+  void ExpireFirstPartyStorageOrigins(bool stop_before_expiring,
+                                      Profile* profile = nullptr);
   size_t WaitForCleanupAfterKeepAlive(Profile* profile = nullptr);
   void ExpectValuesFromFramesAreEmpty(const base::Location& location,
                                       const ValuesFromFrames& values);

--- a/browser/ephemeral_storage/ephemeral_storage_browsertest.h
+++ b/browser/ephemeral_storage/ephemeral_storage_browsertest.h
@@ -93,6 +93,7 @@ class EphemeralStorageBrowserTest : public InProcessBrowserTest {
                                                StorageType storage_type);
   void SetCookieInFrame(content::RenderFrameHost* host, std::string cookie);
   content::EvalJsResult GetCookiesInFrame(content::RenderFrameHost* host);
+  void ExpireFirstPartyStorageOrigins(bool stop_before_expiring, Profile* profile = nullptr);
   size_t WaitForCleanupAfterKeepAlive(Profile* profile = nullptr);
   void ExpectValuesFromFramesAreEmpty(const base::Location& location,
                                       const ValuesFromFrames& values);

--- a/browser/ephemeral_storage/ephemeral_storage_forget_by_default_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_forget_by_default_browsertest.cc
@@ -721,18 +721,17 @@ IN_PROC_BROWSER_TEST_F(EphemeralStorageForgetByDefaultIncognitoBrowserTest,
         return true;
       });
 
-  EXPECT_EQ(0u, WaitForCleanupAfterKeepAlive());
-  EXPECT_EQ(0u, WaitForCleanupAfterKeepAlive(
+  // Still queued, data untouched.
+  EXPECT_EQ(1u, WaitForCleanupAfterKeepAlive());
+  EXPECT_EQ(1u, WaitForCleanupAfterKeepAlive(
                     browser()->GetProfile()->GetOriginalProfile()));
 }
 
 IN_PROC_BROWSER_TEST_F(EphemeralStorageForgetByDefaultIncognitoBrowserTest,
                        DontForgetFirstPartyIfNoBrowserWindowIsActive) {
-  // Expect the cleanup on start to have already cleaned the data.
-  EXPECT_EQ(0u, GetAllCookies().size());
-
-  // So nothing is queued.
+  // A normal window is open again: the deferred cleanup runs on startup.
   EXPECT_EQ(0u, WaitForCleanupAfterKeepAlive());
+  EXPECT_EQ(0u, GetAllCookies().size());
 }
 
 class EphemeralStorageForgetByDefaultDisabledByPolicyTest

--- a/browser/ephemeral_storage/ephemeral_storage_forget_by_default_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_forget_by_default_browsertest.cc
@@ -354,11 +354,13 @@ IN_PROC_BROWSER_TEST_F(EphemeralStorageForgetByDefaultBrowserTest,
   // Navigate to b.com to activate a deferred cleanup for a.com.
   ASSERT_TRUE(
       ui_test_utils::NavigateToURL(browser(), b_site_ephemeral_storage_url_));
+
+  ExpireFirstPartyStorageOrigins(true);
 }
 
 IN_PROC_BROWSER_TEST_F(EphemeralStorageForgetByDefaultBrowserTest,
                        ForgetFirstPartyAfterRestart) {
-  EXPECT_EQ(1u, WaitForCleanupAfterKeepAlive());
+  EXPECT_EQ(0u, WaitForCleanupAfterKeepAlive());
   EXPECT_EQ(0u, GetAllCookies().size());
 }
 
@@ -536,11 +538,13 @@ IN_PROC_BROWSER_TEST_F(EphemeralStorageForgetByDefaultIsDefaultBrowserTest,
   // Navigate to b.com to activate a deferred cleanup for a.com.
   ASSERT_TRUE(
       ui_test_utils::NavigateToURL(browser(), b_site_ephemeral_storage_url_));
+
+  ExpireFirstPartyStorageOrigins(true);
 }
 
 IN_PROC_BROWSER_TEST_F(EphemeralStorageForgetByDefaultIsDefaultBrowserTest,
                        ForgetFirstPartyAfterRestart) {
-  EXPECT_EQ(1u, WaitForCleanupAfterKeepAlive());
+  EXPECT_EQ(0u, WaitForCleanupAfterKeepAlive());
   EXPECT_EQ(0u, GetAllCookies().size());
 }
 
@@ -698,6 +702,9 @@ IN_PROC_BROWSER_TEST_F(EphemeralStorageForgetByDefaultIncognitoBrowserTest,
   // Navigate to b.com to activate a deferred cleanup for a.com.
   ASSERT_TRUE(
       ui_test_utils::NavigateToURL(browser(), b_site_ephemeral_storage_url_));
+
+  // Simulate that the tabs were closed more than 30 seconds ago
+  ExpireFirstPartyStorageOrigins(true);
 }
 
 IN_PROC_BROWSER_TEST_F(EphemeralStorageForgetByDefaultIncognitoBrowserTest,
@@ -721,12 +728,11 @@ IN_PROC_BROWSER_TEST_F(EphemeralStorageForgetByDefaultIncognitoBrowserTest,
 
 IN_PROC_BROWSER_TEST_F(EphemeralStorageForgetByDefaultIncognitoBrowserTest,
                        DontForgetFirstPartyIfNoBrowserWindowIsActive) {
-  // Expect the cleanup did not happen (yet).
-  EXPECT_EQ(1u, GetAllCookies().size());
-
-  // But it is queued and should happen eventually.
-  EXPECT_EQ(1u, WaitForCleanupAfterKeepAlive());
+  // Expect the cleanup on start to have already cleaned the data.
   EXPECT_EQ(0u, GetAllCookies().size());
+
+  // So nothing is queued.
+  EXPECT_EQ(0u, WaitForCleanupAfterKeepAlive());
 }
 
 class EphemeralStorageForgetByDefaultDisabledByPolicyTest

--- a/browser/ephemeral_storage/ephemeral_storage_service_unittest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_service_unittest.cc
@@ -13,6 +13,7 @@
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "base/test/scoped_feature_list.h"
+#include "base/values.h"
 #include "brave/browser/brave_shields/brave_shields_settings_service_factory.h"
 #include "brave/browser/ephemeral_storage/brave_ephemeral_storage_service_delegate.h"
 #include "brave/browser/ephemeral_storage/ephemeral_storage_service_factory.h"
@@ -626,6 +627,138 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
     ScopedVerifyAndClearExpectations verify(mock_delegate_);
     task_environment_.FastForwardBy(base::Seconds(5));
   }
+}
+
+TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
+       CleanupOnAreaReuseAfterKeepAliveExpired) {
+  const GURL url("https://a.com");
+  const std::string ephemeral_domain = std::string(url.host());
+  const auto storage_partition_config =
+      content::StoragePartitionConfig::CreateDefault(profile_.get());
+
+  host_content_settings_map()->SetContentSettingDefaultScope(
+      url, url, ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE,
+      CONTENT_SETTING_BLOCK);
+
+  EXPECT_CALL(*mock_delegate_, GetAutoShredMode(url))
+      .Times(2)
+      .WillRepeatedly(testing::Return(std::nullopt));
+  service_->TLDEphemeralLifetimeCreated(ephemeral_domain,
+                                        storage_partition_config);
+  service_->TLDEphemeralLifetimeDestroyed(ephemeral_domain,
+                                          storage_partition_config, false,
+                                          StorageCleanupMode::kDefault);
+  EXPECT_EQ(
+      profile_->GetPrefs()->GetList(kFirstPartyStorageOriginsToCleanup).size(),
+      1u);
+
+  // Simulate a browser that stayed closed longer than the area keepalive.
+  {
+    ScopedVerifyAndClearExpectations verify_observer(&mock_observer_);
+    ShutdownEphemeralStorageService(service_);
+    task_environment_.FastForwardBy(base::Seconds(31));
+
+    service_ = CreateEphemeralStorageService(
+        profile_.get(), mock_delegate_, &mock_observer_,
+        ExpectFirstWindowOpenedCallback::kDontTrigger);
+    ScopedVerifyAndClearExpectations verify(mock_delegate_);
+    EXPECT_EQ(profile_->GetPrefs()
+                  ->GetList(kFirstPartyStorageOriginsToCleanup)
+                  .size(),
+              1u);
+
+    // The keepalive is already due, so the cleanup happens as soon as the first
+    // window is opened, without waiting for the startup cleanup timer.
+    TLDEphemeralAreaKey key(ephemeral_domain, storage_partition_config);
+    EXPECT_CALL(*mock_delegate_, GetAutoShredMode(url))
+        .WillOnce(testing::Return(std::nullopt));
+    EXPECT_CALL(*mock_delegate_, IsShredBrowsingHistoryEnabled()).Times(0);
+    EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key));
+    mock_delegate_->TriggerFirstWindowOpenedCallback();
+    EXPECT_EQ(profile_->GetPrefs()
+                  ->GetList(kFirstPartyStorageOriginsToCleanup)
+                  .size(),
+              0u);
+  }
+
+  // Using the area again within the startup window doesn't schedule anything
+  // back and the startup cleanup timer has nothing left to do.
+  {
+    ScopedVerifyAndClearExpectations verify(mock_delegate_);
+    ScopedVerifyAndClearExpectations verify_observer(&mock_observer_);
+    EXPECT_CALL(*mock_delegate_, GetAutoShredMode(url))
+        .WillOnce(testing::Return(std::nullopt));
+    service_->TLDEphemeralLifetimeCreated(ephemeral_domain,
+                                          storage_partition_config);
+    task_environment_.FastForwardBy(base::Seconds(5));
+    EXPECT_EQ(profile_->GetPrefs()
+                  ->GetList(kFirstPartyStorageOriginsToCleanup)
+                  .size(),
+              0u);
+  }
+}
+
+TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
+       CleanupLegacyEntryOnStartup) {
+  const GURL url("https://a.com");
+  const std::string ephemeral_domain = std::string(url.host());
+  const auto storage_partition_config =
+      content::StoragePartitionConfig::CreateDefault(profile_.get());
+
+  // Entries stored by older versions are bare url specs without a close time
+  // and are always treated as expired.
+  ShutdownEphemeralStorageService(service_);
+  profile_->GetPrefs()->SetList(kFirstPartyStorageOriginsToCleanup,
+                                base::ListValue().Append(url.spec()));
+  service_ = CreateEphemeralStorageService(
+      profile_.get(), mock_delegate_, &mock_observer_,
+      ExpectFirstWindowOpenedCallback::kDontTrigger);
+
+  ScopedVerifyAndClearExpectations verify(mock_delegate_);
+  TLDEphemeralAreaKey key(ephemeral_domain, storage_partition_config);
+  EXPECT_CALL(*mock_delegate_, GetAutoShredMode(url))
+      .WillOnce(testing::Return(std::nullopt));
+  EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key));
+  mock_delegate_->TriggerFirstWindowOpenedCallback();
+  EXPECT_EQ(
+      profile_->GetPrefs()->GetList(kFirstPartyStorageOriginsToCleanup).size(),
+      0u);
+}
+
+TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
+       NoDuplicateEntriesForReusedArea) {
+  const GURL url("https://a.com");
+  const std::string ephemeral_domain = std::string(url.host());
+  const auto storage_partition_config =
+      content::StoragePartitionConfig::CreateDefault(profile_.get());
+
+  // APP_EXIT areas stay in the pref while they are in use, closing them again
+  // must update the stored entry instead of adding a second one.
+  EXPECT_CALL(*mock_delegate_, GetAutoShredMode(url))
+      .Times(4)
+      .WillRepeatedly(
+          testing::Return(brave_shields::mojom::AutoShredMode::APP_EXIT));
+  EXPECT_CALL(*mock_delegate_, IsShredBrowsingHistoryEnabled())
+      .Times(2)
+      .WillRepeatedly(testing::Return(false));
+
+  service_->TLDEphemeralLifetimeCreated(ephemeral_domain,
+                                        storage_partition_config);
+  service_->TLDEphemeralLifetimeDestroyed(ephemeral_domain,
+                                          storage_partition_config, false,
+                                          StorageCleanupMode::kDefault);
+  EXPECT_EQ(
+      profile_->GetPrefs()->GetList(kFirstPartyStorageOriginsToCleanup).size(),
+      1u);
+
+  service_->TLDEphemeralLifetimeCreated(ephemeral_domain,
+                                        storage_partition_config);
+  service_->TLDEphemeralLifetimeDestroyed(ephemeral_domain,
+                                          storage_partition_config, false,
+                                          StorageCleanupMode::kDefault);
+  EXPECT_EQ(
+      profile_->GetPrefs()->GetList(kFirstPartyStorageOriginsToCleanup).size(),
+      1u);
 }
 
 TEST_F(EphemeralStorageServiceForgetFirstPartyTest,

--- a/browser/ephemeral_storage/ephemeral_storage_service_unittest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_service_unittest.cc
@@ -75,8 +75,7 @@ class MockDelegate : public EphemeralStorageServiceDelegate {
               (override));
   MOCK_METHOD(void,
               CleanupFirstPartyStorageArea,
-              (const TLDEphemeralAreaKey& key,
-               base::OnceClosure callback),
+              (const TLDEphemeralAreaKey& key, base::OnceClosure callback),
               (override));
   MOCK_METHOD(void,
               RegisterFirstWindowOpenedCallback,
@@ -95,7 +94,7 @@ class MockDelegate : public EphemeralStorageServiceDelegate {
               GetAutoShredMode,
               (const GURL& url),
               (override));
-MOCK_METHOD(void,
+  MOCK_METHOD(void,
               ReloadTabIfMatchingEphemeralDomain,
               (const std::string& ephemeral_domain),
               (override));
@@ -108,8 +107,9 @@ MOCK_METHOD(void,
 #endif
   MOCK_METHOD(bool, IsShredBrowsingHistoryEnabled, (), (override));
 
-  void ExpectRegisterFirstWindowOpenedCallback(base::OnceClosure callback,
-                                               std::optional<bool> trigger_callback) {
+  void ExpectRegisterFirstWindowOpenedCallback(
+      base::OnceClosure callback,
+      std::optional<bool> trigger_callback) {
     if (trigger_callback.has_value()) {
       EXPECT_CALL(*this, RegisterFirstWindowOpenedCallback(_))
           .WillOnce([this, trigger_callback](base::OnceClosure callback) {
@@ -135,8 +135,7 @@ MOCK_METHOD(void,
 
  private:
   base::OnceClosure first_window_opened_callback_;
-  base::WeakPtrFactory<EphemeralStorageServiceDelegate> weak_ptr_factory_{
-      this};
+  base::WeakPtrFactory<EphemeralStorageServiceDelegate> weak_ptr_factory_{this};
 };
 
 class MockObserver : public EphemeralStorageServiceObserver {
@@ -196,8 +195,8 @@ class EphemeralStorageServiceTest : public testing::Test {
 
     std::optional<bool> trigger_callback;
     if (expect_first_window_opened_callback) {
-        trigger_callback = expect_first_window_opened_callback.value() ==
-                                   ExpectFirstWindowOpenedCallback::kTrigger;
+      trigger_callback = expect_first_window_opened_callback.value() ==
+                         ExpectFirstWindowOpenedCallback::kTrigger;
     }
     mock_delegate->ExpectRegisterFirstWindowOpenedCallback(base::OnceClosure(),
                                                            trigger_callback);
@@ -230,7 +229,7 @@ class EphemeralStorageServiceTest : public testing::Test {
       if (!dict) {
         continue;
       }
-    
+
       const std::string* url_spec = dict->FindString(kUrlKey);
       if (*url_spec != url.spec()) {
         continue;
@@ -1427,8 +1426,9 @@ TEST_F(EphemeralStorageServiceAutoShredForgetFirstPartyTest, CleanupOnRestart) {
       EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _))
           .Times(test_case.cleanup_first_party_calls);
       ExpireFirstPartyStorageOriginFor(url);
-      if (!test_case.auto_shred_mode || test_case.auto_shred_mode !=
-          brave_shields::mojom::AutoShredMode::NEVER) {
+      if (!test_case.auto_shred_mode ||
+          test_case.auto_shred_mode !=
+              brave_shields::mojom::AutoShredMode::NEVER) {
         EXPECT_CALL(*mock_delegate_, AsWeakPtr());
       }
       mock_delegate_->TriggerFirstWindowOpenedCallback();

--- a/browser/ephemeral_storage/ephemeral_storage_service_unittest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_service_unittest.cc
@@ -98,10 +98,6 @@ class MockDelegate : public EphemeralStorageServiceDelegate {
               ReloadTabIfMatchingEphemeralDomain,
               (const std::string& ephemeral_domain),
               (override));
-  MOCK_METHOD(base::WeakPtr<EphemeralStorageServiceDelegate>,
-              AsWeakPtr,
-              (),
-              (override));
 #if BUILDFLAG(IS_ANDROID)
   MOCK_METHOD(void, TriggerCurrentAppStateNotification, (), (override));
 #endif
@@ -127,10 +123,6 @@ class MockDelegate : public EphemeralStorageServiceDelegate {
   void TriggerFirstWindowOpenedCallback() {
     ASSERT_TRUE(first_window_opened_callback_);
     std::move(first_window_opened_callback_).Run();
-  }
-
-  base::WeakPtr<EphemeralStorageServiceDelegate> GetRealWeakPtr() {
-    return weak_ptr_factory_.GetWeakPtr();
   }
 
  private:
@@ -201,9 +193,6 @@ class EphemeralStorageServiceTest : public testing::Test {
     mock_delegate->ExpectRegisterFirstWindowOpenedCallback(base::OnceClosure(),
                                                            trigger_callback);
     mock_delegate_ptr = mock_delegate.get();
-    ON_CALL(*mock_delegate_ptr, AsWeakPtr())
-        .WillByDefault(testing::Invoke(mock_delegate_ptr.get(),
-                                       &MockDelegate::GetRealWeakPtr));
     auto service = std::make_unique<EphemeralStorageService>(
         profile, HostContentSettingsMapFactory::GetForProfile(profile),
         std::move(mock_delegate));
@@ -548,7 +537,6 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest, CleanupOnRestart) {
         .WillOnce(testing::Return(std::nullopt));
     EXPECT_CALL(*mock_delegate_, IsShredBrowsingHistoryEnabled()).Times(0);
     EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _));
-    EXPECT_CALL(*mock_delegate_, AsWeakPtr());
     ExpireFirstPartyStorageOriginFor(url);
     mock_delegate_->TriggerFirstWindowOpenedCallback();
     EXPECT_EQ(profile_->GetPrefs()
@@ -626,7 +614,6 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest, CleanupOnAppStateChange) {
         .WillOnce(testing::Return(std::nullopt));
     EXPECT_CALL(*mock_delegate_, IsShredBrowsingHistoryEnabled()).Times(0);
     EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _));
-    EXPECT_CALL(*mock_delegate_, AsWeakPtr());
     ExpireFirstPartyStorageOriginFor(url);
     mock_delegate_->TriggerFirstWindowOpenedCallback();
     EXPECT_EQ(profile_->GetPrefs()
@@ -734,7 +721,6 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
         .WillOnce(testing::Return(std::nullopt));
     EXPECT_CALL(*mock_delegate_, IsShredBrowsingHistoryEnabled()).Times(0);
     EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _));
-    EXPECT_CALL(*mock_delegate_, AsWeakPtr());
     mock_delegate_->TriggerFirstWindowOpenedCallback();
     EXPECT_EQ(profile_->GetPrefs()
                   ->GetList(kFirstPartyStorageOriginsToCleanup)
@@ -780,7 +766,6 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
   EXPECT_CALL(*mock_delegate_, GetAutoShredMode(url))
       .WillOnce(testing::Return(std::nullopt));
   EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _));
-  EXPECT_CALL(*mock_delegate_, AsWeakPtr());
   mock_delegate_->TriggerFirstWindowOpenedCallback();
   EXPECT_EQ(
       profile_->GetPrefs()->GetList(kFirstPartyStorageOriginsToCleanup).size(),
@@ -882,7 +867,6 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
     EXPECT_CALL(*mock_delegate_, IsShredBrowsingHistoryEnabled())
         .WillOnce(testing::Return(false));
     EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _));
-    EXPECT_CALL(*mock_delegate_, AsWeakPtr());
     ExpireFirstPartyStorageOriginFor(url);
     mock_delegate_->TriggerFirstWindowOpenedCallback();
     EXPECT_EQ(profile_->GetPrefs()
@@ -962,7 +946,6 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
 
     EXPECT_CALL(*mock_delegate_, IsShredBrowsingHistoryEnabled()).Times(0);
     EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _));
-    EXPECT_CALL(*mock_delegate_, AsWeakPtr());
     ExpireFirstPartyStorageOriginFor(url);
     mock_delegate_->TriggerFirstWindowOpenedCallback();
     EXPECT_EQ(profile_->GetPrefs()
@@ -1034,7 +1017,6 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
         .WillOnce(testing::Return(std::nullopt));
     EXPECT_CALL(*mock_delegate_, IsShredBrowsingHistoryEnabled()).Times(0);
     EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _));
-    EXPECT_CALL(*mock_delegate_, AsWeakPtr());
 
     ExpireFirstPartyStorageOriginFor(url);
 
@@ -1511,11 +1493,6 @@ TEST_F(EphemeralStorageServiceAutoShredForgetFirstPartyTest, CleanupOnRestart) {
       EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _))
           .Times(test_case.cleanup_first_party_calls);
       ExpireFirstPartyStorageOriginFor(url);
-      if (!test_case.auto_shred_mode ||
-          test_case.auto_shred_mode !=
-              brave_shields::mojom::AutoShredMode::NEVER) {
-        EXPECT_CALL(*mock_delegate_, AsWeakPtr());
-      }
       mock_delegate_->TriggerFirstWindowOpenedCallback();
       EXPECT_EQ(profile_->GetPrefs()
                     ->GetList(kFirstPartyStorageOriginsToCleanup)

--- a/browser/ephemeral_storage/ephemeral_storage_service_unittest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_service_unittest.cc
@@ -240,6 +240,22 @@ class EphemeralStorageServiceTest : public testing::Test {
     }
   }
 
+  std::optional<base::Time> GetFirstPartyStorageClosedAtFor(const GURL& url) {
+    for (const auto& value :
+         profile_->GetPrefs()->GetList(kFirstPartyStorageOriginsToCleanup)) {
+      const base::DictValue* dict = value.GetIfDict();
+      if (!dict) {
+        continue;
+      }
+      const std::string* url_spec = dict->FindString(kUrlKey);
+      if (!url_spec || *url_spec != url.spec()) {
+        continue;
+      }
+      return base::ValueToTime(dict->Find(kClosedAtKey));
+    }
+    return std::nullopt;
+  }
+
  protected:
   content::BrowserTaskEnvironment task_environment_;
   std::unique_ptr<TestingProfile> profile_;
@@ -805,6 +821,75 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
   EXPECT_EQ(
       profile_->GetPrefs()->GetList(kFirstPartyStorageOriginsToCleanup).size(),
       1u);
+}
+
+TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
+       CloseTimeIsNotRefreshedForQueuedArea) {
+  const GURL url("https://a.com");
+  const std::string ephemeral_domain = std::string(url.host());
+  const auto storage_partition_config =
+      content::StoragePartitionConfig::CreateDefault(profile_.get());
+
+  {
+    ScopedVerifyAndClearExpectations verify(mock_delegate_);
+    EXPECT_CALL(*mock_delegate_, GetAutoShredMode(url))
+        .Times(2)
+        .WillRepeatedly(
+            testing::Return(brave_shields::mojom::AutoShredMode::APP_EXIT));
+    EXPECT_CALL(*mock_delegate_, IsShredBrowsingHistoryEnabled())
+        .WillOnce(testing::Return(false));
+
+    service_->TLDEphemeralLifetimeCreated(ephemeral_domain,
+                                          storage_partition_config);
+    service_->TLDEphemeralLifetimeDestroyed(ephemeral_domain,
+                                            storage_partition_config, false,
+                                            StorageCleanupMode::kOnExitShred);
+    ASSERT_EQ(GetFirstPartyStorageClosedAtFor(url), base::Time::Min());
+  }
+
+  {
+    ScopedVerifyAndClearExpectations verify(mock_delegate_);
+    EXPECT_CALL(*mock_delegate_, GetAutoShredMode(url))
+        .Times(2)
+        .WillRepeatedly(testing::Return(
+            brave_shields::mojom::AutoShredMode::LAST_TAB_CLOSED));
+    EXPECT_CALL(*mock_delegate_, IsShredBrowsingHistoryEnabled())
+        .WillOnce(testing::Return(false));
+
+    // Reusing and closing the area again (this is what the Android cold start
+    // does with the tabs restored from the previous session) must not stamp a
+    // fresh close time onto the queued entry, otherwise it would never be seen
+    // as expired and would never be cleaned up.
+    service_->TLDEphemeralLifetimeCreated(ephemeral_domain,
+                                          storage_partition_config);
+    service_->TLDEphemeralLifetimeDestroyed(ephemeral_domain,
+                                            storage_partition_config, false,
+                                            StorageCleanupMode::kDefault);
+    EXPECT_GT(GetFirstPartyStorageClosedAtFor(url), base::Time::Min());
+  }
+
+  {
+    ShutdownEphemeralStorageService(service_);
+    service_ = CreateEphemeralStorageService(
+        profile_.get(), mock_delegate_, &mock_observer_,
+        ExpectFirstWindowOpenedCallback::kDontTrigger);
+    ScopedVerifyAndClearExpectations verify(mock_delegate_);
+
+    TLDEphemeralAreaKey key(ephemeral_domain, storage_partition_config);
+    EXPECT_CALL(*mock_delegate_, GetAutoShredMode(url))
+        .WillOnce(
+            testing::Return(brave_shields::mojom::AutoShredMode::APP_EXIT));
+    EXPECT_CALL(*mock_delegate_, IsShredBrowsingHistoryEnabled())
+        .WillOnce(testing::Return(false));
+    EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _));
+    EXPECT_CALL(*mock_delegate_, AsWeakPtr());
+    ExpireFirstPartyStorageOriginFor(url);
+    mock_delegate_->TriggerFirstWindowOpenedCallback();
+    EXPECT_EQ(profile_->GetPrefs()
+                  ->GetList(kFirstPartyStorageOriginsToCleanup)
+                  .size(),
+              0u);
+  }
 }
 
 TEST_F(EphemeralStorageServiceForgetFirstPartyTest,

--- a/browser/ephemeral_storage/ephemeral_storage_service_unittest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_service_unittest.cc
@@ -12,6 +12,8 @@
 
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
+#include "base/json/values_util.h"
+#include "base/memory/weak_ptr.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/values.h"
 #include "brave/browser/brave_shields/brave_shields_settings_service_factory.h"
@@ -32,6 +34,7 @@
 #include "chrome/test/base/testing_profile.h"
 #include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "components/content_settings/core/common/content_settings.h"
+#include "components/prefs/scoped_user_pref_update.h"
 #include "components/sync/test/test_sync_service.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
 #include "content/public/browser/storage_partition_config.h"
@@ -45,7 +48,8 @@ using testing::_;
 
 namespace ephemeral_storage {
 namespace {
-
+constexpr char kUrlKey[] = "u";
+constexpr char kClosedAtKey[] = "t";
 class ScopedVerifyAndClearExpectations {
  public:
   explicit ScopedVerifyAndClearExpectations(void* mock_obj)
@@ -71,7 +75,8 @@ class MockDelegate : public EphemeralStorageServiceDelegate {
               (override));
   MOCK_METHOD(void,
               CleanupFirstPartyStorageArea,
-              (const TLDEphemeralAreaKey& key),
+              (const TLDEphemeralAreaKey& key,
+               base::OnceClosure callback),
               (override));
   MOCK_METHOD(void,
               RegisterFirstWindowOpenedCallback,
@@ -90,21 +95,33 @@ class MockDelegate : public EphemeralStorageServiceDelegate {
               GetAutoShredMode,
               (const GURL& url),
               (override));
+MOCK_METHOD(void,
+              ReloadTabIfMatchingEphemeralDomain,
+              (const std::string& ephemeral_domain),
+              (override));
+  MOCK_METHOD(base::WeakPtr<EphemeralStorageServiceDelegate>,
+              AsWeakPtr,
+              (),
+              (override));
 #if BUILDFLAG(IS_ANDROID)
   MOCK_METHOD(void, TriggerCurrentAppStateNotification, (), (override));
 #endif
   MOCK_METHOD(bool, IsShredBrowsingHistoryEnabled, (), (override));
 
   void ExpectRegisterFirstWindowOpenedCallback(base::OnceClosure callback,
-                                               bool trigger_callback) {
-    EXPECT_CALL(*this, RegisterFirstWindowOpenedCallback(_))
-        .WillOnce([this, trigger_callback](base::OnceClosure callback) {
-          if (trigger_callback) {
-            std::move(callback).Run();
-          } else {
-            first_window_opened_callback_ = std::move(callback);
-          }
-        });
+                                               std::optional<bool> trigger_callback) {
+    if (trigger_callback.has_value()) {
+      EXPECT_CALL(*this, RegisterFirstWindowOpenedCallback(_))
+          .WillOnce([this, trigger_callback](base::OnceClosure callback) {
+            if (trigger_callback.value()) {
+              std::move(callback).Run();
+            } else {
+              first_window_opened_callback_ = std::move(callback);
+            }
+          });
+    } else {
+      EXPECT_CALL(*this, RegisterFirstWindowOpenedCallback(_)).Times(0);
+    }
   }
 
   void TriggerFirstWindowOpenedCallback() {
@@ -112,8 +129,14 @@ class MockDelegate : public EphemeralStorageServiceDelegate {
     std::move(first_window_opened_callback_).Run();
   }
 
+  base::WeakPtr<EphemeralStorageServiceDelegate> GetRealWeakPtr() {
+    return weak_ptr_factory_.GetWeakPtr();
+  }
+
  private:
   base::OnceClosure first_window_opened_callback_;
+  base::WeakPtrFactory<EphemeralStorageServiceDelegate> weak_ptr_factory_{
+      this};
 };
 
 class MockObserver : public EphemeralStorageServiceObserver {
@@ -170,12 +193,18 @@ class EphemeralStorageServiceTest : public testing::Test {
           expect_first_window_opened_callback =
               ExpectFirstWindowOpenedCallback::kTrigger) {
     auto mock_delegate = std::make_unique<testing::StrictMock<MockDelegate>>();
+
+    std::optional<bool> trigger_callback;
     if (expect_first_window_opened_callback) {
-      mock_delegate->ExpectRegisterFirstWindowOpenedCallback(
-          base::OnceClosure(), expect_first_window_opened_callback ==
-                                   ExpectFirstWindowOpenedCallback::kTrigger);
+        trigger_callback = expect_first_window_opened_callback.value() ==
+                                   ExpectFirstWindowOpenedCallback::kTrigger;
     }
+    mock_delegate->ExpectRegisterFirstWindowOpenedCallback(base::OnceClosure(),
+                                                           trigger_callback);
     mock_delegate_ptr = mock_delegate.get();
+    ON_CALL(*mock_delegate_ptr, AsWeakPtr())
+        .WillByDefault(testing::Invoke(mock_delegate_ptr.get(),
+                                       &MockDelegate::GetRealWeakPtr));
     auto service = std::make_unique<EphemeralStorageService>(
         profile, HostContentSettingsMapFactory::GetForProfile(profile),
         std::move(mock_delegate));
@@ -191,6 +220,25 @@ class EphemeralStorageServiceTest : public testing::Test {
     mock_delegate_ = nullptr;
     service->Shutdown();
     service.reset();
+  }
+
+  void ExpireFirstPartyStorageOriginFor(GURL url) {
+    ScopedListPrefUpdate pref_update(profile_->GetPrefs(),
+                                     kFirstPartyStorageOriginsToCleanup);
+    for (auto& value : *pref_update) {
+      base::DictValue* dict = value.GetIfDict();
+      if (!dict) {
+        continue;
+      }
+    
+      const std::string* url_spec = dict->FindString(kUrlKey);
+      if (*url_spec != url.spec()) {
+        continue;
+      }
+
+      // Set past last access time.
+      dict->Set(kClosedAtKey, base::TimeToValue(base::Time::Min()));
+    }
   }
 
  protected:
@@ -407,7 +455,7 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest, CleanupFirstPartyStorage) {
       EXPECT_CALL(mock_observer_, OnCleanupTLDEphemeralArea(key));
       EXPECT_CALL(*mock_delegate_, CleanupTLDEphemeralArea(key))
           .Times(test_case.shields_enabled);
-      EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key))
+      EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _))
           .Times(test_case.should_cleanup);
       service_->TLDEphemeralLifetimeDestroyed(
           ephemeral_domain, storage_partition_config,
@@ -465,8 +513,9 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest, CleanupOnRestart) {
     ScopedVerifyAndClearExpectations verify_observer(&mock_observer_);
     ShutdownEphemeralStorageService(service_);
 
-    service_ = CreateEphemeralStorageService(profile_.get(), mock_delegate_,
-                                             &mock_observer_);
+    service_ = CreateEphemeralStorageService(
+        profile_.get(), mock_delegate_, &mock_observer_,
+        ExpectFirstWindowOpenedCallback::kDontTrigger);
     ScopedVerifyAndClearExpectations verify(mock_delegate_);
     EXPECT_EQ(profile_->GetPrefs()
                   ->GetList(kFirstPartyStorageOriginsToCleanup)
@@ -474,7 +523,8 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest, CleanupOnRestart) {
               1u);
   }
 
-  // Cleanup should happen in 5 seconds after the startup.
+  // Cleanup should happen once the browser is ready after the startup. We
+  // simulate it by calling TriggerFirstWindowOpenedCallback
   {
     ScopedVerifyAndClearExpectations verify(mock_delegate_);
     ScopedVerifyAndClearExpectations verify_observer(&mock_observer_);
@@ -482,8 +532,10 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest, CleanupOnRestart) {
     EXPECT_CALL(*mock_delegate_, GetAutoShredMode(url))
         .WillOnce(testing::Return(std::nullopt));
     EXPECT_CALL(*mock_delegate_, IsShredBrowsingHistoryEnabled()).Times(0);
-    EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key));
-    task_environment_.FastForwardBy(base::Seconds(5));
+    EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _));
+    EXPECT_CALL(*mock_delegate_, AsWeakPtr());
+    ExpireFirstPartyStorageOriginFor(url);
+    mock_delegate_->TriggerFirstWindowOpenedCallback();
     EXPECT_EQ(profile_->GetPrefs()
                   ->GetList(kFirstPartyStorageOriginsToCleanup)
                   .size(),
@@ -543,10 +595,6 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest, CleanupOnAppStateChange) {
     // Simulate app state change.
     service_->TriggerCurrentAppStateNotification();
 
-    // The FirstWindowOpenedCallback should be triggered when app becomes
-    // active.
-    mock_delegate_->TriggerFirstWindowOpenedCallback();
-
     ScopedVerifyAndClearExpectations verify(mock_delegate_);
     EXPECT_EQ(profile_->GetPrefs()
                   ->GetList(kFirstPartyStorageOriginsToCleanup)
@@ -554,7 +602,7 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest, CleanupOnAppStateChange) {
               1u);
   }
 
-  // Cleanup should happen in 5 seconds after the startup.
+  // Cleanup should happen after the startup.
   {
     ScopedVerifyAndClearExpectations verify(mock_delegate_);
     ScopedVerifyAndClearExpectations verify_observer(&mock_observer_);
@@ -562,8 +610,10 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest, CleanupOnAppStateChange) {
     EXPECT_CALL(*mock_delegate_, GetAutoShredMode(url))
         .WillOnce(testing::Return(std::nullopt));
     EXPECT_CALL(*mock_delegate_, IsShredBrowsingHistoryEnabled()).Times(0);
-    EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key));
-    task_environment_.FastForwardBy(base::Seconds(5));
+    EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _));
+    EXPECT_CALL(*mock_delegate_, AsWeakPtr());
+    ExpireFirstPartyStorageOriginFor(url);
+    mock_delegate_->TriggerFirstWindowOpenedCallback();
     EXPECT_EQ(profile_->GetPrefs()
                   ->GetList(kFirstPartyStorageOriginsToCleanup)
                   .size(),
@@ -605,8 +655,9 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
   // Simulate a browser restart. No cleanup should happen at construction.
   {
     ShutdownEphemeralStorageService(service_);
-    service_ = CreateEphemeralStorageService(profile_.get(), mock_delegate_,
-                                             &mock_observer_);
+    service_ = CreateEphemeralStorageService(
+        profile_.get(), mock_delegate_, &mock_observer_,
+        ExpectFirstWindowOpenedCallback::kDontTrigger);
     ScopedVerifyAndClearExpectations verify(mock_delegate_);
     EXPECT_EQ(profile_->GetPrefs()
                   ->GetList(kFirstPartyStorageOriginsToCleanup)
@@ -620,12 +671,6 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
                   ->GetList(kFirstPartyStorageOriginsToCleanup)
                   .size(),
               0u);
-  }
-
-  // Cleanup should NOT happen in 5 seconds after the startup.
-  {
-    ScopedVerifyAndClearExpectations verify(mock_delegate_);
-    task_environment_.FastForwardBy(base::Seconds(5));
   }
 }
 
@@ -673,7 +718,8 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
     EXPECT_CALL(*mock_delegate_, GetAutoShredMode(url))
         .WillOnce(testing::Return(std::nullopt));
     EXPECT_CALL(*mock_delegate_, IsShredBrowsingHistoryEnabled()).Times(0);
-    EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key));
+    EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _));
+    EXPECT_CALL(*mock_delegate_, AsWeakPtr());
     mock_delegate_->TriggerFirstWindowOpenedCallback();
     EXPECT_EQ(profile_->GetPrefs()
                   ->GetList(kFirstPartyStorageOriginsToCleanup)
@@ -718,7 +764,8 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
   TLDEphemeralAreaKey key(ephemeral_domain, storage_partition_config);
   EXPECT_CALL(*mock_delegate_, GetAutoShredMode(url))
       .WillOnce(testing::Return(std::nullopt));
-  EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key));
+  EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _));
+  EXPECT_CALL(*mock_delegate_, AsWeakPtr());
   mock_delegate_->TriggerFirstWindowOpenedCallback();
   EXPECT_EQ(
       profile_->GetPrefs()->GetList(kFirstPartyStorageOriginsToCleanup).size(),
@@ -802,8 +849,9 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
   // Simulate a browser restart. No cleanup should happen at construction.
   {
     ShutdownEphemeralStorageService(service_);
-    service_ = CreateEphemeralStorageService(profile_.get(), mock_delegate_,
-                                             &mock_observer_);
+    service_ = CreateEphemeralStorageService(
+        profile_.get(), mock_delegate_, &mock_observer_,
+        ExpectFirstWindowOpenedCallback::kDontTrigger);
     ScopedVerifyAndClearExpectations verify(mock_delegate_);
     EXPECT_EQ(profile_->GetPrefs()
                   ->GetList(kFirstPartyStorageOriginsToCleanup)
@@ -819,8 +867,8 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
               1u);
   }
 
-  // Cleanup should happen only for the second storage partition in 5 seconds
-  // after the startup.
+  // Cleanup should happen only for the second storage partition after the
+  // startup.
   {
     ScopedVerifyAndClearExpectations verify(mock_delegate_);
     ScopedVerifyAndClearExpectations verify_observer(&mock_observer_);
@@ -829,8 +877,10 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
         .WillOnce(testing::Return(std::nullopt));
 
     EXPECT_CALL(*mock_delegate_, IsShredBrowsingHistoryEnabled()).Times(0);
-    EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key));
-    task_environment_.FastForwardBy(base::Seconds(5));
+    EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _));
+    EXPECT_CALL(*mock_delegate_, AsWeakPtr());
+    ExpireFirstPartyStorageOriginFor(url);
+    mock_delegate_->TriggerFirstWindowOpenedCallback();
     EXPECT_EQ(profile_->GetPrefs()
                   ->GetList(kFirstPartyStorageOriginsToCleanup)
                   .size(),
@@ -889,25 +939,24 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest,
               1u);
   }
 
-  // Cleanup should NOT happen in 5 seconds after the startup.
+  // Cleanup should occur only when the first window opens and there are expired
+  // records older than 30 seconds.
   {
-    ScopedVerifyAndClearExpectations verify(mock_delegate_);
-    task_environment_.FastForwardBy(base::Seconds(5));
-  }
-
-  // Trigger the first window opened callback.
-  mock_delegate_->TriggerFirstWindowOpenedCallback();
-
-  // Cleanup should happen in the next 5 seconds after the window is opened.
-  {
-    ScopedVerifyAndClearExpectations verify(mock_delegate_);
     ScopedVerifyAndClearExpectations verify_observer(&mock_observer_);
+    ScopedVerifyAndClearExpectations verify(mock_delegate_);
+
     TLDEphemeralAreaKey key(ephemeral_domain, storage_partition_config);
     EXPECT_CALL(*mock_delegate_, GetAutoShredMode(url))
         .WillOnce(testing::Return(std::nullopt));
     EXPECT_CALL(*mock_delegate_, IsShredBrowsingHistoryEnabled()).Times(0);
-    EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key));
-    task_environment_.FastForwardBy(base::Seconds(5));
+    EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _));
+    EXPECT_CALL(*mock_delegate_, AsWeakPtr());
+
+    ExpireFirstPartyStorageOriginFor(url);
+
+    // Trigger the first window opened callback.
+    mock_delegate_->TriggerFirstWindowOpenedCallback();
+
     EXPECT_EQ(profile_->GetPrefs()
                   ->GetList(kFirstPartyStorageOriginsToCleanup)
                   .size(),
@@ -923,7 +972,6 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest, OffTheRecordSkipsPrefs) {
 
   Profile* otr_profile = profile_->GetOffTheRecordProfile(
       Profile::OTRProfileID::PrimaryID(), true);
-
   auto otr_service = CreateEphemeralStorageService(
       otr_profile, mock_delegate_, &mock_observer_, std::nullopt);
   host_content_settings_map(otr_profile)
@@ -956,7 +1004,6 @@ TEST_F(EphemeralStorageServiceForgetFirstPartyTest, OffTheRecordSkipsPrefs) {
     otr_service = CreateEphemeralStorageService(otr_profile, mock_delegate_,
                                                 &mock_observer_, std::nullopt);
     ScopedVerifyAndClearExpectations verify(mock_delegate_);
-    task_environment_.FastForwardBy(base::Seconds(5));
   }
 
   ShutdownEphemeralStorageService(otr_service);
@@ -1180,7 +1227,7 @@ TEST_F(EphemeralStorageServiceAutoShredForgetFirstPartyTest,
           .Times(test_case.should_call_observer);
       EXPECT_CALL(*mock_delegate_, CleanupTLDEphemeralArea(key))
           .Times(test_case.should_cleanup_ephemeral_area);
-      EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key))
+      EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _))
           .Times(test_case.should_cleanup_1p_storage);
       service_->TLDEphemeralLifetimeDestroyed(
           ephemeral_domain, storage_partition_config,
@@ -1341,7 +1388,7 @@ TEST_F(EphemeralStorageServiceAutoShredForgetFirstPartyTest, CleanupOnRestart) {
 
       service_ = CreateEphemeralStorageService(
           profile_.get(), mock_delegate_, &mock_observer_,
-          ExpectFirstWindowOpenedCallback::kTrigger);
+          ExpectFirstWindowOpenedCallback::kDontTrigger);
       ScopedVerifyAndClearExpectations verify(mock_delegate_);
       EXPECT_EQ(profile_->GetPrefs()
                     ->GetList(kFirstPartyStorageOriginsToCleanup)
@@ -1349,7 +1396,7 @@ TEST_F(EphemeralStorageServiceAutoShredForgetFirstPartyTest, CleanupOnRestart) {
                 test_case.saved_to_cleanup_list ? 1u : 0u);
     }
 
-    // Cleanup should happen in 5 seconds or immediately after the startup.
+    // Cleanup should happen immediately after the startup.
     {
       ScopedVerifyAndClearExpectations verify(mock_delegate_);
       ScopedVerifyAndClearExpectations verify_observer(&mock_observer_);
@@ -1377,13 +1424,14 @@ TEST_F(EphemeralStorageServiceAutoShredForgetFirstPartyTest, CleanupOnRestart) {
           .Times(test_case.on_cleanup_tld_ephemeral_calls);
       EXPECT_CALL(*mock_delegate_, CleanupTLDEphemeralArea(key))
           .Times(test_case.cleanup_tld_ephemeral_calls);
-      EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key))
+      EXPECT_CALL(*mock_delegate_, CleanupFirstPartyStorageArea(key, _))
           .Times(test_case.cleanup_first_party_calls);
-      if (test_case.auto_shred_mode ==
-          brave_shields::mojom::AutoShredMode::APP_EXIT) {
-        service_->ScheduleFirstPartyStorageAreasCleanupOnStartup();
+      ExpireFirstPartyStorageOriginFor(url);
+      if (!test_case.auto_shred_mode || test_case.auto_shred_mode !=
+          brave_shields::mojom::AutoShredMode::NEVER) {
+        EXPECT_CALL(*mock_delegate_, AsWeakPtr());
       }
-      task_environment_.FastForwardBy(base::Seconds(5));
+      mock_delegate_->TriggerFirstWindowOpenedCallback();
       EXPECT_EQ(profile_->GetPrefs()
                     ->GetList(kFirstPartyStorageOriginsToCleanup)
                     .size(),

--- a/browser/ephemeral_storage/ephemeral_storage_service_unittest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_service_unittest.cc
@@ -220,7 +220,7 @@ class EphemeralStorageServiceTest : public testing::Test {
       }
 
       const std::string* url_spec = dict->FindString(kUrlKey);
-      if (*url_spec != url.spec()) {
+      if (!url_spec || *url_spec != url.spec()) {
         continue;
       }
 

--- a/browser/ephemeral_storage/ephemeral_storage_tab_helper.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_tab_helper.cc
@@ -113,6 +113,7 @@ EphemeralStorageTabHelper::EphemeralStorageTabHelper(WebContents* web_contents)
 }
 
 EphemeralStorageTabHelper::~EphemeralStorageTabHelper() {
+  LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::~EphemeralStorageTabHelper  url:" << (web_contents() ? web_contents()->GetURL().spec() : "n/a");
 #if BUILDFLAG(IS_ANDROID)
   // Always remove observer in destructor using the stored TabModel pointer.
   // We can't rely on web_contents() here as it may already be destroyed.
@@ -137,20 +138,19 @@ void EphemeralStorageTabHelper::EnforceFirstPartyStorageCleanup(
   }
 }
 
-void EphemeralStorageTabHelper::ReloadBypassingCacheWhenReady(base::OnceClosure pre_reload_callback) {
+void EphemeralStorageTabHelper::ReloadBypassingCacheWhenReady() {
    auto& controller = web_contents()->GetController();
-  if (controller.GetPendingEntry() || controller.NeedsReload()) {
+  if (controller.GetPendingEntry()
+      //|| controller.NeedsReload()
+    ) {
     LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::ReloadBypassingCacheWhenReady #100 url:" << web_contents()->GetURL();
-    if(!reload_on_ready_callback_.is_null()) {
-      LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::ReloadBypassingCacheWhenReady Owerwritten #500 url:" << web_contents()->GetURL();
-    }
     reload_on_ready_callback_ =
         base::BindOnce(&EphemeralStorageTabHelper::ReloadBypassingCache,
-                       weak_factory_.GetWeakPtr(), std::move(pre_reload_callback));
+                       weak_factory_.GetWeakPtr());
     return;
   }
   LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::ReloadBypassingCacheWhenReady #200 url:" << web_contents()->GetURL();
-  ReloadBypassingCache(std::move(pre_reload_callback));
+  ReloadBypassingCache();
 }
 
 void EphemeralStorageTabHelper::DidStartNavigation(
@@ -184,33 +184,21 @@ void EphemeralStorageTabHelper::DidFinishNavigation(
   // is created in ReadyToCommitNavigation().
   provisional_tld_ephemeral_lifetimes_.clear();
 
-   if (reload_on_ready_callback_) {
-    // Cancel this navigation (which may be about to serve a stale response
-    // preferring cache, e.g. a tab restore) and reload it bypassing the
-    // cache. NavigationController::Reload() can't be called re-entrantly
-    // from here (DidStartNavigation() runs synchronously from within
-    // NavigateToExistingPendingEntry()), so post it instead.
-    
-    // base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
-    //     FROM_HERE, base::BindOnce(&EphemeralStorageTabHelper::ReloadBypassingCache,
-    //                               weak_factory_.GetWeakPtr()));
-
-    LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::DidFinishNavigation url:" << navigation_handle->GetURL();
-    std::move(reload_on_ready_callback_).Run();
-
-    return;
+  if (navigation_handle->HasCommitted() && !navigation_handle->IsErrorPage() &&
+      reload_on_ready_callback_) {
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE, std::move(reload_on_ready_callback_));
+    LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::DidFinishNavigation url:"
+              << navigation_handle->GetURL();
   }
-
 }
 
 void EphemeralStorageTabHelper::ReadyToCommitNavigation(
     NavigationHandle* navigation_handle) {
   if (!navigation_handle->IsInMainFrame()) {
-//    LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::ReadyToCommitNavigation #100 url:" << navigation_handle->GetURL();
     return;
   }
   if (navigation_handle->IsSameDocument()) {
-//    LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::ReadyToCommitNavigation #101 url:" << navigation_handle->GetURL();
     return;
   }
 
@@ -220,7 +208,6 @@ void EphemeralStorageTabHelper::ReadyToCommitNavigation(
   std::string new_domain = net::URLToEphemeralStorageDomain(new_url);
   std::string previous_domain =
       net::URLToEphemeralStorageDomain(last_committed_url);
-//LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::ReadyToCommitNavigation new_domain:" << new_domain << " previous_domain:" << previous_domain;
   if (new_domain != previous_domain) {
     // Create new storage areas for new ephemeral storage domain.
     CreateEphemeralStorageAreasForDomainAndURL(new_domain, new_url);
@@ -283,13 +270,30 @@ void EphemeralStorageTabHelper::UpdateShieldsState(const GURL& url) {
       url.host(), shields_enabled && cookies_restricted);
 }
 
-void EphemeralStorageTabHelper::ReloadBypassingCache(base::OnceClosure pre_reload_callback) {
-  if(pre_reload_callback) {
-    LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::ReloadBypassingCache callback call url:" << web_contents()->GetURL();
-    std::move(pre_reload_callback).Run();
+void EphemeralStorageTabHelper::ReloadBypassingCache() {
+  if (!web_contents()) {
+    return;
   }
-  web_contents()->GetController().Reload(content::ReloadType::BYPASSING_CACHE,
-                                         false);
+
+  auto& controller = web_contents()->GetController();
+  
+  // Check if a navigation is currently in progress
+  if (controller.GetPendingEntry()) {
+    LOG(WARNING) << "[SHRED] Reload skipped: Pending entry exists. URL: " << web_contents()->GetURL();
+    return;
+  }
+
+  // Check if the WebContents is currently loading (might catch more states)
+  if (web_contents()->IsLoading()) {
+     // Depending on your needs, you might want to force reload even here, 
+     // but usually it's safer to wait or abort.
+     LOG(WARNING) << "[SHRED] Reload skipped: Tab is currently loading. URL: " << web_contents()->GetURL();
+     // You might want to re-post this task or handle it differently
+     return;
+  }
+  
+  LOG(INFO) << "[SHRED] Executing ReloadBypassingCache. URL: " << web_contents()->GetURL();
+  controller.Reload(content::ReloadType::BYPASSING_CACHE, false);
 }
 
 #if BUILDFLAG(IS_ANDROID)
@@ -300,6 +304,7 @@ void EphemeralStorageTabHelper::WillCloseTab(TabAndroid* tab) {
   // Reset TLDEphemeralLifetime when a tab closes, since on Android
   // it may be invoked much later after the tab has actually closed.
   provisional_tld_ephemeral_lifetimes_.clear();
+  LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::WillCloseTab" << web_contents()->GetURL();
   tld_ephemeral_lifetime_.reset();
   weak_factory_.InvalidateWeakPtrs();
   RemoveTabModelObserver(registered_tab_model_, this);

--- a/browser/ephemeral_storage/ephemeral_storage_tab_helper.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_tab_helper.cc
@@ -17,6 +17,7 @@
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/profiles/profile.h"
 #include "content/public/browser/navigation_controller.h"
+#include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/navigation_handle.h"
 #include "content/public/browser/security_principal.h"
 #include "content/public/browser/site_instance.h"
@@ -36,7 +37,6 @@ using content::NavigationHandle;
 using content::WebContents;
 
 namespace ephemeral_storage {
-
 
 #if BUILDFLAG(IS_ANDROID)
 namespace {
@@ -138,15 +138,16 @@ void EphemeralStorageTabHelper::EnforceFirstPartyStorageCleanup(
   }
 }
 
-void EphemeralStorageTabHelper::ReloadBypassingCacheWhenReady() {
-   auto& controller = web_contents()->GetController();
+void EphemeralStorageTabHelper::ReloadBypassingCacheWhenReady(
+    const std::string& cleaned_ephemeral_domain) {
+  auto& controller = web_contents()->GetController();
   if (controller.GetPendingEntry()) {
     reload_on_ready_callback_ =
-        base::BindOnce(&EphemeralStorageTabHelper::ReloadBypassingCache,
-                       weak_factory_.GetWeakPtr());
+        base::BindOnce(&EphemeralStorageTabHelper::MaybeReloadBypassingCache,
+                       weak_factory_.GetWeakPtr(), cleaned_ephemeral_domain);
     return;
   }
-  ReloadBypassingCache();
+  MaybeReloadBypassingCache(cleaned_ephemeral_domain);
 }
 
 void EphemeralStorageTabHelper::DidStartNavigation(
@@ -209,6 +210,10 @@ void EphemeralStorageTabHelper::ReadyToCommitNavigation(
   UpdateShieldsState(new_url);
 }
 
+void EphemeralStorageTabHelper::WebContentsDestroyed() {
+  reload_on_ready_callback_.Reset();
+}
+
 void EphemeralStorageTabHelper::CreateEphemeralStorageAreasForDomainAndURL(
     const std::string& new_domain,
     const GURL& new_url) {
@@ -264,19 +269,45 @@ void EphemeralStorageTabHelper::UpdateShieldsState(const GURL& url) {
       url.host(), shields_enabled && cookies_restricted);
 }
 
-void EphemeralStorageTabHelper::ReloadBypassingCache() {
-  if (!web_contents()) {
+void EphemeralStorageTabHelper::MaybeReloadBypassingCache(
+    const std::string& cleaned_ephemeral_domain) {
+  auto& controller = web_contents()->GetController();
+
+  // Check if a navigation is currently in progress
+  if (controller.GetPendingEntry() || web_contents()->IsLoading()) {
+    const std::string pending_domain =
+        net::URLToEphemeralStorageDomain(web_contents()->GetVisibleURL());
+    if (pending_domain == cleaned_ephemeral_domain) {
+      reload_on_ready_callback_ =
+          base::BindOnce(&EphemeralStorageTabHelper::MaybeReloadBypassingCache,
+                         weak_factory_.GetWeakPtr(), cleaned_ephemeral_domain);
+    } else {
+      DVLOG(1) << __func__ << " Dropped cache-bypassing reload; user "
+               << "navigated to a different ephemeral domain: "
+               << web_contents()->GetVisibleURL();
+    }
     return;
   }
 
-  auto& controller = web_contents()->GetController();
-  
-  // Check if a navigation is currently in progress
-  if (controller.GetPendingEntry() || web_contents()->IsLoading()) {
-     DVLOG(1) << __func__ << " Could not reload while bypassing the cache " << web_contents()->GetURL();
-     return;
+  // Guard against reloading a page the user has navigated to since the
+  // cleanup was requested.
+  const std::string committed_domain =
+      net::URLToEphemeralStorageDomain(web_contents()->GetLastCommittedURL());
+  if (committed_domain != cleaned_ephemeral_domain) {
+    DVLOG(1) << __func__ << " Dropped cache-bypassing reload; committed "
+             << "domain changed: " << web_contents()->GetLastCommittedURL();
+    return;
   }
-  
+
+  // Prevent non-user-initiated reloads from re-triggering purchases, comments,
+  // and similar actions.
+  const content::NavigationEntry* entry =
+      web_contents()->GetController().GetLastCommittedEntry();
+  if (entry && entry->GetHasPostData()) {
+    DVLOG(1) << __func__ << " Dropped cache-bypassing reload; committed "
+             << "entry has POST data.";
+    return;
+  }
   controller.Reload(content::ReloadType::BYPASSING_CACHE, false);
 }
 

--- a/browser/ephemeral_storage/ephemeral_storage_tab_helper.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_tab_helper.cc
@@ -210,10 +210,6 @@ void EphemeralStorageTabHelper::ReadyToCommitNavigation(
   UpdateShieldsState(new_url);
 }
 
-void EphemeralStorageTabHelper::WebContentsDestroyed() {
-  reload_on_ready_callback_.Reset();
-}
-
 void EphemeralStorageTabHelper::CreateEphemeralStorageAreasForDomainAndURL(
     const std::string& new_domain,
     const GURL& new_url) {
@@ -276,7 +272,7 @@ void EphemeralStorageTabHelper::MaybeReloadBypassingCache(
   // Check if a navigation is currently in progress
   if (controller.GetPendingEntry() || web_contents()->IsLoading()) {
     const std::string pending_domain =
-        net::URLToEphemeralStorageDomain(web_contents()->GetVisibleURL());
+        net::URLToEphemeralStorageDomain(web_contents()->GetLastCommittedURL());
     if (pending_domain == cleaned_ephemeral_domain) {
       reload_on_ready_callback_ =
           base::BindOnce(&EphemeralStorageTabHelper::MaybeReloadBypassingCache,
@@ -284,7 +280,7 @@ void EphemeralStorageTabHelper::MaybeReloadBypassingCache(
     } else {
       DVLOG(1) << __func__ << " Dropped cache-bypassing reload; user "
                << "navigated to a different ephemeral domain: "
-               << web_contents()->GetVisibleURL();
+               << web_contents()->GetLastCommittedURL();
     }
     return;
   }
@@ -323,6 +319,7 @@ void EphemeralStorageTabHelper::WillCloseTab(TabAndroid* tab) {
   weak_factory_.InvalidateWeakPtrs();
   RemoveTabModelObserver(registered_tab_model_, this);
   registered_tab_model_ = nullptr;
+  reload_on_ready_callback_.Reset();
 }
 #endif
 

--- a/browser/ephemeral_storage/ephemeral_storage_tab_helper.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_tab_helper.cc
@@ -8,6 +8,7 @@
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_forward.h"
+#include "base/logging.h"
 #include "base/task/sequenced_task_runner.h"
 #include "brave/browser/ephemeral_storage/ephemeral_storage_service_factory.h"
 #include "brave/components/brave_shields/core/browser/brave_shields_utils.h"
@@ -113,7 +114,6 @@ EphemeralStorageTabHelper::EphemeralStorageTabHelper(WebContents* web_contents)
 }
 
 EphemeralStorageTabHelper::~EphemeralStorageTabHelper() {
-  LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::~EphemeralStorageTabHelper  url:" << (web_contents() ? web_contents()->GetURL().spec() : "n/a");
 #if BUILDFLAG(IS_ANDROID)
   // Always remove observer in destructor using the stored TabModel pointer.
   // We can't rely on web_contents() here as it may already be destroyed.
@@ -140,16 +140,12 @@ void EphemeralStorageTabHelper::EnforceFirstPartyStorageCleanup(
 
 void EphemeralStorageTabHelper::ReloadBypassingCacheWhenReady() {
    auto& controller = web_contents()->GetController();
-  if (controller.GetPendingEntry()
-      //|| controller.NeedsReload()
-    ) {
-    LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::ReloadBypassingCacheWhenReady #100 url:" << web_contents()->GetURL();
+  if (controller.GetPendingEntry()) {
     reload_on_ready_callback_ =
         base::BindOnce(&EphemeralStorageTabHelper::ReloadBypassingCache,
                        weak_factory_.GetWeakPtr());
     return;
   }
-  LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::ReloadBypassingCacheWhenReady #200 url:" << web_contents()->GetURL();
   ReloadBypassingCache();
 }
 
@@ -188,8 +184,6 @@ void EphemeralStorageTabHelper::DidFinishNavigation(
       reload_on_ready_callback_) {
     base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
         FROM_HERE, std::move(reload_on_ready_callback_));
-    LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::DidFinishNavigation url:"
-              << navigation_handle->GetURL();
   }
 }
 
@@ -278,21 +272,11 @@ void EphemeralStorageTabHelper::ReloadBypassingCache() {
   auto& controller = web_contents()->GetController();
   
   // Check if a navigation is currently in progress
-  if (controller.GetPendingEntry()) {
-    LOG(WARNING) << "[SHRED] Reload skipped: Pending entry exists. URL: " << web_contents()->GetURL();
-    return;
-  }
-
-  // Check if the WebContents is currently loading (might catch more states)
-  if (web_contents()->IsLoading()) {
-     // Depending on your needs, you might want to force reload even here, 
-     // but usually it's safer to wait or abort.
-     LOG(WARNING) << "[SHRED] Reload skipped: Tab is currently loading. URL: " << web_contents()->GetURL();
-     // You might want to re-post this task or handle it differently
+  if (controller.GetPendingEntry() || web_contents()->IsLoading()) {
+     DVLOG(1) << __func__ << " Could not reload while bypassing the cache " << web_contents()->GetURL();
      return;
   }
   
-  LOG(INFO) << "[SHRED] Executing ReloadBypassingCache. URL: " << web_contents()->GetURL();
   controller.Reload(content::ReloadType::BYPASSING_CACHE, false);
 }
 
@@ -304,7 +288,6 @@ void EphemeralStorageTabHelper::WillCloseTab(TabAndroid* tab) {
   // Reset TLDEphemeralLifetime when a tab closes, since on Android
   // it may be invoked much later after the tab has actually closed.
   provisional_tld_ephemeral_lifetimes_.clear();
-  LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::WillCloseTab" << web_contents()->GetURL();
   tld_ephemeral_lifetime_.reset();
   weak_factory_.InvalidateWeakPtrs();
   RemoveTabModelObserver(registered_tab_model_, this);

--- a/browser/ephemeral_storage/ephemeral_storage_tab_helper.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_tab_helper.cc
@@ -6,12 +6,16 @@
 #include "brave/browser/ephemeral_storage/ephemeral_storage_tab_helper.h"
 
 #include "base/feature_list.h"
+#include "base/functional/bind.h"
+#include "base/functional/callback_forward.h"
+#include "base/task/sequenced_task_runner.h"
 #include "brave/browser/ephemeral_storage/ephemeral_storage_service_factory.h"
 #include "brave/components/brave_shields/core/browser/brave_shields_utils.h"
 #include "brave/components/ephemeral_storage/ephemeral_storage_service.h"
 #include "chrome/browser/content_settings/cookie_settings_factory.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/profiles/profile.h"
+#include "content/public/browser/navigation_controller.h"
 #include "content/public/browser/navigation_handle.h"
 #include "content/public/browser/security_principal.h"
 #include "content/public/browser/site_instance.h"
@@ -133,6 +137,22 @@ void EphemeralStorageTabHelper::EnforceFirstPartyStorageCleanup(
   }
 }
 
+void EphemeralStorageTabHelper::ReloadBypassingCacheWhenReady(base::OnceClosure pre_reload_callback) {
+   auto& controller = web_contents()->GetController();
+  if (controller.GetPendingEntry() || controller.NeedsReload()) {
+    LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::ReloadBypassingCacheWhenReady #100 url:" << web_contents()->GetURL();
+    if(!reload_on_ready_callback_.is_null()) {
+      LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::ReloadBypassingCacheWhenReady Owerwritten #500 url:" << web_contents()->GetURL();
+    }
+    reload_on_ready_callback_ =
+        base::BindOnce(&EphemeralStorageTabHelper::ReloadBypassingCache,
+                       weak_factory_.GetWeakPtr(), std::move(pre_reload_callback));
+    return;
+  }
+  LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::ReloadBypassingCacheWhenReady #200 url:" << web_contents()->GetURL();
+  ReloadBypassingCache(std::move(pre_reload_callback));
+}
+
 void EphemeralStorageTabHelper::DidStartNavigation(
     NavigationHandle* navigation_handle) {
   if (!navigation_handle->IsInMainFrame() ||
@@ -163,14 +183,34 @@ void EphemeralStorageTabHelper::DidFinishNavigation(
   // Clear all provisional ephemeral lifetimes. A committed ephemeral lifetime
   // is created in ReadyToCommitNavigation().
   provisional_tld_ephemeral_lifetimes_.clear();
+
+   if (reload_on_ready_callback_) {
+    // Cancel this navigation (which may be about to serve a stale response
+    // preferring cache, e.g. a tab restore) and reload it bypassing the
+    // cache. NavigationController::Reload() can't be called re-entrantly
+    // from here (DidStartNavigation() runs synchronously from within
+    // NavigateToExistingPendingEntry()), so post it instead.
+    
+    // base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+    //     FROM_HERE, base::BindOnce(&EphemeralStorageTabHelper::ReloadBypassingCache,
+    //                               weak_factory_.GetWeakPtr()));
+
+    LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::DidFinishNavigation url:" << navigation_handle->GetURL();
+    std::move(reload_on_ready_callback_).Run();
+
+    return;
+  }
+
 }
 
 void EphemeralStorageTabHelper::ReadyToCommitNavigation(
     NavigationHandle* navigation_handle) {
   if (!navigation_handle->IsInMainFrame()) {
+//    LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::ReadyToCommitNavigation #100 url:" << navigation_handle->GetURL();
     return;
   }
   if (navigation_handle->IsSameDocument()) {
+//    LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::ReadyToCommitNavigation #101 url:" << navigation_handle->GetURL();
     return;
   }
 
@@ -180,6 +220,7 @@ void EphemeralStorageTabHelper::ReadyToCommitNavigation(
   std::string new_domain = net::URLToEphemeralStorageDomain(new_url);
   std::string previous_domain =
       net::URLToEphemeralStorageDomain(last_committed_url);
+//LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::ReadyToCommitNavigation new_domain:" << new_domain << " previous_domain:" << previous_domain;
   if (new_domain != previous_domain) {
     // Create new storage areas for new ephemeral storage domain.
     CreateEphemeralStorageAreasForDomainAndURL(new_domain, new_url);
@@ -240,6 +281,15 @@ void EphemeralStorageTabHelper::UpdateShieldsState(const GURL& url) {
       brave_shields::ControlType::ALLOW;
   tld_ephemeral_lifetime_->SetShieldsStateOnHost(
       url.host(), shields_enabled && cookies_restricted);
+}
+
+void EphemeralStorageTabHelper::ReloadBypassingCache(base::OnceClosure pre_reload_callback) {
+  if(pre_reload_callback) {
+    LOG(INFO) << "[SHRED] EphemeralStorageTabHelper::ReloadBypassingCache callback call url:" << web_contents()->GetURL();
+    std::move(pre_reload_callback).Run();
+  }
+  web_contents()->GetController().Reload(content::ReloadType::BYPASSING_CACHE,
+                                         false);
 }
 
 #if BUILDFLAG(IS_ANDROID)

--- a/browser/ephemeral_storage/ephemeral_storage_tab_helper.h
+++ b/browser/ephemeral_storage/ephemeral_storage_tab_helper.h
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "base/containers/flat_set.h"
+#include "base/functional/callback_forward.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/unguessable_token.h"
@@ -56,6 +57,7 @@ class EphemeralStorageTabHelper
       const url::Origin& origin);
 
   void EnforceFirstPartyStorageCleanup(StorageCleanupMode mode);
+  void ReloadBypassingCacheWhenReady(base::OnceClosure pre_reload_callback);
 
  private:
   friend class content::WebContentsUserData<EphemeralStorageTabHelper>;
@@ -72,10 +74,15 @@ class EphemeralStorageTabHelper
 
   void CreateProvisionalTLDEphemeralLifetime(
       content::NavigationHandle* navigation_handle);
+  // NavigationController::Reload() can't be called re-entrantly from within
+  // DidStartNavigation(), which runs synchronously inside
+  // NavigateToExistingPendingEntry(). This is posted as a separate task so it
+  // runs after that call has unwound.
   void CreateEphemeralStorageAreasForDomainAndURL(const std::string& new_domain,
                                                   const GURL& new_url);
 
   void UpdateShieldsState(const GURL& url);
+  void ReloadBypassingCache(base::OnceClosure pre_reload_callback);
 
 #if BUILDFLAG(IS_ANDROID)
   // TabModelObserver
@@ -92,6 +99,7 @@ class EphemeralStorageTabHelper
   base::flat_set<scoped_refptr<TLDEphemeralLifetime>>
       provisional_tld_ephemeral_lifetimes_;
   scoped_refptr<TLDEphemeralLifetime> tld_ephemeral_lifetime_;
+  base::OnceClosure reload_on_ready_callback_;
 
   base::WeakPtrFactory<EphemeralStorageTabHelper> weak_factory_{this};
 

--- a/browser/ephemeral_storage/ephemeral_storage_tab_helper.h
+++ b/browser/ephemeral_storage/ephemeral_storage_tab_helper.h
@@ -57,7 +57,7 @@ class EphemeralStorageTabHelper
       const url::Origin& origin);
 
   void EnforceFirstPartyStorageCleanup(StorageCleanupMode mode);
-  void ReloadBypassingCacheWhenReady(base::OnceClosure pre_reload_callback);
+  void ReloadBypassingCacheWhenReady();
 
  private:
   friend class content::WebContentsUserData<EphemeralStorageTabHelper>;
@@ -82,7 +82,7 @@ class EphemeralStorageTabHelper
                                                   const GURL& new_url);
 
   void UpdateShieldsState(const GURL& url);
-  void ReloadBypassingCache(base::OnceClosure pre_reload_callback);
+  void ReloadBypassingCache();
 
 #if BUILDFLAG(IS_ANDROID)
   // TabModelObserver

--- a/browser/ephemeral_storage/ephemeral_storage_tab_helper.h
+++ b/browser/ephemeral_storage/ephemeral_storage_tab_helper.h
@@ -72,7 +72,6 @@ class EphemeralStorageTabHelper
       content::NavigationHandle* navigation_handle) override;
   void ReadyToCommitNavigation(
       content::NavigationHandle* navigation_handle) override;
-  void WebContentsDestroyed() override;
 
   void CreateProvisionalTLDEphemeralLifetime(
       content::NavigationHandle* navigation_handle);

--- a/browser/ephemeral_storage/ephemeral_storage_tab_helper.h
+++ b/browser/ephemeral_storage/ephemeral_storage_tab_helper.h
@@ -75,10 +75,6 @@ class EphemeralStorageTabHelper
 
   void CreateProvisionalTLDEphemeralLifetime(
       content::NavigationHandle* navigation_handle);
-  // NavigationController::Reload() can't be called re-entrantly from within
-  // DidStartNavigation(), which runs synchronously inside
-  // NavigateToExistingPendingEntry(). This is posted as a separate task so it
-  // runs after that call has unwound.
   void CreateEphemeralStorageAreasForDomainAndURL(const std::string& new_domain,
                                                   const GURL& new_url);
 

--- a/browser/ephemeral_storage/ephemeral_storage_tab_helper.h
+++ b/browser/ephemeral_storage/ephemeral_storage_tab_helper.h
@@ -57,7 +57,8 @@ class EphemeralStorageTabHelper
       const url::Origin& origin);
 
   void EnforceFirstPartyStorageCleanup(StorageCleanupMode mode);
-  void ReloadBypassingCacheWhenReady();
+  void ReloadBypassingCacheWhenReady(
+      const std::string& cleaned_ephemeral_domain);
 
  private:
   friend class content::WebContentsUserData<EphemeralStorageTabHelper>;
@@ -71,6 +72,7 @@ class EphemeralStorageTabHelper
       content::NavigationHandle* navigation_handle) override;
   void ReadyToCommitNavigation(
       content::NavigationHandle* navigation_handle) override;
+  void WebContentsDestroyed() override;
 
   void CreateProvisionalTLDEphemeralLifetime(
       content::NavigationHandle* navigation_handle);
@@ -82,7 +84,7 @@ class EphemeralStorageTabHelper
                                                   const GURL& new_url);
 
   void UpdateShieldsState(const GURL& url);
-  void ReloadBypassingCache();
+  void MaybeReloadBypassingCache(const std::string& cleaned_ephemeral_domain);
 
 #if BUILDFLAG(IS_ANDROID)
   // TabModelObserver

--- a/browser/ephemeral_storage/tld_ephemeral_lifetime.cc
+++ b/browser/ephemeral_storage/tld_ephemeral_lifetime.cc
@@ -9,10 +9,10 @@
 #include <map>
 
 #include "base/check.h"
+#include "base/logging.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/no_destructor.h"
 #include "brave/browser/ephemeral_storage/ephemeral_storage_service_factory.h"
-#include "base/logging.h"
 
 namespace ephemeral_storage {
 

--- a/browser/ephemeral_storage/tld_ephemeral_lifetime.cc
+++ b/browser/ephemeral_storage/tld_ephemeral_lifetime.cc
@@ -49,6 +49,7 @@ TLDEphemeralLifetime::~TLDEphemeralLifetime() {
   if (ephemeral_storage_service_) {
     const bool shields_disabled_on_one_of_hosts = std::ranges::any_of(
         shields_state_on_hosts_, [](const auto& v) { return !v.second; });
+LOG(INFO) << "[SHRED] TLDEphemeralLifetime::~TLDEphemeralLifetime  key_.storage_domain:" << key_.storage_domain;
     ephemeral_storage_service_->TLDEphemeralLifetimeDestroyed(
         key_.storage_domain, key_.storage_partition_config,
         shields_disabled_on_one_of_hosts, mode_);

--- a/browser/ephemeral_storage/tld_ephemeral_lifetime.cc
+++ b/browser/ephemeral_storage/tld_ephemeral_lifetime.cc
@@ -40,7 +40,6 @@ TLDEphemeralLifetime::TLDEphemeralLifetime(const TLDEphemeralLifetimeKey& key)
       EphemeralStorageServiceFactory::GetForContext(key.browser_context)
           ->GetWeakPtr();
   DCHECK(ephemeral_storage_service_);
-  LOG(INFO) << "[SHRED] TLDEphemeralLifetime::TLDEphemeralLifetime key:" << key.storage_domain;
   ephemeral_storage_service_->TLDEphemeralLifetimeCreated(
       key.storage_domain, key.storage_partition_config);
 }
@@ -49,7 +48,6 @@ TLDEphemeralLifetime::~TLDEphemeralLifetime() {
   if (ephemeral_storage_service_) {
     const bool shields_disabled_on_one_of_hosts = std::ranges::any_of(
         shields_state_on_hosts_, [](const auto& v) { return !v.second; });
-LOG(INFO) << "[SHRED] TLDEphemeralLifetime::~TLDEphemeralLifetime  key_.storage_domain:" << key_.storage_domain;
     ephemeral_storage_service_->TLDEphemeralLifetimeDestroyed(
         key_.storage_domain, key_.storage_partition_config,
         shields_disabled_on_one_of_hosts, mode_);

--- a/browser/ephemeral_storage/tld_ephemeral_lifetime.cc
+++ b/browser/ephemeral_storage/tld_ephemeral_lifetime.cc
@@ -12,6 +12,7 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/no_destructor.h"
 #include "brave/browser/ephemeral_storage/ephemeral_storage_service_factory.h"
+#include "base/logging.h"
 
 namespace ephemeral_storage {
 
@@ -39,6 +40,7 @@ TLDEphemeralLifetime::TLDEphemeralLifetime(const TLDEphemeralLifetimeKey& key)
       EphemeralStorageServiceFactory::GetForContext(key.browser_context)
           ->GetWeakPtr();
   DCHECK(ephemeral_storage_service_);
+  LOG(INFO) << "[SHRED] TLDEphemeralLifetime::TLDEphemeralLifetime key:" << key.storage_domain;
   ephemeral_storage_service_->TLDEphemeralLifetimeCreated(
       key.storage_domain, key.storage_partition_config);
 }

--- a/chromium_src/net/base/features.cc
+++ b/chromium_src/net/base/features.cc
@@ -58,11 +58,6 @@ BASE_FEATURE(kBraveForgetFirstPartyStorage,
 BASE_FEATURE(kBraveProvisionalTLDEphemeralLifetime,
              base::FEATURE_ENABLED_BY_DEFAULT);
 
-const base::FeatureParam<int>
-    kBraveForgetFirstPartyStorageStartupCleanupDelayInSeconds = {
-        &kBraveForgetFirstPartyStorage,
-        "BraveForgetFirstPartyStorageStartupCleanupDelayInSeconds", 5};
-
 const base::FeatureParam<bool> kBraveForgetFirstPartyStorageByDefault = {
     &kBraveForgetFirstPartyStorage, "BraveForgetFirstPartyStorageByDefault",
     false};

--- a/chromium_src/net/base/features.h
+++ b/chromium_src/net/base/features.h
@@ -26,8 +26,6 @@ NET_EXPORT BASE_DECLARE_FEATURE(kBravePartitionHSTS);
 NET_EXPORT BASE_DECLARE_FEATURE(kBraveTorWindowsHttpsOnly);
 NET_EXPORT BASE_DECLARE_FEATURE(kBraveForgetFirstPartyStorage);
 NET_EXPORT BASE_DECLARE_FEATURE(kBraveProvisionalTLDEphemeralLifetime);
-NET_EXPORT extern const base::FeatureParam<int>
-    kBraveForgetFirstPartyStorageStartupCleanupDelayInSeconds;
 NET_EXPORT extern const base::FeatureParam<bool>
     kBraveForgetFirstPartyStorageByDefault;
 

--- a/components/ephemeral_storage/ephemeral_storage_service.cc
+++ b/components/ephemeral_storage/ephemeral_storage_service.cc
@@ -129,7 +129,9 @@ bool IsFirstPartyStorageAreaKeepAliveExpired(const base::Value& value,
     return true;
   }
   const base::TimeDelta elapsed = base::Time::Now() - *closed_at;
-  LOG(INFO) << "[SHRED] IsFirstPartyStorageAreaKeepAliveExpired closed_at:" << closed_at.value() << " elapsed:" << elapsed.InSeconds() << " keep_alive:" << keep_alive <<  " elapsed >= keep_alive:" << (elapsed >= keep_alive) << " dict:" << (dict ? dict->DebugString() : "n/a");
+  DVLOG(1) << __func__ << " closed_at:" << closed_at.value()
+           << " elapsed:" << elapsed.InSeconds()
+           << " keep_alive:" << keep_alive;
   // A backwards clock jump is treated as an expired keepalive.
   return elapsed.is_negative() || elapsed >= keep_alive;
 }
@@ -437,14 +439,12 @@ void EphemeralStorageService::FirstPartyStorageAreaInUse(
 
   const GURL url(GetFirstPartyStorageURL(ephemeral_domain));
   const auto auto_shred_mode = delegate_->GetAutoShredMode(url);
+  DVLOG(1) << __func__ << " url:" << url;
+
   if (auto_shred_mode.has_value() &&
       auto_shred_mode.value() ==
           brave_shields::mojom::AutoShredMode::APP_EXIT) {
-    LOG(INFO) << "[SHRED] EphemeralStorageService::FirstPartyStorageAreaInUse #100 auto_shred_mode:"
-              << (auto_shred_mode.has_value()
-                      ? static_cast<int>(auto_shred_mode.value())
-                      : -1)
-              << " url:" << url;
+    DVLOG(1) << __func__ << " Skipped for app exit mode url:" << url;
     return;
   }
 
@@ -454,20 +454,9 @@ void EphemeralStorageService::FirstPartyStorageAreaInUse(
           *pref_update, url, storage_partition_config)) {
     keep_alive_expired = IsFirstPartyStorageAreaKeepAliveExpired(
         *queued_area, tld_ephemeral_area_keep_alive_);
-    LOG(INFO) << "[SHRED] EphemeralStorageService::FirstPartyStorageAreaInUse #200 auto_shred_mode:"
-              << (auto_shred_mode.has_value()
-                      ? static_cast<int>(auto_shred_mode.value())
-                      : -1)
-              << " url:" << url;
   }
 
   if (!keep_alive_expired) {
-    LOG(INFO) << "[SHRED] EphemeralStorageService::FirstPartyStorageAreaInUse "
-                 "#300 auto_shred_mode:"
-              << (auto_shred_mode.has_value()
-                      ? static_cast<int>(auto_shred_mode.value())
-                      : -1)
-              << " url:" << url;
     // Make sure to cancel the scheduled cleanup for this area.
     EraseFirstPartyStorageArea(*pref_update, url, storage_partition_config);
     EraseFirstPartyStorageArea(first_party_storage_areas_to_cleanup_on_startup_,
@@ -520,12 +509,6 @@ bool EphemeralStorageService::FirstPartyStorageAreaNotInUse(
   if (!context_->IsOffTheRecord()) {
     ScopedListPrefUpdate pref_update(prefs_,
                                      kFirstPartyStorageOriginsToCleanup);
-LOG(INFO) << "[SHRED] EphemeralStorageService::FirstPartyStorageAreaNotInUse "
-                 "#300 auto_shred_mode:"
-              << (auto_shred_mode.has_value()
-                      ? static_cast<int>(auto_shred_mode.value())
-                      : -1)
-              << " url:" << url;
     // Replace a possibly stale entry to store the actual close time.
     update_fp_storage_origins_to_cleanup_.Run(pref_update, url, storage_partition_config);
   }
@@ -600,9 +583,7 @@ void EphemeralStorageService::CleanupOnStartup() {
   DCHECK(!context_->IsOffTheRecord());
   first_party_storage_areas_to_cleanup_on_startup_ =
       prefs_->GetList(kFirstPartyStorageOriginsToCleanup).Clone();
-
-  LOG(INFO) << "[SHRED] EphemeralStorageService::CleanupOnStartup list:"
-            << first_party_storage_areas_to_cleanup_on_startup_.DebugString();
+  DVLOG(1) << __func__ << " Queued for cleanup:" << first_party_storage_areas_to_cleanup_on_startup_.DebugString();
 
   ScopedListPrefUpdate pref_update(prefs_, kFirstPartyStorageOriginsToCleanup);
 
@@ -612,7 +593,6 @@ void EphemeralStorageService::CleanupOnStartup() {
     pref_update->EraseValue(area_to_cleanup);
     if (!IsFirstPartyStorageAreaKeepAliveExpired(
             area_to_cleanup, tld_ephemeral_area_keep_alive_)) {
-LOG(INFO) << "[SHRED] EphemeralStorageService::CleanupOnStartup #100";
       continue;
     }
 
@@ -620,17 +600,14 @@ LOG(INFO) << "[SHRED] EphemeralStorageService::CleanupOnStartup #100";
         GetFirstPartyStorageURLAndStoragePartitionConfig(area_to_cleanup,
                                                          context_);
     if (!url_and_storage_partition_config) {
-LOG(INFO) << "[SHRED] EphemeralStorageService::CleanupOnStartup #200";
       continue;
     }
 
     const auto& [url, storage_partition_config] =
         *url_and_storage_partition_config;
     if (!url.is_valid()) {
-LOG(INFO) << "[SHRED] EphemeralStorageService::CleanupOnStartup #300";
       continue;
     }
-    LOG(INFO) << "[SHRED] EphemeralStorageService::CleanupOnStartup area_to_cleanup:" << area_to_cleanup.DebugString();
 
     CleanupPendingFirstPartyStorageArea(url, storage_partition_config,
             delegate_->GetAutoShredMode(url), 

--- a/components/ephemeral_storage/ephemeral_storage_service.cc
+++ b/components/ephemeral_storage/ephemeral_storage_service.cc
@@ -12,6 +12,7 @@
 
 #include "base/check.h"
 #include "base/functional/bind.h"
+#include "base/json/values_util.h"
 #include "base/logging.h"
 #include "base/strings/strcat.h"
 #include "base/task/sequenced_task_runner.h"
@@ -37,6 +38,15 @@ namespace ephemeral_storage {
 
 namespace {
 
+// Keys of a first party storage area entry stored in the
+// kFirstPartyStorageOriginsToCleanup pref.
+constexpr char kUrlKey[] = "u";
+constexpr char kPartitionDomainKey[] = "pd";
+constexpr char kPartitionNameKey[] = "pn";
+// Time of the last tab close. Entries stored by older versions don't have it
+// and are always treated as expired.
+constexpr char kClosedAtKey[] = "t";
+
 GURL GetFirstPartyStorageURL(const std::string& ephemeral_domain) {
   return GURL(base::StrCat({url::kHttpsScheme, "://", ephemeral_domain}));
 }
@@ -45,12 +55,78 @@ base::Value GetFirstPartyStorageValueToCleanup(
     const GURL& url,
     const content::StoragePartitionConfig& storage_partition_config) {
   if (storage_partition_config.is_default()) {
-    return base::Value(url.spec());
+    LOG(INFO) << "[SHRED] GetFirstPartyStorageValueToCleanup url:" << url << " is_default:1 storage_partition_config:" << storage_partition_config;
+   // return base::Value(url.spec());
   }
-  return base::Value(base::DictValue()
-                         .Set("u", url.spec())
-                         .Set("pd", storage_partition_config.partition_domain())
-                         .Set("pn", storage_partition_config.partition_name()));
+  return base::Value(
+      base::DictValue()
+          .Set(kUrlKey, url.spec())
+          .Set(kPartitionDomainKey,
+               storage_partition_config.partition_domain())
+          .Set(kPartitionNameKey, storage_partition_config.partition_name())
+          .Set(kClosedAtKey, base::TimeToValue(base::Time::Now())));
+}
+
+// Matches a stored entry by the storage area identity only, ignoring the close
+// time.
+bool IsSameFirstPartyStorageArea(
+    const base::Value& value,
+    const GURL& url,
+    const content::StoragePartitionConfig& storage_partition_config) {
+  if (value.is_string()) {
+    // Entries stored by older versions used a bare url spec for the default
+    // storage partition.
+    return storage_partition_config.is_default() &&
+           value.GetString() == url.spec();
+  }
+  const base::DictValue* dict = value.GetIfDict();
+  if (!dict) {
+    return false;
+  }
+  const std::string* url_spec = dict->FindString(kUrlKey);
+  const std::string* partition_domain = dict->FindString(kPartitionDomainKey);
+  const std::string* partition_name = dict->FindString(kPartitionNameKey);
+  return url_spec && partition_domain && partition_name &&
+         *url_spec == url.spec() &&
+         *partition_domain == storage_partition_config.partition_domain() &&
+         *partition_name == storage_partition_config.partition_name();
+}
+
+const base::Value* FindFirstPartyStorageArea(
+    const base::ListValue& list,
+    const GURL& url,
+    const content::StoragePartitionConfig& storage_partition_config) {
+  for (const base::Value& value : list) {
+    if (IsSameFirstPartyStorageArea(value, url, storage_partition_config)) {
+      return &value;
+    }
+  }
+  return nullptr;
+}
+
+void EraseFirstPartyStorageArea(
+    base::ListValue& list,
+    const GURL& url,
+    const content::StoragePartitionConfig& storage_partition_config) {
+  list.EraseIf([&](const base::Value& value) {
+    return IsSameFirstPartyStorageArea(value, url, storage_partition_config);
+  });
+}
+
+// Returns true if the keepalive that was pending when the area was stored has
+// already elapsed, i.e. using the area again should no longer cancel the queued
+// cleanup.
+bool IsFirstPartyStorageAreaKeepAliveExpired(const base::Value& value,
+                                             base::TimeDelta keep_alive) {
+  const base::DictValue* dict = value.GetIfDict();
+  const std::optional<base::Time> closed_at =
+      dict ? base::ValueToTime(dict->Find(kClosedAtKey)) : std::nullopt;
+  if (!closed_at) {
+    return true;
+  }
+  const base::TimeDelta elapsed = base::Time::Now() - *closed_at;
+  // A backwards clock jump is treated as an expired keepalive.
+  return elapsed.is_negative() || elapsed >= keep_alive;
 }
 
 std::optional<std::pair<GURL, content::StoragePartitionConfig>>
@@ -66,11 +142,18 @@ GetFirstPartyStorageURLAndStoragePartitionConfig(
     return std::nullopt;
   }
   const auto& dict = value.GetDict();
-  const std::string* url_spec = dict.FindString("u");
-  const std::string* partition_domain = dict.FindString("pd");
-  const std::string* partition_name = dict.FindString("pn");
+  const std::string* url_spec = dict.FindString(kUrlKey);
+  const std::string* partition_domain = dict.FindString(kPartitionDomainKey);
+  const std::string* partition_name = dict.FindString(kPartitionNameKey);
   if (!url_spec || !partition_domain || !partition_name) {
     return std::nullopt;
+  }
+  if (partition_domain->empty()) {
+    // The default storage partition is stored with empty partition values,
+    // StoragePartitionConfig::Create() doesn't accept them.
+    return std::make_pair(
+        GURL(*url_spec),
+        content::StoragePartitionConfig::CreateDefault(browser_context));
   }
   return std::make_pair(
       GURL(*url_spec),
@@ -337,23 +420,48 @@ void EphemeralStorageService::FirstPartyStorageAreaInUse(
     return;
   }
 
-  if (!context_->IsOffTheRecord()) {
-    const GURL url(GetFirstPartyStorageURL(ephemeral_domain));
-    const base::Value value_to_cleanup =
-        GetFirstPartyStorageValueToCleanup(url, storage_partition_config);
-    auto auto_shred_mode = delegate_->GetAutoShredMode(url);
-    if (auto_shred_mode.has_value() &&
-        auto_shred_mode.value() ==
-            brave_shields::mojom::AutoShredMode::APP_EXIT) {
-      return;
-    }
+  if (context_->IsOffTheRecord()) {
+    return;
+  }
+
+  const GURL url(GetFirstPartyStorageURL(ephemeral_domain));
+  const auto auto_shred_mode = delegate_->GetAutoShredMode(url);
+  if (auto_shred_mode.has_value() &&
+      auto_shred_mode.value() ==
+          brave_shields::mojom::AutoShredMode::APP_EXIT) {
+    return;
+  }
+
+  bool keep_alive_expired = false;
+  {
     ScopedListPrefUpdate pref_update(prefs_,
                                      kFirstPartyStorageOriginsToCleanup);
-    pref_update->EraseValue(value_to_cleanup);
+    if (const base::Value* queued_area = FindFirstPartyStorageArea(
+            *pref_update, url, storage_partition_config)) {
+      keep_alive_expired = IsFirstPartyStorageAreaKeepAliveExpired(
+          *queued_area, tld_ephemeral_area_keep_alive_);
+    }
+    LOG(INFO) << "[SHRED] FirstPartyStorageAreaInUse #100 Keep Alive Expired \nurl:" << url 
+        << " \nstorage_partition_config:" << storage_partition_config
+        << " \nfirst_party_storage_areas_to_cleanup_on_startup_:" << first_party_storage_areas_to_cleanup_on_startup_.DebugString();
 
+
+    if(!keep_alive_expired) {
+    EraseFirstPartyStorageArea(*pref_update, url, storage_partition_config);
     // Make sure to cancel the scheduled cleanup for this area.
-    first_party_storage_areas_to_cleanup_on_startup_.EraseValue(
-        value_to_cleanup);
+    EraseFirstPartyStorageArea(first_party_storage_areas_to_cleanup_on_startup_,
+                               url, storage_partition_config);
+    }
+  }
+
+  if (keep_alive_expired) {
+ //   LOG(INFO) << "[SHRED] FirstPartyStorageAreaInUse #200 Keep Alive Expired url:" << url << " storage_partition_config:" << storage_partition_config;
+    // The keepalive elapsed while the browser was not running, so the storage
+    // must still be cleaned up even though the area is used again. Do it now,
+    // before the navigation is committed, instead of waiting for the startup
+    // cleanup timer.
+ //   CleanupPendingFirstPartyStorageArea(url, storage_partition_config,
+ //                                       auto_shred_mode);
   }
 }
 
@@ -402,6 +510,8 @@ bool EphemeralStorageService::FirstPartyStorageAreaNotInUse(
   if (!context_->IsOffTheRecord()) {
     ScopedListPrefUpdate pref_update(prefs_,
                                      kFirstPartyStorageOriginsToCleanup);
+    // Replace a possibly stale entry to store the actual close time.
+    EraseFirstPartyStorageArea(*pref_update, url, storage_partition_config);
     pref_update->Append(
         GetFirstPartyStorageValueToCleanup(url, storage_partition_config));
   }
@@ -446,11 +556,28 @@ void EphemeralStorageService::CleanupFirstPartyStorageArea(
   DVLOG(1) << __func__ << " " << key.first << " " << key.second;
   delegate_->CleanupFirstPartyStorageArea(key);
   if (!context_->IsOffTheRecord()) {
-    const base::Value value_to_cleanup = GetFirstPartyStorageValueToCleanup(
-        GetFirstPartyStorageURL(key.first), key.second);
     ScopedListPrefUpdate pref_update(prefs_,
                                      kFirstPartyStorageOriginsToCleanup);
-    pref_update->EraseValue(value_to_cleanup);
+    EraseFirstPartyStorageArea(*pref_update, GetFirstPartyStorageURL(key.first),
+                               key.second);
+  }
+}
+
+void EphemeralStorageService::CleanupPendingFirstPartyStorageArea(
+    const GURL& url,
+    const content::StoragePartitionConfig& storage_partition_config,
+    const std::optional<brave_shields::mojom::AutoShredMode>& auto_shred_mode) {
+  DVLOG(1) << __func__ << " " << url << " " << storage_partition_config;
+  const TLDEphemeralAreaKey key(std::string(url.host()),
+                                storage_partition_config);
+  delegate_->CleanupFirstPartyStorageArea(key);
+
+  if (auto_shred_mode.has_value() &&
+      auto_shred_mode.value() != brave_shields::mojom::AutoShredMode::NEVER &&
+      delegate_->IsShredBrowsingHistoryEnabled()) {
+    // We should clean up the browsing history if shred for browsing history is
+    // enabled.
+    delegate_->CleanupTLDBrowsingHistory(key);
   }
 }
 
@@ -459,6 +586,13 @@ void EphemeralStorageService::ScheduleFirstPartyStorageAreasCleanupOnStartup() {
   DCHECK(!context_->IsOffTheRecord());
   first_party_storage_areas_to_cleanup_on_startup_ =
       prefs_->GetList(kFirstPartyStorageOriginsToCleanup).Clone();
+
+LOG(INFO) << "[SHRED] ScheduleFirstPartyStorageAreasCleanupOnStartup list:" << first_party_storage_areas_to_cleanup_on_startup_.DebugString();
+  // Areas whose keepalive elapsed while the browser was not running are cleaned
+  // up right away: using them again must not cancel a cleanup that is already
+  // due. The remaining ones stay scheduled and can still be cancelled by
+  // FirstPartyStorageAreaInUse().
+  CleanupExpiredFirstPartyStorageAreasOnStartup();
 
   first_party_storage_areas_startup_cleanup_timer_.Start(
       FROM_HERE,
@@ -469,16 +603,53 @@ void EphemeralStorageService::ScheduleFirstPartyStorageAreasCleanupOnStartup() {
                      weak_ptr_factory_.GetWeakPtr()));
 }
 
+void EphemeralStorageService::CleanupExpiredFirstPartyStorageAreasOnStartup() {
+  DCHECK(!context_->IsOffTheRecord());
+  base::ListValue areas_to_cleanup_by_timer;
+  ScopedListPrefUpdate pref_update(prefs_, kFirstPartyStorageOriginsToCleanup);
+
+  for (base::Value& area_to_cleanup :
+       first_party_storage_areas_to_cleanup_on_startup_) {
+    if (!IsFirstPartyStorageAreaKeepAliveExpired(
+            area_to_cleanup, tld_ephemeral_area_keep_alive_)) {
+      areas_to_cleanup_by_timer.Append(std::move(area_to_cleanup));
+      continue;
+    }
+    LOG(INFO) << "[SHRED] CleanupExpiredFirstPartyStorageAreasOnStartup area_to_cleanup:" << area_to_cleanup.DebugString();
+    pref_update->EraseValue(area_to_cleanup);
+
+    const auto url_and_storage_partition_config =
+        GetFirstPartyStorageURLAndStoragePartitionConfig(area_to_cleanup,
+                                                         context_);
+    if (!url_and_storage_partition_config) {
+      LOG(INFO) << "[SHRED] CleanupExpiredFirstPartyStorageAreasOnStartup #100 area_to_cleanup:" << area_to_cleanup.DebugString();
+      continue;
+    }
+    const auto& [url, storage_partition_config] =
+        *url_and_storage_partition_config;
+    if (!url.is_valid()) {
+      LOG(INFO) << "[SHRED] CleanupExpiredFirstPartyStorageAreasOnStartup #200 area_to_cleanup:" << area_to_cleanup.DebugString();
+      continue;
+    }
+    LOG(INFO) << "[SHRED] CleanupExpiredFirstPartyStorageAreasOnStartup #50 area_to_cleanup:" << area_to_cleanup.DebugString();
+    CleanupPendingFirstPartyStorageArea(url, storage_partition_config,
+                                        delegate_->GetAutoShredMode(url));
+  }
+
+  first_party_storage_areas_to_cleanup_on_startup_ =
+      std::move(areas_to_cleanup_by_timer);
+}
+
 void EphemeralStorageService::CleanupOnStartup() {
   DCHECK(!context_->IsOffTheRecord());
   ScopedListPrefUpdate pref_update(prefs_, kFirstPartyStorageOriginsToCleanup);
 
-  for (const auto& url_to_cleanup :
+  for (const auto& area_to_cleanup :
        first_party_storage_areas_to_cleanup_on_startup_) {
     const auto url_and_storage_partition_config =
-        GetFirstPartyStorageURLAndStoragePartitionConfig(url_to_cleanup,
+        GetFirstPartyStorageURLAndStoragePartitionConfig(area_to_cleanup,
                                                          context_);
-    pref_update->EraseValue(url_to_cleanup);
+    pref_update->EraseValue(area_to_cleanup);
     if (!url_and_storage_partition_config) {
       continue;
     }
@@ -487,19 +658,12 @@ void EphemeralStorageService::CleanupOnStartup() {
     if (!url.is_valid()) {
       continue;
     }
+    // The stored entry may have been replaced with a newer close time after the
+    // startup snapshot was taken, erase it by the area identity too.
+    EraseFirstPartyStorageArea(*pref_update, url, storage_partition_config);
 
-    auto key =
-        std::make_pair(std::string(url.host()), storage_partition_config);
-    delegate_->CleanupFirstPartyStorageArea(key);
-
-    const auto auto_shred_mode = delegate_->GetAutoShredMode(url);
-    if (auto_shred_mode.has_value() &&
-        auto_shred_mode.value() != brave_shields::mojom::AutoShredMode::NEVER &&
-        delegate_->IsShredBrowsingHistoryEnabled()) {
-      // We should clean up the browsing history if shred for browsing
-      // history is enabled
-      delegate_->CleanupTLDBrowsingHistory(key);
-    }
+    CleanupPendingFirstPartyStorageArea(url, storage_partition_config,
+                                        delegate_->GetAutoShredMode(url));
   }
   first_party_storage_areas_to_cleanup_on_startup_.clear();
 }

--- a/components/ephemeral_storage/ephemeral_storage_service.cc
+++ b/components/ephemeral_storage/ephemeral_storage_service.cc
@@ -671,7 +671,7 @@ size_t EphemeralStorageService::FireCleanupTimersForTesting() {
   }
   const size_t first_party_storage_areas_to_cleanup_count =
       first_party_storage_areas_to_cleanup_on_startup_.size();
-  DCHECK(first_party_storage_areas_to_cleanup_on_startup_.empty());
+  DCHECK(first_party_storage_areas_to_cleanup_on_startup_.empty());  
   return timers.size() + first_party_storage_areas_to_cleanup_count;
 }
 

--- a/components/ephemeral_storage/ephemeral_storage_service.cc
+++ b/components/ephemeral_storage/ephemeral_storage_service.cc
@@ -54,10 +54,6 @@ GURL GetFirstPartyStorageURL(const std::string& ephemeral_domain) {
 base::Value GetFirstPartyStorageValueToCleanup(
     const GURL& url,
     const content::StoragePartitionConfig& storage_partition_config) {
-  if (storage_partition_config.is_default()) {
-    LOG(INFO) << "[SHRED] GetFirstPartyStorageValueToCleanup url:" << url << " is_default:1 storage_partition_config:" << storage_partition_config;
-   // return base::Value(url.spec());
-  }
   return base::Value(
       base::DictValue()
           .Set(kUrlKey, url.spec())
@@ -133,6 +129,7 @@ std::optional<std::pair<GURL, content::StoragePartitionConfig>>
 GetFirstPartyStorageURLAndStoragePartitionConfig(
     const base::Value& value,
     content::BrowserContext* browser_context) {
+  // Support old format
   if (value.is_string()) {
     return std::make_pair(
         GURL(value.GetString()),
@@ -433,35 +430,18 @@ void EphemeralStorageService::FirstPartyStorageAreaInUse(
   }
 
   bool keep_alive_expired = false;
-  {
-    ScopedListPrefUpdate pref_update(prefs_,
-                                     kFirstPartyStorageOriginsToCleanup);
-    if (const base::Value* queued_area = FindFirstPartyStorageArea(
-            *pref_update, url, storage_partition_config)) {
-      keep_alive_expired = IsFirstPartyStorageAreaKeepAliveExpired(
-          *queued_area, tld_ephemeral_area_keep_alive_);
-    }
-    LOG(INFO) << "[SHRED] FirstPartyStorageAreaInUse #100 Keep Alive Expired \nurl:" << url 
-        << " \nstorage_partition_config:" << storage_partition_config
-        << " \nfirst_party_storage_areas_to_cleanup_on_startup_:" << first_party_storage_areas_to_cleanup_on_startup_.DebugString();
-
-
-    if(!keep_alive_expired) {
-    EraseFirstPartyStorageArea(*pref_update, url, storage_partition_config);
-    // Make sure to cancel the scheduled cleanup for this area.
-    EraseFirstPartyStorageArea(first_party_storage_areas_to_cleanup_on_startup_,
-                               url, storage_partition_config);
-    }
+  ScopedListPrefUpdate pref_update(prefs_, kFirstPartyStorageOriginsToCleanup);
+  if (const base::Value* queued_area = FindFirstPartyStorageArea(
+          *pref_update, url, storage_partition_config)) {
+    keep_alive_expired = IsFirstPartyStorageAreaKeepAliveExpired(
+        *queued_area, tld_ephemeral_area_keep_alive_);
   }
 
-  if (keep_alive_expired) {
- //   LOG(INFO) << "[SHRED] FirstPartyStorageAreaInUse #200 Keep Alive Expired url:" << url << " storage_partition_config:" << storage_partition_config;
-    // The keepalive elapsed while the browser was not running, so the storage
-    // must still be cleaned up even though the area is used again. Do it now,
-    // before the navigation is committed, instead of waiting for the startup
-    // cleanup timer.
- //   CleanupPendingFirstPartyStorageArea(url, storage_partition_config,
- //                                       auto_shred_mode);
+  if (!keep_alive_expired) {
+    // Make sure to cancel the scheduled cleanup for this area.
+    EraseFirstPartyStorageArea(*pref_update, url, storage_partition_config);
+    EraseFirstPartyStorageArea(first_party_storage_areas_to_cleanup_on_startup_,
+                               url, storage_partition_config);
   }
 }
 

--- a/components/ephemeral_storage/ephemeral_storage_service.cc
+++ b/components/ephemeral_storage/ephemeral_storage_service.cc
@@ -13,6 +13,7 @@
 #include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_forward.h"
+#include "base/functional/callback_helpers.h"
 #include "base/json/values_util.h"
 #include "base/logging.h"
 #include "base/strings/strcat.h"
@@ -58,8 +59,7 @@ base::Value GetFirstPartyStorageValueToCleanup(
   return base::Value(
       base::DictValue()
           .Set(kUrlKey, url.spec())
-          .Set(kPartitionDomainKey,
-               storage_partition_config.partition_domain())
+          .Set(kPartitionDomainKey, storage_partition_config.partition_domain())
           .Set(kPartitionNameKey, storage_partition_config.partition_name())
           .Set(kClosedAtKey, base::TimeToValue(base::Time::Now())));
 }
@@ -110,11 +110,13 @@ void EraseFirstPartyStorageArea(
   });
 }
 
-void UpsertFirstPartyStorageOriginsToCleanup(ScopedListPrefUpdate& pref_update, const GURL& url,
+void UpsertFirstPartyStorageOriginsToCleanup(
+    ScopedListPrefUpdate& pref_update,
+    const GURL& url,
     const content::StoragePartitionConfig& storage_partition_config) {
-    EraseFirstPartyStorageArea(*pref_update, url, storage_partition_config);
-    pref_update->Append(
-        GetFirstPartyStorageValueToCleanup(url, storage_partition_config));
+  EraseFirstPartyStorageArea(*pref_update, url, storage_partition_config);
+  pref_update->Append(
+      GetFirstPartyStorageValueToCleanup(url, storage_partition_config));
 }
 
 // Returns true if the keepalive that was pending when the area was stored has
@@ -179,7 +181,8 @@ EphemeralStorageService::EphemeralStorageService(
       host_content_settings_map_(host_content_settings_map),
       delegate_(std::move(delegate)),
       prefs_(user_prefs::UserPrefs::Get(context_)),
-      update_fp_storage_origins_to_cleanup_(base::BindRepeating(&UpsertFirstPartyStorageOriginsToCleanup)) {
+      update_fp_storage_origins_to_cleanup_(
+          base::BindRepeating(&UpsertFirstPartyStorageOriginsToCleanup)) {
   DCHECK(context_);
   DCHECK(host_content_settings_map_);
   DCHECK(delegate_);
@@ -188,9 +191,9 @@ EphemeralStorageService::EphemeralStorageService(
   tld_ephemeral_area_keep_alive_ = base::Seconds(
       net::features::kBraveEphemeralStorageKeepAliveTimeInSeconds.Get());
 
-  RegisterFirstWindowOpenedCallback(base::BindOnce(
-      &EphemeralStorageService::CleanupOnStartup,
-      weak_ptr_factory_.GetWeakPtr()));
+  RegisterFirstWindowOpenedCallback(
+      base::BindOnce(&EphemeralStorageService::CleanupOnStartup,
+                     weak_ptr_factory_.GetWeakPtr()));
 }
 
 EphemeralStorageService::~EphemeralStorageService() = default;
@@ -390,9 +393,9 @@ void EphemeralStorageService::RemoveObserver(
 void EphemeralStorageService::TriggerCurrentAppStateNotification() {
   // Register again, as on Android the EphemeralStorageService may remain alive
   // across multiple app states, requiring the callback to be re-registered.
-  RegisterFirstWindowOpenedCallback(base::BindOnce(
-      &EphemeralStorageService::CleanupOnStartup,
-      weak_ptr_factory_.GetWeakPtr()));
+  RegisterFirstWindowOpenedCallback(
+      base::BindOnce(&EphemeralStorageService::CleanupOnStartup,
+                     weak_ptr_factory_.GetWeakPtr()));
 
   // For real cold start of the application we should not update saved time for
   // items saved in the kFirstPartyStorageOriginsToCleanup
@@ -510,7 +513,8 @@ bool EphemeralStorageService::FirstPartyStorageAreaNotInUse(
     ScopedListPrefUpdate pref_update(prefs_,
                                      kFirstPartyStorageOriginsToCleanup);
     // Replace a possibly stale entry to store the actual close time.
-    update_fp_storage_origins_to_cleanup_.Run(pref_update, url, storage_partition_config);
+    update_fp_storage_origins_to_cleanup_.Run(pref_update, url,
+                                              storage_partition_config);
   }
   return true;
 }
@@ -551,7 +555,7 @@ void EphemeralStorageService::CleanupTLDEphemeralArea(
 void EphemeralStorageService::CleanupFirstPartyStorageArea(
     const TLDEphemeralAreaKey& key) {
   DVLOG(1) << __func__ << " " << key.first << " " << key.second;
-  delegate_->CleanupFirstPartyStorageArea(key);
+  delegate_->CleanupFirstPartyStorageArea(key, base::NullCallback());
   if (!context_->IsOffTheRecord()) {
     ScopedListPrefUpdate pref_update(prefs_,
                                      kFirstPartyStorageOriginsToCleanup);
@@ -564,7 +568,7 @@ void EphemeralStorageService::CleanupPendingFirstPartyStorageArea(
     const GURL& url,
     const content::StoragePartitionConfig& storage_partition_config,
     const std::optional<brave_shields::mojom::AutoShredMode>& auto_shred_mode,
-  base::OnceClosure callback) {
+    base::OnceClosure callback) {
   DVLOG(1) << __func__ << " " << url << " " << storage_partition_config;
   const TLDEphemeralAreaKey key(std::string(url.host()),
                                 storage_partition_config);
@@ -583,18 +587,19 @@ void EphemeralStorageService::CleanupOnStartup() {
   DCHECK(!context_->IsOffTheRecord());
   first_party_storage_areas_to_cleanup_on_startup_ =
       prefs_->GetList(kFirstPartyStorageOriginsToCleanup).Clone();
-  DVLOG(1) << __func__ << " Queued for cleanup:" << first_party_storage_areas_to_cleanup_on_startup_.DebugString();
+  DVLOG(1) << __func__ << " Queued for cleanup:"
+           << first_party_storage_areas_to_cleanup_on_startup_.DebugString();
 
   ScopedListPrefUpdate pref_update(prefs_, kFirstPartyStorageOriginsToCleanup);
 
   std::vector<std::pair<std::string, base::OnceClosure>> ephemeral_domains;
   for (base::Value& area_to_cleanup :
        first_party_storage_areas_to_cleanup_on_startup_) {
-    pref_update->EraseValue(area_to_cleanup);
     if (!IsFirstPartyStorageAreaKeepAliveExpired(
             area_to_cleanup, tld_ephemeral_area_keep_alive_)) {
       continue;
     }
+    pref_update->EraseValue(area_to_cleanup);
 
     const auto url_and_storage_partition_config =
         GetFirstPartyStorageURLAndStoragePartitionConfig(area_to_cleanup,
@@ -609,11 +614,12 @@ void EphemeralStorageService::CleanupOnStartup() {
       continue;
     }
 
-    CleanupPendingFirstPartyStorageArea(url, storage_partition_config,
-            delegate_->GetAutoShredMode(url), 
-            base::BindOnce(
-            &EphemeralStorageServiceDelegate::ReloadTabIfMatchingEphemeralDomain,
-            delegate_->AsWeakPtr(), net::URLToEphemeralStorageDomain(url)));
+    CleanupPendingFirstPartyStorageArea(
+        url, storage_partition_config, delegate_->GetAutoShredMode(url),
+        base::BindOnce(&EphemeralStorageServiceDelegate::
+                           ReloadTabIfMatchingEphemeralDomain,
+                       delegate_->AsWeakPtr(),
+                       net::URLToEphemeralStorageDomain(url)));
   }
 
   first_party_storage_areas_to_cleanup_on_startup_.clear();
@@ -630,11 +636,13 @@ void EphemeralStorageService::RegisterFirstWindowOpenedCallback(
   delegate_->RegisterFirstWindowOpenedCallback(std::move(callback));
 }
 
-void EphemeralStorageService::SetUpdateFirstPartyStorageOriginToCleanUp(bool do_nothing) {
+void EphemeralStorageService::SetUpdateFirstPartyStorageOriginToCleanUp(
+    bool do_nothing) {
   if (do_nothing) {
     update_fp_storage_origins_to_cleanup_ = base::DoNothing();
   } else {
-    update_fp_storage_origins_to_cleanup_ = base::BindRepeating(&UpsertFirstPartyStorageOriginsToCleanup);
+    update_fp_storage_origins_to_cleanup_ =
+        base::BindRepeating(&UpsertFirstPartyStorageOriginsToCleanup);
   }
 }
 
@@ -648,7 +656,7 @@ size_t EphemeralStorageService::FireCleanupTimersForTesting() {
   }
   const size_t first_party_storage_areas_to_cleanup_count =
       first_party_storage_areas_to_cleanup_on_startup_.size();
-  DCHECK(first_party_storage_areas_to_cleanup_on_startup_.empty());  
+  DCHECK(first_party_storage_areas_to_cleanup_on_startup_.empty());
   return timers.size() + first_party_storage_areas_to_cleanup_count;
 }
 

--- a/components/ephemeral_storage/ephemeral_storage_service.cc
+++ b/components/ephemeral_storage/ephemeral_storage_service.cc
@@ -110,6 +110,13 @@ void EraseFirstPartyStorageArea(
   });
 }
 
+void UpsertFirstPartyStorageOriginsToCleanup(ScopedListPrefUpdate& pref_update, const GURL& url,
+    const content::StoragePartitionConfig& storage_partition_config) {
+    EraseFirstPartyStorageArea(*pref_update, url, storage_partition_config);
+    pref_update->Append(
+        GetFirstPartyStorageValueToCleanup(url, storage_partition_config));
+}
+
 // Returns true if the keepalive that was pending when the area was stored has
 // already elapsed, i.e. using the area again should no longer cancel the queued
 // cleanup.
@@ -122,6 +129,7 @@ bool IsFirstPartyStorageAreaKeepAliveExpired(const base::Value& value,
     return true;
   }
   const base::TimeDelta elapsed = base::Time::Now() - *closed_at;
+  LOG(INFO) << "[SHRED] IsFirstPartyStorageAreaKeepAliveExpired closed_at:" << closed_at.value() << " elapsed:" << elapsed.InSeconds() << " keep_alive:" << keep_alive <<  " elapsed >= keep_alive:" << (elapsed >= keep_alive) << " dict:" << (dict ? dict->DebugString() : "n/a");
   // A backwards clock jump is treated as an expired keepalive.
   return elapsed.is_negative() || elapsed >= keep_alive;
 }
@@ -168,7 +176,8 @@ EphemeralStorageService::EphemeralStorageService(
     : context_(context),
       host_content_settings_map_(host_content_settings_map),
       delegate_(std::move(delegate)),
-      prefs_(user_prefs::UserPrefs::Get(context_)) {
+      prefs_(user_prefs::UserPrefs::Get(context_)),
+      update_fp_storage_origins_to_cleanup_(base::BindRepeating(&UpsertFirstPartyStorageOriginsToCleanup)) {
   DCHECK(context_);
   DCHECK(host_content_settings_map_);
   DCHECK(delegate_);
@@ -178,7 +187,7 @@ EphemeralStorageService::EphemeralStorageService(
       net::features::kBraveEphemeralStorageKeepAliveTimeInSeconds.Get());
 
   RegisterFirstWindowOpenedCallback(base::BindOnce(
-      &EphemeralStorageService::ScheduleFirstPartyStorageAreasCleanupOnStartup,
+      &EphemeralStorageService::CleanupOnStartup,
       weak_ptr_factory_.GetWeakPtr()));
 }
 
@@ -380,10 +389,14 @@ void EphemeralStorageService::TriggerCurrentAppStateNotification() {
   // Register again, as on Android the EphemeralStorageService may remain alive
   // across multiple app states, requiring the callback to be re-registered.
   RegisterFirstWindowOpenedCallback(base::BindOnce(
-      &EphemeralStorageService::ScheduleFirstPartyStorageAreasCleanupOnStartup,
+      &EphemeralStorageService::CleanupOnStartup,
       weak_ptr_factory_.GetWeakPtr()));
 
+  // For real cold start of the application we should not update saved time for
+  // items saved in the kFirstPartyStorageOriginsToCleanup
+  SetUpdateFirstPartyStorageOriginToCleanUp(true);
   delegate_->TriggerCurrentAppStateNotification();
+  SetUpdateFirstPartyStorageOriginToCleanUp(false);
 }
 #endif  // BUILDFLAG(IS_ANDROID)
 
@@ -427,6 +440,11 @@ void EphemeralStorageService::FirstPartyStorageAreaInUse(
   if (auto_shred_mode.has_value() &&
       auto_shred_mode.value() ==
           brave_shields::mojom::AutoShredMode::APP_EXIT) {
+    LOG(INFO) << "[SHRED] EphemeralStorageService::FirstPartyStorageAreaInUse #100 auto_shred_mode:"
+              << (auto_shred_mode.has_value()
+                      ? static_cast<int>(auto_shred_mode.value())
+                      : -1)
+              << " url:" << url;
     return;
   }
 
@@ -436,9 +454,20 @@ void EphemeralStorageService::FirstPartyStorageAreaInUse(
           *pref_update, url, storage_partition_config)) {
     keep_alive_expired = IsFirstPartyStorageAreaKeepAliveExpired(
         *queued_area, tld_ephemeral_area_keep_alive_);
+    LOG(INFO) << "[SHRED] EphemeralStorageService::FirstPartyStorageAreaInUse #200 auto_shred_mode:"
+              << (auto_shred_mode.has_value()
+                      ? static_cast<int>(auto_shred_mode.value())
+                      : -1)
+              << " url:" << url;
   }
 
   if (!keep_alive_expired) {
+    LOG(INFO) << "[SHRED] EphemeralStorageService::FirstPartyStorageAreaInUse "
+                 "#300 auto_shred_mode:"
+              << (auto_shred_mode.has_value()
+                      ? static_cast<int>(auto_shred_mode.value())
+                      : -1)
+              << " url:" << url;
     // Make sure to cancel the scheduled cleanup for this area.
     EraseFirstPartyStorageArea(*pref_update, url, storage_partition_config);
     EraseFirstPartyStorageArea(first_party_storage_areas_to_cleanup_on_startup_,
@@ -491,10 +520,14 @@ bool EphemeralStorageService::FirstPartyStorageAreaNotInUse(
   if (!context_->IsOffTheRecord()) {
     ScopedListPrefUpdate pref_update(prefs_,
                                      kFirstPartyStorageOriginsToCleanup);
+LOG(INFO) << "[SHRED] EphemeralStorageService::FirstPartyStorageAreaNotInUse "
+                 "#300 auto_shred_mode:"
+              << (auto_shred_mode.has_value()
+                      ? static_cast<int>(auto_shred_mode.value())
+                      : -1)
+              << " url:" << url;
     // Replace a possibly stale entry to store the actual close time.
-    EraseFirstPartyStorageArea(*pref_update, url, storage_partition_config);
-    pref_update->Append(
-        GetFirstPartyStorageValueToCleanup(url, storage_partition_config));
+    update_fp_storage_origins_to_cleanup_.Run(pref_update, url, storage_partition_config);
   }
   return true;
 }
@@ -547,13 +580,12 @@ void EphemeralStorageService::CleanupFirstPartyStorageArea(
 void EphemeralStorageService::CleanupPendingFirstPartyStorageArea(
     const GURL& url,
     const content::StoragePartitionConfig& storage_partition_config,
-    const std::optional<brave_shields::mojom::AutoShredMode>& auto_shred_mode) {
+    const std::optional<brave_shields::mojom::AutoShredMode>& auto_shred_mode,
+  base::OnceClosure callback) {
   DVLOG(1) << __func__ << " " << url << " " << storage_partition_config;
   const TLDEphemeralAreaKey key(std::string(url.host()),
                                 storage_partition_config);
-LOG(INFO) << "[SHRED] EphemeralStorageService::CleanupPendingFirstPartyStorageArea key: " << key.first << " : " << key.second;
-  // delegate_->ReloadTabsMatchingFirstPartyStorageAreaFromNetwork(key);
-  delegate_->CleanupFirstPartyStorageArea(key);
+  delegate_->CleanupFirstPartyStorageArea(key, std::move(callback));
 
   if (auto_shred_mode.has_value() &&
       auto_shred_mode.value() != brave_shields::mojom::AutoShredMode::NEVER &&
@@ -564,95 +596,49 @@ LOG(INFO) << "[SHRED] EphemeralStorageService::CleanupPendingFirstPartyStorageAr
   }
 }
 
-void EphemeralStorageService::ScheduleFirstPartyStorageAreasCleanupOnStartup() {
-  DVLOG(1) << __func__;
+void EphemeralStorageService::CleanupOnStartup() {
   DCHECK(!context_->IsOffTheRecord());
   first_party_storage_areas_to_cleanup_on_startup_ =
       prefs_->GetList(kFirstPartyStorageOriginsToCleanup).Clone();
 
-LOG(INFO) << "[SHRED] ScheduleFirstPartyStorageAreasCleanupOnStartup list:" << first_party_storage_areas_to_cleanup_on_startup_.DebugString();
-  // Areas whose keepalive elapsed while the browser was not running are cleaned
-  // up right away: using them again must not cancel a cleanup that is already
-  // due. The remaining ones stay scheduled and can still be cancelled by
-  // FirstPartyStorageAreaInUse().
-  CleanupExpiredFirstPartyStorageAreasOnStartup();
+  LOG(INFO) << "[SHRED] EphemeralStorageService::CleanupOnStartup list:"
+            << first_party_storage_areas_to_cleanup_on_startup_.DebugString();
 
-  first_party_storage_areas_startup_cleanup_timer_.Start(
-      FROM_HERE,
-      base::Seconds(
-          net::features::
-              kBraveForgetFirstPartyStorageStartupCleanupDelayInSeconds.Get()),
-      base::BindOnce(&EphemeralStorageService::CleanupOnStartup,
-                     weak_ptr_factory_.GetWeakPtr()));
-}
-
-void EphemeralStorageService::CleanupExpiredFirstPartyStorageAreasOnStartup() {
-  DCHECK(!context_->IsOffTheRecord());
-  base::ListValue areas_to_cleanup_by_timer;
   ScopedListPrefUpdate pref_update(prefs_, kFirstPartyStorageOriginsToCleanup);
 
   std::vector<std::pair<std::string, base::OnceClosure>> ephemeral_domains;
   for (base::Value& area_to_cleanup :
        first_party_storage_areas_to_cleanup_on_startup_) {
+    pref_update->EraseValue(area_to_cleanup);
     if (!IsFirstPartyStorageAreaKeepAliveExpired(
             area_to_cleanup, tld_ephemeral_area_keep_alive_)) {
-      areas_to_cleanup_by_timer.Append(std::move(area_to_cleanup));
+LOG(INFO) << "[SHRED] EphemeralStorageService::CleanupOnStartup #100";
       continue;
     }
-    pref_update->EraseValue(area_to_cleanup);
 
     const auto url_and_storage_partition_config =
         GetFirstPartyStorageURLAndStoragePartitionConfig(area_to_cleanup,
                                                          context_);
     if (!url_and_storage_partition_config) {
+LOG(INFO) << "[SHRED] EphemeralStorageService::CleanupOnStartup #200";
       continue;
     }
 
     const auto& [url, storage_partition_config] =
         *url_and_storage_partition_config;
     if (!url.is_valid()) {
+LOG(INFO) << "[SHRED] EphemeralStorageService::CleanupOnStartup #300";
       continue;
     }
-    LOG(INFO) << "[SHRED] CleanupExpiredFirstPartyStorageAreasOnStartup #50 area_to_cleanup:" << area_to_cleanup.DebugString();
-
-    ephemeral_domains.emplace_back(net::URLToEphemeralStorageDomain(url), base::BindOnce(
-        &EphemeralStorageService::CleanupPendingFirstPartyStorageArea,
-        weak_ptr_factory_.GetWeakPtr(), url, storage_partition_config,
-        delegate_->GetAutoShredMode(url)));
-  }
-
-  // Refresh tabs for the cleaned websites
-  delegate_->ReloadTabIfMatchingEphemeralDomain(std::move(ephemeral_domains));
-
-  first_party_storage_areas_to_cleanup_on_startup_ =
-      std::move(areas_to_cleanup_by_timer);
-}
-
-void EphemeralStorageService::CleanupOnStartup() {
-  DCHECK(!context_->IsOffTheRecord());
-  ScopedListPrefUpdate pref_update(prefs_, kFirstPartyStorageOriginsToCleanup);
-
-  for (const auto& area_to_cleanup :
-       first_party_storage_areas_to_cleanup_on_startup_) {
-    const auto url_and_storage_partition_config =
-        GetFirstPartyStorageURLAndStoragePartitionConfig(area_to_cleanup,
-                                                         context_);
-    pref_update->EraseValue(area_to_cleanup);
-    if (!url_and_storage_partition_config) {
-      continue;
-    }
-    const auto& [url, storage_partition_config] =
-        *url_and_storage_partition_config;
-    if (!url.is_valid()) {
-      continue;
-    }
-    // The stored entry may have been replaced with a newer close time after the
-    // startup snapshot was taken, erase it by the area identity too.
-    EraseFirstPartyStorageArea(*pref_update, url, storage_partition_config);
+    LOG(INFO) << "[SHRED] EphemeralStorageService::CleanupOnStartup area_to_cleanup:" << area_to_cleanup.DebugString();
 
     CleanupPendingFirstPartyStorageArea(url, storage_partition_config,
-                                        delegate_->GetAutoShredMode(url));
+            delegate_->GetAutoShredMode(url), 
+            base::BindOnce(
+            &EphemeralStorageServiceDelegate::ReloadTabIfMatchingEphemeralDomain,
+            delegate_->AsWeakPtr(), net::URLToEphemeralStorageDomain(url)));
   }
+
   first_party_storage_areas_to_cleanup_on_startup_.clear();
 }
 
@@ -665,6 +651,14 @@ void EphemeralStorageService::RegisterFirstWindowOpenedCallback(
   }
 
   delegate_->RegisterFirstWindowOpenedCallback(std::move(callback));
+}
+
+void EphemeralStorageService::SetUpdateFirstPartyStorageOriginToCleanUp(bool do_nothing) {
+  if (do_nothing) {
+    update_fp_storage_origins_to_cleanup_ = base::DoNothing();
+  } else {
+    update_fp_storage_origins_to_cleanup_ = base::BindRepeating(&UpsertFirstPartyStorageOriginsToCleanup);
+  }
 }
 
 size_t EphemeralStorageService::FireCleanupTimersForTesting() {

--- a/components/ephemeral_storage/ephemeral_storage_service.cc
+++ b/components/ephemeral_storage/ephemeral_storage_service.cc
@@ -12,7 +12,6 @@
 
 #include "base/check.h"
 #include "base/functional/bind.h"
-#include "base/functional/callback_forward.h"
 #include "base/functional/callback_helpers.h"
 #include "base/json/values_util.h"
 #include "base/logging.h"
@@ -20,6 +19,7 @@
 #include "base/task/sequenced_task_runner.h"
 #include "base/time/time.h"
 #include "base/timer/timer.h"
+#include "base/values.h"
 #include "brave/components/brave_shields/core/common/features.h"
 #include "brave/components/ephemeral_storage/ephemeral_storage_pref_names.h"
 #include "brave/components/ephemeral_storage/url_storage_checker.h"
@@ -55,13 +55,23 @@ GURL GetFirstPartyStorageURL(const std::string& ephemeral_domain) {
 
 base::Value GetFirstPartyStorageValueToCleanup(
     const GURL& url,
-    const content::StoragePartitionConfig& storage_partition_config) {
-  return base::Value(
+    const content::StoragePartitionConfig& storage_partition_config,
+    std::optional<base::Time> time) {
+  base::DictValue dict =
       base::DictValue()
           .Set(kUrlKey, url.spec())
           .Set(kPartitionDomainKey, storage_partition_config.partition_domain())
-          .Set(kPartitionNameKey, storage_partition_config.partition_name())
-          .Set(kClosedAtKey, base::TimeToValue(base::Time::Now())));
+          .Set(kPartitionNameKey, storage_partition_config.partition_name());
+  dict.Set(kClosedAtKey, base::TimeToValue(time.value_or(base::Time::Now())));
+  return base::Value(std::move(dict));
+}
+
+// Returns the time the last tab using the area was closed. Entries stored by
+// older versions don't have it.
+std::optional<base::Time> GetFirstPartyStorageAreaClosedAt(
+    const base::Value& value) {
+  const base::DictValue* dict = value.GetIfDict();
+  return dict ? base::ValueToTime(dict->Find(kClosedAtKey)) : std::nullopt;
 }
 
 // Matches a stored entry by the storage area identity only, ignoring the close
@@ -89,11 +99,11 @@ bool IsSameFirstPartyStorageArea(
          *partition_name == storage_partition_config.partition_name();
 }
 
-const base::Value* FindFirstPartyStorageArea(
-    const base::ListValue& list,
+base::Value* FindFirstPartyStorageArea(
+    base::ListValue& list,
     const GURL& url,
     const content::StoragePartitionConfig& storage_partition_config) {
-  for (const base::Value& value : list) {
+  for (base::Value& value : list) {
     if (IsSameFirstPartyStorageArea(value, url, storage_partition_config)) {
       return &value;
     }
@@ -110,13 +120,24 @@ void EraseFirstPartyStorageArea(
   });
 }
 
+// Queues the area for cleanup.
 void UpsertFirstPartyStorageOriginsToCleanup(
     ScopedListPrefUpdate& pref_update,
     const GURL& url,
-    const content::StoragePartitionConfig& storage_partition_config) {
-  EraseFirstPartyStorageArea(*pref_update, url, storage_partition_config);
-  pref_update->Append(
-      GetFirstPartyStorageValueToCleanup(url, storage_partition_config));
+    const content::StoragePartitionConfig& storage_partition_config,
+    bool set_elapsed_timestamp) {
+  const auto time =
+      set_elapsed_timestamp ? base::Time::Min() : base::Time::Now();
+  base::Value* queued_area =
+      FindFirstPartyStorageArea(*pref_update, url, storage_partition_config);
+  if (!queued_area || !queued_area->is_dict()) {
+    pref_update->Append(GetFirstPartyStorageValueToCleanup(
+        url, storage_partition_config, time));
+    return;
+  }
+
+  base::DictValue& dict = queued_area->GetDict();
+  dict.Set(kClosedAtKey, base::TimeToValue(time));
 }
 
 // Returns true if the keepalive that was pending when the area was stored has
@@ -124,9 +145,8 @@ void UpsertFirstPartyStorageOriginsToCleanup(
 // cleanup.
 bool IsFirstPartyStorageAreaKeepAliveExpired(const base::Value& value,
                                              base::TimeDelta keep_alive) {
-  const base::DictValue* dict = value.GetIfDict();
   const std::optional<base::Time> closed_at =
-      dict ? base::ValueToTime(dict->Find(kClosedAtKey)) : std::nullopt;
+      GetFirstPartyStorageAreaClosedAt(value);
   if (!closed_at) {
     return true;
   }
@@ -180,9 +200,7 @@ EphemeralStorageService::EphemeralStorageService(
     : context_(context),
       host_content_settings_map_(host_content_settings_map),
       delegate_(std::move(delegate)),
-      prefs_(user_prefs::UserPrefs::Get(context_)),
-      update_fp_storage_origins_to_cleanup_(
-          base::BindRepeating(&UpsertFirstPartyStorageOriginsToCleanup)) {
+      prefs_(user_prefs::UserPrefs::Get(context_)) {
   DCHECK(context_);
   DCHECK(host_content_settings_map_);
   DCHECK(delegate_);
@@ -397,11 +415,7 @@ void EphemeralStorageService::TriggerCurrentAppStateNotification() {
       base::BindOnce(&EphemeralStorageService::CleanupOnStartup,
                      weak_ptr_factory_.GetWeakPtr()));
 
-  // For real cold start of the application we should not update saved time for
-  // items saved in the kFirstPartyStorageOriginsToCleanup
-  SetUpdateFirstPartyStorageOriginToCleanUp(true);
   delegate_->TriggerCurrentAppStateNotification();
-  SetUpdateFirstPartyStorageOriginToCleanUp(false);
 }
 #endif  // BUILDFLAG(IS_ANDROID)
 
@@ -512,9 +526,13 @@ bool EphemeralStorageService::FirstPartyStorageAreaNotInUse(
   if (!context_->IsOffTheRecord()) {
     ScopedListPrefUpdate pref_update(prefs_,
                                      kFirstPartyStorageOriginsToCleanup);
-    // Replace a possibly stale entry to store the actual close time.
-    update_fp_storage_origins_to_cleanup_.Run(pref_update, url,
-                                              storage_partition_config);
+    // For auto-shred on app close, perform the cleanup immediately.
+    const bool set_elapsed_timestamp =
+        auto_shred_mode_enabled &&
+        auto_shred_mode.value() ==
+            brave_shields::mojom::AutoShredMode::APP_EXIT;
+    UpsertFirstPartyStorageOriginsToCleanup(
+        pref_update, url, storage_partition_config, set_elapsed_timestamp);
   }
   return true;
 }
@@ -592,7 +610,6 @@ void EphemeralStorageService::CleanupOnStartup() {
 
   ScopedListPrefUpdate pref_update(prefs_, kFirstPartyStorageOriginsToCleanup);
 
-  std::vector<std::pair<std::string, base::OnceClosure>> ephemeral_domains;
   for (base::Value& area_to_cleanup :
        first_party_storage_areas_to_cleanup_on_startup_) {
     if (!IsFirstPartyStorageAreaKeepAliveExpired(
@@ -634,16 +651,6 @@ void EphemeralStorageService::RegisterFirstWindowOpenedCallback(
   }
 
   delegate_->RegisterFirstWindowOpenedCallback(std::move(callback));
-}
-
-void EphemeralStorageService::SetUpdateFirstPartyStorageOriginToCleanUp(
-    bool do_nothing) {
-  if (do_nothing) {
-    update_fp_storage_origins_to_cleanup_ = base::DoNothing();
-  } else {
-    update_fp_storage_origins_to_cleanup_ =
-        base::BindRepeating(&UpsertFirstPartyStorageOriginsToCleanup);
-  }
 }
 
 size_t EphemeralStorageService::FireCleanupTimersForTesting() {

--- a/components/ephemeral_storage/ephemeral_storage_service.cc
+++ b/components/ephemeral_storage/ephemeral_storage_service.cc
@@ -671,9 +671,6 @@ size_t EphemeralStorageService::FireCleanupTimersForTesting() {
   }
   const size_t first_party_storage_areas_to_cleanup_count =
       first_party_storage_areas_to_cleanup_on_startup_.size();
-  if (first_party_storage_areas_startup_cleanup_timer_.IsRunning()) {
-    first_party_storage_areas_startup_cleanup_timer_.FireNow();
-  }
   DCHECK(first_party_storage_areas_to_cleanup_on_startup_.empty());
   return timers.size() + first_party_storage_areas_to_cleanup_count;
 }

--- a/components/ephemeral_storage/ephemeral_storage_service.cc
+++ b/components/ephemeral_storage/ephemeral_storage_service.cc
@@ -12,6 +12,7 @@
 
 #include "base/check.h"
 #include "base/functional/bind.h"
+#include "base/functional/callback_forward.h"
 #include "base/json/values_util.h"
 #include "base/logging.h"
 #include "base/strings/strcat.h"
@@ -550,6 +551,8 @@ void EphemeralStorageService::CleanupPendingFirstPartyStorageArea(
   DVLOG(1) << __func__ << " " << url << " " << storage_partition_config;
   const TLDEphemeralAreaKey key(std::string(url.host()),
                                 storage_partition_config);
+LOG(INFO) << "[SHRED] EphemeralStorageService::CleanupPendingFirstPartyStorageArea key: " << key.first << " : " << key.second;
+  // delegate_->ReloadTabsMatchingFirstPartyStorageAreaFromNetwork(key);
   delegate_->CleanupFirstPartyStorageArea(key);
 
   if (auto_shred_mode.has_value() &&
@@ -588,6 +591,7 @@ void EphemeralStorageService::CleanupExpiredFirstPartyStorageAreasOnStartup() {
   base::ListValue areas_to_cleanup_by_timer;
   ScopedListPrefUpdate pref_update(prefs_, kFirstPartyStorageOriginsToCleanup);
 
+  std::vector<std::pair<std::string, base::OnceClosure>> ephemeral_domains;
   for (base::Value& area_to_cleanup :
        first_party_storage_areas_to_cleanup_on_startup_) {
     if (!IsFirstPartyStorageAreaKeepAliveExpired(
@@ -595,26 +599,30 @@ void EphemeralStorageService::CleanupExpiredFirstPartyStorageAreasOnStartup() {
       areas_to_cleanup_by_timer.Append(std::move(area_to_cleanup));
       continue;
     }
-    LOG(INFO) << "[SHRED] CleanupExpiredFirstPartyStorageAreasOnStartup area_to_cleanup:" << area_to_cleanup.DebugString();
     pref_update->EraseValue(area_to_cleanup);
 
     const auto url_and_storage_partition_config =
         GetFirstPartyStorageURLAndStoragePartitionConfig(area_to_cleanup,
                                                          context_);
     if (!url_and_storage_partition_config) {
-      LOG(INFO) << "[SHRED] CleanupExpiredFirstPartyStorageAreasOnStartup #100 area_to_cleanup:" << area_to_cleanup.DebugString();
       continue;
     }
+
     const auto& [url, storage_partition_config] =
         *url_and_storage_partition_config;
     if (!url.is_valid()) {
-      LOG(INFO) << "[SHRED] CleanupExpiredFirstPartyStorageAreasOnStartup #200 area_to_cleanup:" << area_to_cleanup.DebugString();
       continue;
     }
     LOG(INFO) << "[SHRED] CleanupExpiredFirstPartyStorageAreasOnStartup #50 area_to_cleanup:" << area_to_cleanup.DebugString();
-    CleanupPendingFirstPartyStorageArea(url, storage_partition_config,
-                                        delegate_->GetAutoShredMode(url));
+
+    ephemeral_domains.emplace_back(net::URLToEphemeralStorageDomain(url), base::BindOnce(
+        &EphemeralStorageService::CleanupPendingFirstPartyStorageArea,
+        weak_ptr_factory_.GetWeakPtr(), url, storage_partition_config,
+        delegate_->GetAutoShredMode(url)));
   }
+
+  // Refresh tabs for the cleaned websites
+  delegate_->ReloadTabIfMatchingEphemeralDomain(std::move(ephemeral_domains));
 
   first_party_storage_areas_to_cleanup_on_startup_ =
       std::move(areas_to_cleanup_by_timer);

--- a/components/ephemeral_storage/ephemeral_storage_service.cc
+++ b/components/ephemeral_storage/ephemeral_storage_service.cc
@@ -466,18 +466,25 @@ void EphemeralStorageService::FirstPartyStorageAreaInUse(
   }
 
   bool keep_alive_expired = false;
-  ScopedListPrefUpdate pref_update(prefs_, kFirstPartyStorageOriginsToCleanup);
-  if (const base::Value* queued_area = FindFirstPartyStorageArea(
-          *pref_update, url, storage_partition_config)) {
+  auto& first_party_storage_areas_to_cleanup_on_startup =
+      prefs_->GetList(kFirstPartyStorageOriginsToCleanup);
+  auto queued_area_it =
+      std::ranges::find_if(first_party_storage_areas_to_cleanup_on_startup,
+                           [&](const base::Value& value) {
+                             return IsSameFirstPartyStorageArea(
+                                 value, url, storage_partition_config);
+                           });
+
+  if (queued_area_it != first_party_storage_areas_to_cleanup_on_startup.end()) {
     keep_alive_expired = IsFirstPartyStorageAreaKeepAliveExpired(
-        *queued_area, tld_ephemeral_area_keep_alive_);
+        *queued_area_it, tld_ephemeral_area_keep_alive_);
   }
 
   if (!keep_alive_expired) {
+    ScopedListPrefUpdate pref_update(prefs_,
+                                     kFirstPartyStorageOriginsToCleanup);
     // Make sure to cancel the scheduled cleanup for this area.
     EraseFirstPartyStorageArea(*pref_update, url, storage_partition_config);
-    EraseFirstPartyStorageArea(first_party_storage_areas_to_cleanup_on_startup_,
-                               url, storage_partition_config);
   }
 }
 
@@ -585,9 +592,9 @@ void EphemeralStorageService::CleanupFirstPartyStorageArea(
 void EphemeralStorageService::CleanupPendingFirstPartyStorageArea(
     const GURL& url,
     const content::StoragePartitionConfig& storage_partition_config,
-    const std::optional<brave_shields::mojom::AutoShredMode>& auto_shred_mode,
     base::OnceClosure callback) {
   DVLOG(1) << __func__ << " " << url << " " << storage_partition_config;
+  const auto auto_shred_mode = delegate_->GetAutoShredMode(url);
   const TLDEphemeralAreaKey key(std::string(url.host()),
                                 storage_partition_config);
   delegate_->CleanupFirstPartyStorageArea(key, std::move(callback));
@@ -603,15 +610,15 @@ void EphemeralStorageService::CleanupPendingFirstPartyStorageArea(
 
 void EphemeralStorageService::CleanupOnStartup() {
   DCHECK(!context_->IsOffTheRecord());
-  first_party_storage_areas_to_cleanup_on_startup_ =
+  base::ListValue first_party_storage_areas_to_cleanup_on_startup =
       prefs_->GetList(kFirstPartyStorageOriginsToCleanup).Clone();
   DVLOG(1) << __func__ << " Queued for cleanup:"
-           << first_party_storage_areas_to_cleanup_on_startup_.DebugString();
+           << first_party_storage_areas_to_cleanup_on_startup.DebugString();
 
   ScopedListPrefUpdate pref_update(prefs_, kFirstPartyStorageOriginsToCleanup);
 
   for (base::Value& area_to_cleanup :
-       first_party_storage_areas_to_cleanup_on_startup_) {
+       first_party_storage_areas_to_cleanup_on_startup) {
     if (!IsFirstPartyStorageAreaKeepAliveExpired(
             area_to_cleanup, tld_ephemeral_area_keep_alive_)) {
       continue;
@@ -632,14 +639,13 @@ void EphemeralStorageService::CleanupOnStartup() {
     }
 
     CleanupPendingFirstPartyStorageArea(
-        url, storage_partition_config, delegate_->GetAutoShredMode(url),
-        base::BindOnce(&EphemeralStorageServiceDelegate::
-                           ReloadTabIfMatchingEphemeralDomain,
-                       delegate_->AsWeakPtr(),
+        url, storage_partition_config,
+        base::BindOnce(&EphemeralStorageService::ReloadTabsForEphemeralDomain,
+                       weak_ptr_factory_.GetWeakPtr(),
                        net::URLToEphemeralStorageDomain(url)));
   }
 
-  first_party_storage_areas_to_cleanup_on_startup_.clear();
+  first_party_storage_areas_to_cleanup_on_startup.clear();
 }
 
 void EphemeralStorageService::RegisterFirstWindowOpenedCallback(
@@ -653,6 +659,11 @@ void EphemeralStorageService::RegisterFirstWindowOpenedCallback(
   delegate_->RegisterFirstWindowOpenedCallback(std::move(callback));
 }
 
+void EphemeralStorageService::ReloadTabsForEphemeralDomain(
+    const std::string& ephemeral_domain) {
+  delegate_->ReloadTabIfMatchingEphemeralDomain(ephemeral_domain);
+}
+
 size_t EphemeralStorageService::FireCleanupTimersForTesting() {
   std::vector<base::OneShotTimer*> timers;
   for (const auto& areas_to_cleanup : tld_ephemeral_areas_to_cleanup_) {
@@ -662,8 +673,7 @@ size_t EphemeralStorageService::FireCleanupTimersForTesting() {
     timer->FireNow();
   }
   const size_t first_party_storage_areas_to_cleanup_count =
-      first_party_storage_areas_to_cleanup_on_startup_.size();
-  DCHECK(first_party_storage_areas_to_cleanup_on_startup_.empty());
+      prefs_->GetList(kFirstPartyStorageOriginsToCleanup).size();
   return timers.size() + first_party_storage_areas_to_cleanup_count;
 }
 

--- a/components/ephemeral_storage/ephemeral_storage_service.h
+++ b/components/ephemeral_storage/ephemeral_storage_service.h
@@ -140,10 +140,10 @@ class EphemeralStorageService : public KeyedService {
   void CleanupPendingFirstPartyStorageArea(
       const GURL& url,
       const content::StoragePartitionConfig& storage_partition_config,
-      const std::optional<brave_shields::mojom::AutoShredMode>& auto_shred_mode,
       base::OnceClosure callback);
 
   void RegisterFirstWindowOpenedCallback(base::OnceClosure callback);
+  void ReloadTabsForEphemeralDomain(const std::string& ephemeral_domain);
 
   size_t FireCleanupTimersForTesting();
 
@@ -157,12 +157,10 @@ class EphemeralStorageService : public KeyedService {
   base::ObserverList<EphemeralStorageServiceObserver> observer_list_;
 
   base::TimeDelta tld_ephemeral_area_keep_alive_;
-  base::TimeDelta first_party_storage_startup_cleanup_delay_;
   std::map<TLDEphemeralAreaKey, std::unique_ptr<base::OneShotTimer>>
       tld_ephemeral_areas_to_cleanup_;
   // Contains First Party Ephemeral Storage tokens to partition storage.
   base::flat_map<std::string, base::UnguessableToken> fpes_tokens_;
-  base::ListValue first_party_storage_areas_to_cleanup_on_startup_;
 
   base::WeakPtrFactory<EphemeralStorageService> weak_ptr_factory_{this};
 };

--- a/components/ephemeral_storage/ephemeral_storage_service.h
+++ b/components/ephemeral_storage/ephemeral_storage_service.h
@@ -14,6 +14,7 @@
 #include "base/containers/flat_map.h"
 #include "base/containers/flat_set.h"
 #include "base/functional/callback.h"
+#include "base/functional/callback_forward.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
@@ -43,6 +44,8 @@ class BrowserContext;
 namespace permissions {
 class PermissionLifetimeManagerBrowserTest;
 }
+
+class ScopedListPrefUpdate;
 
 namespace ephemeral_storage {
 
@@ -133,14 +136,6 @@ class EphemeralStorageService : public KeyedService {
                                bool cleanup_first_party_storage_area,
                                bool cleanup_browsing_history_for_tld);
 
-  // If a website was closed, but not yet cleaned-up because of storage lifetime
-  // keepalive, we store the origin into a pref to perform a cleanup on browser
-  // startup. It's impossible to do a cleanup on shutdown, because the process
-  // is asynchronous and cannot block the browser shutdown.
-  void ScheduleFirstPartyStorageAreasCleanupOnStartup();
-  // Cleans up the stored areas whose keepalive already elapsed and leaves the
-  // rest scheduled for CleanupOnStartup().
-  void CleanupExpiredFirstPartyStorageAreasOnStartup();
   void CleanupOnStartup();
   void CleanupFirstPartyStorageArea(const TLDEphemeralAreaKey& key);
   // Cleans up an area that was queued for cleanup in prefs, i.e. its keepalive
@@ -149,9 +144,11 @@ class EphemeralStorageService : public KeyedService {
       const GURL& url,
       const content::StoragePartitionConfig& storage_partition_config,
       const std::optional<brave_shields::mojom::AutoShredMode>&
-          auto_shred_mode);
+          auto_shred_mode, base::OnceClosure callback);
 
   void RegisterFirstWindowOpenedCallback(base::OnceClosure callback);
+
+  void SetUpdateFirstPartyStorageOriginToCleanUp(bool do_nothing);
 
   size_t FireCleanupTimersForTesting();
 
@@ -159,6 +156,10 @@ class EphemeralStorageService : public KeyedService {
   raw_ptr<HostContentSettingsMap> host_content_settings_map_ = nullptr;
   std::unique_ptr<EphemeralStorageServiceDelegate> delegate_;
   raw_ptr<PrefService> prefs_ = nullptr;
+  base::RepeatingCallback<void(ScopedListPrefUpdate&,
+                               const GURL&,
+                               const content::StoragePartitionConfig&)>
+      update_fp_storage_origins_to_cleanup_;
   // These patterns are removed on service Shutdown.
   base::flat_set<ContentSettingsPattern> patterns_to_cleanup_on_shutdown_;
 

--- a/components/ephemeral_storage/ephemeral_storage_service.h
+++ b/components/ephemeral_storage/ephemeral_storage_service.h
@@ -14,7 +14,6 @@
 #include "base/containers/flat_map.h"
 #include "base/containers/flat_set.h"
 #include "base/functional/callback.h"
-#include "base/functional/callback_forward.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
@@ -44,8 +43,6 @@ class BrowserContext;
 namespace permissions {
 class PermissionLifetimeManagerBrowserTest;
 }
-
-class ScopedListPrefUpdate;
 
 namespace ephemeral_storage {
 
@@ -148,18 +145,12 @@ class EphemeralStorageService : public KeyedService {
 
   void RegisterFirstWindowOpenedCallback(base::OnceClosure callback);
 
-  void SetUpdateFirstPartyStorageOriginToCleanUp(bool do_nothing);
-
   size_t FireCleanupTimersForTesting();
 
   raw_ptr<content::BrowserContext> context_ = nullptr;
   raw_ptr<HostContentSettingsMap> host_content_settings_map_ = nullptr;
   std::unique_ptr<EphemeralStorageServiceDelegate> delegate_;
   raw_ptr<PrefService> prefs_ = nullptr;
-  base::RepeatingCallback<void(ScopedListPrefUpdate&,
-                               const GURL&,
-                               const content::StoragePartitionConfig&)>
-      update_fp_storage_origins_to_cleanup_;
   // These patterns are removed on service Shutdown.
   base::flat_set<ContentSettingsPattern> patterns_to_cleanup_on_shutdown_;
 

--- a/components/ephemeral_storage/ephemeral_storage_service.h
+++ b/components/ephemeral_storage/ephemeral_storage_service.h
@@ -143,8 +143,8 @@ class EphemeralStorageService : public KeyedService {
   void CleanupPendingFirstPartyStorageArea(
       const GURL& url,
       const content::StoragePartitionConfig& storage_partition_config,
-      const std::optional<brave_shields::mojom::AutoShredMode>&
-          auto_shred_mode, base::OnceClosure callback);
+      const std::optional<brave_shields::mojom::AutoShredMode>& auto_shred_mode,
+      base::OnceClosure callback);
 
   void RegisterFirstWindowOpenedCallback(base::OnceClosure callback);
 

--- a/components/ephemeral_storage/ephemeral_storage_service.h
+++ b/components/ephemeral_storage/ephemeral_storage_service.h
@@ -172,7 +172,6 @@ class EphemeralStorageService : public KeyedService {
   // Contains First Party Ephemeral Storage tokens to partition storage.
   base::flat_map<std::string, base::UnguessableToken> fpes_tokens_;
   base::ListValue first_party_storage_areas_to_cleanup_on_startup_;
-  base::OneShotTimer first_party_storage_areas_startup_cleanup_timer_;
 
   base::WeakPtrFactory<EphemeralStorageService> weak_ptr_factory_{this};
 };

--- a/components/ephemeral_storage/ephemeral_storage_service.h
+++ b/components/ephemeral_storage/ephemeral_storage_service.h
@@ -138,8 +138,18 @@ class EphemeralStorageService : public KeyedService {
   // startup. It's impossible to do a cleanup on shutdown, because the process
   // is asynchronous and cannot block the browser shutdown.
   void ScheduleFirstPartyStorageAreasCleanupOnStartup();
+  // Cleans up the stored areas whose keepalive already elapsed and leaves the
+  // rest scheduled for CleanupOnStartup().
+  void CleanupExpiredFirstPartyStorageAreasOnStartup();
   void CleanupOnStartup();
   void CleanupFirstPartyStorageArea(const TLDEphemeralAreaKey& key);
+  // Cleans up an area that was queued for cleanup in prefs, i.e. its keepalive
+  // was still pending when the browser was closed.
+  void CleanupPendingFirstPartyStorageArea(
+      const GURL& url,
+      const content::StoragePartitionConfig& storage_partition_config,
+      const std::optional<brave_shields::mojom::AutoShredMode>&
+          auto_shred_mode);
 
   void RegisterFirstWindowOpenedCallback(base::OnceClosure callback);
 

--- a/components/ephemeral_storage/ephemeral_storage_service_delegate.h
+++ b/components/ephemeral_storage/ephemeral_storage_service_delegate.h
@@ -23,11 +23,11 @@ class EphemeralStorageServiceDelegate {
   virtual void CleanupTLDEphemeralArea(const TLDEphemeralAreaKey& key) = 0;
   // Cleanups non-ephemeral first party storage areas (cache, dom storage).
   virtual void CleanupFirstPartyStorageArea(
-      const TLDEphemeralAreaKey& key,
-      base::OnceClosure callback = base::DoNothing()) = 0;
+      const TLDEphemeralAreaKey& key, base::OnceClosure callback) = 0;
   // Forces already-loaded tabs matching ephemeral_domains to reload, bypassing
   // the HTTP cache, when ready.
-  virtual void ReloadTabIfMatchingEphemeralDomain(const std::string& ephemeral_domain) = 0;
+  virtual void ReloadTabIfMatchingEphemeralDomain(
+      const std::string& ephemeral_domain) = 0;
   virtual void CleanupTLDBrowsingHistory(const TLDEphemeralAreaKey& key) = 0;
   // Registers a callback to be called when the first window is opened.
   virtual void RegisterFirstWindowOpenedCallback(

--- a/components/ephemeral_storage/ephemeral_storage_service_delegate.h
+++ b/components/ephemeral_storage/ephemeral_storage_service_delegate.h
@@ -50,9 +50,6 @@ class EphemeralStorageServiceDelegate {
   virtual void TriggerCurrentAppStateNotification() = 0;
 #endif
   virtual bool IsShredBrowsingHistoryEnabled() = 0;
-
-  // Returns a WeakPtr to the implementation instance.
-  virtual base::WeakPtr<EphemeralStorageServiceDelegate> AsWeakPtr() = 0;
 };
 
 }  // namespace ephemeral_storage

--- a/components/ephemeral_storage/ephemeral_storage_service_delegate.h
+++ b/components/ephemeral_storage/ephemeral_storage_service_delegate.h
@@ -7,6 +7,7 @@
 #define BRAVE_COMPONENTS_EPHEMERAL_STORAGE_EPHEMERAL_STORAGE_SERVICE_DELEGATE_H_
 
 #include "base/functional/callback.h"
+#include "base/functional/callback_helpers.h"
 #include "brave/components/brave_shields/core/common/shields_settings.mojom-data-view.h"
 #include "brave/components/ephemeral_storage/ephemeral_storage_types.h"
 #include "url/gurl.h"
@@ -21,12 +22,12 @@ class EphemeralStorageServiceDelegate {
   // Cleanups ephemeral storages (local storage, cookies).
   virtual void CleanupTLDEphemeralArea(const TLDEphemeralAreaKey& key) = 0;
   // Cleanups non-ephemeral first party storage areas (cache, dom storage).
-  virtual void CleanupFirstPartyStorageArea(const TLDEphemeralAreaKey& key) = 0;
+  virtual void CleanupFirstPartyStorageArea(
+      const TLDEphemeralAreaKey& key,
+      base::OnceClosure callback = base::DoNothing()) = 0;
   // Forces already-loaded tabs matching ephemeral_domains to reload, bypassing
   // the HTTP cache, when ready.
-  virtual void ReloadTabIfMatchingEphemeralDomain(
-      std::vector<std::pair<std::string, base::OnceClosure>>
-          ephemeral_domains) = 0;
+  virtual void ReloadTabIfMatchingEphemeralDomain(const std::string& ephemeral_domain) = 0;
   virtual void CleanupTLDBrowsingHistory(const TLDEphemeralAreaKey& key) = 0;
   // Registers a callback to be called when the first window is opened.
   virtual void RegisterFirstWindowOpenedCallback(
@@ -49,6 +50,9 @@ class EphemeralStorageServiceDelegate {
   virtual void TriggerCurrentAppStateNotification() = 0;
 #endif
   virtual bool IsShredBrowsingHistoryEnabled() = 0;
+
+  // Returns a WeakPtr to the implementation instance.
+  virtual base::WeakPtr<EphemeralStorageServiceDelegate> AsWeakPtr() = 0;
 };
 
 }  // namespace ephemeral_storage

--- a/components/ephemeral_storage/ephemeral_storage_service_delegate.h
+++ b/components/ephemeral_storage/ephemeral_storage_service_delegate.h
@@ -22,6 +22,11 @@ class EphemeralStorageServiceDelegate {
   virtual void CleanupTLDEphemeralArea(const TLDEphemeralAreaKey& key) = 0;
   // Cleanups non-ephemeral first party storage areas (cache, dom storage).
   virtual void CleanupFirstPartyStorageArea(const TLDEphemeralAreaKey& key) = 0;
+  // Forces already-loaded tabs matching ephemeral_domains to reload, bypassing
+  // the HTTP cache, when ready.
+  virtual void ReloadTabIfMatchingEphemeralDomain(
+      std::vector<std::pair<std::string, base::OnceClosure>>
+          ephemeral_domains) = 0;
   virtual void CleanupTLDBrowsingHistory(const TLDEphemeralAreaKey& key) = 0;
   // Registers a callback to be called when the first window is opened.
   virtual void RegisterFirstWindowOpenedCallback(

--- a/components/ephemeral_storage/ephemeral_storage_service_delegate.h
+++ b/components/ephemeral_storage/ephemeral_storage_service_delegate.h
@@ -22,8 +22,8 @@ class EphemeralStorageServiceDelegate {
   // Cleanups ephemeral storages (local storage, cookies).
   virtual void CleanupTLDEphemeralArea(const TLDEphemeralAreaKey& key) = 0;
   // Cleanups non-ephemeral first party storage areas (cache, dom storage).
-  virtual void CleanupFirstPartyStorageArea(
-      const TLDEphemeralAreaKey& key, base::OnceClosure callback) = 0;
+  virtual void CleanupFirstPartyStorageArea(const TLDEphemeralAreaKey& key,
+                                            base::OnceClosure callback) = 0;
   // Forces already-loaded tabs matching ephemeral_domains to reload, bypassing
   // the HTTP cache, when ready.
   virtual void ReloadTabIfMatchingEphemeralDomain(


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58345

Removes the 5-second interval before first-party storage cleanup on browser startup. To determine which queued sites need to be cleaned, it uses the timestamp of when the tab was closed, checking it on startup and cleaning only if it is older than 30 seconds.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
