### PR TITLE
[Wayback] Convert bubble to LocationBarBubbleDelegateView subclass

### DIFF
--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -449,6 +449,7 @@ if (!is_android) {
   brave_chrome_browser_deps += [
     "//brave/browser/ui/split_view",
     "//brave/browser/ui/tabs:impl",
+    "//brave/browser/ui/views/page_action:impl",
     "//brave/browser/ui/webui/brave_new_tab_page_refresh",
     "//brave/browser/ui/webui/brave_new_tab_page_refresh:mojom",
     "//brave/browser/ui/webui/brave_welcome_page",

--- a/browser/ui/brave_browser_actions.cc
+++ b/browser/ui/brave_browser_actions.cc
@@ -69,8 +69,6 @@
 #include "brave/browser/ui/tabs/public/brave_tab_features.h"
 #include "brave/browser/ui/views/page_action/wayback_machine_page_action_controller.h"
 #include "brave/grit/brave_generated_resources.h"
-#include "chrome/browser/ui/views/frame/browser_view.h"
-#include "chrome/browser/ui/views/frame/toolbar_button_provider.h"
 #include "components/tabs/public/tab_interface.h"
 #endif
 
@@ -286,10 +284,7 @@ void BraveBrowserActions::InitializeBrowserActions() {
                   return;
                 }
 
-                BrowserView& browser_view =
-                    CHECK_DEREF(BrowserView::GetBrowserViewForBrowser(bwi));
-                controller->ExecuteAction(
-                    browser_view.toolbar_button_provider(), item);
+                controller->ExecuteAction(item);
               },
               bwi))
           .SetActionId(kActionShowWaybackMachine)

