### PR TITLE
[iOS] Dont allow internal urls to load in subframes

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabPolicyDecider.swift
@@ -89,6 +89,14 @@ extension BrowserViewController: TabPolicyDecider {
 
     // Handle internal:// urls
     if InternalURL.isValid(url: requestURL) {
+      // Internal pages must only ever load as main-frame documents. WKWebView does not enforce
+      // frame-ancestors/X-Frame-Options for custom scheme handlers, so subframe loads must be
+      // blocked here.
+      guard requestInfo.isMainFrame else {
+        Logger.module.error("Denying non-main-frame navigation to internal URL: \(request)")
+        return .cancel
+      }
+
       // Requests for Internal pages have a 60s timeout by default
       let isPrivilegedRequest =
         Int64(request.timeoutInterval) < Int64(Int32.max) || request.isPrivileged

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/InterstitialPages/InternalSchemeHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/InterstitialPages/InternalSchemeHandler.swift
@@ -134,6 +134,18 @@ public class InternalSchemeHandler: NSObject, WKURLSchemeHandler {
         return
       }
 
+      // Internal pages are documents that must only load in the main frame. WKWebView does not
+      // enforce frame-ancestors/X-Frame-Options for custom scheme handlers, so refuse any
+      // non-resource internal load that is not the main document (e.g. an iframe pointing at a
+      // privileged internal page). Subframe navigations are also cancelled in the navigation
+      // policy; this is defense-in-depth for loads that reach the scheme handler directly.
+      if let mainDocumentURL = urlSchemeTask.request.mainDocumentURL,
+        mainDocumentURL != urlSchemeTask.request.url
+      {
+        urlSchemeTask.didFailWithError(InternalPageSchemeHandlerError.notAuthorized)
+        return
+      }
+
       // Need a better way to detect when WebKit is making a request from interactionState vs. a regular request by the user
       // instead of having to check the cache policy
       if !urlSchemeTask.request.isPrivileged


### PR DESCRIPTION
We dont have any reason to allow subframe `internal` url loads at the moment and this lines up with Chrome's WebUI scheme handler
