### PR TITLE
[ast-grep][plaster] Build `tree-sitter-gn` with `gn`

### DIFF
--- a/third_party/ast-grep/BUILD.gn
+++ b/third_party/ast-grep/BUILD.gn
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//testing/test.gni")
+
+if (host_os == "win") {
+  _ast_grep_platform = "win"
+  _exe_suffix = ".exe"
+} else {
+  _exe_suffix = ""
+  if (host_os == "mac") {
+    if (host_cpu == "arm64") {
+      _ast_grep_platform = "mac_arm64"
+    } else {
+      _ast_grep_platform = "mac"
+    }
+  } else {
+    _ast_grep_platform = "linux"
+  }
+}
+_ast_grep_dir = "brave/third_party/ast-grep/ast-grep-$_ast_grep_platform"
+
+config("tree_sitter_gn_config") {
+  include_dirs = [ "//brave/third_party/tree-sitter-gn-src/src" ]
+}
+
+shared_library("tree_sitter_gn") {
+  output_name = "gn"
+  sources = [
+    "//brave/third_party/tree-sitter-gn-src/src/parser.c",
+    "//brave/third_party/tree-sitter-gn-src/src/scanner.c",
+  ]
+  configs -= [ "//build/config/compiler:chromium_code" ]
+  configs += [
+    "//build/config/compiler:no_chromium_code",
+    ":tree_sitter_gn_config",
+  ]
+  if (is_clang) {
+    configs -= [ "//build/config/clang:unsafe_buffers" ]
+  }
+  if (is_posix) {
+    configs -= [ "//build/config/gcc:symbol_visibility_hidden" ]
+    configs += [ "//build/config/gcc:symbol_visibility_default" ]
+  }
+}
+
+test("tree_sitter_gn_unittests") {
+  sources = [ "tree_sitter_gn_unittest.cc" ]
+  defines = [
+    "AST_GREP_BIN=\"$_ast_grep_dir/bin/ast-grep$_exe_suffix\"",
+    "AST_GREP_SGCONFIG=\"$_ast_grep_dir/sgconfig.yml\"",
+  ]
+  data = [
+    "//$_ast_grep_dir/bin/",
+    "//$_ast_grep_dir/lib/",
+    "//$_ast_grep_dir/sgconfig.yml",
+  ]
+  deps = [
+    "//base",
+    "//base/test:run_all_unittests",
+    "//base/test:test_support",
+    "//testing/gmock",
+    "//testing/gtest",
+  ]
+}

--- a/third_party/ast-grep/README.md
+++ b/third_party/ast-grep/README.md
@@ -17,8 +17,8 @@ Useful flags: `--clean` (wipe source and build dirs, start fresh), `-j N`,
 ## Prerequisites
 
 The Chromium Rust toolchain must be available at
-`src/third_party/rust-toolchain/`, and Chromium's clang/lld at
-`src/third_party/llvm-build/`, so only vanilla Chromium is required.
+`src/third_party/rust-toolchain/`, and `gn` on `PATH` (depot_tools) for the
+grammar, so only a synced checkout is required.
 
 ## Outputs
 
@@ -27,6 +27,7 @@ The Chromium Rust toolchain must be available at
 | `third_party/ast-grep-src/`                          | ast-grep source clone         |
 | `third_party/tree-sitter-gn-src/`                    | tree-sitter-gn source clone   |
 | `third_party/ast-grep-intermediate/`                 | `cargo-home/`, `target/`      |
+| `../out/ast-grep-tree-sitter-gn/`                   | grammar-only GN build dir     |
 | `third_party/ast-grep/ast-grep-<os>/bin/ast-grep`    | final ast-grep binary         |
 | `third_party/ast-grep/ast-grep-<os>/lib/gn.<ext>`    | `gn` custom-language library  |
 | `third_party/ast-grep/ast-grep-<os>/sgconfig.yml`    | registers `gn` for ast-grep   |

--- a/third_party/ast-grep/build_tree_sitter_gn.py
+++ b/third_party/ast-grep/build_tree_sitter_gn.py
@@ -10,15 +10,17 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
 import shutil
-import subprocess
 import sys
 from pathlib import Path
 
 import build_utils
-from build_utils import AST_GREP_PLATFORM_DIR, CHROMIUM_ROOT, LLVM_BIN_DIR, \
+from build_utils import AST_GREP_PLATFORM_DIR, BRAVE_ROOT, CHROMIUM_ROOT, \
     THIRD_PARTY