--- a/browser/ui/views/page_action/BUILD.gn
+++ b/browser/ui/views/page_action/BUILD.gn
@@ -101,19 +101,48 @@ source_set("page_action") {
     sources += [
       "wayback_machine_bubble_view.cc",
       "wayback_machine_bubble_view.h",
-      "wayback_machine_page_action_controller.cc",
       "wayback_machine_page_action_controller.h",
     ]
+
+    public_deps = [ "//chrome/browser/ui/views/location_bar" ]
 
     deps += [
       "//brave/app:brave_generated_resources_grit_grit",
       "//brave/components/brave_wayback_machine",
       "//brave/components/vector_icons",
-      "//chrome/browser/ui/actions",
       "//chrome/browser/ui/color:mixers",
       "//chrome/browser/ui/views:layout_provider",
-      "//chrome/browser/ui/views/frame:toolbar_button_provider",
+      "//components/tabs:public",
       "//components/user_prefs",
+      "//ui/actions",
+      "//ui/base",
+      "//ui/views",
+    ]
+  }
+}
+
+source_set("impl") {
+  visibility = [
+    ":unit_tests",
+    "//brave/browser:core",
+  ]
+
+  sources = []
+  deps = [ ":page_action" ]
+
+  if (enable_brave_wayback_machine) {
+    sources += [ "wayback_machine_page_action_controller.cc" ]
+    deps += [
+      "//brave/components/brave_wayback_machine",
+      "//brave/components/vector_icons",
+      "//chrome/browser/ui",
+      "//chrome/browser/ui/actions",
+      "//chrome/browser/ui/browser_window",
+      "//chrome/browser/ui/color:mixers",
+      "//chrome/browser/ui/views/frame:toolbar_button_provider",
+      "//components/tabs:public",
+      "//components/user_prefs",
+      "//content/public/browser",
       "//ui/actions",
       "//ui/base",
       "//ui/views",
@@ -133,6 +162,7 @@ source_set("unit_tests") {
     "test_tab_interface.h",
   ]
   deps = [
+    ":impl",
     "//base",
     "//chrome/browser/ui/page_action",
     "//chrome/browser/ui/page_action:test_support",

--- a/browser/ui/views/page_action/wayback_machine_bubble_view.cc
+++ b/browser/ui/views/page_action/wayback_machine_bubble_view.cc
@@ -54,12 +54,10 @@ gfx::FontList GetFont(int font_size, gfx::Font::Weight weight) {
 }  // namespace
 
 WaybackMachineBubbleView::WaybackMachineBubbleView(
-    base::WeakPtr<content::WebContents> web_contents,
-    views::View* anchor,
+    views::BubbleAnchor anchor,
+    content::WebContents* web_contents,
     actions::ActionItem* item)
-    : BubbleDialogDelegateView(anchor, views::BubbleBorder::TOP_RIGHT),
-      web_contents_(web_contents),
-      item_(item) {
+    : LocationBarBubbleDelegateView(anchor, web_contents), item_(item) {
   if (item_) {
     item_->SetIsShowingBubble(true);
   }
@@ -74,7 +72,7 @@ WaybackMachineBubbleView::WaybackMachineBubbleView(
       /*inside_border_insets*/ gfx::Insets(),
       /*between_child_spacing*/ kPadding));
 
-  auto* tab_helper = GetTabHelper(web_contents_.get());
+  auto* tab_helper = GetTabHelper(web_contents);
   CHECK(tab_helper);
   const bool need_checking =
       tab_helper->wayback_state() == WaybackState::kNeedToCheck;
@@ -137,15 +135,15 @@ WaybackMachineBubbleView::~WaybackMachineBubbleView() {
 }
 
 void WaybackMachineBubbleView::OnAccepted() {
-  if (auto* tab_helper = GetTabHelper(web_contents_.get())) {
+  if (auto* tab_helper = GetTabHelper(web_contents())) {
     tab_helper->FetchWaybackURL();
   }
 }
 
 void WaybackMachineBubbleView::OnDontAskAgain() {
-  if (web_contents_) {
+  if (web_contents()) {
     auto* profile =
-        Profile::FromBrowserContext(web_contents_->GetBrowserContext());
+        Profile::FromBrowserContext(web_contents()->GetBrowserContext());
     profile->GetPrefs()->SetBoolean(kBraveWaybackMachineEnabled, false);
   }
   if (views::Widget* widget = GetWidget()) {

--- a/browser/ui/views/page_action/wayback_machine_bubble_view.h
+++ b/browser/ui/views/page_action/wayback_machine_bubble_view.h
@@ -7,9 +7,9 @@
 #define BRAVE_BROWSER_UI_VIEWS_PAGE_ACTION_WAYBACK_MACHINE_BUBBLE_VIEW_H_
 
 #include "base/memory/raw_ptr.h"
-#include "base/memory/weak_ptr.h"
+#include "chrome/browser/ui/views/location_bar/location_bar_bubble_delegate_view.h"
 #include "ui/base/metadata/metadata_header_macros.h"
-#include "ui/views/bubble/bubble_dialog_delegate_view.h"
+#include "ui/views/bubble/bubble_anchor.h"
 
 namespace actions {
 class ActionItem;
@@ -20,13 +20,15 @@ class WebContents;
 }  // namespace content
 
 // Offers to look up the current page in the Internet Archive after a failed
-// navigation.
-class WaybackMachineBubbleView : public views::BubbleDialogDelegateView {
-  METADATA_HEADER(WaybackMachineBubbleView, views::BubbleDialogDelegateView)
+// navigation. Derives from LocationBarBubbleDelegateView so that it can be
+// shown either in response to a user gesture or automatically, and so that it
+// closes when the tab is hidden or the browser enters fullscreen.
+class WaybackMachineBubbleView : public LocationBarBubbleDelegateView {
+  METADATA_HEADER(WaybackMachineBubbleView, LocationBarBubbleDelegateView)
 
  public:
-  WaybackMachineBubbleView(base::WeakPtr<content::WebContents> web_contents,
-                           views::View* anchor,
+  WaybackMachineBubbleView(views::BubbleAnchor anchor,
+                           content::WebContents* web_contents,
                            actions::ActionItem* item);
   ~WaybackMachineBubbleView() override;
 
@@ -34,7 +36,6 @@ class WaybackMachineBubbleView : public views::BubbleDialogDelegateView {
   void OnAccepted();
   void OnDontAskAgain();
 
-  base::WeakPtr<content::WebContents> web_contents_;
   raw_ptr<actions::ActionItem> item_;
 };
 

--- a/browser/ui/views/page_action/wayback_machine_page_action_controller.cc
+++ b/browser/ui/views/page_action/wayback_machine_page_action_controller.cc
@@ -16,12 +16,15 @@
 #include "brave/components/brave_wayback_machine/brave_wayback_machine_utils.h"
 #include "brave/components/vector_icons/vector_icons.h"
 #include "chrome/browser/ui/actions/chrome_action_id.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/toolbar_button_provider.h"
 #include "components/user_prefs/user_prefs.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/web_contents.h"
 #include "third_party/skia/include/core/SkColor.h"
+#include "ui/actions/actions.h"
 #include "ui/base/models/image_model.h"
 #include "ui/color/color_id.h"
 #include "ui/color/color_provider.h"
@@ -71,6 +74,23 @@ class WaybackIconImageSource : public gfx::CanvasImageSource {
   const gfx::IconDescription badge_description_;
 };
 
+views::BubbleAnchor GetAnchorForBubble(tabs::TabInterface& tab) {
+  auto* bwi = tab.GetBrowserWindowInterface();
+  if (!bwi) {
+    return {};
+  }
+  auto* browser_view = BrowserView::GetBrowserViewForBrowser(bwi);
+  if (!browser_view) {
+    return {};
+  }
+  auto* toolbar_button_provider = browser_view->toolbar_button_provider();
+  if (!toolbar_button_provider) {
+    return {};
+  }
+  return toolbar_button_provider->GetPageActionBubbleAnchor(
+      kActionShowWaybackMachine);
+}
+
 }  // namespace
 
 WaybackMachinePageActionController::WaybackMachinePageActionController(
@@ -115,29 +135,8 @@ void WaybackMachinePageActionController::Init() {
 }
 
 void WaybackMachinePageActionController::ExecuteAction(
-    ToolbarButtonProvider* toolbar_button_provider,
     actions::ActionItem* item) {
-  content::WebContents* const contents = tab_->GetContents();
-  if (!contents) {
-    return;
-  }
-
-  if (bubble_tracker_.view()) {
-    return;
-  }
-
-  views::View* const anchor_view =
-      toolbar_button_provider
-          ->GetPageActionBubbleAnchor(kActionShowWaybackMachine)
-          .GetIfView();
-  if (!anchor_view || !anchor_view->GetWidget()) {
-    return;
-  }
-
-  auto bubble = std::make_unique<WaybackMachineBubbleView>(
-      contents->GetWeakPtr(), anchor_view, item);
-  bubble_tracker_.SetView(bubble.get());
-  views::BubbleDialogDelegateView::CreateBubble(std::move(bubble))->Show();
+  ShowBubble(item, /*user_gesture=*/true);
 }
 
 WaybackMachineBubbleView*
@@ -148,6 +147,34 @@ WaybackMachinePageActionController::GetBubbleViewForTesting() {
 void WaybackMachinePageActionController::OnWaybackStateChanged(
     WaybackState state) {
   UpdatePageAction(tab_->GetContents());
+}
+
+void WaybackMachinePageActionController::ShowBubble(actions::ActionItem* item,
+                                                    bool user_gesture) {
+  content::WebContents* contents = tab_->GetContents();
+  if (!contents) {
+    return;
+  }
+
+  if (bubble_tracker_.view()) {
+    return;
+  }
+
+  const views::BubbleAnchor anchor = GetAnchorForBubble(tab_.get());
+  const views::View* anchor_view = anchor.GetIfView();
+  if (!anchor_view || !anchor_view->GetWidget()) {
+    return;
+  }
+
+  auto bubble =
+      std::make_unique<WaybackMachineBubbleView>(anchor, contents, item);
+  WaybackMachineBubbleView* bubble_view = bubble.get();
+  bubble_tracker_.SetView(bubble_view);
+
+  views::BubbleDialogDelegateView::CreateBubble(std::move(bubble));
+  bubble_view->ShowForReason(user_gesture
+                                 ? LocationBarBubbleDelegateView::USER_GESTURE
+                                 : LocationBarBubbleDelegateView::AUTOMATIC);
 }
 
 void WaybackMachinePageActionController::AttachToTabHelper(

--- a/browser/ui/views/page_action/wayback_machine_page_action_controller.h
+++ b/browser/ui/views/page_action/wayback_machine_page_action_controller.h
@@ -14,7 +14,6 @@
 #include "components/tabs/public/tab_interface.h"
 #include "ui/views/view_tracker.h"
 
-class ToolbarButtonProvider;
 class WaybackMachineBubbleView;
 
 namespace actions {
@@ -44,13 +43,18 @@ class WaybackMachinePageActionController {
 
   void Init();
 
-  void ExecuteAction(ToolbarButtonProvider* toolbar_button_provider,
-                     actions::ActionItem* item);
+  // Shows the bubble in response to a user activating the page action.
+  void ExecuteAction(actions::ActionItem* item);
 
   WaybackMachineBubbleView* GetBubbleViewForTesting();
 
  private:
   void OnWaybackStateChanged(WaybackState state);
+
+  // Creates and shows the bubble, unless one is already showing. A bubble shown
+  // without a user gesture is shown inactive, so that it doesn't take focus
+  // away from the page.
+  void ShowBubble(actions::ActionItem* item, bool user_gesture);
 
   // (Re-)registers for wayback-state updates on |contents|'
   // BraveWaybackMachineTabHelper, since the tab's contents can be swapped out


### PR DESCRIPTION
Subclassing LocationBarBubbleDelegateView will allow the bubble to be displayed automatically on failed navigation, without stealing focus from the page.

<!-- Add brave-browser issue below that this PR will resolve -->
- Prerequisite for https://github.com/brave/brave-browser/issues/51438

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
