### PR TITLE
[Android] Extend omnibox focus scrim through the nav bar

### DIFF
--- a/android/junit/BUILD.gn
+++ b/android/junit/BUILD.gn
@@ -223,6 +223,15 @@ if (is_android) {
     deps = [ "//chrome/android/junit:chrome_junit_tests_helper" ]
   }
 
+  robolectric_library("brave_junit_tests_org.chromium.chrome.browser.omnibox") {
+    sources = [ "src/org/chromium/chrome/browser/omnibox/BraveLocationBarFocusScrimHandlerUnitTest.java" ]
+
+    deps = [
+      "//chrome/android/junit:chrome_junit_tests_helper",
+      "//chrome/browser/ui/android/omnibox:java",
+    ]
+  }
+
   robolectric_library(
       "brave_junit_tests_org.chromium.chrome.browser.omnibox.geo") {
     sources = [ "src/org/chromium/chrome/browser/omnibox/geo/BraveGeolocationHeaderUnitTest.java" ]

--- a/android/junit/src/org/chromium/chrome/browser/omnibox/BraveLocationBarFocusScrimHandlerUnitTest.java
+++ b/android/junit/src/org/chromium/chrome/browser/omnibox/BraveLocationBarFocusScrimHandlerUnitTest.java
@@ -1,0 +1,68 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.omnibox;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.lenient;
+
+import android.view.View;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.robolectric.annotation.Config;
+
+import org.chromium.base.ContextUtils;
+import org.chromium.base.supplier.ObservableSuppliers;
+import org.chromium.base.test.BaseRobolectricTestRunner;
+import org.chromium.chrome.browser.browser_controls.BottomControlsStacker;
+import org.chromium.chrome.browser.browser_controls.BottomControlsStacker.LayerType;
+import org.chromium.components.browser_ui.widget.scrim.ScrimManager;
+import org.chromium.components.browser_ui.widget.scrim.ScrimProperties;
+import org.chromium.ui.modelutil.PropertyModel;
+
+@RunWith(BaseRobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class BraveLocationBarFocusScrimHandlerUnitTest {
+    @Rule public final MockitoRule mMockitoRule = MockitoJUnit.rule();
+
+    @Mock private View mScrimTarget;
+    @Mock private Runnable mClickDelegate;
+    @Mock private LocationBarDataProvider mLocationBarDataProvider;
+    @Mock private ScrimManager mScrimManager;
+    @Mock private BottomControlsStacker mBottomControlsStacker;
+
+    @Test
+    public void testFocusScrim_coversNavigationBarAndBottomChin() {
+        // Catch a regression to using the bottom chin height as the margin.
+        lenient()
+                .doReturn(37)
+                .when(mBottomControlsStacker)
+                .getHeightFromLayerToBottom(LayerType.BOTTOM_CHIN);
+
+        LocationBarFocusScrimHandler scrimHandler =
+                new LocationBarFocusScrimHandler(
+                        mScrimManager,
+                        (visible) -> {},
+                        ContextUtils.getApplicationContext(),
+                        mLocationBarDataProvider,
+                        mClickDelegate,
+                        mScrimTarget,
+                        ObservableSuppliers.createNonNull(0),
+                        mBottomControlsStacker);
+        PropertyModel scrimModel = scrimHandler.getScrimModelForTesting();
+
+        assertTrue(scrimModel.get(ScrimProperties.AFFECTS_NAVIGATION_BAR));
+
+        scrimHandler.updateScrimVisualState();
+
+        assertEquals(0, scrimModel.get(ScrimProperties.BOTTOM_MARGIN));
+    }
+}

--- a/patches/chrome-browser-ui-android-omnibox-java-src-org-chromium-chrome-browser-omnibox-LocationBarFocusScrimHandler.java.patch
+++ b/patches/chrome-browser-ui-android-omnibox-java-src-org-chromium-chrome-browser-omnibox-LocationBarFocusScrimHandler.java.patch
@@ -1,16 +1,8 @@
 diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarFocusScrimHandler.java b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarFocusScrimHandler.java
-index b967a844d73b6e830be27d78b9f1a21d20fab023..f616e8533732012ea3fda02558e2dbf2e5bdee1f 100644
+index b967a844d73b6e830be27d78b9f1a21d20fab023..f829fd99b57bfde67a6a377ab8e59c8f8f5b941c 100644
 --- a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarFocusScrimHandler.java
 +++ b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarFocusScrimHandler.java
-@@ -17,7 +17,6 @@ import org.chromium.base.supplier.ObservableSuppliers;
- import org.chromium.base.supplier.SettableNonNullObservableSupplier;
- import org.chromium.build.annotations.NullMarked;
- import org.chromium.chrome.browser.browser_controls.BottomControlsStacker;
--import org.chromium.chrome.browser.browser_controls.BottomControlsStacker.LayerType;
- import org.chromium.chrome.browser.flags.ChromeFeatureList;
- import org.chromium.components.browser_ui.widget.scrim.ScrimManager;
- import org.chromium.components.browser_ui.widget.scrim.ScrimProperties;
-@@ -47,7 +46,6 @@ public class LocationBarFocusScrimHandler {
+@@ -47,7 +47,6 @@ public class LocationBarFocusScrimHandler {
      private final Context mContext;
      private final NonNullObservableSupplier<Integer> mTabStripHeightSupplier;
      private final Callback<Integer> mTabStripHeightChangeCallback;
@@ -18,7 +10,7 @@ index b967a844d73b6e830be27d78b9f1a21d20fab023..f616e8533732012ea3fda02558e2dbf2
      private final SettableNonNullObservableSupplier<Boolean> mScrimVisibilitySupplier =
              ObservableSuppliers.createNonNull(false);
  
-@@ -72,7 +70,6 @@ public class LocationBarFocusScrimHandler {
+@@ -72,7 +71,6 @@ public class LocationBarFocusScrimHandler {
              BottomControlsStacker bottomControlsStacker) {
          mScrimManager = scrimManager;
          mLocationBarDataProvider = locationBarDataProvider;
@@ -26,7 +18,7 @@ index b967a844d73b6e830be27d78b9f1a21d20fab023..f616e8533732012ea3fda02558e2dbf2
          mContext = context;
          Callback<Boolean> visibilityChangeCallbackWrapper =
                  visible -> {
-@@ -107,6 +104,7 @@ public class LocationBarFocusScrimHandler {
+@@ -107,6 +105,7 @@ public class LocationBarFocusScrimHandler {
                      mScrimModel.set(ScrimProperties.TOP_MARGIN, newHeight);
                  };
          mTabStripHeightSupplier.addSyncObserverAndPostIfNonNull(mTabStripHeightChangeCallback);
@@ -34,7 +26,7 @@ index b967a844d73b6e830be27d78b9f1a21d20fab023..f616e8533732012ea3fda02558e2dbf2
      }
  
  
-@@ -128,9 +126,7 @@ public class LocationBarFocusScrimHandler {
+@@ -128,9 +127,7 @@ public class LocationBarFocusScrimHandler {
              scrimColor = mLightScrimColor;
          }
          mScrimModel.set(ScrimProperties.BACKGROUND_COLOR, scrimColor);

--- a/patches/chrome-browser-ui-android-omnibox-java-src-org-chromium-chrome-browser-omnibox-LocationBarFocusScrimHandler.java.patch
+++ b/patches/chrome-browser-ui-android-omnibox-java-src-org-chromium-chrome-browser-omnibox-LocationBarFocusScrimHandler.java.patch
@@ -1,0 +1,47 @@
+diff --git a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarFocusScrimHandler.java b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarFocusScrimHandler.java
+index b967a844d73b6e830be27d78b9f1a21d20fab023..f616e8533732012ea3fda02558e2dbf2e5bdee1f 100644
+--- a/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarFocusScrimHandler.java
++++ b/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarFocusScrimHandler.java
+@@ -17,7 +17,6 @@ import org.chromium.base.supplier.ObservableSuppliers;
+ import org.chromium.base.supplier.SettableNonNullObservableSupplier;
+ import org.chromium.build.annotations.NullMarked;
+ import org.chromium.chrome.browser.browser_controls.BottomControlsStacker;
+-import org.chromium.chrome.browser.browser_controls.BottomControlsStacker.LayerType;
+ import org.chromium.chrome.browser.flags.ChromeFeatureList;
+ import org.chromium.components.browser_ui.widget.scrim.ScrimManager;
+ import org.chromium.components.browser_ui.widget.scrim.ScrimProperties;
+@@ -47,7 +46,6 @@ public class LocationBarFocusScrimHandler {
+     private final Context mContext;
+     private final NonNullObservableSupplier<Integer> mTabStripHeightSupplier;
+     private final Callback<Integer> mTabStripHeightChangeCallback;
+-    private final BottomControlsStacker mBottomControlsStacker;
+     private final SettableNonNullObservableSupplier<Boolean> mScrimVisibilitySupplier =
+             ObservableSuppliers.createNonNull(false);
+ 
+@@ -72,7 +70,6 @@ public class LocationBarFocusScrimHandler {
+             BottomControlsStacker bottomControlsStacker) {
+         mScrimManager = scrimManager;
+         mLocationBarDataProvider = locationBarDataProvider;
+-        mBottomControlsStacker = bottomControlsStacker;
+         mContext = context;
+         Callback<Boolean> visibilityChangeCallbackWrapper =
+                 visible -> {
+@@ -107,6 +104,7 @@ public class LocationBarFocusScrimHandler {
+                     mScrimModel.set(ScrimProperties.TOP_MARGIN, newHeight);
+                 };
+         mTabStripHeightSupplier.addSyncObserverAndPostIfNonNull(mTabStripHeightChangeCallback);
++        mScrimModel.set(ScrimProperties.AFFECTS_NAVIGATION_BAR, true);
+     }
+ 
+ 
+@@ -128,9 +126,7 @@ public class LocationBarFocusScrimHandler {
+             scrimColor = mLightScrimColor;
+         }
+         mScrimModel.set(ScrimProperties.BACKGROUND_COLOR, scrimColor);
+-        mScrimModel.set(
+-                ScrimProperties.BOTTOM_MARGIN,
+-                mBottomControlsStacker.getHeightFromLayerToBottom(LayerType.BOTTOM_CHIN));
++        mScrimModel.set(ScrimProperties.BOTTOM_MARGIN, 0);
+     }
+ 
+     /** Controls the visibility of scrim overlay. */

--- a/rewrite/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarFocusScrimHandler.java.yaml
+++ b/rewrite/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarFocusScrimHandler.java.yaml
@@ -29,8 +29,7 @@ substitutions:
       Brave hides the bottom toolbar while the omnibox is focused. The system
       navigation area must use the same scrim treatment as the focused page.
     regex:
-      re_pattern:
-        '^( *)(public LocationBarFocusScrimHandler.*?\{.*?)(\n^\1\})'
+      re_pattern: '^( *)(public LocationBarFocusScrimHandler.*?\{.*?)(\n^\1\})'
       re_flags: [DOTALL, MULTILINE]
       replace:
         '\1\2\n\1\1mScrimModel.set(ScrimProperties.AFFECTS_NAVIGATION_BAR,

--- a/rewrite/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarFocusScrimHandler.java.yaml
+++ b/rewrite/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarFocusScrimHandler.java.yaml
@@ -1,0 +1,56 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: 'Remove the unused `LayerType` import.'
+    regex:
+      pattern:
+        "import
+        org.chromium.chrome.browser.browser_controls.BottomControlsStacker.LayerType;\n"
+      replace: ''
+  - description: |-
+      Remove the obsolete bottom-chin layer field.
+
+      Brave uses no bottom-chin height while the omnibox focus scrim is shown.
+    regex:
+      re_pattern:
+        '^[ \t]*private final BottomControlsStacker mBottomControlsStacker;\n'
+      re_flags: [MULTILINE]
+      replace: ''
+  - description: |-
+      Stop assigning the obsolete bottom-chin layer field.
+
+      Brave uses no bottom-chin height while the omnibox focus scrim is shown.
+    regex:
+      re_pattern:
+        '(public LocationBarFocusScrimHandler\([^)]*\) \{.*?\n)[
+        \t]*mBottomControlsStacker = bottomControlsStacker;\n'
+      re_flags: [DOTALL]
+      replace: '\g<1>'
+  - description: |-
+      Apply the omnibox focus scrim to the navigation bar.
+
+      Brave hides the bottom toolbar while the omnibox is focused. The system
+      navigation area must use the same scrim treatment as the focused page.
+    regex:
+      re_pattern:
+        '(public LocationBarFocusScrimHandler\([^)]*\)
+        \{.*?mTabStripHeightSupplier\.addSyncObserverAndPostIfNonNull\(mTabStripHeightChangeCallback\);)(\n[
+        \t]*\})'
+      re_flags: [DOTALL]
+      replace: |-
+        \1
+                mScrimModel.set(ScrimProperties.AFFECTS_NAVIGATION_BAR, true);\2
+  - description: |-
+      Set the omnibox focus scrim bottom margin to zero.
+
+      The focused omnibox hides Brave's bottom toolbar, so it must not reserve
+      the bottom-chin area. This keeps the gesture-navigation region covered.
+    regex:
+      re_pattern:
+        '(public void updateScrimVisualState\(\)
+        \{.*?)(\s*)mScrimModel\.set\(\s*ScrimProperties\.BOTTOM_MARGIN,\s*mBottomControlsStacker\.getHeightFromLayerToBottom\(LayerType\.BOTTOM_CHIN\)\);'
+      re_flags: [DOTALL]
+      replace: '\g<1>\g<2>mScrimModel.set(ScrimProperties.BOTTOM_MARGIN, 0);'

--- a/rewrite/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarFocusScrimHandler.java.yaml
+++ b/rewrite/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarFocusScrimHandler.java.yaml
@@ -4,12 +4,6 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 substitutions:
-  - description: 'Remove the unused `LayerType` import.'
-    regex:
-      pattern:
-        "import
-        org.chromium.chrome.browser.browser_controls.BottomControlsStacker.LayerType;\n"
-      replace: ''
   - description: |-
       Remove the obsolete bottom-chin layer field.
 

--- a/rewrite/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarFocusScrimHandler.java.yaml
+++ b/rewrite/chrome/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/LocationBarFocusScrimHandler.java.yaml
@@ -30,21 +30,17 @@ substitutions:
       navigation area must use the same scrim treatment as the focused page.
     regex:
       re_pattern:
-        '(public LocationBarFocusScrimHandler\([^)]*\)
-        \{.*?mTabStripHeightSupplier\.addSyncObserverAndPostIfNonNull\(mTabStripHeightChangeCallback\);)(\n[
-        \t]*\})'
-      re_flags: [DOTALL]
-      replace: |-
-        \1
-                mScrimModel.set(ScrimProperties.AFFECTS_NAVIGATION_BAR, true);\2
+        '^( *)(public LocationBarFocusScrimHandler.*?\{.*?)(\n^\1\})'
+      re_flags: [DOTALL, MULTILINE]
+      replace:
+        '\1\2\n\1\1mScrimModel.set(ScrimProperties.AFFECTS_NAVIGATION_BAR,
+        true);\3'
   - description: |-
       Set the omnibox focus scrim bottom margin to zero.
 
       The focused omnibox hides Brave's bottom toolbar, so it must not reserve
       the bottom-chin area. This keeps the gesture-navigation region covered.
     regex:
-      re_pattern:
-        '(public void updateScrimVisualState\(\)
-        \{.*?)(\s*)mScrimModel\.set\(\s*ScrimProperties\.BOTTOM_MARGIN,\s*mBottomControlsStacker\.getHeightFromLayerToBottom\(LayerType\.BOTTOM_CHIN\)\);'
+      re_pattern: 'mScrimModel\.set\(\s*ScrimProperties\.BOTTOM_MARGIN,.*?\);'
       re_flags: [DOTALL]
-      replace: '\g<1>\g<2>mScrimModel.set(ScrimProperties.BOTTOM_MARGIN, 0);'
+      replace: 'mScrimModel.set(ScrimProperties.BOTTOM_MARGIN, 0);'

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1837,6 +1837,7 @@ if (is_android) {
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.messages",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.native_page",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.ntp",
+      "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.omnibox",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.omnibox.geo",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.preferences.website",
       "//brave/android/junit:brave_junit_tests_org.chromium.chrome.browser.quick_search_engines",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58344.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

### Screenshots

Note: this new full screen scrim only applies on API >= 30, and when using gesture navigation. The bug itself only occurs in these configurations also.

&nbsp;|Gesture Navigation|Legacy Navigation
--|--|--
`API_37`|<img width="1344" height="2992" alt="Brave-Dev-API-37_2026-09-07_141519_138" src="https://github.com/user-attachments/assets/403101bb-2608-4f56-aeb3-992822c1bf92" />|<img width="1344" height="2992" alt="Brave-Dev-API-37_2026-09-07_151008_330" src="https://github.com/user-attachments/assets/d54c7994-45e2-4336-993e-6a8224832b47" />
`API_29`|<img width="1344" height="2992" alt="Phone-API-29_2026-09-07_150644_266" src="https://github.com/user-attachments/assets/8bf78406-911d-42f7-b623-85a5e8c6f375" />|<img width="1344" height="2992" alt="Phone-API-29_2026-09-07_141646_550" src="https://github.com/user-attachments/assets/ed5a8d88-d4f0-415a-974a-36486a99ece5" />


https://github.com/user-attachments/assets/0a32b03c-f363-4781-a454-1ceda39f4a89