+
+sys.path.insert(0, str(BRAVE_ROOT / 'tools' / 'cr' / 'toolchains'))
+
+from cherry_picks import _check_call
 
 # Pinning the `v1.0.0` tag's commit.
 TREE_SITTER_GN_GIT_URL = (
@@ -27,7 +29,22 @@ TREE_SITTER_GN_REF = 'bc06955bc1e3c9ff8e9b2b2a55b38b94da923c05'
 
 TREE_SITTER_GN_SRC_DIR: Path = THIRD_PARTY / 'tree-sitter-gn-src'
 
-_SHARED_LIB_EXT = {'win32': 'dll', 'darwin': 'dylib'}.get(sys.platform, 'so')
+# The output dir used when building the tree sitter
+GN_OUT_DIR: Path = CHROMIUM_ROOT / 'out' / 'ast-grep-tree-sitter-gn'
+
+# the target for the tree-sitter shared library
+GN_LABEL = '//brave/third_party/ast-grep:tree_sitter_gn'
+
+# the target for the unit test.
+GN_TEST_LABEL = '//brave/third_party/ast-grep:tree_sitter_gn_unittests'
+
+_GN_ARGS = ' '.join([
+    f'root_extra_deps = ["{GN_LABEL}", "{GN_TEST_LABEL}"]',
+    'is_debug = false',
+    'is_component_build = false',
+    'dcheck_always_on = false',
+    'symbol_level = 0',
+])
 
 # `The file providing details of how to load the custom tree-sitter.
 _SGCONFIG_TEMPLATE = """\
@@ -39,64 +56,66 @@ customLanguages:
 """
 
 
-def _windows_sdk_lib_dirs() -> list[Path]:
-    """VC tools + Windows SDK import-library directories.
+def _gn_built_output(label: str) -> Path:
+    """The file `label` builds to, as GN reports it.
     """
-    sys.path.insert(0, str(CHROMIUM_ROOT / 'build'))
-    from vs_toolchain import (
-        FindVCComponentRoot,  # noqa: E402
-        SDK_VERSION,
-        SetEnvironmentAndGetSDKDir)
-    sdk_dir = Path(SetEnvironmentAndGetSDKDir())
-    return [
-        Path(FindVCComponentRoot('Tools')) / 'lib' / 'x64',
-        sdk_dir / 'Lib' / SDK_VERSION / 'um' / 'x64',
-        sdk_dir / 'Lib' / SDK_VERSION / 'ucrt' / 'x64',
-    ]
+    outputs = _check_call('gn',
+                          'desc',
+                          str(GN_OUT_DIR),
+                          label,
+                          'outputs',
+                          cwd=CHROMIUM_ROOT,
+                          capture_output=True).stdout.split()
+    if not outputs:
+        raise RuntimeError(f'`gn desc` reported no outputs for {label}')
+
+    # GN lists the primary output first, with any others are link byproducts,
+    # such as a `.TOC` file or an import library.
+    built = CHROMIUM_ROOT / outputs[0].removeprefix('//')
+    if not built.is_file():
+        raise RuntimeError(f'ninja finished but {label} left no {built}')
+    return built
 
 
-def _compile(output: Path) -> None:
-    """Compile `parser.c` + `scanner.c` into the shared library at `output`.
-
-    `parser.c`'s pre-generated ABI (14) sits within ast-grep's tree-sitter
-    compatible range ([13, 15] as of tree-sitter 0.26), so it is used as-is,
-    with no `tree-sitter generate` step.
+def _compile() -> Path:
+    """Build the grammar and its test, returning the shared library's path.
     """
-    src_dir = TREE_SITTER_GN_SRC_DIR / 'src'
-    sources = [src_dir / 'parser.c', src_dir / 'scanner.c']
+    logging.info('Generating %s', GN_OUT_DIR)
+    _check_call('gn',
+                'gen',
+                str(GN_OUT_DIR),
+                f'--args={_GN_ARGS}',
+                cwd=CHROMIUM_ROOT)
 
-    env = dict(os.environ)
-    if sys.platform == 'win32':
-        clang_cl = LLVM_BIN_DIR / 'clang-cl.exe'
-        cmd = [
-            str(clang_cl), '/LD', '/O2', f'-I{src_dir}', *map(str, sources),
-            f'-Fe:{output}', '-fuse-ld=lld', '-link', '/EXPORT:tree_sitter_gn'
-        ]
-        env['LIB'] = os.pathsep.join(str(p) for p in _windows_sdk_lib_dirs())
-    else:
-        clang = LLVM_BIN_DIR / 'clang'
-        shared_flag = '-dynamiclib' if sys.platform == 'darwin' else '-shared'
-        cmd = [
-            str(clang), shared_flag, '-fPIC', '-O2', '-fuse-ld=lld',
-            f'-I{src_dir}', *map(str, sources), '-o',
-            str(output)
-        ]
-        if sys.platform == 'darwin':
-            sdk_path = subprocess.run(['xcrun', '--show-sdk-path'],
-                                      check=True,
-                                      capture_output=True,
-                                      text=True).stdout.strip()
-            cmd += ['-isysroot', sdk_path]
+    logging.info('Compiling tree-sitter-gn')
+    targets = [label.removeprefix('//') for label in (GN_LABEL, GN_TEST_LABEL)]
+    # `autoninja` rather than `ninja`, so whichever of siso or ninja the
+    # generated `args.gn` calls for is the one that runs.
+    _check_call('autoninja',
+                '-C',
+                str(GN_OUT_DIR),
+                *targets,
+                cwd=CHROMIUM_ROOT)
 
-    logging.info('Compiling tree-sitter-gn -> %s', output)
-    subprocess.run(cmd, check=True, env=env)
+    return _gn_built_output(GN_LABEL)
+
+
+def _run_test() -> None:
+    """Check ast-grep loads the freshly installed grammar.
+
+    Runs after installation, since the test scans with the `sgconfig.yml` and
+    library that land in `AST_GREP_PLATFORM_DIR`, not the build output.
+    """
+    test_bin = _gn_built_output(GN_TEST_LABEL)
+    logging.info('Running %s', test_bin.name)
+    _check_call(str(test_bin))
 
 
 def build(clean: bool = False) -> Path:
     """Build the `gn` custom-language library into `AST_GREP_PLATFORM_DIR/lib/`.
 
     Also (re)writes `AST_GREP_PLATFORM_DIR/sgconfig.yml` registering it.
-    Returns the compiled library's path.
+    Returns the installed library's path.
     """
     if clean and TREE_SITTER_GN_SRC_DIR.exists():
         logging.info('Removing %s', TREE_SITTER_GN_SRC_DIR)
@@ -106,10 +125,14 @@ def build(clean: bool = False) -> Path:
                                      TREE_SITTER_GN_REF,
                                      TREE_SITTER_GN_SRC_DIR)
 
