### PR TITLE
Fix UaF in ChromeTestChromeMainDelegate

### DIFF
--- a/patches/chrome-test-base-chrome_test_launcher.cc.patch
+++ b/patches/chrome-test-base-chrome_test_launcher.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/test/base/chrome_test_launcher.cc b/chrome/test/base/chrome_test_launcher.cc
-index cf96f5cdd460dbb380ec91f5e1176777e58f72a1..1fd406183015d5bbaf86f58a140e2eceac3669c7 100644
+index cf96f5cdd460dbb380ec91f5e1176777e58f72a1..16b9de03b9f564c81307708367989f42c699cf6d 100644
 --- a/chrome/test/base/chrome_test_launcher.cc
 +++ b/chrome/test/base/chrome_test_launcher.cc
 @@ -42,6 +42,7 @@

--- a/patches/chrome-test-base-chrome_test_launcher.cc.patch
+++ b/patches/chrome-test-base-chrome_test_launcher.cc.patch
@@ -10,12 +10,13 @@ index cf96f5cdd460dbb380ec91f5e1176777e58f72a1..1fd406183015d5bbaf86f58a140e2ece
  #include "content/public/common/content_switches.h"
  #include "content/public/renderer/render_frame.h"
  #include "content/public/renderer/render_frame_observer.h"
-@@ -208,7 +209,9 @@ ChromeTestChromeMainDelegate::ChromeTestChromeMainDelegate()
+@@ -208,7 +209,10 @@ ChromeTestChromeMainDelegate::ChromeTestChromeMainDelegate()
      : ChromeMainDelegate({.exe_entry_point_ticks = base::TimeTicks::Now()}) {}
  #endif
  
 -ChromeTestChromeMainDelegate::~ChromeTestChromeMainDelegate() = default;
 +ChromeTestChromeMainDelegate::~ChromeTestChromeMainDelegate() {
++  content::SetContentClient(&chrome_content_client_);
 +  content::SetRendererClientForTesting(nullptr);
 +}
  

--- a/rewrite/chrome/test/base/chrome_test_launcher.cc.yaml
+++ b/rewrite/chrome/test/base/chrome_test_launcher.cc.yaml
@@ -36,7 +36,14 @@ substitutions:
       which PartitionAlloc's BackupRefPtr flags as a dangling-pointer bug
       once chrome_content_renderer_client_ is actually freed. Null it out
       first so the later raw_ptr release sees an already-cleared pointer.
+
+      SetRendererClientForTesting() writes through the global ContentClient
+      (g_client). RenderViewTest-based browser tests replace g_client with a
+      heap TestContentClient and destroy it in ~RenderViewTest, before this
+      destructor runs. Rebind g_client to chrome_content_client_ first so
+      we clear our renderer_ raw_ptr.
     preempt_function_impl:
       function_name: ChromeTestChromeMainDelegate::~ChromeTestChromeMainDelegate
       code: |
+        content::SetContentClient(&chrome_content_client_);
         content::SetRendererClientForTesting(nullptr);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/internal/issues/1874

The root cause is that `RenderViewTest` is specific. It does extra `ContentClient` override [here](https://source.chromium.org/chromium/chromium/src/+/main:content/public/test/render_view_test.cc;l=473?q=content%2Fpublic%2Ftest%2Frender_view_test.cc).

Before:
```
> ../src/out/Static/brave_browser_tests --enable-logging=stderr --v=0 --gtest_filter=JsSkusBrowserTest.* --test-launcher-jobs=4
...
[       OK ] JsSkusBrowserTest.AttachSkus (156 ms)
[----------] 1 test from JsSkusBrowserTest (157 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (157 ms total)
[  PASSED  ] 1 test.
=================================================================
==135990==ERROR: AddressSanitizer: heap-use-after-free on address 0x7b64c474b1a8 at pc 0x559fc7330dbc bp 0x7ffc6e615cb0 sp 0x7ffc6e615ca8
READ of size 8 at 0x7b64c474b1a8 thread T0
    #0 0x559fc7330dbb in GetForExtraction base/allocator/partition_allocator/src/partition_alloc/pointers/raw_ptr.h:996:47
```

After:
```
> ../out/Static/brave_browser_tests --enable-logging=stderr --v=0 --gtest_filter=JsSkusBrowserTest.* --test-launcher-jobs=4
IMPORTANT DEBUGGING NOTE: each test is run inside its own process.
For debugging a test inside a debugger, use the
--gtest_filter=<your_test_name> flag along with either
--single-process-tests (to run the test in one launcher/browser process) or
--single-process (to do the above, and also run Chrome in single-process mode).
Using sharding settings from environment. This is shard 0/1
Using 4 parallel jobs.
[1/1] JsSkusBrowserTest.AttachSkus (923 ms)
SUCCESS: all tests passed.
Tests took 0 seconds.
```

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
