### PR TITLE
[deps] Print `setdep` hint on CI jobs

### DIFF
--- a/third_party/ast-grep/package_ast_grep.py
+++ b/third_party/ast-grep/package_ast_grep.py
@@ -70,6 +70,13 @@ def _package_name() -> str:
     return f'ast-grep-{_ast_grep_version()}-{_platform_tag()}.tar.gz'
 
 
+def _extra_deps_path() -> str:
+    """This host's `EXTRA_DEPS` key: the install dir, checkout-relative.
+    """
+    return build_utils.AST_GREP_PLATFORM_DIR.relative_to(
+        build_utils.CHROMIUM_ROOT.parent).as_posix()
+
+
 def _create_archive(out_dir: Path) -> Path:
     """Archive the *contents* of this host's `ast-grep-<os>/` tree into *out_dir*.
 
@@ -134,6 +141,10 @@ def main() -> int:
     logging.info('Done.')
     logging.info('ast-grep package: %s', archive)
     logging.info('  sha256: %s  (%d bytes)', sha256, size)
+    logging.info(
+        'Update EXTRA_DEPS with (from src/brave):\n\n'
+        'vpython3 tools/cr/install_extra_deps.py setdep \\\n'
+        '  -r %s@%s,%s,%d', _extra_deps_path(), archive.name, sha256, size)
     return 0
 
 

--- a/third_party/node/README.md
+++ b/third_party/node/README.md
@@ -31,7 +31,8 @@ their integrity. Everything is installed into a single `node_modules/` tree.
   `package.json` using whatever `node`/`npm` is on the system PATH, and
   refreshes the lockfile.
 - [`package_node_modules.py`](package_node_modules.py) packs the `node_modules/`
-  contents into `node_modules.tar.gz` and prints the object details to record.
+  contents into `node_modules.tar.gz` and prints the
+  `install_extra_deps.py setdep` command that repins its `EXTRA_DEPS` entry.
 
 Tools installed this way are run via their in-package entry point, e.g. pnpm:
 

--- a/third_party/node/package_node.py
+++ b/third_party/node/package_node.py
@@ -38,6 +38,20 @@ from upload import S3Uploader, summarise
 # This directory: third_party/node.
 _NODE_DIR = Path(__file__).resolve().parent
 
+# `EXTRA_DEPS` keys its entries by checkout-relative install path, so every
+# entry packaged here hangs off this prefix (e.g. `<prefix>/node-linux-x64`).
+EXTRA_DEPS_PREFIX = 'src/brave/third_party/node'
+
+
+def print_setdep_command(revisions: list[str]) -> None:
+    """Print the `install_extra_deps.py setdep` command repinning `revisions`.
+    """
+    command = ' \\\n'.join([
+        'vpython3 tools/cr/install_extra_deps.py setdep',
+        *(f'  -r {revision}' for revision in revisions),
+    ])
+    print(f'\nRepin EXTRA_DEPS with (from src/brave):\n\n{command}')
+
 
 def package(tarball_name: str, deployed_dir: str,
             output_dir: Path) -> Path | None:
@@ -97,8 +111,10 @@ def main() -> int:
         logging.basicConfig(level=logging.INFO, format='%(message)s')
         uploader = S3Uploader(bucket='brave-build-deps-public')
 
-    results: list[tuple[str, str, int]] = []
-    for _archive, tarball_name, deployed_dir in PLATFORMS:
+    # Sorted so the `-r` arguments come out in a stable order run to run
+    # (`PLATFORMS` is a frozenset).
+    revisions: list[str] = []
+    for _archive, tarball_name, deployed_dir in sorted(PLATFORMS):
         tarball = package(tarball_name, deployed_dir, args.output_dir)
         if tarball is None:
             continue
@@ -106,17 +122,14 @@ def main() -> int:
         if uploader is not None:
             result = uploader.upload(tarball, prefix='nodejs', sign=False)
             print(f'\nUpload summary:\n{summarise(result)}')
-            results.append((tarball.name, result.sha256, result.size_bytes))
+            sha256, size = result.sha256, result.size_bytes
         else:
             sha256, size = sha256_and_size(tarball)
-            results.append((tarball.name, sha256, size))
+        revisions.append(f'{EXTRA_DEPS_PREFIX}/{deployed_dir}@'
+                         f'{tarball.name},{sha256},{size}')
 
-    if results and uploader is None:
-        # Echo the values needed to update the EXTRA_DEPS entry after upload.
-        print('\nObject details for install_extra_deps.py:')
-        for name, sha256, size in results:
-            print(f"  object_name: '{name}'")
-            print(f"  sha256sum:   '{sha256}'  ({size} bytes)")
+    if revisions:
+        print_setdep_command(revisions)
     return 0
 
 

--- a/third_party/node/package_node_modules.py
+++ b/third_party/node/package_node_modules.py
@@ -21,7 +21,8 @@ sys.path.insert(
     str(Path(__file__).resolve().parents[2] / 'tools' / 'cr' / 'toolchains'))
 
 # pylint: disable=wrong-import-position
-from package_node import sha256_and_size
+from package_node import (EXTRA_DEPS_PREFIX, print_setdep_command,
+                          sha256_and_size)
 from upload import S3Uploader, summarise
 
 # This directory: third_party/node.
@@ -97,11 +98,10 @@ def main() -> int:
     else:
         sha256, size = sha256_and_size(tarball)
 
-        # Echo the values needed to update the EXTRA_DEPS entry (after upload).
-        print('\nObject details for install_extra_deps.py:')
-        print(f"  object_name: '{tarball.name}'")
-        print(f"  sha256sum:   '{sha256}'  ({size} bytes)")
-
+    print_setdep_command([
+        f'{EXTRA_DEPS_PREFIX}/{NODE_MODULES_DIR.name}@'
+        f'{tarball.name},{sha256},{size}'
+    ])
     return 0
 
 


### PR DESCRIPTION
This change adds prints for `setdep` calls once a job has uploaded to
the bucket, which is the next step a user has to take to use the
uploaded artefact.

Bug: https://github.com/brave/brave-browser/issues/56723
