### PR TITLE
[iOS] Fix regional filter lists not enabled by default based on device language

### DIFF
--- a/ios/brave-ios/Sources/Brave/WebFilters/FilterListStorage.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/FilterListStorage.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import BraveCore
+import BraveShields
 import Combine
 import Data
 import Foundation
@@ -86,19 +87,28 @@ import Preferences
     from regionalFilterLists: [AdblockFilterListCatalogEntry],
     adBlockService: AdblockService
   ) {
+    // Filter lists that focus on the user's language are enabled by default, but only the first
+    // time we see a catalog so that the user may disable them afterwards.
+    let enableDefaultLanguageLists =
+      !Preferences.Shields.checkedDefaultRegionalFilterLists.value
+
     var filterLists = regionalFilterLists.enumerated().compactMap {
       index,
       entry -> FilterList? in
       let setting = allFilterListSettings.first(where: {
         $0.componentId == entry.componentId
       })
-      // Some special filter lists don't have specific UI to disable it
-      // (except for disabling all of ad-blocking)
-      // For example the "default" and "first-party" list is controlled using our general Ad-block and TP toggle.
-      let isEnabled =
-        entry.hidden
-        ? entry.defaultEnabled
-        : setting?.isEnabled
+      let isEnabled: Bool?
+      if entry.hidden {
+        // Some special filter lists don't have specific UI to disable it
+        // (except for disabling all of ad-blocking)
+        // For example the "default" and "first-party" list is controlled using our general Ad-block and TP toggle.
+        isEnabled = entry.defaultEnabled
+      } else if enableDefaultLanguageLists && entry.matchesCurrentLanguage {
+        isEnabled = true
+      } else {
+        isEnabled = setting?.isEnabled
+      }
 
       return FilterList(
         from: entry,
@@ -125,6 +135,10 @@ import Preferences
     // Create missing filter lists
     for filterList in filterLists {
       upsert(filterList: filterList)
+    }
+
+    if !regionalFilterLists.isEmpty {
+      Preferences.Shields.checkedDefaultRegionalFilterLists.value = true
     }
 
     FilterListSetting.save(inMemory: !persistChanges)
@@ -297,14 +311,19 @@ import Preferences
   }
 }
 
-// MARK: - FilterListLanguageProvider - A way to share `defaultToggle` logic between multiple structs/classes
+// MARK: - Language matching
 
 extension AdblockFilterListCatalogEntry {
-  @available(iOS 16, *)
-  /// A list of regions that this filter list focuses on.
-  /// An empty set means this filter list doesn't focus on any specific region.
-  fileprivate var supportedLanguageCodes: Set<Locale.LanguageCode> {
+  /// A list of languages that this filter list focuses on.
+  /// An empty set means this filter list doesn't focus on any specific language.
+  private var supportedLanguageCodes: Set<Locale.LanguageCode> {
     return Set(languages.map({ Locale.LanguageCode($0) }))
+  }
+
+  /// Whether this filter list focuses on the language the browser is currently displayed in.
+  var matchesCurrentLanguage: Bool {
+    guard let languageCode = Locale.current.language.languageCode else { return false }
+    return supportedLanguageCodes.contains(languageCode)
   }
 }
 

--- a/ios/brave-ios/Sources/BraveShields/ShieldPreferences.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldPreferences.swift
@@ -59,6 +59,12 @@ extension Preferences {
       key: "shields.advanced-controls-visible",
       default: false
     )
+    /// Whether or not we've enabled the regional filter lists that match the user's language.
+    /// This is only done once so the user may disable them afterwards.
+    public static let checkedDefaultRegionalFilterLists = Option<Bool>(
+      key: "shields.checked-default-regional-filter-lists",
+      default: false
+    )
     /// Whether or not we've reported the initial state of shields for p3a
     public static let initialP3AStateReportedRevision = Option<Int>(
       key: "shields.initial-p3a-state-reported-revision",


### PR DESCRIPTION
Enable filter lists based on device language once (matches desktop behaviour, user can disable and it will remain disabled). This will affect new and existing users.

- Resolves https://github.com/brave/brave-browser/issues/58808

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

### Testplan

1. Change device language to one with regional filter lists (ex. German has EasyList Germany, Japanese has Adguard Japanese filters).
2. Run the app and verify regional lists are enabled by default in Settings > Shields & Privacy > Content Filtering
    - Enabling regional lists is logic that runs only once, so changing language again later currently won't enable the new language lists
3. Disable one of the regional lists that was enabled for selected language
4. Relaunch the app and verify that regional list remains disabled.
