### PR TITLE
[iOS] Defer QuickView entry until HTTPS upgrade succeeds

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -97,12 +97,6 @@ extension BrowserViewController: TabManagerDelegate {
     // When `BraveShieldsTabHelper+TabPolicyDecider` is moved to `BraveShields` target,
     // we should add it as a policy decider at initialization.
     tab.addPolicyDecider(braveShieldsHelper)
-    if FeatureList.kBraveHttpsByDefault.enabled {
-      tab.httpsUpgradeHelper = .init(
-        tab: tab,
-        httpsUpgradeExceptionsService: braveCore.httpsUpgradeExceptionsService
-      )
-    }
     tab.cosmeticFilteringTabHelper = .init(tab: tab)
     tab.logins = .init(tab: tab, passwordAPI: profileController.passwordAPI)
     tab.protectionStats = .init(tab: tab)
@@ -145,6 +139,18 @@ extension BrowserViewController: TabManagerDelegate {
       }
     }
 
+    // Must be added before `braveSearch`. HttpsUpgradeTabHelper needs first look at a
+    // main-frame http navigation so it can attempt the upgrade before BraveSearchTabHelper
+    // decides whether to route it into QuickView. BraveSearchTabHelper recognizes a reissued
+    // https request via `tab.httpsUpgradeHelper?.pendingUpgrade` and only opens QuickView once
+    // `tabDidFinishNavigation` confirms it actually landed on the upgraded (or
+    // gracefully-rolled-back) page rather than a failure/interstitial.
+    if FeatureList.kBraveHttpsByDefault.enabled {
+      tab.httpsUpgradeHelper = .init(
+        tab: tab,
+        httpsUpgradeExceptionsService: braveCore.httpsUpgradeExceptionsService
+      )
+    }
     tab.braveSearch = .init(tab: tab, rewards: rewards, searchEngines: profile.searchEngines)
     tab.braveSearch?.presentSearchResultClickedInfoBar = { [weak self] in
       guard let self else { return }
@@ -163,6 +169,7 @@ extension BrowserViewController: TabManagerDelegate {
         syncAPI: profileController.syncAPI,
         sendTabAPI: profileController.sendTabAPI,
         historyAPI: profileController.historyAPI,
+        httpsUpgradeExceptionsService: braveCore.httpsUpgradeExceptionsService,
         onOpenInNewTab: { [weak self] request, isPrivateMode in
           guard let self else { return }
           self.tabManager.addTabAndSelect(

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -97,6 +97,18 @@ extension BrowserViewController: TabManagerDelegate {
     // When `BraveShieldsTabHelper+TabPolicyDecider` is moved to `BraveShields` target,
     // we should add it as a policy decider at initialization.
     tab.addPolicyDecider(braveShieldsHelper)
+    // Must be added before `braveSearch`. HttpsUpgradeTabHelper needs first look at a
+    // main-frame http navigation so it can attempt the upgrade before BraveSearchTabHelper
+    // decides whether to route it into QuickView. BraveSearchTabHelper recognizes a reissued
+    // https request via `tab.httpsUpgradeHelper?.pendingUpgrade` and only opens QuickView once
+    // `tabDidFinishNavigation` confirms it actually landed on the upgraded (or
+    // gracefully-rolled-back) page rather than a failure/interstitial.
+    if FeatureList.kBraveHttpsByDefault.enabled {
+      tab.httpsUpgradeHelper = .init(
+        tab: tab,
+        httpsUpgradeExceptionsService: braveCore.httpsUpgradeExceptionsService
+      )
+    }
     tab.cosmeticFilteringTabHelper = .init(tab: tab)
     tab.logins = .init(tab: tab, passwordAPI: profileController.passwordAPI)
     tab.protectionStats = .init(tab: tab)
@@ -139,18 +151,6 @@ extension BrowserViewController: TabManagerDelegate {
       }
     }
 
-    // Must be added before `braveSearch`. HttpsUpgradeTabHelper needs first look at a
-    // main-frame http navigation so it can attempt the upgrade before BraveSearchTabHelper
-    // decides whether to route it into QuickView. BraveSearchTabHelper recognizes a reissued
-    // https request via `tab.httpsUpgradeHelper?.pendingUpgrade` and only opens QuickView once
-    // `tabDidFinishNavigation` confirms it actually landed on the upgraded (or
-    // gracefully-rolled-back) page rather than a failure/interstitial.
-    if FeatureList.kBraveHttpsByDefault.enabled {
-      tab.httpsUpgradeHelper = .init(
-        tab: tab,
-        httpsUpgradeExceptionsService: braveCore.httpsUpgradeExceptionsService
-      )
-    }
     tab.braveSearch = .init(tab: tab, rewards: rewards, searchEngines: profile.searchEngines)
     tab.braveSearch?.presentSearchResultClickedInfoBar = { [weak self] in
       guard let self else { return }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/QuickView/QuickViewController.swift
@@ -24,6 +24,7 @@ class QuickViewController: UIViewController {
   private let syncAPI: BraveSyncAPI
   private let sendTabAPI: BraveSendTabAPI
   private let historyAPI: BraveHistoryAPI
+  private let httpsUpgradeExceptionsService: HTTPSUpgradeExceptionsService
   private let toolbarViewModel: QuickViewToolbarModel
   private lazy var toolbarHostingController = UIHostingController(
     rootView: QuickViewToolbarView(viewModel: toolbarViewModel)
@@ -63,6 +64,7 @@ class QuickViewController: UIViewController {
     syncAPI: BraveSyncAPI,
     sendTabAPI: BraveSendTabAPI,
     historyAPI: BraveHistoryAPI,
+    httpsUpgradeExceptionsService: HTTPSUpgradeExceptionsService,
     onOpenInNewTab: ((URLRequest, Bool) -> Void)?,
     onOpenInNewWindow: ((URL, Bool) -> Void)?,
     onAttachTab: ((any TabState) -> Void)?,
@@ -73,6 +75,7 @@ class QuickViewController: UIViewController {
     self.syncAPI = syncAPI
     self.sendTabAPI = sendTabAPI
     self.historyAPI = historyAPI
+    self.httpsUpgradeExceptionsService = httpsUpgradeExceptionsService
     self.toolbarViewModel = QuickViewToolbarModel(
       url: url,
       isPrivate: profile.isOffTheRecord
@@ -141,6 +144,12 @@ class QuickViewController: UIViewController {
       tab.cosmeticFilteringTabHelper = .init(tab: tab)
       tab.scriptletsTabHelper = .init(tab: tab)
       tab.blockedDomainTabHelper = .init(tab: tab)
+      if FeatureList.kBraveHttpsByDefault.enabled {
+        tab.httpsUpgradeHelper = .init(
+          tab: tab,
+          httpsUpgradeExceptionsService: httpsUpgradeExceptionsService
+        )
+      }
     }
     tab.protectionStats = .init(tab: tab)
     tab.readerMode = .init(tab: tab, readerModeCache: ReaderModeScriptHandler.cache(for: tab))
@@ -769,6 +778,12 @@ extension QuickViewController: TabObserver {
     {
       tab.detachedPrivacyHelper = detachedTabPrivacyHelper
       tab.blockedDomainTabHelper = .init(tab: tab)
+      if FeatureList.kBraveHttpsByDefault.enabled {
+        tab.httpsUpgradeHelper = .init(
+          tab: tab,
+          httpsUpgradeExceptionsService: httpsUpgradeExceptionsService
+        )
+      }
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchTabHelper.swift
@@ -4,10 +4,12 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import BraveCore
+import BraveShared
 import BraveShields
 import Foundation
 import OSLog
 import Preferences
+import Shared
 @_spi(ChromiumWebViewAccess) import Web
 
 extension TabDataValues {
@@ -34,6 +36,12 @@ class BraveSearchTabHelper: TabObserver, TabPolicyDecider, BraveSearchMakeDefaul
   var presentSearchResultClickedInfoBar: (() -> Void)?
 
   var presentInQuickView: ((URL, any TabState) -> Void)?
+
+  /// A link click on Brave Search's `/ask` page that `HttpsUpgradeTabHelper` upgraded to
+  /// `https` before we could route it into QuickView. We let it load for real in this tab
+  /// and only open QuickView once `tabDidFinishNavigation` confirms it actually landed on
+  /// the upgraded page rather than a failure/interstitial.
+  private var pendingQuickViewUpgradeURL: URL?
 
   init(tab: some TabState, rewards: BraveRewards, searchEngines: SearchEngines) {
     self.tab = tab
@@ -141,11 +149,39 @@ class BraveSearchTabHelper: TabObserver, TabPolicyDecider, BraveSearchMakeDefaul
       // The website waits on us until this is called with either results or null.
       injectResults(into: tab)
     }
+
+    resolvePendingQuickViewUpgrade(tab: tab)
   }
 
   func tabWillBeDestroyed(_ tab: some TabState) {
+    pendingQuickViewUpgradeURL = nil
     tab.removeObserver(self)
     tab.removePolicyDecider(self)
+  }
+
+  /// Checks whether a navigation we deferred a QuickView decision on (see
+  /// `shouldAllowRequest`) actually landed on the expected upgraded page, and if so, opens
+  /// QuickView now. Otherwise leaves the tab exactly as `HttpsUpgradeTabHelper` left it
+  private func resolvePendingQuickViewUpgrade(tab: some TabState) {
+    guard let pendingUpgradeURL = pendingQuickViewUpgradeURL else { return }
+    pendingQuickViewUpgradeURL = nil
+    guard let committedURL = tab.lastCommittedURL,
+      committedURL.baseDomain == pendingUpgradeURL.baseDomain,
+      InternalURL(committedURL) == nil
+    else {
+      return
+    }
+    // The upgrade succeeded, but it actually navigated this (real, visible) tab away from
+    // `/ask` to get there. Restore `/ask` before handing off to QuickView, which does its
+    // own fresh load of the same (now known-good) URL in a separate, throwaway tab.
+    if tab.backForwardList?.backList.isEmpty == false {
+      tab.goBack()
+    }
+    // Use the URL that actually finished loading, not the originally-expected `https` one:
+    // standard mode's silent fallback lands on plain `http` (already allow-listed by
+    // `HttpsUpgradeTabHelper` at this point), and re-requesting `https` here would just
+    // repeat the same failure inside QuickView's own tab instead of showing the working page.
+    presentInQuickView?(committedURL, tab)
   }
 
   // MARK: - TabPolicyDecider
@@ -223,16 +259,39 @@ class BraveSearchTabHelper: TabObserver, TabPolicyDecider, BraveSearchMakeDefaul
       braveSearchResultAdManager = nil
     }
 
-    if FeatureList.kQuickViewEnabled.enabled,
-      Preferences.General.openLinkInQuickViewMode.value,
+    guard FeatureList.kQuickViewEnabled.enabled, Preferences.General.openLinkInQuickViewMode.value
+    else {
+      return .allow
+    }
+
+    if await shouldOpenInQuickView(
+      requestURL: requestURL,
+      isMainFrame: requestInfo.isMainFrame,
+      navigationType: requestInfo.navigationType,
+      isUserInitiated: requestInfo.isUserInitiated,
+      tab: tab
+    ) {
+      presentInQuickView?(requestURL, tab)
+      return .cancel
+    }
+
+    // `HttpsUpgradeTabHelper` runs before us and may have already cancelled the original
+    // click and reissued it as this `https` request, so `requestInfo` here just describes a
+    // programmatic reload, not the real click. Recover the real click's info from the
+    // upgrade it's continuing, and if it would have qualified for QuickView, let the
+    // navigation actually load (`HttpsUpgradeTabHelper` owns its outcome from here) and
+    // decide whether to open QuickView once it finishes — see `resolvePendingQuickViewUpgrade`.
+    if let pending = tab.httpsUpgradeHelper?.pendingUpgrade,
+      pending.upgradedURL == requestURL,
       await shouldOpenInQuickView(
         requestURL: requestURL,
-        requestInfo: requestInfo,
+        isMainFrame: requestInfo.isMainFrame,
+        navigationType: pending.originalRequestInfo.navigationType,
+        isUserInitiated: pending.originalRequestInfo.isUserInitiated,
         tab: tab
       )
     {
-      presentInQuickView?(requestURL, tab)
-      return .cancel
+      pendingQuickViewUpgradeURL = requestURL
     }
 
     return .allow
@@ -338,12 +397,14 @@ class BraveSearchTabHelper: TabObserver, TabPolicyDecider, BraveSearchMakeDefaul
 
   private func shouldOpenInQuickView(
     requestURL: URL,
-    requestInfo: WebRequestInfo,
+    isMainFrame: Bool,
+    navigationType: WebNavigationType,
+    isUserInitiated: Bool,
     tab: some TabState
   ) async -> Bool {
-    guard requestInfo.isMainFrame,
-      requestInfo.navigationType == .linkActivated,
-      requestInfo.isUserInitiated,
+    guard isMainFrame,
+      navigationType == .linkActivated,
+      isUserInitiated,
       let sourceURL = tab.lastCommittedURL,
       BraveSearchManager.isValidURL(sourceURL),  // sourceURL needs to be valid brave search url
       sourceURL.path == "/ask",

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Internal/HTTPBlockedScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Internal/HTTPBlockedScriptHandler.swift
@@ -71,9 +71,10 @@ class HTTPBlockedScriptHandler: TabContentScript {
   @MainActor private func didGoBack(tab: some TabState) {
     tab.httpsUpgradeHelper?.cancelUpgrade()
     if tab.backForwardList?.backList.isEmpty == true {
-      // interstitial was opened in a new tab
-      tabManager?.addTabToRecentlyClosed(tab)
-      tabManager?.removeTab(tab)
+      // we will redirect user back to NTP home screen if there is nothing to
+      // go back to. This is aligned with BlockedDomain handler
+      tab.loadRequest(PrivilegedRequest(url: TabManager.ntpInteralURL) as URLRequest)
+      return
     } else {
       tab.goBack()
     }

--- a/ios/brave-ios/Sources/BraveShields/HttpsUpgradeTabHelper.swift
+++ b/ios/brave-ios/Sources/BraveShields/HttpsUpgradeTabHelper.swift
@@ -32,10 +32,25 @@ public class HttpsUpgradeTabHelper {
   private weak var tab: (any TabState)?
   private let httpsUpgradeExceptionsService: HTTPSUpgradeExceptionsService
 
-  /// The request that was upgraded to HTTPS.
+  /// An HTTP navigation that was rewritten to HTTPS, and the context needed to
+  /// validate/rollback it later.
+  public struct PendingUpgrade {
+    /// The original `http` request.
+    public let originalRequest: URLRequest
+    /// The `WebRequestInfo` that accompanied the original request, e.g. whether it
+    /// came from a user-initiated link click.
+    public let originalRequestInfo: WebRequestInfo
+    /// The `https` URL the original request was rewritten to.
+    public let upgradedURL: URL
+  }
+
+  /// The upgrade currently being attempted, if any.
   ///
   /// This allows us to rollback the upgrade when the upgraded navigation fails.
-  public private(set) var upgradedHTTPSRequest: URLRequest?
+  public private(set) var pendingUpgrade: PendingUpgrade?
+
+  /// The request that was upgraded to HTTPS.
+  public var upgradedHTTPSRequest: URLRequest? { pendingUpgrade?.originalRequest }
 
   /// A timer that's started on HTTPS upgrade. If the upgrade hasn't completed
   /// within `upgradeTimeout`, it is cancelled and we fallback to HTTP or show
@@ -60,7 +75,7 @@ public class HttpsUpgradeTabHelper {
 
   /// Clear any stored upgrade without rolling it back.
   public func cancelUpgrade() {
-    upgradedHTTPSRequest = nil
+    pendingUpgrade = nil
     upgradeTimeoutTimer?.invalidate()
     upgradeTimeoutTimer = nil
   }
@@ -154,7 +169,11 @@ extension HttpsUpgradeTabHelper: TabPolicyDecider {
 
     Logger.module.debug("Upgrading `\(requestURL.absoluteString)` to HTTPS")
 
-    upgradedHTTPSRequest = request
+    pendingUpgrade = PendingUpgrade(
+      originalRequest: request,
+      originalRequestInfo: requestInfo,
+      upgradedURL: upgradedURL
+    )
     upgradeTimeoutTimer?.invalidate()
 
     var modifiedRequest = request
@@ -179,8 +198,14 @@ extension HttpsUpgradeTabHelper: TabPolicyDecider {
 
 // MARK: - TabObserver
 extension HttpsUpgradeTabHelper: TabObserver {
+
   public func tabDidCommitNavigation(_ tab: some TabState) {
-    // Reset the stored http request now that the load has committed.
+    // Do NOT cancel the upgrade here: a navigation can commit and then immediately fail
+    // (see `didFailNavigationWithError`), so committing does not mean the upgraded load
+    // actually succeeded. Only clear the tracked upgrade once the navigation truly finishes.
+  }
+
+  public func tabDidFinishNavigation(_ tab: some TabState) {
     cancelUpgrade()
   }
 

--- a/ios/brave-ios/Sources/BraveShields/HttpsUpgradeTabHelper.swift
+++ b/ios/brave-ios/Sources/BraveShields/HttpsUpgradeTabHelper.swift
@@ -200,9 +200,12 @@ extension HttpsUpgradeTabHelper: TabPolicyDecider {
 extension HttpsUpgradeTabHelper: TabObserver {
 
   public func tabDidCommitNavigation(_ tab: some TabState) {
-    // Do NOT cancel the upgrade here: a navigation can commit and then immediately fail
-    // (see `didFailNavigationWithError`), so committing does not mean the upgraded load
-    // actually succeeded. Only clear the tracked upgrade once the navigation truly finishes.
+    // Upgraded load can still fail after commit, so only discard it if some
+    // other navigation superseded the upgrade.
+    guard let upgradedURL = upgradedHTTPSRequest?.url,
+      tab.lastCommittedURL?.baseDomain != upgradedURL.baseDomain
+    else { return }
+    cancelUpgrade()
   }
 
   public func tabDidFinishNavigation(_ tab: some TabState) {


### PR DESCRIPTION
Previously QuickView opened immediately on an /ask-page link click, before any http->https upgrade was attempted, so a slow or failing upgrade played out visibly inside QuickView. `HttpsUpgradeTabHelper` has to be ahead of `BraveSearchTabHelper` so the upgrade runs first, and let `BraveSearchTabHelper` defer its QuickView decision until the navigation actually resolves - only opening QuickView once it lands on real content, and leaving the tab as a normal failed/interstitial page otherwise.

Also fixes a related `HttpsUpgradeTabHelper` bug: a failed https load can commit Chromium's own net-error page before `didFailNavigationWithError` fires, so clearing the pending upgrade on `tabDidCommitNavigation` raced ahead of the fallback logic that needs it. Moved to `tabDidFinishNavigation`, which only fires on genuine success. This also makes sure http request can be opened in QuickView in standard mode (upgrade failed -> display http in QuickView)

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

**Test:**

**New behavior — deferred QuickView on upgrade**
(enable quickview feature flag)

**1. Successful upgrade:**
- Standard mode — On Brave Search's /ask page, tap a link to an http:// URL whose host also serves valid https (http://www.google.com) . Verify an upgraded request will be opened in Quickview 
- Strict mode — Same as above

**2. Upgrade failed with error or silent http fallback (timeout)**
- strict mode — On Brave Search's /ask page, tap an http:// link to a host with no https support at all (http://www.alwayshttp.com). Verify QuickView never appears; the /ask tab itself navigates to the http-blocked interstitial. 
- standard mode — On Brave Search's /ask page, tap an http:// link to a host with no https support at all(http://www.alwayshttp.com), in strict mode. Expect: QuickView sheet shows up with http request (original request)

**Regression — paths that must be unaffected**
1. Already-https link on /ask — Tap a normal https:// link on /ask. Expect: QuickView opens  exactly as before
2. kBraveHttpsByDefault disabled — With the feature flag off, tap an http:// link on /ask. Expect: QuickView opens immediately with the plain http content, same as before this change
3. Ordinary (non-/ask) http→https upgrade — Type an http:// URL into the omnibox, or click an http link on any page that is not /ask. Expect: upgrade/fallback/interstitial behavior is completely unchanged from before
4. QuickView feature/preference off — tap an http link on /ask. Expect: normal upgrade behavior in-place, no QuickView involvement at all

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
