### PR TITLE
Removes Travel and Docs items from main menu. (uplift to 1.96.x)

### DIFF
--- a/browser/resources/settings/brave_routes.ts
+++ b/browser/resources/settings/brave_routes.ts
@@ -154,6 +154,13 @@ export default function addBraveRoutes(r: Partial<SettingsRoutes>) {
   if (r.SYNC) {
     delete r.SYNC
   }
+  // Delete identity docs and travel autofill routes
+  if (r.IDENTITY_DOCS) {
+    delete r.IDENTITY_DOCS
+  }
+  if (r.TRAVEL) {
+    delete r.TRAVEL
+  }
   // Delete /syncSetup/advanced
   if (r.SYNC_ADVANCED) {
     delete r.SYNC_ADVANCED

--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -141,6 +141,17 @@ void BraveAppMenuModel::BuildPasswordsAndAutofillSubmenu() {
           GetIndexOfCommandId(kPasswordsAndAutofillMenuPlaceholder).value()));
   CHECK(autofill_menu_model);
 
+  if (IsCommandIdEnabled(IDC_SHOW_IDENTITY_DOCS)) {
+    autofill_menu_model->RemoveItemAt(
+        autofill_menu_model->GetIndexOfCommandId(IDC_SHOW_IDENTITY_DOCS)
+            .value());
+  }
+
+  if (IsCommandIdEnabled(IDC_SHOW_TRAVEL)) {
+    autofill_menu_model->RemoveItemAt(
+        autofill_menu_model->GetIndexOfCommandId(IDC_SHOW_TRAVEL).value());
+  }
+
   if (IsCommandIdEnabled(IDC_SHOW_EMAIL_ALIASES)) {
     const auto index =
         autofill_menu_model->GetIndexOfCommandId(IDC_SHOW_PASSWORD_MANAGER);

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -2546,6 +2546,12 @@
 # model
 -AppMenuModelTest.ModelHasIcons
 
+# These tests fail because we disable identity docs and travel pages in
+# autofill settings and hamburger menu.
+-AutofillAiPolicyTest.SettingsNotDisabledByPolicy/*
+-BrowserCommandControllerBrowserTest.ExecuteShowIdentityDocs
+-BrowserCommandControllerBrowserTest.ExecuteShowTravel
+
 # Tests below this point have not been diagnosed or had issues created yet.
 -All/DeclarativeNetRequestBrowserTest.RendererCacheCleared/*
 -All/FromGWSNavigationAndKeepAliveRequestBrowserTest.TwoDifferentCategoryRequestAndTwoDifferentCategoryNavigationsFromSRP/*


### PR DESCRIPTION
Uplift of #39615
Resolves https://github.com/brave/brave-browser/issues/58672

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.