### PR TITLE
Postpone BlockchainRegistry::ParseLists()

### DIFF
--- a/components/brave_wallet/browser/keyring_service.cc
+++ b/components/brave_wallet/browser/keyring_service.cc
@@ -2693,6 +2693,10 @@ void KeyringService::Unlock(const std::string& password,
   }
   ResetAutoLockTimer();
 
+  // Defer BlockchainRegistry list parsing until unlock so startup does not
+  // pay for ParseLists when the wallet is never opened.
+  WalletDataFilesInstaller::GetInstance().OnWalletUnlocked();
+
   std::move(callback).Run(true);
 }
 

--- a/components/brave_wallet/browser/wallet_data_files_installer.cc
+++ b/components/brave_wallet/browser/wallet_data_files_installer.cc
@@ -202,8 +202,11 @@ void WalletDataFilesInstaller::MaybeRegisterWalletDataFilesComponent(
 
 void WalletDataFilesInstaller::MaybeRegisterWalletDataFilesComponentOnDemand(
     InstallCallback install_callback) {
+  // Create/restore/import need the lists now
+  parsing_allowed_ = true;
+
   if (registered_ || !delegate_) {  // delegate_ can be nullptr in tests.
-    std::move(install_callback).Run();
+    MaybeParseLists(std::move(install_callback));
     return;
   }
 
@@ -220,9 +223,30 @@ void WalletDataFilesInstaller::MaybeRegisterWalletDataFilesComponentOnDemand(
 }
 
 void WalletDataFilesInstaller::OnComponentReady(const base::FilePath& path) {
-  auto callback =
-      install_callback_ ? std::move(install_callback_) : base::DoNothing();
+  install_dir_ = path;
+  MaybeParseLists(TakeInstallCallback());
+}
+
+void WalletDataFilesInstaller::OnWalletUnlocked() {
+  parsing_allowed_ = true;
+  MaybeParseLists(TakeInstallCallback());
+}
+
+void WalletDataFilesInstaller::MaybeParseLists(InstallCallback callback) {
+  if (!parsing_allowed_ || !install_dir_.has_value()) {
+    std::move(callback).Run();
+    return;
+  }
+
+  const base::FilePath path = std::move(*install_dir_);
+  install_dir_.reset();
+
   BlockchainRegistry::GetInstance()->ParseLists(path, std::move(callback));
+}
+
+WalletDataFilesInstaller::InstallCallback
+WalletDataFilesInstaller::TakeInstallCallback() {
+  return install_callback_ ? std::move(install_callback_) : base::DoNothing();
 }
 
 void WalletDataFilesInstaller::OnEvent(
@@ -232,9 +256,7 @@ void WalletDataFilesInstaller::OnEvent(
   }
 
   if (item.state == update_client::ComponentState::kUpdateError) {
-    if (install_callback_) {
-      std::move(install_callback_).Run();
-    }
+    TakeInstallCallback().Run();
   }
 }
 
@@ -242,6 +264,8 @@ void WalletDataFilesInstaller::Reset() {
   component_updater_observation_.Reset();
   delegate_.reset();
   registered_ = false;
+  parsing_allowed_ = false;
+  install_dir_.reset();
   install_callback_.Reset();
 }
 

--- a/components/brave_wallet/browser/wallet_data_files_installer.h
+++ b/components/brave_wallet/browser/wallet_data_files_installer.h
@@ -51,6 +51,9 @@ class WalletDataFilesInstaller
 
   void OnComponentReady(const base::FilePath& path);
 
+  // Parses installed wallet data lists if available.
+  void OnWalletUnlocked();
+
   // component_updater::ComponentUpdateService::Observer:
   void OnEvent(const update_client::CrxUpdateItem& item) override;
 
@@ -63,6 +66,8 @@ class WalletDataFilesInstaller
 
   void RegisterWalletDataFilesComponentInternal(
       component_updater::ComponentUpdateService* cus);
+  void MaybeParseLists(InstallCallback callback);
+  InstallCallback TakeInstallCallback();
 
   base::ScopedObservation<component_updater::ComponentUpdateService,
                           component_updater::ComponentUpdateService::Observer>
@@ -70,6 +75,8 @@ class WalletDataFilesInstaller
 
   std::unique_ptr<WalletDataFilesInstallerDelegate> delegate_;
   bool registered_ = false;
+  bool parsing_allowed_ = false;
+  std::optional<base::FilePath> install_dir_;
   InstallCallback install_callback_;
 };
 

--- a/components/brave_wallet/browser/wallet_data_files_installer_unittest.cc
+++ b/components/brave_wallet/browser/wallet_data_files_installer_unittest.cc
@@ -159,6 +159,12 @@ class WalletDataFilesInstallerUnitTest : public testing::Test {
     run_loop.Run();
   }
 
+  bool UnlockWallet(const std::string& password) {
+    base::test::TestFuture<bool> future;
+    keyring_service()->Unlock(password, future.GetCallback());
+    return future.Take();
+  }
+
   void ImportFromExternalWallet() {
     base::RunLoop run_loop;
     brave_wallet_service_->ImportFromExternalWallet(
@@ -242,6 +248,70 @@ TEST_F(WalletDataFilesInstallerUnitTest,
   RunUntilIdle();
 }
 
+// Startup registration must not parse lists until the wallet is unlocked.
+TEST_F(WalletDataFilesInstallerUnitTest,
+       StartupComponentReady_DefersParsingUntilUnlock) {
+  EXPECT_CALL(*updater(), RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  local_state()->SetTime(kBraveWalletLastUnlockTime, base::Time::Now());
+  installer().MaybeRegisterWalletDataFilesComponent(updater(), local_state());
+  RunUntilIdle();
+
+  WriteCoingeckoIdsMapToFile();
+  installer().OnComponentReady(install_dir());
+  RunUntilIdle();
+  EXPECT_TRUE(registry()->IsEmptyForTesting());
+
+  installer().OnWalletUnlocked();
+  RunUntilIdle();
+  EXPECT_FALSE(registry()->IsEmptyForTesting());
+}
+
+TEST_F(WalletDataFilesInstallerUnitTest,
+       UnlockBeforeComponentReady_ParsesWhenReady) {
+  installer().OnWalletUnlocked();
+  EXPECT_TRUE(registry()->IsEmptyForTesting());
+
+  WriteCoingeckoIdsMapToFile();
+  installer().OnComponentReady(install_dir());
+  RunUntilIdle();
+  EXPECT_FALSE(registry()->IsEmptyForTesting());
+}
+
+// KeyringService::Unlock (not a direct OnWalletUnlocked call) is what
+// production uses after startup deferral.
+TEST_F(WalletDataFilesInstallerUnitTest, KeyringUnlock_ParsesDeferredLists) {
+  EXPECT_CALL(*updater(), RegisterComponent(testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  local_state()->SetTime(kBraveWalletLastUnlockTime, base::Time::Now());
+  installer().MaybeRegisterWalletDataFilesComponent(updater(), local_state());
+  RunUntilIdle();
+
+  WriteCoingeckoIdsMapToFile();
+  installer().OnComponentReady(install_dir());
+  RunUntilIdle();
+  EXPECT_TRUE(registry()->IsEmptyForTesting());
+
+  // RestoreWalletSync creates an existing wallet without the on-demand path.
+  ASSERT_TRUE(keyring_service()->RestoreWalletSync(kMnemonicDivideCruise,
+                                                   kTestWalletPassword, false));
+  keyring_service()->Lock();
+  EXPECT_TRUE(registry()->IsEmptyForTesting());
+
+  EXPECT_FALSE(UnlockWallet("wrong-password"));
+  RunUntilIdle();
+  EXPECT_TRUE(registry()->IsEmptyForTesting());
+
+  EXPECT_TRUE(UnlockWallet(kTestWalletPassword));
+  RunUntilIdle();
+  EXPECT_FALSE(registry()->IsEmptyForTesting());
+  EXPECT_EQ(registry()->GetCoingeckoId(
+                "0xa", "0x7f5c764cbc14f9669b88837ca1490cca17c31607"),
+            "usd-coin");
+}
+
 TEST_F(WalletDataFilesInstallerUnitTest, OnDemandInstallAndParsing_EmptyPath) {
   EXPECT_CALL(*updater(), RegisterComponent(testing::_))
       .Times(1)
@@ -309,6 +379,23 @@ TEST_F(WalletDataFilesInstallerUnitTest,
 
   RunUntilIdle();
   EXPECT_TRUE(registry()->IsEmptyForTesting());
+}
+
+TEST_F(WalletDataFilesInstallerUnitTest,
+       RestoreAfterStartupRegistration_ParsesOnDemand) {
+  EXPECT_CALL(*updater(), RegisterComponent(testing::_))
+      .WillOnce(testing::Return(true));
+  local_state()->SetTime(kBraveWalletLastUnlockTime, base::Time::Now());
+  installer().MaybeRegisterWalletDataFilesComponent(updater(), local_state());
+  RunUntilIdle();
+
+  WriteCoingeckoIdsMapToFile();
+  installer().OnComponentReady(install_dir());
+  RunUntilIdle();
+  EXPECT_TRUE(registry()->IsEmptyForTesting());
+
+  RestoreWallet();
+  EXPECT_FALSE(registry()->IsEmptyForTesting());
 }
 
 TEST_F(WalletDataFilesInstallerUnitTest,


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/53692

## Test plan
We need to verify that the wallet works as expected despite postponing some work.
1. start a browser, create a wallet
2. backup the seed phrase
3. restart the browser
4. unlock the wallet
5. check `Available assets` list is non-empty (Portfolio => "+" => Available assets)
6. restart the browser with a fresh profile
7. restore the wallet from the seed phrase
8. check `Available assets` list is non-empty again. 

<img width="50%" alt="Image" src="https://github.com/user-attachments/assets/23ebecca-8806-4af8-af28-c5a09b28e679" />

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