+    library = _compile()
+
     lib_dir = AST_GREP_PLATFORM_DIR / 'lib'
     lib_dir.mkdir(parents=True, exist_ok=True)
-    output = lib_dir / f'gn.{_SHARED_LIB_EXT}'
-    _compile(output)
+    # GN's own extension is reused, dropping its platform-specific prefix.
+    output = lib_dir / f'gn{library.suffix}'
+    logging.info('Installing %s -> %s', library, output)
+    shutil.copy2(library, output)
 
     # Write the `sgconfig.yml` registering the library, so ast-grep can find it.
     sgconfig_path = AST_GREP_PLATFORM_DIR / 'sgconfig.yml'
@@ -117,6 +140,8 @@ def build(clean: bool = False) -> Path:
     sgconfig_path.write_text(_SGCONFIG_TEMPLATE %
                              {'library_path': lib_rel.as_posix()},
                              newline='\n')
+
+    _run_test()
     return output
 
 

--- a/third_party/ast-grep/build_utils.py
+++ b/third_party/ast-grep/build_utils.py
@@ -19,14 +19,13 @@ BRAVE_ROOT: Path = Path(__file__).resolve().parents[2]
 CHROMIUM_ROOT: Path = BRAVE_ROOT.parent
 THIRD_PARTY: Path = BRAVE_ROOT / 'third_party'
 
-# Chromium's own clang/lld, fetched by `tools/clang/scripts/update.py` as part
-# of `gclient sync`.
-LLVM_BIN_DIR: Path = (CHROMIUM_ROOT / 'third_party' / 'llvm-build' /
-                      'Release+Asserts' / 'bin')
-
 
 def platform_dir() -> str:
-    """Host-OS token used in ast-grep's per-platform dir name (`ast-grep-<os>`)."""
+    """Host-OS token in ast-grep's per-platform dir name (`ast-grep-<os>`).
+
+    Mirrored by `_ast_grep_platform` in `third_party/ast-grep/BUILD.gn`, which
+    the unit test uses to find this tree.
+    """
     if sys.platform == 'darwin':
         return 'mac_arm64' if platform.machine() == 'arm64' else 'mac'
     if sys.platform == 'win32':

