### PR TITLE
[toolchain] Adding `build_rustc_from_scratch` to the WASM job

### DIFF
--- a/tools/cr/tarball_installer_test.py
+++ b/tools/cr/tarball_installer_test.py
@@ -587,8 +587,9 @@ class MainTest(unittest.TestCase):
         install.assert_called_once()
         installer = install.call_args.args[0]
         self.assertEqual(installer.dest_dir, m._WORKSPACE_ROOT / dep)
+        # Read from the table, so bumping the pinned node does not fail here.
         self.assertEqual(installer.object_name,
-                         'node-v24.18.0-linux-x64.tar.gz')
+                         m.EXTRA_DEPS[dep]['objects'][0]['object_name'])
 
     def test_rejects_unknown_dep(self):
         with contextlib.redirect_stderr(io.StringIO()):

--- a/tools/cr/toolchains/build_rust_toolchain.py
+++ b/tools/cr/toolchains/build_rust_toolchain.py
@@ -190,6 +190,9 @@ STAGE1_RUSTLIB = Path('stage1') / 'lib' / 'rustlib'
 STAGE0_STD = Path('stage0-std')
 STAGE0_RUSTLIB = Path('stage0-sysroot') / 'lib' / 'rustlib'
 
+# Relative path to the beta `cargo`.
+STAGE0_CARGO = Path('stage0') / 'bin' / CARGO
+
 # vpython3 that is selected by `depot_tools` from `$PATH`.
 # This little Windows specific quirk is only needed when calling this script on
 # Windows using git bash.
@@ -553,15 +556,14 @@ class ToolchainBuilder:
             prebuilt_bin = (
                 Path(self._build_rust_module.RUST_TOOLCHAIN_OUT_DIR) / 'bin')
             rustc = prebuilt_bin / RUSTC
-            cargo = prebuilt_bin / CARGO
-            for tool in (rustc, cargo):
-                if not tool.is_file():
-                    raise RuntimeError(
-                        f'Prebuilt Rust tool not found: {tool}. The '
-                        f'--no-full-toolchain build uses the toolchain gclient '
-                        f'syncs to {prebuilt_bin.parent} as bootstrap\'s '
-                        f'stage-0; run `gclient sync` or pass --full-toolchain.'
-                    )
+            if not rustc.is_file():
+                raise RuntimeError(
+                    f'Prebuilt Rust tool not found: {rustc}. The '
+                    f'--no-full-toolchain build uses the toolchain gclient '
+                    f'syncs to {prebuilt_bin.parent} as bootstrap\'s '
+                    f'stage-0')
+            cargo = (Path(self._build_rust_module.RUST_BUILD_DIR) /
+                     target_triple / STAGE0_CARGO)
             _check_call(str(self._vpython_path),
                         'build_rust.py',
                         '--run-xpy',

--- a/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.expected/linux.json
@@ -259,7 +259,8 @@
       "1",
       "--clear",
       "--no-full-toolchain",
-      "--upload"
+      "--upload",
+      "--use-prebuilt-rustc"
     ],
     "name": "build rust toolchain"
   },

--- a/tools/recipes/recipes/toolchains/rust/package_rust.expected/mac.json
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.expected/mac.json
@@ -320,7 +320,8 @@
       "1",
       "--clear",
       "--no-full-toolchain",
-      "--upload"
+      "--upload",
+      "--use-prebuilt-rustc"
     ],
     "name": "build rust toolchain"
   },

--- a/tools/recipes/recipes/toolchains/rust/package_rust.proto
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.proto
@@ -13,5 +13,8 @@ message InputProperties {
   int32 brave_subrevision = 1;
   // Chromium ref (tag or branch) whose Rust toolchain is packaged.
   string chromium_ref = 2;
+  // Build a stage-1 rustc from scratch, rather than compiling the wasm32 std
+  // against the prebuilt rustc gclient syncs (the default).
+  bool build_rustc_from_scratch = 3;
 }
 

--- a/tools/recipes/recipes/toolchains/rust/package_rust.py
+++ b/tools/recipes/recipes/toolchains/rust/package_rust.py
@@ -28,20 +28,24 @@ def RunSteps(api: RecipeScriptApi, properties: InputProperties) -> None:
     brave_core_root = api.brave_core_checkout.deploy('tools/cr/toolchains')
 
     vpython3 = api.depot_tools.vpython3()
+    cmd = [
+        vpython3,
+        brave_core_root / 'tools/cr/toolchains/build_rust_toolchain.py',
+        '--out-dir',
+        api.path.out,
+        '--chromium-src',
+        chromium_src,
+        '--brave-subrevision',
+        str(properties.brave_subrevision),
+        '--clear',
+        '--no-full-toolchain',
+        '--upload',
+    ]
+    cmd.append('--no-use-prebuilt-rustc' if properties.
+               build_rustc_from_scratch else '--use-prebuilt-rustc')
+
     with api.osx_sdk.ensure(chromium_src):
-        api.step('build rust toolchain', [
-            vpython3,
-            brave_core_root / 'tools/cr/toolchains/build_rust_toolchain.py',
-            '--out-dir',
-            api.path.out,
-            '--chromium-src',
-            chromium_src,
-            '--brave-subrevision',
-            str(properties.brave_subrevision),
-            '--clear',
-            '--no-full-toolchain',
-            '--upload',
-        ])
+        api.step('build rust toolchain', cmd)
 
 
 def GenTests(api):
@@ -66,7 +70,25 @@ def GenTests(api):
                          'build rust toolchain', ['--brave-subrevision', '1']),
         api.post_process(post_process.StepCommandContains,
                          'build rust toolchain', ['--upload']),
+        api.post_process(post_process.StepCommandContains,
+                         'build rust toolchain', ['--use-prebuilt-rustc']),
         api.post_process(post_process.StatusSuccess),
+    )
+    # `build_rustc_from_scratch` flips the build script's compiler flag; unset
+    # (every other test) is the prebuilt rustc.
+    yield api.test(
+        'build rustc from scratch',
+        api.platform.name('linux'),
+        api.chromium_checkout.with_git_cache(),
+        api.chromium_checkout.git_cache_populated(),
+        api.brave_core_checkout.deployed('tools/cr/toolchains'),
+        api.properties(brave_subrevision=1,
+                       chromium_ref='151.0.7917.1',
+                       build_rustc_from_scratch=True),
+        api.post_process(post_process.StepCommandContains,
+                         'build rust toolchain', ['--no-use-prebuilt-rustc']),
+        api.post_process(post_process.StatusSuccess),
+        api.post_process(post_process.DropExpectation),
     )
     # On mac, the checkout's pinned Xcode is installed/selected around the
     # build step, then reset afterward.


### PR DESCRIPTION
This is an optional property that permits the job to build the toolchain
using a rustc compiler built from scratch. We normally don't want to do
that, but having the ability to select this mode is useful when trying
to investigate certain toolchain failures, where short term alternatives
are necessary.
