### PR TITLE
[Android] Don't prompt to save an address on forms without one

### DIFF
--- a/android/junit/src/org/chromium/chrome/browser/autofill/BraveAutofillServiceImplUnitTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/autofill/BraveAutofillServiceImplUnitTest.java
@@ -7,6 +7,11 @@ package org.chromium.chrome.browser.autofill;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import android.view.View;
+import android.view.autofill.AutofillId;
 
 import androidx.test.filters.SmallTest;
 
@@ -15,6 +20,9 @@ import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
 import org.chromium.base.test.BaseRobolectricTestRunner;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /** Unit tests for pure utility methods in {@link BraveAutofillServiceImpl}. */
 @RunWith(BaseRobolectricTestRunner.class)
@@ -214,5 +222,51 @@ public class BraveAutofillServiceImplUnitTest {
         // "California" does not exact-match either, does not prefix-match either,
         // but starts with "CALIF" (pass 3).
         assertEquals(1, BraveAutofillServiceImpl.matchListOption(options, "California"));
+    }
+
+    // --- pickRequiredSaveField ---
+
+    private static Map<String, AutofillId> mapWithKeys(String... keys) {
+        Map<String, AutofillId> map = new HashMap<>();
+        for (int i = 0; i < keys.length; i++) {
+            map.put(keys[i], new AutofillId(i + 1));
+        }
+        return map;
+    }
+
+    @Test
+    @SmallTest
+    public void pickRequiredSaveField_noAddressComponent_returnsNull() {
+        // The system prompt reads "Save address to Brave?" and Android shows it when the
+        // activity finishes, so a form with no address component must not arm it at all.
+        assertNull(
+                BraveAutofillServiceImpl.pickRequiredSaveField(
+                        mapWithKeys(
+                                View.AUTOFILL_HINT_NAME,
+                                View.AUTOFILL_HINT_EMAIL_ADDRESS,
+                                View.AUTOFILL_HINT_PHONE)));
+    }
+
+    @Test
+    @SmallTest
+    public void pickRequiredSaveField_prefersStreetAddress() {
+        Map<String, AutofillId> fields =
+                mapWithKeys(
+                        View.AUTOFILL_HINT_POSTAL_ADDRESS,
+                        View.AUTOFILL_HINT_POSTAL_CODE,
+                        View.AUTOFILL_HINT_NAME);
+        assertSame(
+                fields.get(View.AUTOFILL_HINT_POSTAL_ADDRESS),
+                BraveAutofillServiceImpl.pickRequiredSaveField(fields));
+    }
+
+    @Test
+    @SmallTest
+    public void pickRequiredSaveField_postalCodeOnly_returnsPostalCode() {
+        Map<String, AutofillId> fields =
+                mapWithKeys(View.AUTOFILL_HINT_POSTAL_CODE, View.AUTOFILL_HINT_NAME);
+        assertSame(
+                fields.get(View.AUTOFILL_HINT_POSTAL_CODE),
+                BraveAutofillServiceImpl.pickRequiredSaveField(fields));
     }
 }

--- a/android/junit/src/org/chromium/chrome/browser/autofill/BraveAutofillViewStructureParserUnitTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/autofill/BraveAutofillViewStructureParserUnitTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertTrue;
 
 import android.view.View;
 import android.view.autofill.AutofillId;
+import android.view.inputmethod.EditorInfo;
 
 import androidx.test.filters.SmallTest;
 
