### PR TITLE
[iptc] Fix file upload showing temp file name after selection

### DIFF
--- a/browser/file_select/BUILD.gn
+++ b/browser/file_select/BUILD.gn
@@ -53,3 +53,16 @@ if (!is_android) {
     defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
   }
 }
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "brave_file_select_image_metadata_stripper_unittest.cc" ]
+
+  deps = [
+    ":file_select",
+    "//base",
+    "//base/test:test_support",
+    "//testing/gtest",
+  ]
+}

--- a/browser/file_select/brave_file_select_image_metadata_stripper.cc
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.cc
@@ -6,10 +6,10 @@
 #include "brave/browser/file_select/brave_file_select_image_metadata_stripper.h"
 
 #include <algorithm>
-#include <functional>
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
 #include "base/check_is_test.h"
 #include "base/containers/extend.h"
 #include "base/feature_list.h"
@@ -18,6 +18,7 @@
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/logging.h"
+#include "base/strings/string_number_conversions.h"
 #include "base/task/task_traits.h"
 #include "base/task/thread_pool.h"
 #include "brave/components/image_metadata_stripper/common/features.h"
@@ -70,76 +71,124 @@ bool HasStrippableImage(
       });
 }
 
+// Helps to ensure we only touch files in the |temp_root_dir| we created.
+bool CanDeleteTempPath(const base::FilePath& temp_root_dir,
+                       const base::FilePath& temp_path) {
+  return !temp_path.empty() && !temp_path.ReferencesParent() &&
+         (temp_path == temp_root_dir || temp_root_dir.IsParent(temp_path));
+}
+
 // Algorithm:
