### PR TITLE
Avoid tinting tabs for achromatic user colors

### DIFF
--- a/browser/ui/color/BUILD.gn
+++ b/browser/ui/color/BUILD.gn
@@ -9,9 +9,12 @@ source_set("unit_tests") {
   sources = [ "brave_color_mixers_unittest.cc" ]
 
   deps = [
+    "//brave/ui/color:nala_color_id",
     "//chrome/browser/ui/color:color_headers",
     "//chrome/browser/ui/color:mixers",
+    "//skia",
     "//testing/gtest",
     "//ui/color",
+    "//ui/color:mixers",
   ]
 }

--- a/browser/ui/color/brave_color_mixers_unittest.cc
+++ b/browser/ui/color/brave_color_mixers_unittest.cc
@@ -20,7 +20,6 @@ class BraveColorMixersTest : public testing::Test {
   BraveColorMixersTest() = default;
 
   ui::ColorProvider& color_provider() { return color_provider_; }
-  ui::ColorProviderKey& color_provider_key() { return color_provider_key_; }
 
   void AddColorMixers() {
     // AddChromeColorMixers() calls all our mixers.
@@ -75,8 +74,9 @@ TEST_F(BraveColorMixersTest, AchromaticUserColorLeavesTabColorsUntintedTest) {
           nala::kColorDesktopbrowserTabbarHoverTabHorizontal));
 }
 
-// The counterpart of the test above: a user color with a hue must still be
-// tinted, so that disabling tinting altogether can't pass as a fix.
+// The counterpart of AchromaticUserColorLeavesTabColorsUntintedTest: a user
+// color with a hue must still be tinted, so that disabling tinting altogether
+// can't pass as a fix.
 TEST_F(BraveColorMixersTest, ChromaticUserColorTintsTabColorsTest) {
   SetAccentUserColor(SkColorSetRGB(0xFF, 0x00, 0x00));
   AddUiAndChromeColorMixers();

--- a/browser/ui/color/brave_color_mixers_unittest.cc
+++ b/browser/ui/color/brave_color_mixers_unittest.cc
@@ -5,9 +5,13 @@
 
 #include <cmath>
 
+#include "brave/browser/ui/color/brave_color_id.h"
+#include "brave/ui/color/nala/nala_color_id.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "chrome/browser/ui/color/chrome_color_mixers.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/skia/include/core/SkColor.h"
+#include "ui/color/color_mixers.h"
 #include "ui/color/color_provider.h"
 #include "ui/color/color_provider_key.h"
 
@@ -16,10 +20,18 @@ class BraveColorMixersTest : public testing::Test {
   BraveColorMixersTest() = default;
 
   ui::ColorProvider& color_provider() { return color_provider_; }
+  ui::ColorProviderKey& color_provider_key() { return color_provider_key_; }
 
   void AddColorMixers() {
     // AddChromeColorMixers() calls all our mixers.
     AddChromeColorMixers(&color_provider_, color_provider_key_);
+  }
+
+  // Nala colors are defined by the ui/ mixers, which run before the Chrome
+  // ones.
+  void AddUiAndChromeColorMixers() {
+    ui::AddColorMixers(&color_provider_, color_provider_key_);
+    AddColorMixers();
   }
 
  private:
@@ -37,4 +49,24 @@ TEST_F(BraveColorMixersTest, ColorOverrideTest) {
                         std::ceil(0.10f * 255.0f)));
   EXPECT_EQ(color_provider().GetColor(kColorOmniboxSecurityChipText),
             color_provider().GetColor(kColorOmniboxSecurityChipDangerous));
+}
+
+// The "Grey" theme's user color is achromatic, so tab colors must not be
+// tinted - HSLShift() would read its hue as 0 and turn them red.
+TEST_F(BraveColorMixersTest, AchromaticUserColorLeavesTabColorsUntintedTest) {
+  color_provider_key().user_color = SkColorSetRGB(0x88, 0x88, 0x88);
+  color_provider_key().user_color_source =
+      ui::ColorProviderKey::UserColorSource::kAccent;
+  AddUiAndChromeColorMixers();
+
+  EXPECT_EQ(color_provider().GetColor(kColorBraveVerticalTabActiveBackground),
+            color_provider().GetColor(
+                nala::kColorDesktopbrowserTabbarActiveTabVertical));
+  EXPECT_EQ(color_provider().GetColor(kColorBraveVerticalTabHoveredBackground),
+            color_provider().GetColor(
+                nala::kColorDesktopbrowserTabbarHoverTabVertical));
+  EXPECT_EQ(
+      color_provider().GetColor(kColorTabBackgroundInactiveHoverFrameActive),
+      color_provider().GetColor(
+          nala::kColorDesktopbrowserTabbarHoverTabHorizontal));
 }

