### PR TITLE
[cr155][plaster] Passs `--no-ext-diff` when creating diffs

### DIFF
--- a/build/commands/lib/gitPatcher.test.js
+++ b/build/commands/lib/gitPatcher.test.js
@@ -23,6 +23,7 @@ function runGitAsyncWithErrorLog(repoPath, gitArgs) {
 function getPatch(gitRepoPath, modifiedFilePath) {
   const singleDiffArgs = [
     'diff',
+    '--no-ext-diff',
     '--src-prefix=a/',
     '--dst-prefix=b/',
     '--full-index',

--- a/build/commands/lib/updatePatches.js
+++ b/build/commands/lib/updatePatches.js
@@ -131,6 +131,7 @@ async function writePatchFiles(
     const singleDiffArgs = [
       ...gitConfigArgs,
       'diff',
+      '--no-ext-diff',
       '--src-prefix=a/',
       '--dst-prefix=b/',
       '--default-prefix',

--- a/build/commands/lib/updatePatches.test.js
+++ b/build/commands/lib/updatePatches.test.js
@@ -25,6 +25,7 @@ function runGit(repoPath, args) {
 async function writePatchAsPlaster(repoPath, patchDirPath, repoRelativePath) {
   const patchContents = await runGit(repoPath, [
     'diff',
+    '--no-ext-diff',
     '--src-prefix=a/',
     '--dst-prefix=b/',
     '--default-prefix',

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -369,6 +369,7 @@ class PatchinfoBuilder:
             '-c',
             'diff.algorithm=histogram',
             'diff',
+            '--no-ext-diff',
             '--src-prefix=a/',
             '--dst-prefix=b/',
             '--default-prefix',

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -202,6 +202,9 @@ class PlasterTest(unittest.TestCase):
             ('-c',
              f'core.attributesFile={plaster.PLASTER_GITATTRIBUTES_PATH}'),
             pinned_options)
+        # The env below cancels out the global and system config, but not the
+        # repository's own, so an external driver has to be turned off by flag.
+        self.assertIn('--no-ext-diff', diff_args)
         diff_env = diff_calls[0].kwargs.get('env', {})
         self.assertEqual(diff_env.get('GIT_ATTR_NOSYSTEM'), '1')
         self.assertEqual(diff_env.get('GIT_CONFIG_GLOBAL'), '/dev/null')
@@ -1214,6 +1217,7 @@ class PlasterTest(unittest.TestCase):
         # pass without exercising anything.
         objc_diff = self.fake_chromium_src._run_git_command([
             '-c', f'core.attributesFile={ambient_attributes}', 'diff',
+            '--no-ext-diff',
             str(test_file)
         ], self.fake_chromium_src.chromium)
         objc_header = next(line for line in objc_diff.splitlines()

--- a/tools/cr/test/fake_chromium_repo.py
+++ b/tools/cr/test/fake_chromium_repo.py
@@ -383,8 +383,8 @@ class FakeChromiumRepo:
                 # returns from the diff file.
                 result = subprocess.run(
                     [
-                        'git', 'diff', '--src-prefix=a/', '--dst-prefix=b/',
-                        '--default-prefix', '--full-index',
+                        'git', 'diff', '--no-ext-diff', '--src-prefix=a/',
+                        '--dst-prefix=b/', '--default-prefix', '--full-index',
                         '--ignore-space-at-eol', filename
                     ],
                     stdout=subprocess.PIPE,

--- a/tools/cr/toolchain.py
+++ b/tools/cr/toolchain.py
@@ -259,8 +259,12 @@ class Toolchain:
 
     def _diff(self, working: Version | str, target: Version | str) -> str:
         """Diffs this toolchain's files across the `working..target` range."""
-        return repository.chromium.run_git('diff', str(working), str(target),
-                                           '--', *self.spec.files)
+        # `--no-ext-diff` because a `diff.external` driver would render the
+        # change its own way, without the +/- prefixes `get_assigned_value`
+        # looks for, silently reporting every toolchain as unchanged.
+        return repository.chromium.run_git('diff',
+                                           '--no-ext-diff', str(working),
+                                           str(target), '--', *self.spec.files)
 
     def was_updated(self, working: Version | str,
                     target: Version | str) -> bool:


### PR DESCRIPTION
This is a safer way to make sure no external diffing tool gets involved.

Bug: https://github.com/brave/brave-browser/issues/58307
