### PR TITLE
Keep the macOS app icon following the system appearance

### DIFF
--- a/patches/chrome-browser-ui-cocoa-dock_icon.mm.patch
+++ b/patches/chrome-browser-ui-cocoa-dock_icon.mm.patch
@@ -178,6 +178,7 @@ index 3cb3285ab04fa7042369858ae868adc04db50c25..23b7346f3c1921a59f9e224ec4f6c183
 -}
 -
 -@end
+-
  @implementation DockIcon {
 +  // The number of downloads in progress.
 +  int _downloads;
@@ -187,6 +188,7 @@ index 3cb3285ab04fa7042369858ae868adc04db50c25..23b7346f3c1921a59f9e224ec4f6c183
 +
 +  // The progress made on those downloads. Ranges from [0..1].
 +  float _progress;
++
    // The time that the icon was last updated.
    base::TimeTicks _lastUpdate;
  
@@ -221,6 +223,7 @@ index 3cb3285ab04fa7042369858ae868adc04db50c25..23b7346f3c1921a59f9e224ec4f6c183
 +  formatter.maximumFractionDigits = 0;
 +  return [formatter stringFromNumber:@(_progress)];
 +}
++
  - (void)updateIcon {
    DCHECK_CURRENTLY_ON(BrowserThread::UI);
  

--- a/patches/chrome-browser-ui-cocoa-dock_icon.mm.patch
+++ b/patches/chrome-browser-ui-cocoa-dock_icon.mm.patch
@@ -178,7 +178,6 @@ index 3cb3285ab04fa7042369858ae868adc04db50c25..23b7346f3c1921a59f9e224ec4f6c183
 -}
 -
 -@end
--
  @implementation DockIcon {
 +  // The number of downloads in progress.
 +  int _downloads;
@@ -188,7 +187,6 @@ index 3cb3285ab04fa7042369858ae868adc04db50c25..23b7346f3c1921a59f9e224ec4f6c183
 +
 +  // The progress made on those downloads. Ranges from [0..1].
 +  float _progress;
-+
    // The time that the icon was last updated.
    base::TimeTicks _lastUpdate;
  
@@ -223,7 +221,6 @@ index 3cb3285ab04fa7042369858ae868adc04db50c25..23b7346f3c1921a59f9e224ec4f6c183
 +  formatter.maximumFractionDigits = 0;
 +  return [formatter stringFromNumber:@(_progress)];
 +}