@@ -457,5 +458,181 @@ public class BraveAutofillViewStructureParserUnitTest {
     @SmallTest
     public void mapComputedAutofillHint_unknownValue_returnsNull() {
         assertNull(BraveAutofillViewStructureParser.mapComputedAutofillHint("UNKNOWN_FIELD_TYPE"));
+    }
+
+    // --- isOmnibox ---
+
+    @Test
+    @SmallTest
+    public void isOmnibox_uriInputType_returnsTrue() {
+        assertTrue(
+                BraveAutofillViewStructureParser.isOmnibox(
+                        EditorInfo.TYPE_CLASS_TEXT | EditorInfo.TYPE_TEXT_VARIATION_URI));
+    }
+
+    @Test
+    @SmallTest
+    public void isOmnibox_postalAddressInputType_returnsFalse() {
+        // Variation values are not flags: TYPE_TEXT_VARIATION_POSTAL_ADDRESS (0x70) contains the
+        // bits of TYPE_TEXT_VARIATION_URI (0x10), so they must be compared after masking.
+        assertFalse(
+                BraveAutofillViewStructureParser.isOmnibox(
+                        EditorInfo.TYPE_CLASS_TEXT
+                                | EditorInfo.TYPE_TEXT_VARIATION_POSTAL_ADDRESS));
+    }
+
+    @Test
+    @SmallTest
+    public void isOmnibox_webEmailInputType_returnsFalse() {
+        assertFalse(
+                BraveAutofillViewStructureParser.isOmnibox(
+                        EditorInfo.TYPE_CLASS_TEXT
+                                | EditorInfo.TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS));
+    }
+
+    @Test
+    @SmallTest
+    public void isOmnibox_plainTextInputType_returnsFalse() {
+        assertFalse(BraveAutofillViewStructureParser.isOmnibox(EditorInfo.TYPE_CLASS_TEXT));
+    }
+
+    // --- inferHint ---
+
+    @Test
+    @SmallTest
+    public void inferHint_postalAddressInputType_returnsPostalAddress() {
+        // The postal-address input type must not be mistaken for the URL bar — see isOmnibox.
+        assertEquals(
+                View.AUTOFILL_HINT_POSTAL_ADDRESS,
+                BraveAutofillViewStructureParser.inferHint(
+                        EditorInfo.TYPE_CLASS_TEXT | EditorInfo.TYPE_TEXT_VARIATION_POSTAL_ADDRESS,
+                        "address_line_1"));
+    }
+
+    @Test
+    @SmallTest
+    public void inferHint_uriInputType_returnsNull() {
+        assertNull(
+                BraveAutofillViewStructureParser.inferHint(
+                        EditorInfo.TYPE_CLASS_TEXT | EditorInfo.TYPE_TEXT_VARIATION_URI,
+                        "address"));
+    }
+
+    @Test
+    @SmallTest
+    public void inferHint_unrecognizedText_returnsNull() {
+        // Null lets getHint() fall through to the HTML/computed-hint layer. Any non-null value
+        // here would end classification for the node before that layer runs.
+        assertNull(BraveAutofillViewStructureParser.inferHint(EditorInfo.TYPE_CLASS_TEXT, "notes"));
+    }
+
+    @Test
+    @SmallTest
+    public void inferHint_null_returnsNull() {
+        assertNull(BraveAutofillViewStructureParser.inferHint(EditorInfo.TYPE_CLASS_TEXT, null));
+    }
+
+    @Test
+    @SmallTest
+    public void inferHint_labelText_returnsNull() {
+        assertNull(
+                BraveAutofillViewStructureParser.inferHint(
+                        EditorInfo.TYPE_CLASS_TEXT, "address_label"));
+    }
+
+    @Test
+    @SmallTest
+    public void inferHint_emailKeyword_returnsEmail() {
+        assertEquals(
+                View.AUTOFILL_HINT_EMAIL_ADDRESS,
+                BraveAutofillViewStructureParser.inferHint(
+                        EditorInfo.TYPE_CLASS_TEXT, "Enter your email"));
+    }
+
+    @Test
+    @SmallTest
+    public void inferHint_cityKeyword_returnsCity() {
+        assertEquals(
+                BraveAutofillViewStructureParser.HINT_CITY,
+                BraveAutofillViewStructureParser.inferHint(EditorInfo.TYPE_CLASS_TEXT, "City"));
+    }
+
+    // --- isSaveableAddressForm ---
+
+    @Test
+    @SmallTest
+    public void isSaveableAddressForm_emailAndPassword_returnsFalse() {
+        assertFalse(
+                BraveAutofillViewStructureParser.isSaveableAddressForm(
+                        mapWithKeys(
+                                View.AUTOFILL_HINT_EMAIL_ADDRESS, View.AUTOFILL_HINT_PASSWORD)));
+    }
+
+    @Test
+    @SmallTest
+    public void isSaveableAddressForm_nameCompanyAndPhone_returnsFalse() {
+        // A contact editor: personal details, no address component anywhere.
+        assertFalse(
+                BraveAutofillViewStructureParser.isSaveableAddressForm(
+                        mapWithKeys(
+                                View.AUTOFILL_HINT_NAME,
+                                BraveAutofillViewStructureParser.HINT_COMPANY,
+                                View.AUTOFILL_HINT_PHONE)));
+    }
+
+    @Test
+    @SmallTest
+    public void isSaveableAddressForm_noFields_returnsFalse() {
+        assertFalse(BraveAutofillViewStructureParser.isSaveableAddressForm(mapWithKeys()));
+    }
+
+    @Test
+    @SmallTest
+    public void isSaveableAddressForm_streetAndCity_returnsTrue() {
+        assertTrue(
+                BraveAutofillViewStructureParser.isSaveableAddressForm(
+                        mapWithKeys(
+                                View.AUTOFILL_HINT_POSTAL_ADDRESS,
+                                BraveAutofillViewStructureParser.HINT_CITY)));
+    }
+
+    @Test
+    @SmallTest
+    public void isSaveableAddressForm_streetAndCityWithPassword_returnsTrue() {
+        // Two components is a real address form even on a registration screen.
+        assertTrue(
+                BraveAutofillViewStructureParser.isSaveableAddressForm(
+                        mapWithKeys(
+                                View.AUTOFILL_HINT_POSTAL_ADDRESS,
+                                BraveAutofillViewStructureParser.HINT_CITY,
+                                View.AUTOFILL_HINT_PASSWORD)));
+    }
+
+    @Test
+    @SmallTest
+    public void isSaveableAddressForm_postalCodeOnly_returnsFalse() {
+        assertFalse(
+                BraveAutofillViewStructureParser.isSaveableAddressForm(
+                        mapWithKeys(View.AUTOFILL_HINT_POSTAL_CODE)));
+    }
+
+    @Test
+    @SmallTest
+    public void isSaveableAddressForm_postalCodeAndName_returnsTrue() {
+        assertTrue(
+                BraveAutofillViewStructureParser.isSaveableAddressForm(
+                        mapWithKeys(View.AUTOFILL_HINT_POSTAL_CODE, View.AUTOFILL_HINT_NAME)));
+    }
+
+    @Test
+    @SmallTest
+    public void isSaveableAddressForm_postalCodeAndNameWithPassword_returnsFalse() {
+        // One component is not enough to override a sign-in screen.
+        assertFalse(
+                BraveAutofillViewStructureParser.isSaveableAddressForm(
+                        mapWithKeys(
+                                View.AUTOFILL_HINT_POSTAL_CODE,
+                                View.AUTOFILL_HINT_NAME,
+                                View.AUTOFILL_HINT_PASSWORD)));
     }
 }

