### PR TITLE
[iOS] Improve Reader Mode CSP handling

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/ReaderModeHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/ReaderModeHandler.swift
@@ -54,55 +54,15 @@ public class ReaderModeHandler: InternalSchemeResponse {
     // Must generate a unique nonce, every single time as per Content-Policy spec.
     let setTitleNonce = UUID().uuidString.replacingOccurrences(of: "-", with: "")
 
-    // Create our own CSPs
-    var policies = [
-      ("default-src", "'none'"),
-      ("base-uri", "'none'"),
-      ("form-action", "'none'"),
-      ("frame-ancestors", "'none'"),
-      //("sandbox", ""),                  // Do not enable `sandbox` as it causes `Wikipedia` to not work and possibly other pages
-      ("upgrade-insecure-requests", "1"),
-      ("img-src", "*"),
-      ("style-src", "\(InternalURL.baseUrl) '\(ReaderModeHandler.readerModeStyleHash)'"),
-      ("font-src", "\(InternalURL.baseUrl)"),
-      ("script-src", "'nonce-\(setTitleNonce)'"),
-    ]
-
-    // Parse CSP Header
-    if let originalCSP = headers.first(where: { $0.key.lowercased() == "content-security-policy" })?
-      .value
-    {
-      var originalPolicies = [(String, String)]()
-      let policiesStrings = originalCSP.components(separatedBy: ";")
-        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-      for policy in policiesStrings {
-        let components = policy.components(separatedBy: " ")
-        if components.count == 1 {
-          originalPolicies.append((policy, ""))
-        } else {
-          let key = components[0]
-          let value = components[1...].joined(separator: " ")
-          originalPolicies.append((key, value))
-        }
-      }
-
-      // Remove unwanted policies
-      originalPolicies.removeAll(where: { key, _ in
-        key == "report-uri" || key == "report-to"
-      })
-
-      if originalPolicies.contains(where: { key, _ in key == "img-src" }) {
-        policies.removeAll(where: { key, _ in key == "img-src" })
-      }
-
-      // Add original CSPs onto our own
-      policies.append(contentsOf: originalPolicies)
-    }
-
-    headers["Content-Security-Policy"] = String(
-      policies.map({ (key, value) in
-        return value.isEmpty ? "\(key);" : "\(key) \(value);"
-      }).joined(by: " ")
+    // Only the img-src directive is adopted from the original page's CSP. Remove the original
+    // header (its key casing may differ) so it is not emitted alongside our own policy.
+    let originalCSP = headers.first(where: {
+      $0.key.lowercased() == "content-security-policy"
+    })?.value
+    headers = headers.filter({ $0.key.lowercased() != "content-security-policy" })
+    headers["Content-Security-Policy"] = ReaderModeHandler.contentSecurityPolicy(
+      originalCSP: originalCSP,
+      scriptNonce: setTitleNonce
     )
 
     if url.url.lastPathComponent == "page-exists" {
@@ -172,5 +132,46 @@ public class ReaderModeHandler: InternalSchemeResponse {
 
     assert(false)
     return nil
+  }
+
+  /// Builds the Content-Security-Policy header value for a reader mode page.
+  ///
+  /// Only the `img-src` directive is adopted from the original page's CSP so that images the
+  /// original page allowed can still load. Every other directive is ignored so that a page cannot
+  /// weaken the reader mode policy, e.g. via `script-src-elem`/`script-src-attr` which take
+  /// precedence over the nonce-based `script-src` for inline event handlers, or `frame-src` which
+  /// would allow framing internal pages.
+  static func contentSecurityPolicy(originalCSP: String?, scriptNonce: String) -> String {
+    // Create our own CSPs
+    var policies = [
+      ("default-src", "'none'"),
+      ("base-uri", "'none'"),
+      ("form-action", "'none'"),
+      ("frame-ancestors", "'none'"),
+      //("sandbox", ""),                  // Do not enable `sandbox` as it causes `Wikipedia` to not work and possibly other pages
+      ("upgrade-insecure-requests", "1"),
+      ("img-src", "*"),
+      ("style-src", "\(InternalURL.baseUrl) '\(ReaderModeHandler.readerModeStyleHash)'"),
+      ("font-src", "\(InternalURL.baseUrl)"),
+      ("script-src", "'nonce-\(scriptNonce)'"),
+    ]
+
+    if let originalCSP {
+      let policiesStrings = originalCSP.components(separatedBy: ";")
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      for policy in policiesStrings {
+        let components = policy.components(separatedBy: " ").filter({ !$0.isEmpty })
+        guard components.count > 1, components[0].lowercased() == "img-src" else { continue }
+        // Strip control characters so the value cannot break header serialization
+        let value = components[1...].joined(separator: " ").filter({ !$0.isNewline })
+        guard !value.isEmpty else { continue }
+        policies.removeAll(where: { key, _ in key == "img-src" })
+        policies.append(("img-src", value))
+      }
+    }
+
+    return policies.map({ (key, value) in
+      return value.isEmpty ? "\(key);" : "\(key) \(value);"
+    }).joined(separator: " ")
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/ReaderModeHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/ReaderModeHandler.swift
@@ -156,22 +156,45 @@ public class ReaderModeHandler: InternalSchemeResponse {
       ("script-src", "'nonce-\(scriptNonce)'"),
     ]
 
+    // The original value may be a comma-separated list of policies since `allHeaderFields`
+    // coalesces repeated CSP headers. Each policy is enforced in conjunction with the others,
+    // so an `img-src` is adopted from each one.
+    var adoptedBaseImageSource = false
+    var additionalImageSources: [String] = []
     if let originalCSP {
-      let policiesStrings = originalCSP.components(separatedBy: ";")
-        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-      for policy in policiesStrings {
-        let components = policy.components(separatedBy: " ").filter({ !$0.isEmpty })
-        guard components.count > 1, components[0].lowercased() == "img-src" else { continue }
-        // Strip control characters so the value cannot break header serialization
-        let value = components[1...].joined(separator: " ").filter({ !$0.isNewline })
-        guard !value.isEmpty else { continue }
-        policies.removeAll(where: { key, _ in key == "img-src" })
-        policies.append(("img-src", value))
+      for originalPolicy in originalCSP.components(separatedBy: ",") {
+        let directives = originalPolicy.components(separatedBy: ";")
+          .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        for directive in directives {
+          // Directive tokens may be separated by any whitespace, not just spaces
+          let components = directive.components(separatedBy: .whitespacesAndNewlines).filter({
+            !$0.isEmpty
+          })
+          guard components.first?.lowercased() == "img-src" else { continue }
+          // Strip newline characters so the value cannot break header serialization
+          // An empty source list (a bare `img-src`) is valid and blocks all image loads
+          let value = components.dropFirst().joined(separator: " ").filter({ !$0.isNewline })
+          if !adoptedBaseImageSource {
+            policies.removeAll(where: { key, _ in key == "img-src" })
+            policies.append(("img-src", value))
+            adoptedBaseImageSource = true
+          } else {
+            // The base policy already adopted an `img-src`, so retain this one as its own
+            // policy to preserve the intersection semantics of the original policies
+            additionalImageSources.append(value)
+          }
+          // CSP uses the first occurrence of a directive and ignores later duplicates
+          break
+        }
       }
     }
 
-    return policies.map({ (key, value) in
+    var serialized = policies.map({ (key, value) in
       return value.isEmpty ? "\(key);" : "\(key) \(value);"
     }).joined(separator: " ")
+    for source in additionalImageSources {
+      serialized += source.isEmpty ? ", img-src" : ", img-src \(source)"
+    }
+    return serialized
   }
 }

--- a/ios/brave-ios/Tests/ClientTests/ReaderModeHandlerTests.swift
+++ b/ios/brave-ios/Tests/ClientTests/ReaderModeHandlerTests.swift
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import XCTest
+
+@testable import Brave
+
+final class ReaderModeHandlerTests: XCTestCase {
+
+  private func directives(
+    of csp: String
+  ) -> [(String, String)] {
+    csp.components(separatedBy: ";")
+      .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+      .filter { !$0.isEmpty }
+      .map { directive in
+        let components = directive.components(separatedBy: " ").filter { !$0.isEmpty }
+        return (components[0], components.dropFirst().joined(separator: " "))
+      }
+  }
+
+  private func makeCSP(originalCSP: String? = nil, nonce: String = "test-nonce") -> String {
+    ReaderModeHandler.contentSecurityPolicy(originalCSP: originalCSP, scriptNonce: nonce)
+  }
+
+  func testBasePolicyWithoutOriginalCSP() {
+    let directives = directives(of: makeCSP())
+    XCTAssertTrue(directives.contains(where: { $0 == ("script-src", "'nonce-test-nonce'") }))
+    XCTAssertTrue(directives.contains(where: { $0 == ("default-src", "'none'") }))
+    XCTAssertTrue(directives.contains(where: { $0 == ("frame-ancestors", "'none'") }))
+    XCTAssertTrue(directives.contains(where: { $0 == ("img-src", "*") }))
+  }
+
+  /// The original page's CSP must not be able to weaken the reader mode policy. Directives such
+  /// as `script-src-attr` take precedence over the nonce-based `script-src` for inline event
+  /// handlers, and `frame-src` would permit framing privileged internal pages.
+  func testOriginalCSPDirectivesOtherThanImgSrcAreDropped() {
+    let csp = makeCSP(
+      originalCSP:
+        "script-src-attr 'unsafe-inline'; frame-src internal: *; script-src 'unsafe-inline'; style-src *"
+    )
+    let directives = directives(of: csp)
+    XCTAssertFalse(directives.contains(where: { $0.0 == "script-src-attr" }))
+    XCTAssertFalse(directives.contains(where: { $0.0 == "script-src-elem" }))
+    XCTAssertFalse(directives.contains(where: { $0.0 == "frame-src" }))
+    XCTAssertFalse(directives.contains(where: { $0.0 == "style-src" && $0.1 == "*" }))
+    // Our own directives must remain intact
+    XCTAssertTrue(directives.contains(where: { $0 == ("script-src", "'nonce-test-nonce'") }))
+    XCTAssertTrue(directives.contains(where: { $0 == ("default-src", "'none'") }))
+  }
+
+  /// The `img-src` directive is the only one adopted from the original page's CSP, and it
+  /// replaces our own default `img-src *`
+  func testOriginalCSPImgSrcIsAdopted() {
+    let directives = directives(
+      of: makeCSP(originalCSP: "img-src https: data:; default-src 'self'")
+    )
+    let imgSrc = directives.filter { $0.0 == "img-src" }
+    XCTAssertEqual(imgSrc.count, 1)
+    XCTAssertEqual(imgSrc.first?.1, "https: data:")
+    XCTAssertFalse(directives.contains(where: { $0.0 == "default-src" && $0.1 == "'self'" }))
+  }
+
+  /// Directive names are matched case-insensitively
+  func testOriginalCSPImgSrcCaseInsensitive() {
+    let directives = directives(of: makeCSP(originalCSP: "IMG-SRC https:"))
+    let imgSrc = directives.filter { $0.0 == "img-src" }
+    XCTAssertEqual(imgSrc.count, 1)
+    XCTAssertEqual(imgSrc.first?.1, "https:")
+  }
+
+  /// A malformed directive must not be able to smuggle in additional directives or remove our
+  /// default `img-src`
+  func testOriginalCSPMalformedImgSrcIsIgnored() {
+    let directives = directives(of: makeCSP(originalCSP: "img-src"))
+    XCTAssertTrue(directives.contains(where: { $0 == ("img-src", "*") }))
+  }
+}

--- a/ios/brave-ios/Tests/ClientTests/ReaderModeHandlerTests.swift
+++ b/ios/brave-ios/Tests/ClientTests/ReaderModeHandlerTests.swift
@@ -26,6 +26,11 @@ final class ReaderModeHandlerTests: XCTestCase {
     ReaderModeHandler.contentSecurityPolicy(originalCSP: originalCSP, scriptNonce: nonce)
   }
 
+  /// Splits a serialized CSP into its comma-separated policies, each parsed into directives
+  private func policies(of csp: String) -> [[(String, String)]] {
+    csp.components(separatedBy: ",").map { directives(of: $0) }
+  }
+
   func testBasePolicyWithoutOriginalCSP() {
     let directives = directives(of: makeCSP())
     XCTAssertTrue(directives.contains(where: { $0 == ("script-src", "'nonce-test-nonce'") }))
@@ -40,7 +45,7 @@ final class ReaderModeHandlerTests: XCTestCase {
   func testOriginalCSPDirectivesOtherThanImgSrcAreDropped() {
     let csp = makeCSP(
       originalCSP:
-        "script-src-attr 'unsafe-inline'; frame-src internal: *; script-src 'unsafe-inline'; style-src *"
+        "script-src-attr 'unsafe-inline'; script-src-elem *; frame-src internal: *; script-src 'unsafe-inline'; style-src *"
     )
     let directives = directives(of: csp)
     XCTAssertFalse(directives.contains(where: { $0.0 == "script-src-attr" }))
@@ -72,10 +77,67 @@ final class ReaderModeHandlerTests: XCTestCase {
     XCTAssertEqual(imgSrc.first?.1, "https:")
   }
 
-  /// A malformed directive must not be able to smuggle in additional directives or remove our
-  /// default `img-src`
-  func testOriginalCSPMalformedImgSrcIsIgnored() {
+  /// A bare `img-src` is a valid directive with an empty source list which blocks all image
+  /// loads. It must be preserved rather than falling back to the permissive `img-src *`
+  func testOriginalCSPEmptyImgSrcIsAdopted() {
     let directives = directives(of: makeCSP(originalCSP: "img-src"))
-    XCTAssertTrue(directives.contains(where: { $0 == ("img-src", "*") }))
+    let imgSrc = directives.filter { $0.0 == "img-src" }
+    XCTAssertEqual(imgSrc.count, 1)
+    XCTAssertEqual(imgSrc.first?.1, "")
+  }
+
+  /// Directive tokens may be separated by any whitespace, not just spaces
+  func testOriginalCSPImgSrcTabSeparatedIsAdopted() {
+    let directives = directives(of: makeCSP(originalCSP: "img-src\thttps:"))
+    let imgSrc = directives.filter { $0.0 == "img-src" }
+    XCTAssertEqual(imgSrc.count, 1)
+    XCTAssertEqual(imgSrc.first?.1, "https:")
+  }
+
+  /// CSP uses the first occurrence of a directive and ignores later duplicates, so a page
+  /// cannot loosen its own restrictive `img-src` by appending a second one
+  func testOriginalCSPDuplicateImgSrcUsesFirstOccurrence() {
+    let directives = directives(
+      of: makeCSP(originalCSP: "img-src 'none'; img-src *")
+    )
+    let imgSrc = directives.filter { $0.0 == "img-src" }
+    XCTAssertEqual(imgSrc.count, 1)
+    XCTAssertEqual(imgSrc.first?.1, "'none'")
+  }
+
+  /// `allHeaderFields` coalesces repeated CSP headers into a comma-separated policy list, so an
+  /// `img-src` appearing after the comma must still be adopted
+  func testOriginalCSPImgSrcInSecondPolicyIsAdopted() {
+    let policies = policies(
+      of: makeCSP(originalCSP: "default-src 'none', img-src https:")
+    )
+    XCTAssertEqual(policies.count, 1)
+    let imgSrc = policies[0].filter { $0.0 == "img-src" }
+    XCTAssertEqual(imgSrc.count, 1)
+    XCTAssertEqual(imgSrc.first?.1, "https:")
+  }
+
+  /// Directives from a subsequent coalesced policy must not leak into the base policy
+  func testOriginalCSPSecondPolicyDirectivesAreDropped() {
+    let policies = policies(
+      of: makeCSP(originalCSP: "img-src https:, default-src 'none'")
+    )
+    XCTAssertEqual(policies.count, 1)
+    let imgSrc = policies[0].filter { $0.0 == "img-src" }
+    XCTAssertEqual(imgSrc.count, 1)
+    XCTAssertEqual(imgSrc.first?.1, "https:")
+  }
+
+  /// When multiple coalesced policies each specify `img-src`, the restrictions must intersect,
+  /// so each additional `img-src` is emitted as its own policy
+  func testOriginalCSPImgSrcInMultiplePoliciesIntersect() {
+    let policies = policies(
+      of: makeCSP(originalCSP: "img-src data:, img-src https:")
+    )
+    XCTAssertEqual(policies.count, 2)
+    XCTAssertEqual(policies[0].filter { $0.0 == "img-src" }.first?.1, "data:")
+    XCTAssertEqual(policies[1].count, 1)
+    XCTAssertEqual(policies[1].first?.0, "img-src")
+    XCTAssertEqual(policies[1].first?.1, "https:")
   }
 }


### PR DESCRIPTION
Only adopt `img-src` directive from the original CSP

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58735