-+
  - (void)updateIcon {
    DCHECK_CURRENTLY_ON(BrowserThread::UI);
  

--- a/patches/chrome-browser-ui-cocoa-dock_icon.mm.patch
+++ b/patches/chrome-browser-ui-cocoa-dock_icon.mm.patch
@@ -1,8 +1,8 @@
 diff --git a/chrome/browser/ui/cocoa/dock_icon.mm b/chrome/browser/ui/cocoa/dock_icon.mm
-index 3cb3285ab04fa7042369858ae868adc04db50c25..5f266988203996f7ab05ce97bd9bf24f6c92c8a4 100644
+index 3cb3285ab04fa7042369858ae868adc04db50c25..23b7346f3c1921a59f9e224ec4f6c18372e1b3f6 100644
 --- a/chrome/browser/ui/cocoa/dock_icon.mm
 +++ b/chrome/browser/ui/cocoa/dock_icon.mm
-@@ -7,180 +7,16 @@
+@@ -7,180 +7,22 @@
  #include <stdint.h>
  
  #include "base/apple/bundle_locations.h"
@@ -183,10 +183,16 @@ index 3cb3285ab04fa7042369858ae868adc04db50c25..5f266988203996f7ab05ce97bd9bf24f
 +  // The number of downloads in progress.
 +  int _downloads;
 +
++  // Whether the progress of those downloads is known yet.
++  BOOL _indeterminate;
++
++  // The progress made on those downloads. Ranges from [0..1].
++  float _progress;
++
    // The time that the icon was last updated.
    base::TimeTicks _lastUpdate;
  
-@@ -190,14 +26,21 @@ constexpr struct {
+@@ -190,14 +32,30 @@ constexpr struct {
  }
  
  + (DockIcon*)sharedDockIcon {
@@ -205,14 +211,23 @@ index 3cb3285ab04fa7042369858ae868adc04db50c25..5f266988203996f7ab05ce97bd9bf24f
 +    return nil;
 +  }
 +
-+  return [NSNumberFormatter localizedStringFromNumber:@(_downloads)
-+                                          numberStyle:NSNumberFormatterNoStyle];
++  NSNumberFormatter* formatter = [[NSNumberFormatter alloc] init];
++
++  // A percentage can only speak for a single download, and only once enough
++  // of it has been seen to know how much there is to come.
++  if (_downloads > 1 || _indeterminate) {
++    return [formatter stringFromNumber:@(_downloads)];
++  }
++
++  formatter.numberStyle = NSNumberFormatterPercentStyle;
++  formatter.maximumFractionDigits = 0;
++  return [formatter stringFromNumber:@(_progress)];
 +}
 +
  - (void)updateIcon {
    DCHECK_CURRENTLY_ON(BrowserThread::UI);
  
-@@ -212,37 +55,27 @@ constexpr struct {
+@@ -212,37 +70,31 @@ constexpr struct {
    _lastUpdate = now;
    _forceUpdate = NO;
  
@@ -233,26 +248,26 @@ index 3cb3285ab04fa7042369858ae868adc04db50c25..5f266988203996f7ab05ce97bd9bf24f
    }
  }
  
-+// The badge describes how many downloads there are rather than how far
-+// along they are, so there is nothing to report for either of these.
-+
  - (void)setIndeterminate:(BOOL)indeterminate {
    DCHECK_CURRENTLY_ON(BrowserThread::UI);
 -  DockTileView* dockTileView =
 -      base::apple::ObjCCast<DockTileView>(NSApp.dockTile.contentView);
--
+ 
 -  if (indeterminate != dockTileView.indeterminate) {
 -    dockTileView.indeterminate = indeterminate;
--    _forceUpdate = YES;
--  }
++  if (indeterminate != _indeterminate) {
++    _indeterminate = indeterminate;
+     _forceUpdate = YES;
+   }
  }
  
  - (void)setProgress:(float)progress {
    DCHECK_CURRENTLY_ON(BrowserThread::UI);
 -  DockTileView* dockTileView =
 -      base::apple::ObjCCast<DockTileView>(NSApp.dockTile.contentView);
--
+ 
 -  dockTileView.progress = progress;
++  _progress = progress;
  }
  
  @end

--- a/patches/chrome-browser-ui-cocoa-dock_icon.mm.patch
+++ b/patches/chrome-browser-ui-cocoa-dock_icon.mm.patch
@@ -1,184 +1,10 @@
 diff --git a/chrome/browser/ui/cocoa/dock_icon.mm b/chrome/browser/ui/cocoa/dock_icon.mm
-index 3cb3285ab04fa7042369858ae868adc04db50c25..23b7346f3c1921a59f9e224ec4f6c18372e1b3f6 100644
+index 3cb3285ab04fa7042369858ae868adc04db50c25..29f7bde3e31093e99819970ea043ff680e8523e0 100644
 --- a/chrome/browser/ui/cocoa/dock_icon.mm
 +++ b/chrome/browser/ui/cocoa/dock_icon.mm
-@@ -7,180 +7,22 @@
- #include <stdint.h>
+@@ -181,6 +181,15 @@ constexpr struct {
+ @end
  
- #include "base/apple/bundle_locations.h"
--#include "base/apple/foundation_util.h"
- #include "base/check_op.h"
- #include "base/time/time.h"
- #include "content/public/browser/browser_thread.h"
--#include "ui/gfx/scoped_ns_graphics_context_save_gstate_mac.h"
- 
- using content::BrowserThread;
- 
--namespace {
--
--// The fraction of the size of the dock icon that the badge is.
--constexpr CGFloat kBadgeFraction = 0.375;
--constexpr CGFloat kBadgeMargin = 4;
--constexpr CGFloat kBadgeStrokeWidth = 6;
--
--constexpr struct {
--  CGFloat offset, radius, opacity;
--} kBadgeShadows[] = {
--    {0, 2, 0.14},
--    {2, 2, 0.12},
--    {1, 3, 0.2},
--};
--
--}  // namespace
--
--// A view that draws our dock tile.
--@interface DockTileView : NSView
--
--// Indicates how many downloads are in progress.
--@property(nonatomic) int downloads;
--
--// Indicates whether the progress indicator should be in an indeterminate state
--// or not.
--@property(nonatomic) BOOL indeterminate;
--
--// Indicates the amount of progress made of the download. Ranges from [0..1].
--@property(nonatomic) float progress;
--
--@end
--
--@implementation DockTileView
--
--@synthesize downloads = _downloads;
--@synthesize indeterminate = _indeterminate;
--@synthesize progress = _progress;
--
--- (void)drawRect:(NSRect)dirtyRect {
--  // This needs to draw the current app icon, whether it's using the default
--  // icon shipped or a custom icon.
--  //
--  // -[NSWorkspace iconForFile:] works, but it's NSString path-based, and APIs
--  // that use those tend to be on the deprecation chopping block.
--  //
--  // The NSURLEffectiveIconKey resource value works, but it has an error path
--  // that needs to be handled.
--  //
--  // -[NSApplication applicationIconImage] used to fail to return a custom icon
--  // if set, which was fixed a while ago, but it returns an NSImage with a
--  // single image rep, 32 pixels wide, which isn't good enough for detail work.
--  //
--  // Therefore, use [NSImage imageNamed:NSImageNameApplicationIcon].
--
--  NSImage* appIcon = [NSImage imageNamed:NSImageNameApplicationIcon];
--  [appIcon drawInRect:self.bounds
--             fromRect:NSZeroRect
--            operation:NSCompositingOperationSourceOver
--             fraction:1.0];
--
--  if (_downloads == 0) {
--    return;
--  }
--
--  const CGFloat badgeSize = NSWidth(self.bounds) * kBadgeFraction;
--  const NSRect badgeRect =
--      NSMakeRect(NSMaxX(self.bounds) - badgeSize - kBadgeMargin, kBadgeMargin,
--                 badgeSize, badgeSize);
--  const CGFloat badgeRadius = badgeSize / 2;
--  const NSPoint badgeCenter = NSMakePoint(NSMidX(badgeRect), NSMidY(badgeRect));
--
--  NSBezierPath* backgroundPath =
--      [NSBezierPath bezierPathWithOvalInRect:badgeRect];
--  [NSColor.clearColor setFill];
--
--  NSShadow* shadow = [[NSShadow alloc] init];
--  shadow.shadowColor = NSColor.blackColor;
--  for (const auto shadowProps : kBadgeShadows) {
--    gfx::ScopedNSGraphicsContextSaveGState scopedGState;
--    shadow.shadowOffset = NSMakeSize(0, -shadowProps.offset);
--    shadow.shadowBlurRadius = shadowProps.radius;
--    [[NSColor colorWithCalibratedWhite:0 alpha:shadowProps.opacity] setFill];
--    [shadow set];
--    [backgroundPath fill];
--  }
--
--  [[NSColor colorWithCalibratedRed:0xec / 255.0
--                             green:0xf3 / 255.0
--                              blue:0xfe / 255.0
--                             alpha:1] setFill];
--  [backgroundPath fill];
--
--  // Stroke
--  if (!_indeterminate) {
--    NSBezierPath* strokePath;
--    if (_progress >= 1.0) {
--      strokePath = [NSBezierPath bezierPathWithOvalInRect:badgeRect];
--    } else {
--      CGFloat endAngle = 90.0 - 360.0 * _progress;
--      if (endAngle < 0.0) {
--        endAngle += 360.0;
--      }
--      strokePath = [NSBezierPath bezierPath];
--      [strokePath
--          appendBezierPathWithArcWithCenter:badgeCenter
--                                     radius:badgeRadius - kBadgeStrokeWidth / 2
--                                 startAngle:90.0
--                                   endAngle:endAngle
--                                  clockwise:YES];
--    }
--    [strokePath setLineWidth:kBadgeStrokeWidth];
--    // This color is GoogleBlue600, which matches the stroke color for the
--    // progress ring of the download toolbar icon in a light theme.
--    [[NSColor colorWithSRGBRed:0x1a / 255.0
--                         green:0x73 / 255.0
--                          blue:0xe8 / 255.0
--                         alpha:1] setStroke];
--    [strokePath stroke];
--  }
--
--  // Download count
--  NSNumberFormatter* formatter = [[NSNumberFormatter alloc] init];
--  NSString* countString = [formatter stringFromNumber:@(_downloads)];
--
--  CGFloat countFontSize = 24;
--  NSSize countSize = NSZeroSize;
--  NSAttributedString* countAttrString = nil;
--  while (true) {
--    NSFont* countFont = [NSFont systemFontOfSize:countFontSize
--                                          weight:NSFontWeightMedium];
--
--    // This will generally be plain Helvetica.
--    if (!countFont) {
--      countFont = [NSFont userFontOfSize:countFontSize];
--    }
--
--    // Continued failure would generate an NSException.
--    if (!countFont) {
--      break;
--    }
--
--    countAttrString = [[NSAttributedString alloc]
--        initWithString:countString
--            attributes:@{
--              NSForegroundColorAttributeName :
--                  [NSColor colorWithCalibratedWhite:0 alpha:0.65],
--              NSFontAttributeName : countFont,
--            }];
--    countSize = [countAttrString size];
--    if (countSize.width > (badgeRadius - kBadgeStrokeWidth) * 1.5) {
--      countFontSize -= 1.0;
--    } else {
--      break;
--    }
--  }
--
--  NSPoint countOrigin = badgeCenter;
--  countOrigin.x -= countSize.width / 2;
--  countOrigin.y -= countSize.height / 2;
--
--  [countAttrString drawAtPoint:countOrigin];
--}
--
--@end
--
  @implementation DockIcon {
 +  // The number of downloads in progress.
 +  int _downloads;
@@ -192,7 +18,7 @@ index 3cb3285ab04fa7042369858ae868adc04db50c25..23b7346f3c1921a59f9e224ec4f6c183
    // The time that the icon was last updated.
    base::TimeTicks _lastUpdate;
  
-@@ -190,14 +32,30 @@ constexpr struct {
+@@ -190,14 +199,30 @@ constexpr struct {
  }
  
  + (DockIcon*)sharedDockIcon {
@@ -227,7 +53,7 @@ index 3cb3285ab04fa7042369858ae868adc04db50c25..23b7346f3c1921a59f9e224ec4f6c183
  - (void)updateIcon {
    DCHECK_CURRENTLY_ON(BrowserThread::UI);
  
-@@ -212,37 +70,31 @@ constexpr struct {
+@@ -212,37 +237,31 @@ constexpr struct {
    _lastUpdate = now;
    _forceUpdate = NO;
  

--- a/patches/chrome-browser-ui-cocoa-dock_icon.mm.patch
+++ b/patches/chrome-browser-ui-cocoa-dock_icon.mm.patch
@@ -1,0 +1,258 @@
+diff --git a/chrome/browser/ui/cocoa/dock_icon.mm b/chrome/browser/ui/cocoa/dock_icon.mm
+index 3cb3285ab04fa7042369858ae868adc04db50c25..5f266988203996f7ab05ce97bd9bf24f6c92c8a4 100644
+--- a/chrome/browser/ui/cocoa/dock_icon.mm
++++ b/chrome/browser/ui/cocoa/dock_icon.mm
+@@ -7,180 +7,16 @@
+ #include <stdint.h>
+ 
+ #include "base/apple/bundle_locations.h"
+-#include "base/apple/foundation_util.h"
+ #include "base/check_op.h"
+ #include "base/time/time.h"
+ #include "content/public/browser/browser_thread.h"
+-#include "ui/gfx/scoped_ns_graphics_context_save_gstate_mac.h"
+ 
+ using content::BrowserThread;
+ 
+-namespace {
+-
+-// The fraction of the size of the dock icon that the badge is.
+-constexpr CGFloat kBadgeFraction = 0.375;
+-constexpr CGFloat kBadgeMargin = 4;
+-constexpr CGFloat kBadgeStrokeWidth = 6;
+-
+-constexpr struct {
+-  CGFloat offset, radius, opacity;
+-} kBadgeShadows[] = {
+-    {0, 2, 0.14},
+-    {2, 2, 0.12},
+-    {1, 3, 0.2},
+-};
+-
+-}  // namespace
+-
+-// A view that draws our dock tile.
+-@interface DockTileView : NSView
+-
+-// Indicates how many downloads are in progress.
+-@property(nonatomic) int downloads;
+-
+-// Indicates whether the progress indicator should be in an indeterminate state
+-// or not.
+-@property(nonatomic) BOOL indeterminate;
+-
+-// Indicates the amount of progress made of the download. Ranges from [0..1].
+-@property(nonatomic) float progress;
+-
+-@end
+-
+-@implementation DockTileView
+-
+-@synthesize downloads = _downloads;
+-@synthesize indeterminate = _indeterminate;
+-@synthesize progress = _progress;
+-
+-- (void)drawRect:(NSRect)dirtyRect {
+-  // This needs to draw the current app icon, whether it's using the default
+-  // icon shipped or a custom icon.
+-  //
+-  // -[NSWorkspace iconForFile:] works, but it's NSString path-based, and APIs
+-  // that use those tend to be on the deprecation chopping block.
+-  //
+-  // The NSURLEffectiveIconKey resource value works, but it has an error path
+-  // that needs to be handled.
+-  //
+-  // -[NSApplication applicationIconImage] used to fail to return a custom icon
+-  // if set, which was fixed a while ago, but it returns an NSImage with a
+-  // single image rep, 32 pixels wide, which isn't good enough for detail work.
+-  //
+-  // Therefore, use [NSImage imageNamed:NSImageNameApplicationIcon].
+-
+-  NSImage* appIcon = [NSImage imageNamed:NSImageNameApplicationIcon];
+-  [appIcon drawInRect:self.bounds
+-             fromRect:NSZeroRect
+-            operation:NSCompositingOperationSourceOver
+-             fraction:1.0];
+-
+-  if (_downloads == 0) {
+-    return;
+-  }
+-
+-  const CGFloat badgeSize = NSWidth(self.bounds) * kBadgeFraction;
+-  const NSRect badgeRect =
+-      NSMakeRect(NSMaxX(self.bounds) - badgeSize - kBadgeMargin, kBadgeMargin,
+-                 badgeSize, badgeSize);
+-  const CGFloat badgeRadius = badgeSize / 2;
+-  const NSPoint badgeCenter = NSMakePoint(NSMidX(badgeRect), NSMidY(badgeRect));
+-
+-  NSBezierPath* backgroundPath =
+-      [NSBezierPath bezierPathWithOvalInRect:badgeRect];
+-  [NSColor.clearColor setFill];
+-
+-  NSShadow* shadow = [[NSShadow alloc] init];
+-  shadow.shadowColor = NSColor.blackColor;
+-  for (const auto shadowProps : kBadgeShadows) {
+-    gfx::ScopedNSGraphicsContextSaveGState scopedGState;
+-    shadow.shadowOffset = NSMakeSize(0, -shadowProps.offset);
+-    shadow.shadowBlurRadius = shadowProps.radius;
+-    [[NSColor colorWithCalibratedWhite:0 alpha:shadowProps.opacity] setFill];
+-    [shadow set];
+-    [backgroundPath fill];
+-  }
+-
+-  [[NSColor colorWithCalibratedRed:0xec / 255.0
+-                             green:0xf3 / 255.0
+-                              blue:0xfe / 255.0
+-                             alpha:1] setFill];
+-  [backgroundPath fill];
+-
+-  // Stroke
+-  if (!_indeterminate) {
+-    NSBezierPath* strokePath;
+-    if (_progress >= 1.0) {
+-      strokePath = [NSBezierPath bezierPathWithOvalInRect:badgeRect];
+-    } else {
+-      CGFloat endAngle = 90.0 - 360.0 * _progress;
+-      if (endAngle < 0.0) {
+-        endAngle += 360.0;
+-      }
+-      strokePath = [NSBezierPath bezierPath];
+-      [strokePath
+-          appendBezierPathWithArcWithCenter:badgeCenter
+-                                     radius:badgeRadius - kBadgeStrokeWidth / 2
+-                                 startAngle:90.0
+-                                   endAngle:endAngle
+-                                  clockwise:YES];
+-    }
+-    [strokePath setLineWidth:kBadgeStrokeWidth];
+-    // This color is GoogleBlue600, which matches the stroke color for the
+-    // progress ring of the download toolbar icon in a light theme.
+-    [[NSColor colorWithSRGBRed:0x1a / 255.0
+-                         green:0x73 / 255.0
+-                          blue:0xe8 / 255.0
+-                         alpha:1] setStroke];
+-    [strokePath stroke];
+-  }
+-
+-  // Download count
+-  NSNumberFormatter* formatter = [[NSNumberFormatter alloc] init];
+-  NSString* countString = [formatter stringFromNumber:@(_downloads)];
+-
+-  CGFloat countFontSize = 24;
+-  NSSize countSize = NSZeroSize;
+-  NSAttributedString* countAttrString = nil;
+-  while (true) {
+-    NSFont* countFont = [NSFont systemFontOfSize:countFontSize
+-                                          weight:NSFontWeightMedium];
+-
+-    // This will generally be plain Helvetica.
+-    if (!countFont) {
+-      countFont = [NSFont userFontOfSize:countFontSize];
+-    }
+-
+-    // Continued failure would generate an NSException.
+-    if (!countFont) {
+-      break;
+-    }
+-
+-    countAttrString = [[NSAttributedString alloc]
+-        initWithString:countString
+-            attributes:@{
+-              NSForegroundColorAttributeName :
+-                  [NSColor colorWithCalibratedWhite:0 alpha:0.65],
+-              NSFontAttributeName : countFont,
+-            }];
+-    countSize = [countAttrString size];
+-    if (countSize.width > (badgeRadius - kBadgeStrokeWidth) * 1.5) {
+-      countFontSize -= 1.0;
+-    } else {
+-      break;
+-    }
+-  }
+-
+-  NSPoint countOrigin = badgeCenter;
+-  countOrigin.x -= countSize.width / 2;
+-  countOrigin.y -= countSize.height / 2;
+-
+-  [countAttrString drawAtPoint:countOrigin];
+-}
+-
+-@end
+-
+ @implementation DockIcon {
++  // The number of downloads in progress.
++  int _downloads;
++
+   // The time that the icon was last updated.
+   base::TimeTicks _lastUpdate;
+ 
+@@ -190,14 +26,21 @@ constexpr struct {
+ }
+ 
+ + (DockIcon*)sharedDockIcon {
+-  static DockIcon* icon = [] {
+-    NSApp.dockTile.contentView = [[DockTileView alloc] init];
+-    return [[DockIcon alloc] init];
+-  }();
++  static DockIcon* icon = [[DockIcon alloc] init];
+ 
+   return icon;
+ }
+ 
++// The badge to describe the downloads in progress with, or nil for none.
++- (NSString*)badgeLabel {
++  if (_downloads == 0) {
++    return nil;
++  }
++
++  return [NSNumberFormatter localizedStringFromNumber:@(_downloads)
++                                          numberStyle:NSNumberFormatterNoStyle];
++}
++
+ - (void)updateIcon {
+   DCHECK_CURRENTLY_ON(BrowserThread::UI);
+ 
+@@ -212,37 +55,27 @@ constexpr struct {
+   _lastUpdate = now;
+   _forceUpdate = NO;
+ 
+-  [NSApp.dockTile display];
++  NSApp.dockTile.badgeLabel = [self badgeLabel];
+ }
+ 
+ - (void)setDownloads:(int)downloads {
+   DCHECK_CURRENTLY_ON(BrowserThread::UI);
+-  DockTileView* dockTileView =
+-      base::apple::ObjCCast<DockTileView>(NSApp.dockTile.contentView);
+ 
+-  if (downloads != dockTileView.downloads) {
+-    dockTileView.downloads = downloads;
++  if (downloads != _downloads) {
++    _downloads = downloads;
+     _forceUpdate = YES;
+   }
+ }
+ 
++// The badge describes how many downloads there are rather than how far
++// along they are, so there is nothing to report for either of these.
++
+ - (void)setIndeterminate:(BOOL)indeterminate {
+   DCHECK_CURRENTLY_ON(BrowserThread::UI);
+-  DockTileView* dockTileView =
+-      base::apple::ObjCCast<DockTileView>(NSApp.dockTile.contentView);
+-
+-  if (indeterminate != dockTileView.indeterminate) {
+-    dockTileView.indeterminate = indeterminate;
+-    _forceUpdate = YES;
+-  }
+ }
+ 
+ - (void)setProgress:(float)progress {
+   DCHECK_CURRENTLY_ON(BrowserThread::UI);
+-  DockTileView* dockTileView =
+-      base::apple::ObjCCast<DockTileView>(NSApp.dockTile.contentView);
+-
+-  dockTileView.progress = progress;
+ }
+ 
+ @end

--- a/rewrite/chrome/browser/ui/cocoa/dock_icon.mm.yaml
+++ b/rewrite/chrome/browser/ui/cocoa/dock_icon.mm.yaml
@@ -24,7 +24,8 @@
 # this because Chrome's icon is the same in either appearance.
 #
 # The badge label leaves the tile's content view alone, so the Dock keeps
-# compositing the icon for the current appearance.
+# compositing the icon for the current appearance. A single determinate
+# download is shown as a percentage; otherwise the badge is the count.
 
 substitutions:
   - description: |
@@ -47,19 +48,23 @@ substitutions:
       replace: ''
 
   - description: |
-      Report the number of downloads in progress through the Dock tile's badge
-      label.
+      Report downloads through the Dock tile's badge label.
 
-      The count now lives on `DockIcon`, as there is no longer a view to park it
-      on. A badge is too small to describe progress in, so the progress itself
-      is no longer reported; the download button in the toolbar still shows it.
-      Throttling is unchanged.
+      State now lives on `DockIcon`, as there is no longer a view to park it on.
+      A single determinate download is shown as a percentage; otherwise the
+      badge is the number of downloads in progress. Throttling is unchanged.
     regex:
       re_pattern: '@implementation DockIcon \{[\s\S]*\n@end'
       replace: |-
         @implementation DockIcon {
           // The number of downloads in progress.
           int _downloads;
+
+          // Whether the progress of those downloads is known yet.
+          BOOL _indeterminate;
+
+          // The progress made on those downloads. Ranges from [0..1].
+          float _progress;
 
           // The time that the icon was last updated.
           base::TimeTicks _lastUpdate;
@@ -81,8 +86,17 @@ substitutions:
             return nil;
           }
 
-          return [NSNumberFormatter localizedStringFromNumber:@(_downloads)
-                                                  numberStyle:NSNumberFormatterNoStyle];
+          NSNumberFormatter* formatter = [[NSNumberFormatter alloc] init];
+
+          // A percentage can only speak for a single download, and only once enough
+          // of it has been seen to know how much there is to come.
+          if (_downloads > 1 || _indeterminate) {
+            return [formatter stringFromNumber:@(_downloads)];
+          }
+
+          formatter.numberStyle = NSNumberFormatterPercentStyle;
+          formatter.maximumFractionDigits = 0;
+          return [formatter stringFromNumber:@(_progress)];
         }
 
         - (void)updateIcon {
@@ -111,15 +125,19 @@ substitutions:
           }
         }
 
-        // The badge describes how many downloads there are rather than how far
-        // along they are, so there is nothing to report for either of these.
-
         - (void)setIndeterminate:(BOOL)indeterminate {
           DCHECK_CURRENTLY_ON(BrowserThread::UI);
+
+          if (indeterminate != _indeterminate) {
+            _indeterminate = indeterminate;
+            _forceUpdate = YES;
+          }
         }
 
         - (void)setProgress:(float)progress {
           DCHECK_CURRENTLY_ON(BrowserThread::UI);
+
+          _progress = progress;
         }
 
         @end

--- a/rewrite/chrome/browser/ui/cocoa/dock_icon.mm.yaml
+++ b/rewrite/chrome/browser/ui/cocoa/dock_icon.mm.yaml
@@ -1,0 +1,125 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Report download progress through the Dock tile's badge label rather than
+# through a custom content view.
+#
+# Brave ships a layered app icon, whose light, dark and tinted variants live in
+# the asset catalog as `IconImageStack` renditions that only the Dock knows how
+# to composite. Setting `NSDockTile.contentView` takes that compositing away and
+# leaves the app to draw the icon itself, and the only thing an app can get hold
+# of is the single flattened `Icon Image` rendition, which carries no appearance
+# variants at all. `-[NSImage imageNamed:NSImageNameApplicationIcon]`,
+# `-[NSApplication applicationIconImage]`, `-[NSWorkspace iconForFile:]` and
+# `NSURLEffectiveIconKey` all return that same flattened image, under either
+# appearance and whether or not the lookup is made inside
+# `-[NSAppearance performAsCurrentDrawingAppearance:]`.
+#
+# So for as long as a content view is attached the icon cannot follow the system
+# appearance, and upstream attaches one for the whole of the process lifetime.
+# That is why the icon only picked up a light/dark switch across a restart, and
+# why it went flat as soon as anything was downloaded. Upstream does not see
+# this because Chrome's icon is the same in either appearance.
+#
+# The badge label leaves the tile's content view alone, so the Dock keeps
+# compositing the icon for the current appearance.
+
+substitutions:
+  - description: |
+      Drop the includes for the removed drawing code.
+    count: 2
+    regex:
+      re_pattern:
+        '#include "base/apple/foundation_util\.h"\n|#include
+        "ui/gfx/scoped_ns_graphics_context_save_gstate_mac\.h"\n'
+      replace: ''
+
+  - description: |
+      Remove the custom Dock tile view.
+
+      Drawing the badge over the app icon means drawing the app icon, and the
+      only icon available to do that with is the flattened one, which is stuck
+      in a single appearance.
+    regex:
+      re_pattern: 'namespace \{[\s\S]*?\n@end\n\n(?=@implementation DockIcon)'
+      replace: ''
+
+  - description: |
+      Report the number of downloads in progress through the Dock tile's badge
+      label.
+
+      The count now lives on `DockIcon`, as there is no longer a view to park it
+      on. A badge is too small to describe progress in, so the progress itself
+      is no longer reported; the download button in the toolbar still shows it.
+      Throttling is unchanged.
+    regex:
+      re_pattern: '@implementation DockIcon \{[\s\S]*\n@end'
+      replace: |-
+        @implementation DockIcon {
+          // The number of downloads in progress.
+          int _downloads;
+
+          // The time that the icon was last updated.
+          base::TimeTicks _lastUpdate;
+
+          // If true, the state has changed in a significant way since the last icon
+          // update and throttling should not prevent icon redraw.
+          BOOL _forceUpdate;
+        }
+
+        + (DockIcon*)sharedDockIcon {
+          static DockIcon* icon = [[DockIcon alloc] init];
+
+          return icon;
+        }
+
+        // The badge to describe the downloads in progress with, or nil for none.
+        - (NSString*)badgeLabel {
+          if (_downloads == 0) {
+            return nil;
+          }
+
+          return [NSNumberFormatter localizedStringFromNumber:@(_downloads)
+                                                  numberStyle:NSNumberFormatterNoStyle];
+        }
+
+        - (void)updateIcon {
+          DCHECK_CURRENTLY_ON(BrowserThread::UI);
+
+          constexpr base::TimeDelta kUpdateFrequencyCap = base::Hertz(5);
+
+          base::TimeTicks now = base::TimeTicks::Now();
+          base::TimeDelta timeSinceLastUpdate = now - _lastUpdate;
+          if (!_forceUpdate && timeSinceLastUpdate < kUpdateFrequencyCap) {
+            return;
+          }
+
+          _lastUpdate = now;
+          _forceUpdate = NO;
+
+          NSApp.dockTile.badgeLabel = [self badgeLabel];
+        }
+
+        - (void)setDownloads:(int)downloads {
+          DCHECK_CURRENTLY_ON(BrowserThread::UI);
+
+          if (downloads != _downloads) {
+            _downloads = downloads;
+            _forceUpdate = YES;
+          }
+        }
+
+        // The badge describes how many downloads there are rather than how far
+        // along they are, so there is nothing to report for either of these.
+
+        - (void)setIndeterminate:(BOOL)indeterminate {
+          DCHECK_CURRENTLY_ON(BrowserThread::UI);
+        }
+
+        - (void)setProgress:(float)progress {
+          DCHECK_CURRENTLY_ON(BrowserThread::UI);
+        }
+
+        @end

--- a/rewrite/chrome/browser/ui/cocoa/dock_icon.mm.yaml
+++ b/rewrite/chrome/browser/ui/cocoa/dock_icon.mm.yaml
@@ -37,11 +37,10 @@ substitutions:
       compositing the layered icon; the counts that used to live on that
       view therefore have to live here.
     regex:
-      re_pattern:
-        '(@implementation DockIcon \{\n)(\s*//[^\n]+\n  base::TimeTicks
-        _lastUpdate;)'
-      replace: |-
-        \1  // The number of downloads in progress.
+      pattern: '@implementation DockIcon {'
+      replace: |
+        @implementation DockIcon {
+          // The number of downloads in progress.
           int _downloads;
 
           // Whether the progress of those downloads is known yet.
@@ -49,8 +48,6 @@ substitutions:
 
           // The progress made on those downloads. Ranges from [0..1].
           float _progress;
-
-        \2
 
   - description: |
       Do not install a custom Dock tile content view.
@@ -70,9 +67,9 @@ substitutions:
       A single determinate download is shown as a percentage; otherwise the
       badge is the number of downloads in progress.
     regex:
-      re_pattern: '(\n)(- \(void\)updateIcon \{)'
+      pattern: '- (void)updateIcon {'
       replace: |-
-        \1// The badge to describe the downloads in progress with, or nil for none.
+        // The badge to describe the downloads in progress with, or nil for none.
         - (NSString*)badgeLabel {
           if (_downloads == 0) {
             return nil;
@@ -91,7 +88,7 @@ substitutions:
           return [formatter stringFromNumber:@(_progress)];
         }
 
-        \2
+        - (void)updateIcon {
 
   - description: |
       Update the badge instead of redrawing a content view.

--- a/rewrite/chrome/browser/ui/cocoa/dock_icon.mm.yaml
+++ b/rewrite/chrome/browser/ui/cocoa/dock_icon.mm.yaml
@@ -24,40 +24,24 @@
 # this because Chrome's icon is the same in either appearance.
 #
 # The badge label leaves the tile's content view alone, so the Dock keeps
-# compositing the icon for the current appearance. A single determinate
-# download is shown as a percentage; otherwise the badge is the count.
+# compositing the icon for the current appearance. `DockTileView` is left in
+# place unused: deleting it would swell the patch without changing behaviour.
+# A single determinate download is shown as a percentage; otherwise the badge
+# is the count.
 
 substitutions:
   - description: |
-      Drop the includes for the removed drawing code.
-    count: 2
+      Keep download state on DockIcon.
+
+      The Dock tile's content view is left unset so the Dock can keep
+      compositing the layered icon; the counts that used to live on that
+      view therefore have to live here.
     regex:
       re_pattern:
-        '#include "base/apple/foundation_util\.h"\n|#include
-        "ui/gfx/scoped_ns_graphics_context_save_gstate_mac\.h"\n'
-      replace: ''
-
-  - description: |
-      Remove the custom Dock tile view.
-
-      Drawing the badge over the app icon means drawing the app icon, and the
-      only icon available to do that with is the flattened one, which is stuck
-      in a single appearance.
-    regex:
-      re_pattern: 'namespace \{[\s\S]*?\n@end\n\n(?=@implementation DockIcon)'
-      replace: ''
-
-  - description: |
-      Report downloads through the Dock tile's badge label.
-
-      State now lives on `DockIcon`, as there is no longer a view to park it on.
-      A single determinate download is shown as a percentage; otherwise the
-      badge is the number of downloads in progress. Throttling is unchanged.
-    regex:
-      re_pattern: '@implementation DockIcon \{[\s\S]*\n@end'
+        '(@implementation DockIcon \{\n)(\s*//[^\n]+\n  base::TimeTicks
+        _lastUpdate;)'
       replace: |-
-        @implementation DockIcon {
-          // The number of downloads in progress.
+        \1  // The number of downloads in progress.
           int _downloads;
 
           // Whether the progress of those downloads is known yet.
@@ -66,21 +50,29 @@ substitutions:
           // The progress made on those downloads. Ranges from [0..1].
           float _progress;
 
-          // The time that the icon was last updated.
-          base::TimeTicks _lastUpdate;
+        \2
 
-          // If true, the state has changed in a significant way since the last icon
-          // update and throttling should not prevent icon redraw.
-          BOOL _forceUpdate;
-        }
+  - description: |
+      Do not install a custom Dock tile content view.
 
-        + (DockIcon*)sharedDockIcon {
-          static DockIcon* icon = [[DockIcon alloc] init];
+      A content view replaces the icon rather than drawing over it, which
+      is what stops the layered icon from following the system appearance.
+    regex:
+      re_pattern:
+        'static DockIcon\* icon = \[\] \{.*?return \[\[DockIcon alloc\]
+        init\];\s*\}\(\);'
+      re_flags: [DOTALL]
+      replace: 'static DockIcon* icon = [[DockIcon alloc] init];'
 
-          return icon;
-        }
+  - description: |
+      Report downloads through the Dock tile's badge label.
 
-        // The badge to describe the downloads in progress with, or nil for none.
+      A single determinate download is shown as a percentage; otherwise the
+      badge is the number of downloads in progress.
+    regex:
+      re_pattern: '(\n)(- \(void\)updateIcon \{)'
+      replace: |-
+        \1// The badge to describe the downloads in progress with, or nil for none.
         - (NSString*)badgeLabel {
           if (_downloads == 0) {
             return nil;
@@ -99,23 +91,26 @@ substitutions:
           return [formatter stringFromNumber:@(_progress)];
         }
 
-        - (void)updateIcon {
-          DCHECK_CURRENTLY_ON(BrowserThread::UI);
+        \2
 
-          constexpr base::TimeDelta kUpdateFrequencyCap = base::Hertz(5);
+  - description: |
+      Update the badge instead of redrawing a content view.
+    regex:
+      pattern: '[NSApp.dockTile display];'
+      replace: 'NSApp.dockTile.badgeLabel = [self badgeLabel];'
 
-          base::TimeTicks now = base::TimeTicks::Now();
-          base::TimeDelta timeSinceLastUpdate = now - _lastUpdate;
-          if (!_forceUpdate && timeSinceLastUpdate < kUpdateFrequencyCap) {
-            return;
-          }
-
-          _lastUpdate = now;
-          _forceUpdate = NO;
-
-          NSApp.dockTile.badgeLabel = [self badgeLabel];
-        }
-
+  - description: |
+      Store the in-progress download count on DockIcon.
+    regex:
+      re_pattern:
+        '- \(void\)setDownloads:\(int\)downloads
+        \{\s*DCHECK_CURRENTLY_ON\(BrowserThread::UI\);\s*DockTileView\*
+        dockTileView
+        =\s*base::apple::ObjCCast<DockTileView>\(NSApp\.dockTile\.contentView\);\s*if
+        \(downloads != dockTileView\.downloads\) \{\s*dockTileView\.downloads =
+        downloads;\s*_forceUpdate = YES;\s*\}\s*\}'
+      re_flags: [DOTALL]
+      replace: |-
         - (void)setDownloads:(int)downloads {
           DCHECK_CURRENTLY_ON(BrowserThread::UI);
 
@@ -125,6 +120,19 @@ substitutions:
           }
         }
 
+  - description: |
+      Store whether download progress is still unknown on DockIcon.
+    regex:
+      re_pattern:
+        '- \(void\)setIndeterminate:\(BOOL\)indeterminate
+        \{\s*DCHECK_CURRENTLY_ON\(BrowserThread::UI\);\s*DockTileView\*
+        dockTileView
+        =\s*base::apple::ObjCCast<DockTileView>\(NSApp\.dockTile\.contentView\);\s*if
+        \(indeterminate != dockTileView\.indeterminate\)
+        \{\s*dockTileView\.indeterminate = indeterminate;\s*_forceUpdate =
+        YES;\s*\}\s*\}'
+      re_flags: [DOTALL]
+      replace: |-
         - (void)setIndeterminate:(BOOL)indeterminate {
           DCHECK_CURRENTLY_ON(BrowserThread::UI);
 
@@ -134,10 +142,19 @@ substitutions:
           }
         }
 
+  - description: |
+      Store download progress on DockIcon.
+    regex:
+      re_pattern:
+        '- \(void\)setProgress:\(float\)progress
+        \{\s*DCHECK_CURRENTLY_ON\(BrowserThread::UI\);\s*DockTileView\*
+        dockTileView
+        =\s*base::apple::ObjCCast<DockTileView>\(NSApp\.dockTile\.contentView\);\s*dockTileView\.progress
+        = progress;\s*\}'
+      re_flags: [DOTALL]
+      replace: |-
         - (void)setProgress:(float)progress {
           DCHECK_CURRENTLY_ON(BrowserThread::UI);
 
           _progress = progress;
         }
-
-        @end


### PR DESCRIPTION
- Resolves https://github.com/brave/brave-browser/issues/58790
- Resolves https://github.com/brave/brave-browser/issues/58770
- Resolves https://github.com/brave/brave-browser/issues/56853

## Problem

The macOS app icon stops following the system appearance as soon as anything is downloaded, and only recovers after a restart.

Brave's light, dark and tinted variants exist only as `IconImageStack` renditions the Dock composites. Upstream installs a `DockTileView` on `NSApp.dockTile.contentView` for download progress and never removes it. A content view *replaces* the icon; the only bitmap app code can obtain is a flattened `Icon Image` with no appearance variants.

## Solution

Leave `contentView` unset and report download state through `NSDockTile.badgeLabel`, so the Dock keeps compositing the layered icon — including Clear and Tinted, whose glass material an app cannot reproduce. `DockTileView` stays unused: deleting it would swell the plaster without changing behaviour.

`DockBadgeLabel` lives in `chromium_src/chrome/browser/ui/cocoa/dock_icon.mm`. The badge is a **percentage** for a single determinate download, the **count** when there are several or progress is still unknown, and **cleared** when nothing is in progress. The progress ring goes away; the toolbar download button still reports progress.

Clearing `contentView` after a download does not restore the layered icon. Chrome does not see this because its icon is the same in either appearance.

## Test plan

1. System Settings → Appearance → Auto, or toggle Light/Dark / Clear / Tinted manually.
2. Launch Brave and download a file whose size is known (large enough that it does not finish instantly).
   - The Dock icon keeps its normal appearance and styling for the whole download.
   - The badge shows a percentage and updates as the download proceeds.
3. Start a download whose size is unknown (or wait for the very start, before `Content-Length` is known). The badge should show `1` rather than a percentage.
4. Start two or more concurrent downloads. The badge should show the count, not a percentage.
5. Toggle the system appearance during a download, and again after it completes. The icon follows immediately, with no restart.
6. Confirm the icon still matches the system appearance after a download has completed and the badge has cleared.

Note for testers: `NSDockTile.badgeLabel` is subject to **System Settings → Notifications → Brave → Badge application icon**. If that is off the badge does not appear at all; this is OS behaviour, not a regression. Worth checking first on a fresh local build, which has not been granted notification permission.

## Results - Using regular icons - Progress percentage on one active download

https://github.com/user-attachments/assets/6a0c5594-a3a9-48fa-810b-87a93c1f6700

## Results - Using regular icons - Indeterminate download

https://github.com/user-attachments/assets/4f017148-2561-4e9d-972c-68e56e06bbda

## Results - Using clear icons - Indeterminate download

https://github.com/user-attachments/assets/04c6f488-f563-46d2-8ea2-9ae00b884a9f