-// 1) Iterate over each item in the |selected_files|.
-// 2) If the "ith" item is not strippable, continue with 1.
-// 3) If the "ith" is stripppable then:
-//    3.a) Copy the contents of "ith" item into a temporary file.
-//    3.b) Try and strip the metadata from the temporary file.
-//         3.b.1) If failed: Delete the temporary file and go to Step 1.
-//         3.b.2) Otherwise, mark the temporay file for upload and then later
-//         for deletion.
+// 1) Create one unique temporary root directory for this selection.
+// 2) Iterate over each item in the |selected_files|.
+// 3) If the "ith" item is not strippable, continue with 2.
+// 4) If the "ith" is strippable then:
+//    4.a) Copy it into a unique subdir of the root, and use the filename of
+//    the original file. On macOS file controls show the name the user picked.
+//    4.b) Try and strip the metadata from that copy.
+//         4.b.1) If failed: Delete the subdir and go to Step 2.
+//         4.b.2) Otherwise, mark the copy for upload.
+// 5) If nothing was stripped, delete the temporary root directory created in
+// step 1.
+// 6) Else we queue the temporary root directory created in step 1 for
+// deletion via |temporary_files|.
 StripResult StripListOnBlockingThread(
     std::vector<blink::mojom::FileChooserFileInfoPtr> selected_files) {
   StripResult result;
-  auto temp_file_deleter = [&result](base::FilePath&& temp) {
-    // The guard helps to schedule the delete to upstream's delete lifecycle
-    // if ever our own attempt to delete the temporary file failed.
-    if (!base::DeleteFile(temp)) {
-      result.temp_files.push_back(std::move(temp));
+
+  // 1) Create one unique temporary root directory for this selection.
+  base::FilePath temp_root_dir;
+  if (!base::CreateNewTempDirectory(kUploadStripTempDirPrefix,
+                                    &temp_root_dir)) {
+    LOG(ERROR) << "Upload strip skipped; temp directory could not be created.";
+    result.selected_files = std::move(selected_files);
+    return result;
+  }
+
+  // This will be used to create teh sub directory inside the |temp_root_dir|.
+  size_t temp_sub_dir_index = 0;
+
+  // Delete the |temp_root_dir| if no stripping was done, or a sub
+  // directory. If the deletion fails, we push the path to be cleaned up in
+  // upstream's DeleteTemporaryFiles cleanup.
+  auto temp_dir_deleter = [root = temp_root_dir, &result](base::FilePath path) {
+    if (!CanDeleteTempPath(root, path) || !base::DeletePathRecursively(path)) {
+      result.temp_files.push_back(std::move(path));
     }
   };
 
+  bool stripped_any = false;
+  // 2. Iterate over each item in the |selected_files|.
   for (auto& info : selected_files) {
+    // File issues. Skip.
     if (!info || !info->is_native_file()) {
       continue;
     }
-    const base::FilePath& src = info->get_native_file()->file_path;
+    auto& native = info->get_native_file();
+    const base::FilePath src = native->file_path;
+
+    const base::FilePath basename = src.BaseName();
+    // File issues. Skip. "" or "../" as they can't be used to create a
+    // corresponding temporary file with the same base name. The later could
+    // escpae the |temp_root_dir| isolation.
+    if (basename.empty() || basename.ReferencesParent()) {
+      continue;
+    }
+
+    // 3. If the "ith" item is not strippable, continue with 2.
     if (!IsStrippableImagePath(src)) {
       continue;
     }
 
-    base::FilePath temp;
-    if (!base::CreateTemporaryFile(&temp)) {
-      LOG(ERROR) << "Upload strip skipped; temp file could not be created: "
+    // 4.a) Copy it into a unique subdir of the root, ...
+    const base::FilePath sub_dir_path =
+        temp_root_dir.AppendASCII(base::NumberToString(temp_sub_dir_index++));
+    if (!base::CreateDirectory(sub_dir_path)) {
+      LOG(ERROR) << "Upload strip skipped; temp subdir could not be created: "
                  << src;
       continue;
     }
 
-    if (!base::CopyFile(src, temp)) {
+    // 4.a) ... and use the filename of the original file.
+    const base::FilePath temp_stripped_file = sub_dir_path.Append(basename);
+    if (!base::CopyFile(src, temp_stripped_file)) {
       DVLOG(1) << "Upload strip skipped; Failed to copy the image file to a "
                   "temporary file.";
-      temp_file_deleter(std::move(temp));
+      temp_dir_deleter(sub_dir_path);
       continue;
     }
 
-    // We try and remove the iptc metadata from the file.
-    const bool success = RemoveIptcMetadata(
-        image_metadata_stripper::StrippingClient::kFileSelect, temp);
-    if (!success) {
+    // 4.b) Try and strip the metadata from that copy.
+    if (!RemoveIptcMetadata(
+            image_metadata_stripper::StrippingClient::kFileSelect,
+            temp_stripped_file)) {
       DVLOG(1) << "No stripping occured; keeping original: " << src;
-      temp_file_deleter(std::move(temp));
+      // 4.b.1) If failed: Delete the subdir and go to Step 2.
+      temp_dir_deleter(sub_dir_path);
       continue;
     }
 
-    // Re-write the file path of the original upload file, with our temporary's
-    // file path. This keeps the overall |selected_files| untouched which is
-    // then moved directly to the result.
-    // TODO(https://github.com/brave/brave-browser/issues/5238): On macOS the
-    // file control shows the temp basename (e.g.
-    // .com.brave.Browser.channelNameHere.XXXXXX).
-    // LayoutThemeMac::DisplayNameForFile uses NSFileManager displayNameAtPath
-    // of the backing path so even setting display_name / File.name is not
-    // enough. See
-    // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/
-    // renderer/core/layout/layout_theme_mac.mm;l=60 for details.
-    // Need to figure out how to handle this issue.
-    info->get_native_file()->file_path = temp;
-
-    // Mark the temporary file for deletion later via the upstream's
-    // DeleteTemporaryFiles method.
-    result.temp_files.push_back(std::move(temp));
+    // 4.b.2) Otherwise, mark the copy for upload.
+    // We are swapping out the path of the original file with
+    // |temp_stripped_file| which has been stripped of metadata.
+    native->file_path = temp_stripped_file;
+    if (native->display_name.empty()) {
+      native->display_name = basename.AsUTF16Unsafe();
+    }
+    // This would defer the deletion of the |temp_root_dir| cleanup to the
+    // upstream which will delete it once the tab is closed.
+    stripped_any = true;
   }
+
+  if (!stripped_any) {
+    // 5) If nothing was stripped, delete the temporary root directory.
+    temp_dir_deleter(std::move(temp_root_dir));
+  } else {
+    // Else we queue the temporary root directory created in step 1 for deletion
+    // via |temporary_files|.
+    result.temp_files.push_back(std::move(temp_root_dir));
+  }
+
   result.selected_files = std::move(selected_files);
   return result;
 }
@@ -210,6 +259,30 @@ bool MaybeStripImageMetadataForUpload(
 void SetStripCompletedCallbackForTesting(  // IN-TEST
     base::OnceCallback<void(std::vector<base::FilePath>)>* callback) {
   g_on_strip_completed_callback_for_testing_ = callback;
+}
+
+void DeleteImageMetadataStripperTemporaryDir(
+    std::vector<base::FilePath>& paths) {
+  const auto temp_root_dir =
+      std::ranges::find_if(paths, [](const base::FilePath& path) {
+        return !path.empty() && !path.ReferencesParent() &&
+               path.BaseName().value().find(kUploadStripTempDirPrefix) !=
+                   base::FilePath::StringType::npos &&
+               base::DirectoryExists(path);
+      });
+
+  if (temp_root_dir == paths.end()) {
+    return;
+  }
+
+  if (!base::DeletePathRecursively(*temp_root_dir)) {
+    LOG(ERROR) << "Failed to delete the temporary directory for image metadata "
+                  "stripper. dir:"
+               << *temp_root_dir;
+  }
+
+  // Remove from the list.
+  paths.erase(temp_root_dir);
 }
 
 }  // namespace brave

--- a/browser/file_select/brave_file_select_image_metadata_stripper.cc
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/file_select/brave_file_select_image_metadata_stripper.h"
 
 #include <algorithm>
+#include <functional>
 #include <utility>
 #include <vector>
 
@@ -125,7 +126,7 @@ StripResult StripListOnBlockingThread(
       continue;
     }
     auto& native = info->get_native_file();
-    const base::FilePath src = native->file_path;
+    const base::FilePath& src = native->file_path;
 
     const base::FilePath basename = src.BaseName();
     // File issues. Skip. "" or "../" as they can't be used to create a
@@ -256,12 +257,7 @@ bool MaybeStripImageMetadataForUpload(
   return true;
 }
 
-void SetStripCompletedCallbackForTesting(  // IN-TEST
-    base::OnceCallback<void(std::vector<base::FilePath>)>* callback) {
-  g_on_strip_completed_callback_for_testing_ = callback;
-}
-
-void DeleteImageMetadataStripperTemporaryDir(
+void MaybeDeleteImageMetadataStripperTemporaryDir(
     std::vector<base::FilePath>& paths) {
   const auto temp_root_dir =
       std::ranges::find_if(paths, [](const base::FilePath& path) {
@@ -283,6 +279,11 @@ void DeleteImageMetadataStripperTemporaryDir(
 
   // Remove from the list.
   paths.erase(temp_root_dir);
+}
+
+void SetStripCompletedCallbackForTesting(  // IN-TEST
+    base::OnceCallback<void(std::vector<base::FilePath>)>* callback) {
+  g_on_strip_completed_callback_for_testing_ = callback;
 }
 
 }  // namespace brave

--- a/browser/file_select/brave_file_select_image_metadata_stripper.cc
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.cc
@@ -16,6 +16,7 @@
 #include "base/feature_list.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/logging.h"
@@ -72,51 +73,34 @@ bool HasStrippableImage(
       });
 }
 
-// Helps to ensure we only touch files in the |temp_root_dir| we created.
-bool CanDeleteTempPath(const base::FilePath& temp_root_dir,
-                       const base::FilePath& temp_path) {
-  return !temp_path.empty() && !temp_path.ReferencesParent() &&
-         (temp_path == temp_root_dir || temp_root_dir.IsParent(temp_path));
-}
-
 // Algorithm:
 // 1) Create one unique temporary root directory for this selection.
 // 2) Iterate over each item in the |selected_files|.
 // 3) If the "ith" item is not strippable, continue with 2.
 // 4) If the "ith" is strippable then:
-//    4.a) Copy it into a unique subdir of the root, and use the filename of
-//    the original file. On macOS file controls show the name the user picked.
-//    4.b) Try and strip the metadata from that copy.
-//         4.b.1) If failed: Delete the subdir and go to Step 2.
-//         4.b.2) Otherwise, mark the copy for upload.
-// 5) If nothing was stripped, delete the temporary root directory created in
-// step 1.
-// 6) Else we queue the temporary root directory created in step 1 for
-// deletion via |temporary_files|.
+//    4.a) Copy it into a unique `ScopedTempDir` subdir of the root, and use the
+//    filename of the original file. On macOS file controls show the name the
+//    user picked. 4.b) Try and strip the metadata from that copy.
+//         4.b.1) If failed: ScopedTempDir automatically deletes the subdir.
+//         4.b.2) Otherwise, Take() the subdir and mark the copy for upload.
+// 5) If nothing was stripped, ScopedTempDir deletes the temporary root
+// directory created in step 1.
+// 6) Else Take() the path and queue it for deletion via |temporary_files|.
 StripResult StripListOnBlockingThread(
     std::vector<blink::mojom::FileChooserFileInfoPtr> selected_files) {
   StripResult result;
 
   // 1) Create one unique temporary root directory for this selection.
-  base::FilePath temp_root_dir;
-  if (!base::CreateNewTempDirectory(kUploadStripTempDirPrefix,
-                                    &temp_root_dir)) {
+  base::ScopedTempDir temp_root;
+  if (!temp_root.CreateUniqueTempDir(kUploadStripTempDirPrefix)) {
     LOG(ERROR) << "Upload strip skipped; temp directory could not be created.";
     result.selected_files = std::move(selected_files);
     return result;
   }
+  const base::FilePath& temp_root_dir = temp_root.GetPath();
 
-  // This will be used to create teh sub directory inside the |temp_root_dir|.
+  // This will be used to create the sub directory inside the |temp_root_dir|.
   size_t temp_sub_dir_index = 0;
-
-  // Delete the |temp_root_dir| if no stripping was done, or a sub
-  // directory. If the deletion fails, we push the path to be cleaned up in
-  // upstream's DeleteTemporaryFiles cleanup.
-  auto temp_dir_deleter = [root = temp_root_dir, &result](base::FilePath path) {
-    if (!CanDeleteTempPath(root, path) || !base::DeletePathRecursively(path)) {
-      result.temp_files.push_back(std::move(path));
-    }
-  };
 
   bool stripped_any = false;
   // 2. Iterate over each item in the |selected_files|.
@@ -142,20 +126,20 @@ StripResult StripListOnBlockingThread(
     }
 
     // 4.a) Copy it into a unique subdir of the root, ...
-    const base::FilePath sub_dir_path =
-        temp_root_dir.AppendASCII(base::NumberToString(temp_sub_dir_index++));
-    if (!base::CreateDirectory(sub_dir_path)) {
+    base::ScopedTempDir sub_dir;
+    if (!sub_dir.Set(temp_root_dir.AppendASCII(
+            base::NumberToString(temp_sub_dir_index++)))) {
       LOG(ERROR) << "Upload strip skipped; temp subdir could not be created: "
                  << src;
       continue;
     }
 
     // 4.a) ... and use the filename of the original file.
-    const base::FilePath temp_stripped_file = sub_dir_path.Append(basename);
+    const base::FilePath temp_stripped_file =
+        sub_dir.GetPath().Append(basename);
     if (!base::CopyFile(src, temp_stripped_file)) {
       DVLOG(1) << "Upload strip skipped; Failed to copy the image file to a "
                   "temporary file.";
-      temp_dir_deleter(sub_dir_path);
       continue;
     }
 
@@ -164,8 +148,7 @@ StripResult StripListOnBlockingThread(
             image_metadata_stripper::StrippingClient::kFileSelect,
             temp_stripped_file)) {
       DVLOG(1) << "No stripping occured; keeping original: " << src;
-      // 4.b.1) If failed: Delete the subdir and go to Step 2.
-      temp_dir_deleter(sub_dir_path);
+      // 4.b.1) If failed: ScopedTempDir deletes the subdir.
       continue;
     }
 
@@ -176,18 +159,15 @@ StripResult StripListOnBlockingThread(
     if (native->display_name.empty()) {
       native->display_name = basename.AsUTF16Unsafe();
     }
-    // This would defer the deletion of the |temp_root_dir| cleanup to the
-    // upstream which will delete it once the tab is closed.
+    // Keep the stripped copy under the parent until FileSelectHelper cleanup.
+    sub_dir.Take();
     stripped_any = true;
   }
 
-  if (!stripped_any) {
-    // 5) If nothing was stripped, delete the temporary root directory.
-    temp_dir_deleter(std::move(temp_root_dir));
-  } else {
-    // Else we queue the temporary root directory created in step 1 for deletion
-    // via |temporary_files|.
-    result.temp_files.push_back(std::move(temp_root_dir));
+  if (stripped_any) {
+    // Queue the temporary root for FileSelectHelper cleanup. Take() so the
+    // copies survive until the tab closes.
+    result.temp_files.push_back(temp_root.Take());
   }
 
   result.selected_files = std::move(selected_files);

--- a/browser/file_select/brave_file_select_image_metadata_stripper.h
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.h
@@ -33,8 +33,8 @@ inline constexpr base::FilePath::CharType kUploadStripTempDirPrefix[] =
 // strippable JPEG into a unique subdirectory of one temporary parent directory
 // (so the original basename is preserved) and that copy is what gets uploaded.
 // Only the parent directory is added to |temporary_files|;
-// `DeleteImageMetadataStripperTemporaryDir` recursively deletes it after the
-// upload completes.
+// `MaybeDeleteImageMetadataStripperTemporaryDir` recursively deletes it
+// after the upload completes.
 //
 // |already_processed| helps to avoid looping between `NotifyListenerAndEnd`
 // and `MaybeStripImageMetadataForUpload` by letting `NotifyListenerAndEnd` know
@@ -52,8 +52,9 @@ bool MaybeStripImageMetadataForUpload(
         notify);
 
 // Recursively deletes the upload-strip temp directory (basename contains
-// `kUploadStripTempDirPrefix`) which holds the stripped copies.
-void DeleteImageMetadataStripperTemporaryDir(
+// `kUploadStripTempDirPrefix`) which holds the stripped copies. No-ops if
+// |paths| has no matching directory.
+void MaybeDeleteImageMetadataStripperTemporaryDir(
     std::vector<base::FilePath>& paths);
 
 // Test-only: The caller owns |callback| and must keep

--- a/browser/file_select/brave_file_select_image_metadata_stripper.h
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.h
@@ -8,15 +8,16 @@
 
 #include <vector>
 
+#include "base/files/file_path.h"
 #include "base/functional/callback.h"
 #include "base/functional/callback_forward.h"
 #include "third_party/blink/public/mojom/choosers/file_chooser.mojom-forward.h"
 
-namespace base {
-class FilePath;
-}  // namespace base
-
 namespace brave {
+
+// Prefix passed to CreateNewTempDirectory for stripped upload copies.
+inline constexpr base::FilePath::CharType kUploadStripTempDirPrefix[] =
+    FILE_PATH_LITERAL("brave_upload_strip");
 
 // A method which is called when the browser is about to hand over the selected
 // files via `NotifyListenerAndEnd`. This method is responsible for stripping
@@ -28,10 +29,12 @@ namespace brave {
 // `NotifyListenerAndEnd` asynchronously via |notify| callback to join back with
 // the regular execution.
 //
-// The method does not actually strip any metadata from
-// the original file while uploading instead it create a temporary file and that
-// gets uploaded. This temporary file path gets added to the |temporary_files|
-// list to flag it for deletion once the upload is complete.
+// The method does not strip metadata from the original file. It copies each
+// strippable JPEG into a unique subdirectory of one temporary parent directory
+// (so the original basename is preserved) and that copy is what gets uploaded.
+// Only the parent directory is added to |temporary_files|;
+// `DeleteImageMetadataStripperTemporaryDir` recursively deletes it after the
+// upload completes.
 //
 // |already_processed| helps to avoid looping between `NotifyListenerAndEnd`
 // and `MaybeStripImageMetadataForUpload` by letting `NotifyListenerAndEnd` know
@@ -47,6 +50,11 @@ bool MaybeStripImageMetadataForUpload(
     std::vector<blink::mojom::FileChooserFileInfoPtr>& list,
     base::OnceCallback<void(std::vector<blink::mojom::FileChooserFileInfoPtr>)>
         notify);
+
+// Recursively deletes the upload-strip temp directory (basename contains
+// `kUploadStripTempDirPrefix`) which holds the stripped copies.
+void DeleteImageMetadataStripperTemporaryDir(
+    std::vector<base::FilePath>& paths);
 
 // Test-only: The caller owns |callback| and must keep
 // it alive until it fires; pass nullptr to clear it.

--- a/browser/file_select/brave_file_select_image_metadata_stripper.h
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.h
@@ -15,7 +15,7 @@
 
 namespace brave {
 
-// Prefix passed to CreateNewTempDirectory for stripped upload copies.
+// Prefix passed to CreateUniqueTempDir for stripped upload copies.
 inline constexpr base::FilePath::CharType kUploadStripTempDirPrefix[] =
     FILE_PATH_LITERAL("brave_upload_strip");
 

--- a/browser/file_select/brave_file_select_image_metadata_stripper_browsertest.cc
+++ b/browser/file_select/brave_file_select_image_metadata_stripper_browsertest.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/file_select/brave_file_select_image_metadata_stripper.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -219,12 +220,8 @@ class FileSelectImageMetadataStripperBase : public InProcessBrowserTest {
   }
 
   bool DoesNotExists(const std::vector<base::FilePath>& paths) {
-    for (const auto& path : paths) {
-      if (PathExists(path)) {
-        return false;
-      }
-    }
-    return true;
+    return std::ranges::none_of(
+        paths, [this](const base::FilePath& path) { return PathExists(path); });
   }
 
   std::string SelectedFileName(content::WebContents* web_contents) {
@@ -292,8 +289,6 @@ IN_PROC_BROWSER_TEST_F(FileSelectImageMetadataStripperBrowserTest,
   // Only the parent temp directory is queued for cleanup.
   const std::vector<base::FilePath> temp_paths = strip_completed_future_.Take();
   ASSERT_EQ(1u, temp_paths.size());
-  EXPECT_EQ(fbmd_test_image_path_.BaseName(),
-            StrippedCopyIn(temp_paths[0]).BaseName());
   EXPECT_TRUE(PathExists(StrippedCopyIn(temp_paths[0])));
 
   // 2. Check the bytes the server received are the scrubbed bytes.
@@ -336,10 +331,6 @@ IN_PROC_BROWSER_TEST_F(FileSelectImageMetadataStripperBrowserTest,
   // 1. Check each pick creates a distinct temporary copy, and the earlier one
   // is kept alive (by its own FileSelectHelper) until the tab goes away.
   EXPECT_NE(first_temp_paths[0], second_temp_paths[0]);
-  EXPECT_EQ(fbmd_test_image_path_.BaseName(),
-            StrippedCopyIn(first_temp_paths[0]).BaseName());
-  EXPECT_EQ(fbmd_test_image_path_.BaseName(),
-            StrippedCopyIn(second_temp_paths[0]).BaseName());
   EXPECT_TRUE(PathExists(StrippedCopyIn(first_temp_paths[0])));
   EXPECT_TRUE(PathExists(StrippedCopyIn(second_temp_paths[0])));
   EXPECT_EQ(kUploadTestFileName, SelectedFileName(web_contents));
@@ -379,8 +370,6 @@ IN_PROC_BROWSER_TEST_F(FileSelectImageMetadataStripperBrowserTest,
   // directory is queued (holding the stripped copy).
   const std::vector<base::FilePath> temp_paths = strip_completed_future_.Take();
   ASSERT_EQ(1u, temp_paths.size());
-  EXPECT_EQ(fbmd_test_image_path_.BaseName(),
-            StrippedCopyIn(temp_paths[0]).BaseName());
   EXPECT_EQ(kUploadTestFileName, SelectedFileName(web_contents));
 
   // 2. Check the uploaded payload carries both files: the image scrubbed of

--- a/browser/file_select/brave_file_select_image_metadata_stripper_browsertest.cc
+++ b/browser/file_select/brave_file_select_image_metadata_stripper_browsertest.cc
@@ -213,6 +213,26 @@ class FileSelectImageMetadataStripperBase : public InProcessBrowserTest {
     return base::PathExists(path);
   }
 
+  // The stripper copies the first JPEG to |parent|/0/<original basename>.
+  base::FilePath StrippedCopyIn(const base::FilePath& parent) {
+    return parent.AppendASCII("0").AppendASCII(kUploadTestFileName);
+  }
+
+  bool DoesNotExists(const std::vector<base::FilePath>& paths) {
+    for (const auto& path : paths) {
+      if (PathExists(path)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  std::string SelectedFileName(content::WebContents* web_contents) {
+    return content::EvalJs(web_contents,
+                           "document.getElementById('fileinput').files[0].name")
+        .ExtractString();
+  }
+
   base::FilePath fbmd_test_image_path_;
   // Provides the callback for SetStripCompletedCallbackForTesting to intercept
   // the temporary files to test clean-up behaviour.
@@ -267,10 +287,14 @@ IN_PROC_BROWSER_TEST_F(FileSelectImageMetadataStripperBrowserTest,
   content::WebContents* web_contents =
       OpenTabAndSelectFiles({fbmd_test_image_path_});
 
-  // 1. Check stripping created a temporary file.
-  const std::vector<base::FilePath> temp_files = strip_completed_future_.Take();
-  ASSERT_EQ(1u, temp_files.size());
-  const base::FilePath temp_path = temp_files[0];
+  EXPECT_EQ(kUploadTestFileName, SelectedFileName(web_contents));
+
+  // Only the parent temp directory is queued for cleanup.
+  const std::vector<base::FilePath> temp_paths = strip_completed_future_.Take();
+  ASSERT_EQ(1u, temp_paths.size());
+  EXPECT_EQ(fbmd_test_image_path_.BaseName(),
+            StrippedCopyIn(temp_paths[0]).BaseName());
+  EXPECT_TRUE(PathExists(StrippedCopyIn(temp_paths[0])));
 
   // 2. Check the bytes the server received are the scrubbed bytes.
   EXPECT_FALSE(ContainsFbmd(UploadFileAndInterceptContent(web_contents)))
@@ -281,8 +305,8 @@ IN_PROC_BROWSER_TEST_F(FileSelectImageMetadataStripperBrowserTest,
   // upload flow.
   browser()->tab_strip_model()->CloseWebContentsAt(
       1, TabCloseTypes::CLOSE_USER_GESTURE);
-  EXPECT_TRUE(base::test::RunUntil([&]() { return !PathExists(temp_path); }))
-      << "Temporary upload file should be deleted after the upload completes";
+  EXPECT_TRUE(base::test::RunUntil([&]() { return DoesNotExists(temp_paths); }))
+      << "Temporary upload files should be deleted after the upload completes";
 }
 
 IN_PROC_BROWSER_TEST_F(FileSelectImageMetadataStripperBrowserTest,
@@ -291,13 +315,11 @@ IN_PROC_BROWSER_TEST_F(FileSelectImageMetadataStripperBrowserTest,
   content::WebContents* web_contents =
       OpenTabAndSelectFiles({fbmd_test_image_path_});
 
-  // Keep track of the temporary file which was created for this selection. Will
-  // be used later.
-  const std::vector<base::FilePath> first_temp_files =
+  // Keep track of the temporary paths which were created for this selection.
+  const std::vector<base::FilePath> first_temp_paths =
       strip_completed_future_.Take();
-  ASSERT_EQ(1u, first_temp_files.size());
-  const base::FilePath first_temp = first_temp_files[0];
-  EXPECT_TRUE(PathExists(first_temp));
+  ASSERT_EQ(1u, first_temp_paths.size());
+  EXPECT_TRUE(PathExists(StrippedCopyIn(first_temp_paths[0])));
 
   // Pick again.
   // This resets the callback provided to the
@@ -307,17 +329,20 @@ IN_PROC_BROWSER_TEST_F(FileSelectImageMetadataStripperBrowserTest,
   // Pick the same file.
   SelectFilesInPicker(web_contents, {fbmd_test_image_path_});
 
-  // Temporary file created for this new upload.
-  const std::vector<base::FilePath> second_temp_files =
+  const std::vector<base::FilePath> second_temp_paths =
       strip_completed_future_.Take();
-  ASSERT_EQ(1u, second_temp_files.size());
-  const base::FilePath second_temp = second_temp_files[0];
+  ASSERT_EQ(1u, second_temp_paths.size());
 
   // 1. Check each pick creates a distinct temporary copy, and the earlier one
   // is kept alive (by its own FileSelectHelper) until the tab goes away.
-  EXPECT_NE(first_temp, second_temp);
-  EXPECT_TRUE(PathExists(first_temp));
-  EXPECT_TRUE(PathExists(second_temp));
+  EXPECT_NE(first_temp_paths[0], second_temp_paths[0]);
+  EXPECT_EQ(fbmd_test_image_path_.BaseName(),
+            StrippedCopyIn(first_temp_paths[0]).BaseName());
+  EXPECT_EQ(fbmd_test_image_path_.BaseName(),
+            StrippedCopyIn(second_temp_paths[0]).BaseName());
+  EXPECT_TRUE(PathExists(StrippedCopyIn(first_temp_paths[0])));
+  EXPECT_TRUE(PathExists(StrippedCopyIn(second_temp_paths[0])));
+  EXPECT_EQ(kUploadTestFileName, SelectedFileName(web_contents));
 
   // The most recently picked file is scrubbed and is what gets uploaded.
   EXPECT_FALSE(ContainsFbmd(UploadFileAndInterceptContent(web_contents)))
@@ -328,7 +353,7 @@ IN_PROC_BROWSER_TEST_F(FileSelectImageMetadataStripperBrowserTest,
   browser()->tab_strip_model()->CloseWebContentsAt(
       1, TabCloseTypes::CLOSE_USER_GESTURE);
   EXPECT_TRUE(base::test::RunUntil([&]() {
-    return !PathExists(first_temp) && !PathExists(second_temp);
+    return DoesNotExists(first_temp_paths) && DoesNotExists(second_temp_paths);
   })) << "All temporary upload files should be deleted after the tab closes";
 }
 
@@ -350,10 +375,13 @@ IN_PROC_BROWSER_TEST_F(FileSelectImageMetadataStripperBrowserTest,
   content::WebContents* web_contents =
       OpenTabAndSelectFiles({fbmd_test_image_path_, text_path});
 
-  // 1. Check since only the JPEG is strippable, exactly one temporary copy
-  // is created.
-  const std::vector<base::FilePath> temp_files = strip_completed_future_.Take();
-  ASSERT_EQ(1u, temp_files.size());
+  // 1. Check since only the JPEG is strippable, exactly one parent temp
+  // directory is queued (holding the stripped copy).
+  const std::vector<base::FilePath> temp_paths = strip_completed_future_.Take();
+  ASSERT_EQ(1u, temp_paths.size());
+  EXPECT_EQ(fbmd_test_image_path_.BaseName(),
+            StrippedCopyIn(temp_paths[0]).BaseName());
+  EXPECT_EQ(kUploadTestFileName, SelectedFileName(web_contents));
 
   // 2. Check the uploaded payload carries both files: the image scrubbed of
   // FBMD and the text file intact.

--- a/browser/file_select/brave_file_select_image_metadata_stripper_unittest.cc
+++ b/browser/file_select/brave_file_select_image_metadata_stripper_unittest.cc
@@ -55,7 +55,7 @@ TEST_F(BraveFileSelectImageMetadataStripperUnitTest,
       base::WriteFile(temp_root_dir.AppendASCII("photo.jpg"), "stripped"));
 
   std::vector<base::FilePath> paths = {temp_root_dir};
-  DeleteImageMetadataStripperTemporaryDir(paths);
+  MaybeDeleteImageMetadataStripperTemporaryDir(paths);
 
   EXPECT_TRUE(paths.empty());
   EXPECT_FALSE(base::PathExists(temp_root_dir));
@@ -67,7 +67,7 @@ TEST_F(BraveFileSelectImageMetadataStripperUnitTest,
   const base::FilePath leftover = CreateUnrelatedTempFile();
 
   std::vector<base::FilePath> paths = {leftover};
-  DeleteImageMetadataStripperTemporaryDir(paths);
+  MaybeDeleteImageMetadataStripperTemporaryDir(paths);
 
   ASSERT_EQ(1u, paths.size());
   EXPECT_EQ(leftover, paths[0]);
@@ -85,7 +85,7 @@ TEST_F(BraveFileSelectImageMetadataStripperUnitTest,
   cleanup_.push_back(prefixed_file);
 
   std::vector<base::FilePath> paths = {prefixed_file};
-  DeleteImageMetadataStripperTemporaryDir(paths);
+  MaybeDeleteImageMetadataStripperTemporaryDir(paths);
 
   ASSERT_EQ(1u, paths.size());
   EXPECT_EQ(prefixed_file, paths[0]);

--- a/browser/file_select/brave_file_select_image_metadata_stripper_unittest.cc
+++ b/browser/file_select/brave_file_select_image_metadata_stripper_unittest.cc
@@ -1,0 +1,95 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/file_select/brave_file_select_image_metadata_stripper.h"
+
+#include <vector>
+
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave {
+
+class BraveFileSelectImageMetadataStripperUnitTest : public testing::Test {
+ protected:
+  void TearDown() override {
+    for (const auto& path : cleanup_) {
+      base::DeletePathRecursively(path);
+    }
+  }
+
+  // Same CreateNewTempDirectory prefix as production `temp_root_dir`.
+  base::FilePath CreateTempRootDir() {
+    base::FilePath temp_root_dir;
+    EXPECT_TRUE(base::CreateNewTempDirectory(kUploadStripTempDirPrefix,
+                                             &temp_root_dir));
+    cleanup_.push_back(temp_root_dir);
+    return temp_root_dir;
+  }
+
+  base::FilePath CreateUnrelatedTempFile() {
+    base::FilePath file;
+    EXPECT_TRUE(base::CreateTemporaryFile(&file));
+    cleanup_.push_back(file);
+    return file;
+  }
+
+  base::FilePath CreateUnrelatedTempDir() {
+    base::FilePath dir;
+    EXPECT_TRUE(
+        base::CreateNewTempDirectory(FILE_PATH_LITERAL("other_prefix"), &dir));
+    cleanup_.push_back(dir);
+    return dir;
+  }
+
+  std::vector<base::FilePath> cleanup_;
+};
+
+TEST_F(BraveFileSelectImageMetadataStripperUnitTest,
+       DeletesTempRootAndRemovesItFromTheList) {
+  const base::FilePath temp_root_dir = CreateTempRootDir();
+  ASSERT_TRUE(
+      base::WriteFile(temp_root_dir.AppendASCII("photo.jpg"), "stripped"));
+
+  std::vector<base::FilePath> paths = {temp_root_dir};
+  DeleteImageMetadataStripperTemporaryDir(paths);
+
+  EXPECT_TRUE(paths.empty());
+  EXPECT_FALSE(base::PathExists(temp_root_dir));
+}
+
+TEST_F(BraveFileSelectImageMetadataStripperUnitTest,
+       LeavesNonTempRootFilesUntouched) {
+  // Create another unrelated directory.
+  const base::FilePath leftover = CreateUnrelatedTempFile();
+
+  std::vector<base::FilePath> paths = {leftover};
+  DeleteImageMetadataStripperTemporaryDir(paths);
+
+  ASSERT_EQ(1u, paths.size());
+  EXPECT_EQ(leftover, paths[0]);
+  EXPECT_TRUE(base::PathExists(leftover));
+}
+
+TEST_F(BraveFileSelectImageMetadataStripperUnitTest,
+       IgnoresAFileWhoseNameContainsTheBraveUploadStripPrefix) {
+  // The token in the basename is not enough; the path must be a directory.
+  const base::FilePath leftover = CreateUnrelatedTempFile();
+  const base::FilePath prefixed_file = leftover.DirName().Append(
+      base::FilePath::StringType(kUploadStripTempDirPrefix) +
+      FILE_PATH_LITERAL("_not_a_dir"));
+  ASSERT_TRUE(base::CopyFile(leftover, prefixed_file));
+  cleanup_.push_back(prefixed_file);
+
+  std::vector<base::FilePath> paths = {prefixed_file};
+  DeleteImageMetadataStripperTemporaryDir(paths);
+
+  ASSERT_EQ(1u, paths.size());
+  EXPECT_EQ(prefixed_file, paths[0]);
+  EXPECT_TRUE(base::PathExists(prefixed_file));
+}
+
+}  // namespace brave

--- a/chromium_src/chrome/browser/file_select_helper.cc
+++ b/chromium_src/chrome/browser/file_select_helper.cc
@@ -32,7 +32,7 @@ bool MaybeStripImageMetadataForUpload(
 // |paths| to find the temporary root directory that was created by our stripper
 // and deletes it recursively. It also removes the entry from |paths| after
 // deletion.
-void DeleteImageMetadataStripperTemporaryDir(
+void MaybeDeleteImageMetadataStripperTemporaryDir(
     std::vector<base::FilePath>& paths);
 
 }  // namespace brave

--- a/chromium_src/chrome/browser/file_select_helper.cc
+++ b/chromium_src/chrome/browser/file_select_helper.cc
@@ -16,8 +16,8 @@ class FilePath;
 
 namespace brave {
 
-// The upload-metadata strip is spliced into NotifyListenerAndEnd by
-// rewrite/chrome/browser/file_select_helper.cc.yaml. Defined in
+// The upload-metadata strip is spliced into NotifyListenerAndEnd and
+// DeleteFiles by rewrite/chrome/browser/file_select_helper.cc.yaml. Defined in
 // brave/browser/file_select/brave_file_select_image_metadata_stripper.cc, and
 // declared here so that chrome/browser does not depend on Brave targets.
 bool MaybeStripImageMetadataForUpload(
@@ -26,6 +26,14 @@ bool MaybeStripImageMetadataForUpload(
     std::vector<blink::mojom::FileChooserFileInfoPtr>& list,
     base::OnceCallback<void(std::vector<blink::mojom::FileChooserFileInfoPtr>)>
         notify);
+
+// Called from the upstream when it tries to delete the temporary files which
+// were created during the file select process. This method iterates over the
+// |paths| to find the temporary root directory that was created by our stripper
+// and deletes it recursively. It also removes the entry from |paths| after
+// deletion.
+void DeleteImageMetadataStripperTemporaryDir(
+    std::vector<base::FilePath>& paths);
 
 }  // namespace brave
 

--- a/patches/chrome-browser-file_select_helper.cc.patch
+++ b/patches/chrome-browser-file_select_helper.cc.patch
@@ -1,8 +1,16 @@
 diff --git a/chrome/browser/file_select_helper.cc b/chrome/browser/file_select_helper.cc
-index 9b7c30c3b2f7c3489d32a0e82a3ce0288d249f98..68db99d19aeffe40a6abdcb7685c96978f59e09b 100644
+index 9b7c30c3b2f7c3489d32a0e82a3ce0288d249f98..ac017342d09b20ecdbcfdbf561a91392ba63c7ee 100644
 --- a/chrome/browser/file_select_helper.cc
 +++ b/chrome/browser/file_select_helper.cc
-@@ -463,6 +463,11 @@ void FileSelectHelper::ContentAnalysisCompletionCallback(
+@@ -73,6 +73,7 @@ DEFINE_LOCAL_ELEMENT_IDENTIFIER_VALUE(kCancelButtonId);
+ namespace {
+ 
+ void DeleteFiles(std::vector<base::FilePath> paths) {
++  brave::DeleteImageMetadataStripperTemporaryDir(paths);
+   for (auto& file_path : paths)
+     base::DeleteFile(file_path);
+ }
+@@ -463,6 +464,11 @@ void FileSelectHelper::ContentAnalysisCompletionCallback(
  
  void FileSelectHelper::NotifyListenerAndEnd(
      std::vector<blink::mojom::FileChooserFileInfoPtr> list) {

--- a/patches/chrome-browser-file_select_helper.cc.patch
+++ b/patches/chrome-browser-file_select_helper.cc.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/file_select_helper.cc b/chrome/browser/file_select_helper.cc
-index 9b7c30c3b2f7c3489d32a0e82a3ce0288d249f98..ac017342d09b20ecdbcfdbf561a91392ba63c7ee 100644
+index 9b7c30c3b2f7c3489d32a0e82a3ce0288d249f98..528afa6178c09092a2d4bc155befb39c44d64df3 100644
 --- a/chrome/browser/file_select_helper.cc
 +++ b/chrome/browser/file_select_helper.cc
 @@ -73,6 +73,7 @@ DEFINE_LOCAL_ELEMENT_IDENTIFIER_VALUE(kCancelButtonId);
  namespace {
  
  void DeleteFiles(std::vector<base::FilePath> paths) {
-+  brave::DeleteImageMetadataStripperTemporaryDir(paths);
++  brave::MaybeDeleteImageMetadataStripperTemporaryDir(paths);
    for (auto& file_path : paths)
      base::DeleteFile(file_path);
  }

--- a/rewrite/chrome/browser/file_select_helper.cc.yaml
+++ b/rewrite/chrome/browser/file_select_helper.cc.yaml
@@ -18,3 +18,15 @@ substitutions:
                 base::BindOnce(&FileSelectHelper::NotifyListenerAndEnd, this))) {
           return;
         }
+
+  - description: |-
+      Recursively delete Brave-owned upload-strip temp directories.
+
+      FileSelectHelper::DeleteFiles uses DeleteFile, which cannot remove a
+      non-empty directory. The metadata stripper creates one temporary root directory
+      which contains K sub-directories where each sub-directory is mapped to one stripped image.
+      This method helps to recursively delete only the temporary root directory we created for a stripping stage.
+    preempt_function_impl:
+      function_name: DeleteFiles
+      code: |-
+        brave::DeleteImageMetadataStripperTemporaryDir(paths);

--- a/rewrite/chrome/browser/file_select_helper.cc.yaml
+++ b/rewrite/chrome/browser/file_select_helper.cc.yaml
@@ -29,4 +29,4 @@ substitutions:
     preempt_function_impl:
       function_name: DeleteFiles
       code: |-
-        brave::DeleteImageMetadataStripperTemporaryDir(paths);
+        brave::MaybeDeleteImageMetadataStripperTemporaryDir(paths);

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -176,6 +176,7 @@ test("brave_unit_tests") {
     "//brave/browser/content_settings:unit_tests",
     "//brave/browser/ephemeral_storage:unit_tests",
     "//brave/browser/external_protocol:unit_tests",
+    "//brave/browser/file_select:unit_tests",
     "//brave/browser/global_privacy_control:unit_tests",
     "//brave/browser/metrics:brave_metrics_unit_tests",
     "//brave/browser/misc_metrics:unit_tests",


### PR DESCRIPTION
This change fixes the issue where we may show the temporary file name while uploading an image a user selected which was stripped of metadata. We rely on temporary files to not touch the original file contents and upload that instead. During the upload flow, we swap the selected path of the originally selected file with the temp file path while preserving the display name. This is enough for most OSs but not in MacOS which displays the random temp file name.

In `macOS` the renderer uses the **file path** to derive the name [[1]](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/layout/layout_theme_mac.mm;l=60) which bypasses the already supplied [display name](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/choosers/file_chooser.mojom;l=90) in the selected file [_info_](https://sourcegraph.com/r/github.com/brave/brave-core/-/blob/browser/file_select/brave_file_select_image_metadata_stripper.cc?L93). Therefore, to fix the issue on MacOS we needed to embed the original filename somehow at the end of the temporary file path. We couldn't simply create one temporary root folder, and add our temp file (with the same filename as original file) as leaf because there could be a UJ where the user selects `/0/brave.jpg`, and then another file `/1/brave.jpg` from another directory, which will result in the temporary file created for the last selected file (say /1/brave.jpg) overwriting the previous entry (/0/brave.jpg) since they shared the same parent folder. Hence, we need sub-directories for each temporary stripped image file to avoid such name collisions. 

These temporary files gets cleaned-up by the new patched method `DeleteImageMetadataStripperTemporaryDir` which gets called from inside [DeleteFiles](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/file_select_helper.cc;l=77). The current upstream implementation only deletes a folder if empty, therefore we needed to add this patch.
 
This change adds browser tests and also unit tests for the same. 

### Manual Testing (demo)
- Checks the uploaded filename seen by the user is not a temp file name, and matches with the original file the user was uploading.

- Checks the files are deleted from the Brave's temporary directory when the tab is closed (which destroys the file select picker)

https://github.com/user-attachments/assets/46d02893-82fe-410c-8c71-4787b8c2bf36

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/58705

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