--- a/browser/autofill/android/java/src/org/chromium/chrome/browser/autofill/BraveAutofillServiceImpl.java
+++ b/browser/autofill/android/java/src/org/chromium/chrome/browser/autofill/BraveAutofillServiceImpl.java
@@ -183,8 +183,10 @@ public class BraveAutofillServiceImpl extends SplitCompatAutofillService.Impl {
      * etc.). Each field in the dataset gets an appropriate {@link AutofillValue}: {@code forText()}
      * for text inputs or {@code forList(index)} for dropdowns/selects.
      *
-     * <p>The response also includes {@link SaveInfo} so the system prompts "Save to Brave?" when
-     * the user fills a form manually — even if we had no profiles to suggest.
+     * <p>The response also includes {@link SaveInfo} so the system prompts "Save address to Brave?"
+     * when the user fills a form manually — but only for forms that look like a real address form,
+     * and only keyed on a field that has to hold an address for the prompt to make sense. See
+     * {@link BraveAutofillViewStructureParser#isSaveableAddressForm}.
      *
      * @param fields Map of hint key → AutofillId from the view structure parser.
      * @param nodesMap Map of AutofillId → ViewNode for determining field types.
@@ -210,6 +212,7 @@ public class BraveAutofillServiceImpl extends SplitCompatAutofillService.Impl {
 
         // Build one Dataset per saved profile. Each dataset fills all matching fields at once
         // when the user taps the suggestion.
+        boolean addedDataset = false;
         for (AutofillProfile profile : profileList) {
             // Map detected field hints to profile data values. Only fields that exist in
             // both the form and the profile (non-empty) get included.
@@ -334,30 +337,40 @@ public class BraveAutofillServiceImpl extends SplitCompatAutofillService.Impl {
                 // matched fields are dropdowns with no matching option).
                 if (hasValues) {
                     fillResponse.addDataset(dataset.build());
+                    addedDataset = true;
                 }
             }
         }
 
         try {
-            // Set up SaveInfo so Android shows "Save to Brave?" after form submission.
-            // We require just one key field (name, email, etc.) to be filled — the rest are
-            // optional. This way the save prompt appears even if the user skips some fields.
-            AutofillId requiredId = pickRequiredSaveField(fields);
-            SaveInfo.Builder saveInfoBuilder =
-                    new SaveInfo.Builder(
-                            SaveInfo.SAVE_DATA_TYPE_ADDRESS, new AutofillId[] {requiredId});
-            List<AutofillId> optionalIds = new ArrayList<>();
-            for (AutofillId id : fields.values()) {
-                if (!id.equals(requiredId)) {
-                    optionalIds.add(id);
+            // Arm the system "Save address to Brave?" prompt only for forms that actually look
+            // like an address form, and only on a field that must hold an address for the prompt
+            // to be correct — Android shows it when the activity finishes, not on submit, so a
+            // required field like "email" produces address prompts for forms with no address.
+            AutofillId requiredId =
+                    BraveAutofillViewStructureParser.isSaveableAddressForm(fields)
+                            ? pickRequiredSaveField(fields)
+                            : null;
+            if (requiredId != null) {
+                SaveInfo.Builder saveInfoBuilder =
+                        new SaveInfo.Builder(
+                                SaveInfo.SAVE_DATA_TYPE_ADDRESS, new AutofillId[] {requiredId});
+                List<AutofillId> optionalIds = new ArrayList<>();
+                for (AutofillId id : fields.values()) {
+                    if (!id.equals(requiredId)) {
+                        optionalIds.add(id);
+                    }
                 }
+                if (!optionalIds.isEmpty()) {
+                    saveInfoBuilder.setOptionalIds(optionalIds.toArray(new AutofillId[0]));
+                }
+                fillResponse.setSaveInfo(saveInfoBuilder.build());
+            } else if (!addedDataset) {
+                // Builder.build() throws unless the response offers a dataset or save info.
+                callback.onSuccess(null);
+                return;
             }
-            if (!optionalIds.isEmpty()) {
-                saveInfoBuilder.setOptionalIds(optionalIds.toArray(new AutofillId[0]));
-            }
-            fillResponse.setSaveInfo(saveInfoBuilder.build());
-            FillResponse response = fillResponse.build();
-            callback.onSuccess(response);
+            callback.onSuccess(fillResponse.build());
         } catch (Exception e) {
             Log.e(TAG, "Error sending FillResponse", e);
             callback.onSuccess(null);
@@ -425,24 +438,31 @@ public class BraveAutofillServiceImpl extends SplitCompatAutofillService.Impl {
     }
 
     /**
-     * Picks the most likely-to-be-filled field as the single required {@link SaveInfo} field.
-     * Android only shows the "Save?" prompt if ALL required fields are filled, so we require just
-     * one common field and make everything else optional.
+     * Picks the single required {@link SaveInfo} field. Android only shows the save prompt when
+     * every required field has a value, so this must be a field whose value makes the form an
+     * address: requiring a name or an email prompts for forms that contain no address at all.
+     *
+     * <p>Country is excluded because it is usually a dropdown with a preselected value, which would
+     * satisfy the requirement without the user entering anything, and address line 2 is excluded
+     * because it is routinely left empty on genuine address forms.
+     *
+     * @return The field to require, or null if the form has no address component — in which case no
+     *     save info should be attached at all.
      */
-    private static AutofillId pickRequiredSaveField(Map<String, AutofillId> fields) {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    static @Nullable AutofillId pickRequiredSaveField(Map<String, AutofillId> fields) {
         String[] preferred = {
-            View.AUTOFILL_HINT_NAME,
-            BraveAutofillViewStructureParser.HINT_FIRST_NAME,
-            View.AUTOFILL_HINT_EMAIL_ADDRESS,
             View.AUTOFILL_HINT_POSTAL_ADDRESS,
-            View.AUTOFILL_HINT_PHONE,
+            View.AUTOFILL_HINT_POSTAL_CODE,
+            BraveAutofillViewStructureParser.HINT_CITY,
+            BraveAutofillViewStructureParser.HINT_STATE,
         };
         for (String key : preferred) {
             if (fields.containsKey(key)) {
                 return fields.get(key);
             }
         }
-        return fields.values().iterator().next();
+        return null;
     }
 
     /**

--- a/browser/autofill/android/java/src/org/chromium/chrome/browser/autofill/BraveAutofillViewStructureParser.java
+++ b/browser/autofill/android/java/src/org/chromium/chrome/browser/autofill/BraveAutofillViewStructureParser.java
@@ -218,6 +218,49 @@ public class BraveAutofillViewStructureParser {
                 || fields.containsKey(HINT_COMPANY);
     }
 
+    // Postal components — the fields that make a form an actual address form, as opposed to
+    // the personal details (name, email, phone) that any form may collect.
+    private static final String[] ADDRESS_COMPONENTS = {
+        View.AUTOFILL_HINT_POSTAL_ADDRESS,
+        HINT_ADDRESS_LINE2,
+        View.AUTOFILL_HINT_POSTAL_CODE,
+        HINT_CITY,
+        HINT_STATE,
+        HINT_COUNTRY,
+    };
+
+    /**
+     * Returns true if the detected fields look like an address form worth offering to save.
+     *
+     * <p>Deliberately stricter than {@link #hasAddressFields}, which gates whether we offer to
+     * fill: the system save prompt reads "Save address to Brave?", so a lone name, email or phone
+     * field must not arm it — otherwise every sign-in screen asks the user to save an address. A
+     * single heuristically matched component is not enough either, since substring matching in
+     * {@link #inferHint} classifies resource ids like {@code empty_state_text} as a state field.
+     */
+    public static boolean isSaveableAddressForm(Map<String, AutofillId> fields) {
+        int components = 0;
+        for (String component : ADDRESS_COMPONENTS) {
+            if (fields.containsKey(component)) {
+                components++;
+            }
+        }
+        // Two components (street + city, zip + state, ...) is a real address form — offer to
+        // save it even on a registration screen that also asks for a password.
+        if (components >= 2) {
+            return true;
+        }
+        if (components == 0) {
+            return false;
+        }
+        // A single component needs corroboration: a name, and no sign-in fields.
+        if (fields.containsKey(View.AUTOFILL_HINT_PASSWORD)
+                || fields.containsKey(View.AUTOFILL_HINT_USERNAME)) {
+            return false;
+        }
+        return fields.containsKey(View.AUTOFILL_HINT_NAME) || fields.containsKey(HINT_FIRST_NAME);
+    }
+
     /** Recursively walks the view tree, classifying each node and collecting autofillable ones. */
     private static void addAutofillableFields(Map<String, AutofillId> fields, ViewNode node) {
         String hint = getHint(node, fields);
@@ -276,17 +319,17 @@ public class BraveAutofillViewStructureParser {
         // Skip hints already taken — e.g. id="address-line1" matches "address" but that
         // slot may already be filled by the actual street address field.
         String viewHint = node.getHint();
-        String hint = inferHint(node, viewHint);
+        String hint = inferHint(node.getInputType(), viewHint);
         if (hint != null && !existingFields.containsKey(hint)) return hint;
 
         String resourceId = node.getIdEntry();
-        hint = inferHint(node, resourceId);
+        hint = inferHint(node.getInputType(), resourceId);
         if (hint != null && !existingFields.containsKey(hint)) return hint;
 
         CharSequence text = node.getText();
         CharSequence className = node.getClassName();
         if (text != null && className != null && className.toString().contains(EDIT_TEXT_CLASS)) {
-            hint = inferHint(node, text.toString());
+            hint = inferHint(node.getInputType(), text.toString());
             if (hint != null && !existingFields.containsKey(hint)) return hint;
         }
 
@@ -336,10 +379,10 @@ public class BraveAutofillViewStructureParser {
         String hint = mapComputedAutofillHint(computedHints);
         if (hint != null && !existingFields.containsKey(hint)) return hint;
 
-        hint = inferHint(node, nameAttr);
+        hint = inferHint(node.getInputType(), nameAttr);
         if (hint != null && !existingFields.containsKey(hint)) return hint;
 
-        hint = inferHint(node, labelAttr);
+        hint = inferHint(node.getInputType(), labelAttr);
         if (hint != null && !existingFields.containsKey(hint)) return hint;
 
         return null;
@@ -409,11 +452,11 @@ public class BraveAutofillViewStructureParser {
      * <p>Skips nodes that look like labels/containers (not actual input fields) and omnibox fields
      * (URL bars should not trigger autofill).
      *
-     * <p>As a fallback, returns the raw lowercased hint for any enabled autofillable field that
-     * didn't match a known keyword. This ensures we don't silently ignore fields — they'll appear
-     * in the detected fields map but won't match any profile data.
+     * @return A canonical hint key, or null if nothing matched — callers fall through to the next
+     *     detection layer.
      */
-    private static @Nullable String inferHint(ViewNode node, @Nullable String actualHint) {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    static @Nullable String inferHint(int inputType, @Nullable String actualHint) {
         if (actualHint == null || actualHint.isEmpty()) return null;
 
         String hint = actualHint.toLowerCase(Locale.getDefault());
@@ -424,7 +467,7 @@ public class BraveAutofillViewStructureParser {
         }
 
         // Skip the browser's URL bar.
-        if (isOmnibox(node)) {
+        if (isOmnibox(inputType)) {
             return null;
         }
 
@@ -471,20 +514,23 @@ public class BraveAutofillViewStructureParser {
             return HINT_COUNTRY;
         }
 
-        // Fallback: return the raw hint for any enabled autofillable field. These won't match
-        // any profile data in BraveAutofillServiceImpl, but they'll be included in the field
-        // map so SaveInfo can track them.
-        if (node.isEnabled() && node.getAutofillType() != View.AUTOFILL_TYPE_NONE) {
-            return hint;
-        }
         return null;
     }
 
-    /** Detects the browser's URL bar by checking for URI input type. */
-    private static boolean isOmnibox(ViewNode node) {
-        int inputType = node.getInputType();
-        return (inputType & EditorInfo.TYPE_TEXT_VARIATION_URI)
-                == EditorInfo.TYPE_TEXT_VARIATION_URI;
+    /**
+     * Detects the browser's URL bar by checking for URI input type.
+     *
+     * <p>Input type variations are values within {@link EditorInfo#TYPE_MASK_VARIATION}, not
+     * individual flags, so they must be compared after masking: {@code TYPE_TEXT_VARIATION_URI}
+     * (0x10) is a subset of the bits of {@code TYPE_TEXT_VARIATION_POSTAL_ADDRESS} (0x70) and
+     * {@code TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS} (0xD0), and a bare bit test would discard those
+     * real address and email fields as URL bars.
+     */
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    static boolean isOmnibox(int inputType) {
+        return (inputType & EditorInfo.TYPE_MASK_CLASS) == EditorInfo.TYPE_CLASS_TEXT
+                && (inputType & EditorInfo.TYPE_MASK_VARIATION)
+                        == EditorInfo.TYPE_TEXT_VARIATION_URI;
     }
 
     /**


### PR DESCRIPTION
The autofill service attached SaveInfo(SAVE_DATA_TYPE_ADDRESS) whenever a form contained any one of name, email or phone, and required only that field to be filled. Android shows the save prompt when the activity finishes, so users saw "Save address to Brave?" after closing unrelated apps — a contact editor or any sign-in screen was enough to arm it.

Attach save info only for forms with two address components, or one plus a name and no sign-in fields, and key it on a field that has to hold an address, so the prompt cannot appear unless the user entered one.

Fix two detection bugs found alongside it: isOmnibox() bit-tested TYPE_TEXT_VARIATION_URI instead of masking the variation, discarding textPostalAddress and textWebEmailAddress fields as URL bars; and inferHint() returned a raw fallback hint that ended classification before the computed-autofill-hints layer could run.

Resolves: https://github.com/brave/brave-browser/issues/58660

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
