### PR TITLE
[iOS] Add iOS-specific query parameters for prepopulated search engines

### DIFF
--- a/components/search_engines/brave_prepopulated_engines.cc
+++ b/components/search_engines/brave_prepopulated_engines.cc
@@ -152,6 +152,8 @@ const PrepopulatedEngine brave_ecosia =
                        "https://www.ecosia.org/search?tt="
 #if BUILDFLAG(IS_ANDROID)
                        "42b8ae98"
+#elif BUILDFLAG(IS_IOS)
+                       "d188c5da"
 #else
                        "e8eb07a6"
 #endif
@@ -193,7 +195,7 @@ const PrepopulatedEngine brave_yandex =
                        u"Yandex",
                        nullptr,
                        "https://yandex.ru/search/?clid="
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
                        "2423859"
 #else
                        "2353835"
@@ -214,6 +216,8 @@ const PrepopulatedEngine brave_search = MakeBravePrepopulatedEngine(
     "https://search.brave.com/search?q={searchTerms}&source="
 #if BUILDFLAG(IS_ANDROID)
     "android",
+#elif BUILDFLAG(IS_IOS)
+    "ios",
 #else
     "desktop",
 #endif
@@ -222,6 +226,8 @@ const PrepopulatedEngine brave_search = MakeBravePrepopulatedEngine(
     "suggest?q={searchTerms}&rich=true&rich_verticals=true&source="
 #if BUILDFLAG(IS_ANDROID)
     "android",
+#elif BUILDFLAG(IS_IOS)
+    "ios",
 #else
     "desktop",
 #endif
@@ -262,7 +268,7 @@ const PrepopulatedEngine brave_yahoo_jp = ModifyEngineParams(
     nullptr,  // keyword
     // search url
     "https://search.yahoo.co.jp/search?p={searchTerms}&ei={inputEncoding}&fr="
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
     "brave-mobile_ext",
 #else
     "brave-desktop_ext",
@@ -272,7 +278,7 @@ const PrepopulatedEngine brave_yahoo_jp = ModifyEngineParams(
     "webassistSearch?p={searchTerms}&appid="
     "dj00aiZpPXVyZmc2WDgzWnA5SSZzPWNvbnN1bWVyc2VjcmV0Jng9MTE-"
     "&output=fxjson&fr="
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
     "brave-mobile_ext",
 #else
     "brave-desktop_ext",
@@ -280,7 +286,7 @@ const PrepopulatedEngine brave_yahoo_jp = ModifyEngineParams(
     // image url
     "https://search.yahoo.co.jp/image/"
     "search?p={searchTerms}&ei={inputEncoding}&fr="
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_IOS)
     "brave-mobile_ext",
 #else
     "brave-desktop_ext",

--- a/components/search_engines/brave_prepopulated_engines.h
+++ b/components/search_engines/brave_prepopulated_engines.h
@@ -26,7 +26,7 @@ namespace TemplateURLPrepopulateData {
 // For more info, see:
 // ComputeMergeEnginesRequirements in components/search_engines/util.cc;
 
-inline constexpr int kBraveCurrentDataVersion = 33;
+inline constexpr int kBraveCurrentDataVersion = 34;
 
 // DO NOT CHANGE THIS ONE. Used for backfilling kBraveDefaultSearchVersion.
 inline constexpr int kBraveFirstTrackedDataVersion = 6;


### PR DESCRIPTION
In preparation for using `TemplateURLService` in iOS to handle search engine selection add the same query parameters that are typically in the `ios/brave-ios/Sources/Brave/Assets/SearchPlugins` xml definitions.