--- a/third_party/ast-grep/tree_sitter_gn_unittest.cc
+++ b/third_party/ast-grep/tree_sitter_gn_unittest.cc
@@ -1,0 +1,124 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "base/base_paths.h"
+#include "base/command_line.h"
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/json/json_reader.h"
+#include "base/path_service.h"
+#include "base/process/launch.h"
+#include "base/strings/string_split.h"
+#include "base/test/values_test_util.h"
+#include "base/values.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace {
+
+constexpr char kGnSource[] = R"(shared_library("gn") {
+  output_name = "gn"
+  sources = [ "parser.c" ]
+})";
+
+constexpr char kPatternRule[] =
+    "{id: pattern, language: gn, rule: {pattern: output_name = $VALUE}}";
+constexpr char kNodeKindRule[] =
+    "{id: node_kind, language: gn, rule: {kind: assignment_statement}}";
+
+class TreeSitterGnTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    base::FilePath source_root;
+    ASSERT_TRUE(
+        base::PathService::Get(base::DIR_SRC_TEST_DATA_ROOT, &source_root));
+
+    ast_grep_ = source_root.Append(base::FilePath::FromASCII(AST_GREP_BIN));
+    sgconfig_ =
+        source_root.Append(base::FilePath::FromASCII(AST_GREP_SGCONFIG));
+    ASSERT_TRUE(base::PathExists(ast_grep_)) << ast_grep_;
+    ASSERT_TRUE(base::PathExists(sgconfig_)) << sgconfig_;
+
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+
+    // A `.gn` extension, so the scan also exercises the extension mapping
+    // `sgconfig.yml` registers for the custom language.
+    gn_file_ = temp_dir_.GetPath().AppendASCII("test.gn");
+    ASSERT_TRUE(base::WriteFile(gn_file_, kGnSource));
+  }
+
+  // Scans `gn_file_` with `rule`, returning one dict per reported match.
+  std::vector<base::DictValue> Scan(std::string_view rule) {
+    base::CommandLine command(ast_grep_);
+    command.AppendArg("scan");
+    command.AppendArg("--inline-rules");
+    command.AppendArg(std::string(rule));
+    command.AppendArg("--config");
+    command.AppendArgPath(sgconfig_);
+    command.AppendArg("--json=stream");
+    command.AppendArgPath(gn_file_);
+
+    std::string output;
+    if (!base::GetAppOutputAndError(command, &output)) {
+      ADD_FAILURE() << command.GetCommandLineString() << "\n" << output;
+      return {};
+    }
+
+    // A successful run should only produce a JSON value of the match.
+    std::vector<base::DictValue> matches;
+    for (std::string_view line : base::SplitStringPiece(
+             output, "\n", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY)) {
+      std::optional<base::DictValue> match =
+          base::JSONReader::ReadDict(line, base::JSON_PARSE_RFC);
+      if (!match) {
+        ADD_FAILURE() << "not a JSON object: " << line;
+        continue;
+      }
+      matches.push_back(std::move(*match));
+    }
+    return matches;
+  }
+
+  // the path to the ast-grep binary
+  base::FilePath ast_grep_;
+
+  // the path to the sg config file used to load the tree-sitter-gn grammar
+  base::FilePath sgconfig_;
+
+  // a test gn file
+  base::FilePath gn_file_;
+
+  // the temp dir used during the test.
+  base::ScopedTempDir temp_dir_;
+};
+
+TEST_F(TreeSitterGnTest, LoadsGnGrammar) {
+  const std::vector<base::DictValue> matches = Scan(kPatternRule);
+  ASSERT_EQ(matches.size(), 1u);
+  EXPECT_THAT(matches.front(), base::test::IsSupersetOfValue(R"json({
+        "language": "gn",
+        "text": "output_name = \"gn\"",
+        "metaVariables": {"single": {"VALUE": {"text": "\"gn\""}}}
+      })json"));
+}
+
+TEST_F(TreeSitterGnTest, ExposesGnNodeKinds) {
+  const std::vector<base::DictValue> matches = Scan(kNodeKindRule);
+  EXPECT_THAT(matches,
+              ::testing::ElementsAre(
+                  base::test::IsSupersetOfValue(
+                      R"json({"text": "output_name = \"gn\""})json"),
+                  base::test::IsSupersetOfValue(
+                      R"json({"text": "sources = [ \"parser.c\" ]"})json")));
+}
+
+}  // namespace


### PR DESCRIPTION
This change aligns the build process for this shared library with the
rest of our build, using chromium tooling for it. This gn target is not
wired with the rest of the codebase, and it requires a vanilla Chromium
checkout to work.

Bug: https://github.com/brave/brave-browser/issues/58378
