### PR TITLE
Retry OnUnlockLayout instead of crashing if session restore is still in progress (uplift to 1.96.x)

### DIFF
--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -587,7 +587,16 @@ void BraveTabContainer::PaintBoundingBoxForSplitTab(
 }
 
 void BraveTabContainer::OnUnlockLayout() {
-  CHECK(!IsSessionRestoreInProgress());
+  if (IsSessionRestoreInProgress()) {
+    // Session restore for this profile is still (or again) in progress by
+    // the time this deferred task runs (e.g. during the profile chooser
+    // startup flow). Wait for it to finish rather than unlocking early.
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE, base::BindOnce(&BraveTabContainer::OnUnlockLayout,
+                                  weak_factory_.GetWeakPtr()));
+    return;
+  }
+
   layout_locked_ = false;
 
   InvalidateIdealBounds();


### PR DESCRIPTION
Uplift of #39624
Resolves https://github.com/brave/brave-browser/issues/58777

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.