--- a/browser/ui/color/brave_color_mixers_unittest.cc
+++ b/browser/ui/color/brave_color_mixers_unittest.cc
@@ -34,6 +34,12 @@ class BraveColorMixersTest : public testing::Test {
     AddColorMixers();
   }
 
+  void SetAccentUserColor(SkColor color) {
+    color_provider_key_.user_color = color;
+    color_provider_key_.user_color_source =
+        ui::ColorProviderKey::UserColorSource::kAccent;
+  }
+
  private:
   ui::ColorProvider color_provider_;
   ui::ColorProviderKey color_provider_key_;
@@ -54,9 +60,7 @@ TEST_F(BraveColorMixersTest, ColorOverrideTest) {
 // The "Grey" theme's user color is achromatic, so tab colors must not be
 // tinted - HSLShift() would read its hue as 0 and turn them red.
 TEST_F(BraveColorMixersTest, AchromaticUserColorLeavesTabColorsUntintedTest) {
-  color_provider_key().user_color = SkColorSetRGB(0x88, 0x88, 0x88);
-  color_provider_key().user_color_source =
-      ui::ColorProviderKey::UserColorSource::kAccent;
+  SetAccentUserColor(SkColorSetRGB(0x88, 0x88, 0x88));
   AddUiAndChromeColorMixers();
 
   EXPECT_EQ(color_provider().GetColor(kColorBraveVerticalTabActiveBackground),
@@ -66,6 +70,24 @@ TEST_F(BraveColorMixersTest, AchromaticUserColorLeavesTabColorsUntintedTest) {
             color_provider().GetColor(
                 nala::kColorDesktopbrowserTabbarHoverTabVertical));
   EXPECT_EQ(
+      color_provider().GetColor(kColorTabBackgroundInactiveHoverFrameActive),
+      color_provider().GetColor(
+          nala::kColorDesktopbrowserTabbarHoverTabHorizontal));
+}
+
+// The counterpart of the test above: a user color with a hue must still be
+// tinted, so that disabling tinting altogether can't pass as a fix.
+TEST_F(BraveColorMixersTest, ChromaticUserColorTintsTabColorsTest) {
+  SetAccentUserColor(SkColorSetRGB(0xFF, 0x00, 0x00));
+  AddUiAndChromeColorMixers();
+
+  EXPECT_NE(color_provider().GetColor(kColorBraveVerticalTabActiveBackground),
+            color_provider().GetColor(
+                nala::kColorDesktopbrowserTabbarActiveTabVertical));
+  EXPECT_NE(color_provider().GetColor(kColorBraveVerticalTabHoveredBackground),
+            color_provider().GetColor(
+                nala::kColorDesktopbrowserTabbarHoverTabVertical));
+  EXPECT_NE(
       color_provider().GetColor(kColorTabBackgroundInactiveHoverFrameActive),
       color_provider().GetColor(
           nala::kColorDesktopbrowserTabbarHoverTabHorizontal));

--- a/browser/ui/color/brave_color_mixers_unittest.cc
+++ b/browser/ui/color/brave_color_mixers_unittest.cc
@@ -51,12 +51,25 @@ TEST_F(BraveColorMixersTest, ColorOverrideTest) {
             color_provider().GetColor(kColorOmniboxSecurityChipDangerous));
 }
 
-// The "Grey" theme's user color is achromatic, so tab colors must not be
-// tinted - HSLShift() would read its hue as 0 and turn them red.
-TEST_F(BraveColorMixersTest, AchromaticUserColorLeavesTabColorsUntintedTest) {
-  color_provider_key().user_color = SkColorSetRGB(0x88, 0x88, 0x88);
+// Tab colors come straight from the generated Nala palette. Shifting them in
+// HSL on top of that amplifies the hue that 8-bit rounding leaves in these
+// near-grey colors, which tinted the neutral themes ("Grey" red, "Cool grey"
+// pink).
+class BraveTabPaletteColorMixersTest
+    : public BraveColorMixersTest,
+      public testing::WithParamInterface<SkColor> {};
+
+INSTANTIATE_TEST_SUITE_P(All,
+                         BraveTabPaletteColorMixersTest,
+                         testing::Values(SkColorSetRGB(0x88, 0x88, 0x88),
+                                         SkColorSetRGB(0x8C, 0xAB, 0xE4)));
+
+TEST_P(BraveTabPaletteColorMixersTest, AccentColorLeavesTabColorsUntintedTest) {
+  color_provider_key().user_color = GetParam();
   color_provider_key().user_color_source =
       ui::ColorProviderKey::UserColorSource::kAccent;
+  color_provider_key().scheme_variant =
+      ui::ColorProviderKey::SchemeVariant::kNeutral;
   AddUiAndChromeColorMixers();
 
   EXPECT_EQ(color_provider().GetColor(kColorBraveVerticalTabActiveBackground),
@@ -69,4 +82,12 @@ TEST_F(BraveColorMixersTest, AchromaticUserColorLeavesTabColorsUntintedTest) {
       color_provider().GetColor(kColorTabBackgroundInactiveHoverFrameActive),
       color_provider().GetColor(
           nala::kColorDesktopbrowserTabbarHoverTabHorizontal));
+  EXPECT_EQ(
+      color_provider().GetColor(kColorBraveSplitViewTileBackgroundHorizontal),
+      color_provider().GetColor(
+          nala::kColorDesktopbrowserTabbarSplitViewBackgroundHorizontal));
+  EXPECT_EQ(
+      color_provider().GetColor(kColorBraveSplitViewTileBackgroundVertical),
+      color_provider().GetColor(
+          nala::kColorDesktopbrowserTabbarSplitViewBackgroundVertical));
 }

--- a/browser/ui/color/brave_color_mixers_unittest.cc
+++ b/browser/ui/color/brave_color_mixers_unittest.cc
@@ -51,25 +51,12 @@ TEST_F(BraveColorMixersTest, ColorOverrideTest) {
             color_provider().GetColor(kColorOmniboxSecurityChipDangerous));
 }
 
-// Tab colors come straight from the generated Nala palette. Shifting them in
-// HSL on top of that amplifies the hue that 8-bit rounding leaves in these
-// near-grey colors, which tinted the neutral themes ("Grey" red, "Cool grey"
-// pink).
-class BraveTabPaletteColorMixersTest
-    : public BraveColorMixersTest,
-      public testing::WithParamInterface<SkColor> {};
-
-INSTANTIATE_TEST_SUITE_P(All,
-                         BraveTabPaletteColorMixersTest,
-                         testing::Values(SkColorSetRGB(0x88, 0x88, 0x88),
-                                         SkColorSetRGB(0x8C, 0xAB, 0xE4)));
-
-TEST_P(BraveTabPaletteColorMixersTest, AccentColorLeavesTabColorsUntintedTest) {
-  color_provider_key().user_color = GetParam();
+// The "Grey" theme's user color is achromatic, so tab colors must not be
+// tinted - HSLShift() would read its hue as 0 and turn them red.
+TEST_F(BraveColorMixersTest, AchromaticUserColorLeavesTabColorsUntintedTest) {
+  color_provider_key().user_color = SkColorSetRGB(0x88, 0x88, 0x88);
   color_provider_key().user_color_source =
       ui::ColorProviderKey::UserColorSource::kAccent;
-  color_provider_key().scheme_variant =
-      ui::ColorProviderKey::SchemeVariant::kNeutral;
   AddUiAndChromeColorMixers();
 
   EXPECT_EQ(color_provider().GetColor(kColorBraveVerticalTabActiveBackground),
@@ -82,12 +69,4 @@ TEST_P(BraveTabPaletteColorMixersTest, AccentColorLeavesTabColorsUntintedTest) {
       color_provider().GetColor(kColorTabBackgroundInactiveHoverFrameActive),
       color_provider().GetColor(
           nala::kColorDesktopbrowserTabbarHoverTabHorizontal));
-  EXPECT_EQ(
-      color_provider().GetColor(kColorBraveSplitViewTileBackgroundHorizontal),
-      color_provider().GetColor(
-          nala::kColorDesktopbrowserTabbarSplitViewBackgroundHorizontal));
-  EXPECT_EQ(
-      color_provider().GetColor(kColorBraveSplitViewTileBackgroundVertical),
-      color_provider().GetColor(
-          nala::kColorDesktopbrowserTabbarSplitViewBackgroundVertical));
 }

--- a/browser/ui/tabs/brave_tab_color_mixer.cc
+++ b/browser/ui/tabs/brave_tab_color_mixer.cc
@@ -5,10 +5,17 @@
 
 #include "brave/browser/ui/tabs/brave_tab_color_mixer.h"
 
+#include <utility>
+
+#include "base/containers/fixed_flat_map.h"
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
+#include "base/functional/callback_forward.h"
+#include "base/logging.h"
 #include "brave/browser/ui/color/brave_color_id.h"
+#include "brave/ui/color/brave_ref_color_mixer.h"
 #include "brave/ui/color/nala/nala_color_id.h"
+#include "chrome/browser/themes/theme_properties.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "ui/color/color_id.h"
 #include "ui/color/color_mixer.h"
@@ -16,6 +23,7 @@
 #include "ui/color/color_provider_key.h"
 #include "ui/color/color_recipe.h"
 #include "ui/color/color_transform.h"
+#include "ui/gfx/color_utils.h"
 
 #if defined(TOOLKIT_VIEWS)
 #include "brave/browser/ui/darker_theme/darker_theme_color_transform_factory.h"
@@ -23,6 +31,113 @@
 #endif  // defined(TOOLKIT_VIEWS)
 
 namespace tabs {
+
+namespace {
+
+// An achromatic user color carries no hue - SkColorToHSL() reports 0 for it,
+// which HSLShift() would then apply as red. Its generated palette is already
+// neutral, so use the palette colors without any tinting.
+bool ShouldTintWithUserColor(const ui::ColorProviderKey& key) {
+  if (!ShouldUseAccentTintedPalette(key)) {
+    return false;
+  }
+
+  const SkColor user_color = *key.user_color;
+  return SkColorGetR(user_color) != SkColorGetG(user_color) ||
+         SkColorGetG(user_color) != SkColorGetB(user_color);
+}
+
+SkColor GetActiveVerticalTabBackgroundColor(const ui::ColorProviderKey& key,
+                                            SkColor input,
+                                            const ui::ColorMixer& mixer) {
+  const auto default_color =
+      mixer.GetResultColor(nala::kColorDesktopbrowserTabbarActiveTabVertical);
+  if (!ShouldTintWithUserColor(key)) {
+    return default_color;
+  }
+
+  // Extract Hue of tab foreground color and apply Saturation and Lightness for
+  // vertical tabs.
+  color_utils::HSL hsl;
+  color_utils::SkColorToHSL(*key.user_color, &hsl);
+
+  hsl.s = 0.6;    // A little more saturation as default color is grayish.
+  hsl.l = 0.485;  // A little bit darker
+
+  return color_utils::HSLShift(default_color, hsl);
+}
+
+SkColor GetHoveredTabBackgroundColor(const ui::ColorProviderKey& key,
+                                     nala::Color default_color_id,
+                                     SkColor input,
+                                     const ui::ColorMixer& mixer) {
+  CHECK(default_color_id == nala::kColorDesktopbrowserTabbarHoverTabVertical ||
+        default_color_id == nala::kColorDesktopbrowserTabbarHoverTabHorizontal);
+
+  const auto default_color = mixer.GetResultColor(default_color_id);
+  if (!ShouldTintWithUserColor(key)) {
+    // Defaults to Nala if no user color.
+    return default_color;
+  }
+
+  CHECK_EQ(std::to_underlying(ui::ColorProviderKey::ColorMode::kLight), 0);
+  CHECK_EQ(std::to_underlying(ui::ColorProviderKey::ColorMode::kDark), 1);
+
+  constexpr auto kHSLShiftMap =
+      base::MakeFixedFlatMap<nala::Color, std::array<color_utils::HSL, 2>>({
+          {nala::kColorDesktopbrowserTabbarHoverTabVertical,
+           {color_utils::HSL{
+                .h = -1, .s = 0.5, .l = 0.8},  // Light mode : lighter
+            color_utils::HSL{
+                .h = -1, .s = 0.6, .l = 0.5}}},  // Dark mode : More saturation
+          {nala::kColorDesktopbrowserTabbarHoverTabHorizontal,
+           {color_utils::HSL{
+                .h = -1,
+                .s = 0.9,
+                .l = 0.8},  // Light-mode: More saturation and lighter
+            color_utils::HSL{
+                .h = -1,
+                .s = 0.55,
+                .l = 0.52}}},  // Dark-mode: A little more saturation
+                               // and a little bit darker
+      });
+
+  const color_utils::HSL& shift =
+      kHSLShiftMap.at(default_color_id).at(std::to_underlying(key.color_mode));
+  return color_utils::HSLShift(default_color, shift);
+}
+
+SkColor GetSplitViewTileBackgroundColor(const ui::ColorProviderKey& key,
+                                        nala::Color default_color_id,
+                                        SkColor input,
+                                        const ui::ColorMixer& mixer) {
+  const auto default_color = mixer.GetResultColor(default_color_id);
+  if (!ShouldTintWithUserColor(key)) {
+    return default_color;
+  }
+
+  CHECK_EQ(std::to_underlying(ui::ColorProviderKey::ColorMode::kLight), 0);
+  CHECK_EQ(std::to_underlying(ui::ColorProviderKey::ColorMode::kDark), 1);
+
+  // Derive split view tile backgrounds similarly to hovered tab backgrounds,
+  // keeping the original hue while adjusting saturation and lightness
+  // depending on the color mode and orientation.
+  constexpr auto kHSLShiftMap =
+      base::MakeFixedFlatMap<nala::Color, std::array<color_utils::HSL, 2>>({
+          {nala::kColorDesktopbrowserTabbarSplitViewBackgroundHorizontal,
+           {color_utils::HSL{.h = -1, .s = 0.65, .l = 0.59},   // Light mode
+            color_utils::HSL{.h = -1, .s = 0.55, .l = 0.4}}},  // Dark mode
+          {nala::kColorDesktopbrowserTabbarSplitViewBackgroundVertical,
+           {color_utils::HSL{.h = -1, .s = 0.5, .l = 0.52},    // Light mode
+            color_utils::HSL{.h = -1, .s = 0.6, .l = 0.52}}},  // Dark mode
+      });
+
+  const color_utils::HSL& shift =
+      kHSLShiftMap.at(default_color_id).at(std::to_underlying(key.color_mode));
+  return color_utils::HSLShift(default_color, shift);
+}
+
+}  // namespace
 
 void AddBraveTabThemeColorMixer(ui::ColorProvider* provider,
                                 const ui::ColorProviderKey& key) {
@@ -43,19 +158,23 @@ void AddBraveTabThemeColorMixer(ui::ColorProvider* provider,
                        kColorBraveVerticalTabInactiveBackground,
                        /* 40% opacity */ 0.4 * SK_AlphaOPAQUE)};
   } else {
-    mixer[kColorBraveSplitViewTileBackgroundHorizontal] = {
-        nala::kColorDesktopbrowserTabbarSplitViewBackgroundHorizontal};
-    mixer[kColorBraveSplitViewTileBackgroundVertical] = {
-        nala::kColorDesktopbrowserTabbarSplitViewBackgroundVertical};
+    mixer[kColorBraveSplitViewTileBackgroundHorizontal] = {base::BindRepeating(
+        &GetSplitViewTileBackgroundColor, key,
+        nala::kColorDesktopbrowserTabbarSplitViewBackgroundHorizontal)};
+    mixer[kColorBraveSplitViewTileBackgroundVertical] = {base::BindRepeating(
+        &GetSplitViewTileBackgroundColor, key,
+        nala::kColorDesktopbrowserTabbarSplitViewBackgroundVertical)};
     mixer[kColorBraveSplitViewTileBackgroundBorder] = {SK_ColorTRANSPARENT};
     mixer[kColorBraveSplitViewTileDivider] = {
         nala::kColorDesktopbrowserTabbarSplitViewDivider};
     mixer[kColorBraveVerticalTabActiveBackground] = {
-        nala::kColorDesktopbrowserTabbarActiveTabVertical};
-    mixer[kColorTabBackgroundInactiveHoverFrameActive] = {
-        nala::kColorDesktopbrowserTabbarHoverTabHorizontal};
+        base::BindRepeating(&GetActiveVerticalTabBackgroundColor, key)};
+    mixer[kColorTabBackgroundInactiveHoverFrameActive] = {base::BindRepeating(
+        &GetHoveredTabBackgroundColor, key,
+        nala::kColorDesktopbrowserTabbarHoverTabHorizontal)};
     mixer[kColorBraveVerticalTabHoveredBackground] = {
-        nala::kColorDesktopbrowserTabbarHoverTabVertical};
+        base::BindRepeating(&GetHoveredTabBackgroundColor, key,
+                            nala::kColorDesktopbrowserTabbarHoverTabVertical)};
   }
 
   mixer[kColorBraveVerticalTabInactiveBackground] = {kColorToolbar};

--- a/browser/ui/tabs/brave_tab_color_mixer.cc
+++ b/browser/ui/tabs/brave_tab_color_mixer.cc
@@ -34,12 +34,25 @@ namespace tabs {
 
 namespace {
 
+// An achromatic user color carries no hue - SkColorToHSL() reports 0 for it,
+// which HSLShift() would then apply as red. Its generated palette is already
+// neutral, so use the palette colors without any tinting.
+bool ShouldTintWithUserColor(const ui::ColorProviderKey& key) {
+  if (!ShouldUseAccentTintedPalette(key)) {
+    return false;
+  }
+
+  const SkColor user_color = *key.user_color;
+  return SkColorGetR(user_color) != SkColorGetG(user_color) ||
+         SkColorGetG(user_color) != SkColorGetB(user_color);
+}
+
 SkColor GetActiveVerticalTabBackgroundColor(const ui::ColorProviderKey& key,
                                             SkColor input,
                                             const ui::ColorMixer& mixer) {
   const auto default_color =
       mixer.GetResultColor(nala::kColorDesktopbrowserTabbarActiveTabVertical);
-  if (!ShouldUseAccentTintedPalette(key)) {
+  if (!ShouldTintWithUserColor(key)) {
     return default_color;
   }
 
@@ -62,7 +75,7 @@ SkColor GetHoveredTabBackgroundColor(const ui::ColorProviderKey& key,
         default_color_id == nala::kColorDesktopbrowserTabbarHoverTabHorizontal);
 
   const auto default_color = mixer.GetResultColor(default_color_id);
-  if (!ShouldUseAccentTintedPalette(key)) {
+  if (!ShouldTintWithUserColor(key)) {
     // Defaults to Nala if no user color.
     return default_color;
   }
@@ -99,7 +112,7 @@ SkColor GetSplitViewTileBackgroundColor(const ui::ColorProviderKey& key,
                                         SkColor input,
                                         const ui::ColorMixer& mixer) {
   const auto default_color = mixer.GetResultColor(default_color_id);
-  if (!ShouldUseAccentTintedPalette(key)) {
+  if (!ShouldTintWithUserColor(key)) {
     return default_color;
   }
 

--- a/browser/ui/tabs/brave_tab_color_mixer.cc
+++ b/browser/ui/tabs/brave_tab_color_mixer.cc
@@ -42,6 +42,10 @@ bool ShouldTintWithUserColor(const ui::ColorProviderKey& key) {
     return false;
   }
 
+  if (!key.user_color.has_value()) {
+    return false;
+  }
+
   const SkColor user_color = *key.user_color;
   return SkColorGetR(user_color) != SkColorGetG(user_color) ||
          SkColorGetG(user_color) != SkColorGetB(user_color);

--- a/browser/ui/tabs/brave_tab_color_mixer.cc
+++ b/browser/ui/tabs/brave_tab_color_mixer.cc
@@ -5,17 +5,10 @@
 
 #include "brave/browser/ui/tabs/brave_tab_color_mixer.h"
 
-#include <utility>
-
-#include "base/containers/fixed_flat_map.h"
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
-#include "base/functional/callback_forward.h"
-#include "base/logging.h"
 #include "brave/browser/ui/color/brave_color_id.h"
-#include "brave/ui/color/brave_ref_color_mixer.h"
 #include "brave/ui/color/nala/nala_color_id.h"
-#include "chrome/browser/themes/theme_properties.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "ui/color/color_id.h"
 #include "ui/color/color_mixer.h"
@@ -23,7 +16,6 @@
 #include "ui/color/color_provider_key.h"
 #include "ui/color/color_recipe.h"
 #include "ui/color/color_transform.h"
-#include "ui/gfx/color_utils.h"
 
 #if defined(TOOLKIT_VIEWS)
 #include "brave/browser/ui/darker_theme/darker_theme_color_transform_factory.h"
@@ -31,113 +23,6 @@
 #endif  // defined(TOOLKIT_VIEWS)
 
 namespace tabs {
-
-namespace {
-
-// An achromatic user color carries no hue - SkColorToHSL() reports 0 for it,
-// which HSLShift() would then apply as red. Its generated palette is already
-// neutral, so use the palette colors without any tinting.
-bool ShouldTintWithUserColor(const ui::ColorProviderKey& key) {
-  if (!ShouldUseAccentTintedPalette(key)) {
-    return false;
-  }
-
-  const SkColor user_color = *key.user_color;
-  return SkColorGetR(user_color) != SkColorGetG(user_color) ||
-         SkColorGetG(user_color) != SkColorGetB(user_color);
-}
-
-SkColor GetActiveVerticalTabBackgroundColor(const ui::ColorProviderKey& key,
-                                            SkColor input,
-                                            const ui::ColorMixer& mixer) {
-  const auto default_color =
-      mixer.GetResultColor(nala::kColorDesktopbrowserTabbarActiveTabVertical);
-  if (!ShouldTintWithUserColor(key)) {
-    return default_color;
-  }
-
-  // Extract Hue of tab foreground color and apply Saturation and Lightness for
-  // vertical tabs.
-  color_utils::HSL hsl;
-  color_utils::SkColorToHSL(*key.user_color, &hsl);
-
-  hsl.s = 0.6;    // A little more saturation as default color is grayish.
-  hsl.l = 0.485;  // A little bit darker
-
-  return color_utils::HSLShift(default_color, hsl);
-}
-
-SkColor GetHoveredTabBackgroundColor(const ui::ColorProviderKey& key,
-                                     nala::Color default_color_id,
-                                     SkColor input,
-                                     const ui::ColorMixer& mixer) {
-  CHECK(default_color_id == nala::kColorDesktopbrowserTabbarHoverTabVertical ||
-        default_color_id == nala::kColorDesktopbrowserTabbarHoverTabHorizontal);
-
-  const auto default_color = mixer.GetResultColor(default_color_id);
-  if (!ShouldTintWithUserColor(key)) {
-    // Defaults to Nala if no user color.
-    return default_color;
-  }
-
-  CHECK_EQ(std::to_underlying(ui::ColorProviderKey::ColorMode::kLight), 0);
-  CHECK_EQ(std::to_underlying(ui::ColorProviderKey::ColorMode::kDark), 1);
-
-  constexpr auto kHSLShiftMap =
-      base::MakeFixedFlatMap<nala::Color, std::array<color_utils::HSL, 2>>({
-          {nala::kColorDesktopbrowserTabbarHoverTabVertical,
-           {color_utils::HSL{
-                .h = -1, .s = 0.5, .l = 0.8},  // Light mode : lighter
-            color_utils::HSL{
-                .h = -1, .s = 0.6, .l = 0.5}}},  // Dark mode : More saturation
-          {nala::kColorDesktopbrowserTabbarHoverTabHorizontal,
-           {color_utils::HSL{
-                .h = -1,
-                .s = 0.9,
-                .l = 0.8},  // Light-mode: More saturation and lighter
-            color_utils::HSL{
-                .h = -1,
-                .s = 0.55,
-                .l = 0.52}}},  // Dark-mode: A little more saturation
-                               // and a little bit darker
-      });
-
-  const color_utils::HSL& shift =
-      kHSLShiftMap.at(default_color_id).at(std::to_underlying(key.color_mode));
-  return color_utils::HSLShift(default_color, shift);
-}
-
-SkColor GetSplitViewTileBackgroundColor(const ui::ColorProviderKey& key,
-                                        nala::Color default_color_id,
-                                        SkColor input,
-                                        const ui::ColorMixer& mixer) {
-  const auto default_color = mixer.GetResultColor(default_color_id);
-  if (!ShouldTintWithUserColor(key)) {
-    return default_color;
-  }
-
-  CHECK_EQ(std::to_underlying(ui::ColorProviderKey::ColorMode::kLight), 0);
-  CHECK_EQ(std::to_underlying(ui::ColorProviderKey::ColorMode::kDark), 1);
-
-  // Derive split view tile backgrounds similarly to hovered tab backgrounds,
-  // keeping the original hue while adjusting saturation and lightness
-  // depending on the color mode and orientation.
-  constexpr auto kHSLShiftMap =
-      base::MakeFixedFlatMap<nala::Color, std::array<color_utils::HSL, 2>>({
-          {nala::kColorDesktopbrowserTabbarSplitViewBackgroundHorizontal,
-           {color_utils::HSL{.h = -1, .s = 0.65, .l = 0.59},   // Light mode
-            color_utils::HSL{.h = -1, .s = 0.55, .l = 0.4}}},  // Dark mode
-          {nala::kColorDesktopbrowserTabbarSplitViewBackgroundVertical,
-           {color_utils::HSL{.h = -1, .s = 0.5, .l = 0.52},    // Light mode
-            color_utils::HSL{.h = -1, .s = 0.6, .l = 0.52}}},  // Dark mode
-      });
-
-  const color_utils::HSL& shift =
-      kHSLShiftMap.at(default_color_id).at(std::to_underlying(key.color_mode));
-  return color_utils::HSLShift(default_color, shift);
-}
-
-}  // namespace
 
 void AddBraveTabThemeColorMixer(ui::ColorProvider* provider,
                                 const ui::ColorProviderKey& key) {
@@ -158,23 +43,19 @@ void AddBraveTabThemeColorMixer(ui::ColorProvider* provider,
                        kColorBraveVerticalTabInactiveBackground,
                        /* 40% opacity */ 0.4 * SK_AlphaOPAQUE)};
   } else {
-    mixer[kColorBraveSplitViewTileBackgroundHorizontal] = {base::BindRepeating(
-        &GetSplitViewTileBackgroundColor, key,
-        nala::kColorDesktopbrowserTabbarSplitViewBackgroundHorizontal)};
-    mixer[kColorBraveSplitViewTileBackgroundVertical] = {base::BindRepeating(
-        &GetSplitViewTileBackgroundColor, key,
-        nala::kColorDesktopbrowserTabbarSplitViewBackgroundVertical)};
+    mixer[kColorBraveSplitViewTileBackgroundHorizontal] = {
+        nala::kColorDesktopbrowserTabbarSplitViewBackgroundHorizontal};
+    mixer[kColorBraveSplitViewTileBackgroundVertical] = {
+        nala::kColorDesktopbrowserTabbarSplitViewBackgroundVertical};
     mixer[kColorBraveSplitViewTileBackgroundBorder] = {SK_ColorTRANSPARENT};
     mixer[kColorBraveSplitViewTileDivider] = {
         nala::kColorDesktopbrowserTabbarSplitViewDivider};
     mixer[kColorBraveVerticalTabActiveBackground] = {
-        base::BindRepeating(&GetActiveVerticalTabBackgroundColor, key)};
-    mixer[kColorTabBackgroundInactiveHoverFrameActive] = {base::BindRepeating(
-        &GetHoveredTabBackgroundColor, key,
-        nala::kColorDesktopbrowserTabbarHoverTabHorizontal)};
+        nala::kColorDesktopbrowserTabbarActiveTabVertical};
+    mixer[kColorTabBackgroundInactiveHoverFrameActive] = {
+        nala::kColorDesktopbrowserTabbarHoverTabHorizontal};
     mixer[kColorBraveVerticalTabHoveredBackground] = {
-        base::BindRepeating(&GetHoveredTabBackgroundColor, key,
-                            nala::kColorDesktopbrowserTabbarHoverTabVertical)};
+        nala::kColorDesktopbrowserTabbarHoverTabVertical};
   }
 
   mixer[kColorBraveVerticalTabInactiveBackground] = {kColorToolbar};


### PR DESCRIPTION
Selecting the "Grey" theme turned tabs red. Its user color is achromatic, and `SkColorToHSL()` reports a hue of 0 (red) for such colors, which `HSLShift()` then applied to the whole tab palette.

`brave_tab_color_mixer.cc`: add `ShouldTintWithUserColor()`, which extends `ShouldUseAccentTintedPalette()` with a check that the user color has an actual hue (R, G and B not all equal). Use it in place of `ShouldUseAccentTintedPalette()` at the three tinting sites - active vertical tab background, hovered tab background (vertical and horizontal), and split view tile background - so achromatic accents fall back to the untinted Nala palette, whose generated colors are already neutral.

`brave_color_mixers_unittest.cc`: add `AchromaticUserColorLeavesTabColorsUntintedTest`, which sets an achromatic `user_color` with `UserColorSource::kAccent` and asserts the active vertical, hovered vertical and hovered horizontal tab colors still match their Nala ids. Add `AddUiAndChromeColorMixers()` helper, since Nala colors come from the `ui/` mixers that run before the Chrome ones.

`BUILD.gn`: add the `nala_color_id`, `//skia` and `//ui/color:mixers` deps the test needs.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58747

## Results - Gray theme (The conflicting one)

<img width="1586" height="970" alt="image" src="https://github.com/user-attachments/assets/c7b040b3-f413-4348-a339-11c4e6a47090" />

<img width="1586" height="970" alt="image" src="https://github.com/user-attachments/assets/2260d633-0bdf-4528-921c-b6087249263a" />

<img width="1586" height="970" alt="image" src="https://github.com/user-attachments/assets/8fef9f1a-8c34-41eb-b8f3-f79d1d2c17ce" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/ec0657bb-5df3-4aa1-8dc4-79e7d7580cc9" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/b21baa26-bc5e-4a44-a3ef-c2d3fee38ab9" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/4d82e65c-6071-45c1-899e-8c23865aa0b8" />

### Split view 
<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/cdc73af1-fb62-45ce-8eb5-0e13ff689dc2" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/168dc3c0-e13b-4dc6-aa4e-528bd6883f80" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/f12d8444-0f49-4196-a9e1-4496df98aa59" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/02e33ff5-dec5-4b2e-9638-8705f0b0e18c" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/3a390434-3273-49fc-ab3d-0641e458769e" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/3a6a630f-397b-4112-8155-df39d2e74183" />


-------------------
## Result - Other themes don't break - Yellow

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/56ca4c82-a941-4591-b589-1ccbf4cbed50" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/73ac839a-4c8b-40dc-8d16-f7109f666700" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/f4b6c15e-067a-4e52-821c-7ea5539390ef" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/f802e890-d3b7-4ce8-942b-a8e2667c9061" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/d79c39cc-5ae3-4f64-95d0-3a9e209312fc" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/b5fa038c-b0c0-4e03-93cb-b9d000ccec6c" />

## Result - Other themes don't break - Cool grey

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/cadb23b9-1c16-4c2b-997d-54bdeefe89ce" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/e4db19ed-f443-438f-9bcc-3765cdcba080" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/b2b8289a-9073-49af-b736-6333309596b4" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/84aecb94-3b01-48a2-acf1-acf67963e977" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/e94dec7d-1a80-43b1-b285-7e4162cdaa9c" />

<img width="1520" height="904" alt="image" src="https://github.com/user-attachments/assets/36703126-acb2-4e68-ab9c-665b2fa7eb6b" />

------------
## Result - Private tabs

<img width="1586" height="970" alt="image" src="https://github.com/user-attachments/assets/2acc8eb3-d42d-4b08-ab17-a728be2f569a" />

<img width="1586" height="970" alt="image" src="https://github.com/user-attachments/assets/c8bd4907-d6a4-4ca0-8a2e-1b1a94fc61cc" />


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

