### PR TITLE
[VPN 2.0] Add AgentLauncher scaffolding to start the VPN agent

### DIFF
--- a/components/brave_vpn/browser/v2/agent/BUILD.gn
+++ b/components/brave_vpn/browser/v2/agent/BUILD.gn
@@ -11,9 +11,20 @@ static_library("agent") {
   sources = [
     "agent_client.cc",
     "agent_client.h",
+    "agent_launcher.cc",
+    "agent_launcher.h",
+    "agent_launcher_internal.h",
     "browser_endpoint_impl.cc",
     "browser_endpoint_impl.h",
   ]
+
+  if (is_mac) {
+    sources += [ "agent_launcher_mac.mm" ]
+  } else if (is_linux) {
+    sources += [ "agent_launcher_linux.cc" ]
+  } else if (is_win) {
+    sources += [ "agent_launcher_win.cc" ]
+  }
 
   public_deps = [
     "//base",
@@ -37,6 +48,8 @@ source_set("test_support") {
   sources = [
     "test/fake_agent.cc",
     "test/fake_agent.h",
+    "test/fake_agent_launcher.cc",
+    "test/fake_agent_launcher.h",
   ]
 
   public_deps = [

--- a/components/brave_vpn/browser/v2/agent/agent_launcher.cc
+++ b/components/brave_vpn/browser/v2/agent/agent_launcher.cc
@@ -1,0 +1,55 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/agent/agent_launcher.h"
+
+#include <string_view>
+#include <utility>
+
+#include "base/files/file_path.h"
+#include "base/functional/bind.h"
+#include "base/task/bind_post_task.h"
+#include "base/task/task_traits.h"
+#include "base/task/thread_pool.h"
+#include "brave/components/brave_vpn/browser/v2/agent/agent_launcher_internal.h"
+
+namespace brave_vpn::v2 {
+namespace {
+void LaunchIfFound(AgentLauncher::LaunchFailureCallback failure_callback,
+                   const base::FilePath& agent_path) {
+  if (agent_path.empty()) {
+    std::move(failure_callback).Run(AgentLauncher::LaunchError::kAppNotFound);
+    return;
+  }
+  internal::LaunchAgentProcess(
+      base::BindPostTaskToCurrentDefault(std::move(failure_callback)),
+      agent_path);
+}
+}  // namespace
+
+// static
+std::string_view AgentLauncher::ErrorToString(LaunchError error) {
+  switch (error) {
+    case LaunchError::kAppNotFound:
+      return "agent not found";
+    case LaunchError::kLaunchFailed:
+      return "launch failed";
+  }
+}
+
+AgentLauncher::~AgentLauncher() = default;
+
+void AgentLauncher::Launch(LaunchFailureCallback failure_callback) {
+  // Get the agent path on a blocking sequence, then launch the agent process on
+  // the UI sequence. A platform-specific LaunchAgentProcess() will decide
+  // whether it needs to post another blocking task to do the actual launch. The
+  // reply runs on the calling sequence.
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce(&internal::GetValidAgentPath),
+      base::BindOnce(&LaunchIfFound, std::move(failure_callback)));
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/agent/agent_launcher.h
+++ b/components/brave_vpn/browser/v2/agent/agent_launcher.h
@@ -1,0 +1,50 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_AGENT_AGENT_LAUNCHER_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_AGENT_AGENT_LAUNCHER_H_
+
+#include <string_view>
+
+#include "base/functional/callback.h"
+
+namespace brave_vpn::v2 {
+// AgentLauncher starts the VPN agent process.
+//
+// Fire-and-forget by design. The launcher does not check whether the agent is
+// already running, does not verify the binary, does not wait for the agent to
+// come up, and does not report success. The callback exists purely so the
+// caller learns that process creation itself failed, and can stop waiting.
+//
+// AgentLauncher instances are cheap and are owned per profile. Two profiles
+// launching concurrently is harmless: the VPN agent process enforces its own
+// singleton, and a duplicate agent instance exits quietly.
+class AgentLauncher {
+ public:
+  enum class LaunchError {
+    // The agent app was not found where it was expected to be.
+    kAppNotFound,
+    // Process creation was attempted and did not happen.
+    kLaunchFailed,
+  };
+  using LaunchFailureCallback = base::OnceCallback<void(LaunchError)>;
+
+  static std::string_view ErrorToString(LaunchError error);
+
+  AgentLauncher() = default;
+  virtual ~AgentLauncher();
+
+  AgentLauncher(const AgentLauncher&) = delete;
+  AgentLauncher& operator=(const AgentLauncher&) = delete;
+
+  // Creates a detached agent process. Returns immediately; the work happens on
+  // a blocking sequence. Safe to call more than once, though callers are not
+  // expected to need it.
+  virtual void Launch(LaunchFailureCallback failure_callback);
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_AGENT_AGENT_LAUNCHER_H_

--- a/components/brave_vpn/browser/v2/agent/agent_launcher_internal.h
+++ b/components/brave_vpn/browser/v2/agent/agent_launcher_internal.h
@@ -1,0 +1,30 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_AGENT_AGENT_LAUNCHER_INTERNAL_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_AGENT_AGENT_LAUNCHER_INTERNAL_H_
+
+#include "base/files/file_path.h"
+#include "brave/components/brave_vpn/browser/v2/agent/agent_launcher.h"
+
+namespace brave_vpn::v2::internal {
+
+// Absolute path of the agent executable (Windows, Linux) or app bundle (macOS),
+// derived from the browser's own install location. Returns an empty path if the
+// install layout is unrecognized, or the agent executable cannot be found.
+base::FilePath GetValidAgentPath();
+
+// Creates a detached agent process. The new process must survive this browser
+// exiting, must not inherit its handles or standard streams, and must not be
+// visible to the user. Called on the UI sequence, so this must not block. The
+// blocking work is posted if the platform API is synchronous. Failure callback
+// runs exactly once on failure; it is already bound to the caller's sequence,
+// so it may be run, or dropped, from any sequence.
+void LaunchAgentProcess(AgentLauncher::LaunchFailureCallback failure_callback,
+                        const base::FilePath& agent_path);
+
+}  // namespace brave_vpn::v2::internal
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_AGENT_AGENT_LAUNCHER_INTERNAL_H_

--- a/components/brave_vpn/browser/v2/agent/agent_launcher_linux.cc
+++ b/components/brave_vpn/browser/v2/agent/agent_launcher_linux.cc
@@ -1,0 +1,29 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/files/file_path.h"
+#include "base/notimplemented.h"
+#include "brave/components/brave_vpn/browser/v2/agent/agent_launcher_internal.h"
+
+namespace brave_vpn::v2::internal {
+
+base::FilePath GetValidAgentPath() {
+  // TODO(https://github.com/brave/brave-browser/issues/58600)
+  // Implement agent path building and validation logic for Linux.
+  // Empty path means there is no valid agent executable found.
+  NOTIMPLEMENTED_LOG_ONCE()
+      << "GetValidAgentPath() is not yet implemented on Linux";
+  return {};
+}
+
+void LaunchAgentProcess(AgentLauncher::LaunchFailureCallback failure_callback,
+                        const base::FilePath& agent_path) {
+  // TODO(https://github.com/brave/brave-browser/issues/58600)
+  // Implement agent launch logic for Linux using appropriate Linux APIs.
+  NOTIMPLEMENTED_LOG_ONCE()
+      << "LaunchAgentProcess() is not yet implemented on Linux";
+}
+
+}  // namespace brave_vpn::v2::internal

--- a/components/brave_vpn/browser/v2/agent/agent_launcher_mac.mm
+++ b/components/brave_vpn/browser/v2/agent/agent_launcher_mac.mm
@@ -1,0 +1,29 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/files/file_path.h"
+#include "base/notimplemented.h"
+#include "brave/components/brave_vpn/browser/v2/agent/agent_launcher_internal.h"
+
+namespace brave_vpn::v2::internal {
+
+base::FilePath GetValidAgentPath() {
+  // TODO(https://github.com/brave/brave-browser/issues/58243)
+  // Implement agent path building and validation logic for macOS.
+  // Empty path means there is no valid agent executable found.
+  NOTIMPLEMENTED_LOG_ONCE()
+      << "GetValidAgentPath() is not yet implemented on macOS";
+  return {};
+}
+
+void LaunchAgentProcess(AgentLauncher::LaunchFailureCallback failure_callback,
+                        const base::FilePath& agent_path) {
+  // TODO(https://github.com/brave/brave-browser/issues/58243)
+  // Implement agent launch logic for macOS using LaunchServices.
+  NOTIMPLEMENTED_LOG_ONCE()
+      << "LaunchAgentProcess() is not yet implemented on macOS";
+}
+
+}  // namespace brave_vpn::v2::internal

--- a/components/brave_vpn/browser/v2/agent/agent_launcher_win.cc
+++ b/components/brave_vpn/browser/v2/agent/agent_launcher_win.cc
@@ -1,0 +1,29 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/files/file_path.h"
+#include "base/notimplemented.h"
+#include "brave/components/brave_vpn/browser/v2/agent/agent_launcher_internal.h"
+
+namespace brave_vpn::v2::internal {
+
+base::FilePath GetValidAgentPath() {
+  // TODO(https://github.com/brave/brave-browser/issues/58243)
+  // Implement agent path building and validation logic for Windows.
+  // Empty path means there is no valid agent executable found.
+  NOTIMPLEMENTED_LOG_ONCE()
+      << "GetValidAgentPath() is not yet implemented on Windows";
+  return {};
+}
+
+void LaunchAgentProcess(AgentLauncher::LaunchFailureCallback failure_callback,
+                        const base::FilePath& agent_path) {
+  // TODO(https://github.com/brave/brave-browser/issues/58243)
+  // Implement agent launch logic for Windows using appropriate Windows APIs.
+  NOTIMPLEMENTED_LOG_ONCE()
+      << "LaunchAgentProcess() is not yet implemented on Windows";
+}
+
+}  // namespace brave_vpn::v2::internal

--- a/components/brave_vpn/browser/v2/agent/test/fake_agent_launcher.cc
+++ b/components/brave_vpn/browser/v2/agent/test/fake_agent_launcher.cc
@@ -1,0 +1,21 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_vpn/browser/v2/agent/test/fake_agent_launcher.h"
+
+#include <utility>
+
+namespace brave_vpn::v2 {
+
+FakeAgentLauncher::FakeAgentLauncher(Record* record) : record_(record) {}
+
+FakeAgentLauncher::~FakeAgentLauncher() = default;
+
+void FakeAgentLauncher::Launch(LaunchFailureCallback failure_callback) {
+  ++record_->launch_count;
+  record_->last_failure_callback = std::move(failure_callback);
+}
+
+}  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/agent/test/fake_agent_launcher.h
+++ b/components/brave_vpn/browser/v2/agent/test/fake_agent_launcher.h
@@ -1,0 +1,33 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_AGENT_TEST_FAKE_AGENT_LAUNCHER_H_
+#define BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_AGENT_TEST_FAKE_AGENT_LAUNCHER_H_
+
+#include "base/memory/raw_ptr.h"
+#include "brave/components/brave_vpn/browser/v2/agent/agent_launcher.h"
+
+namespace brave_vpn::v2 {
+
+class FakeAgentLauncher : public AgentLauncher {
+ public:
+  struct Record {
+    int launch_count = 0;
+    AgentLauncher::LaunchFailureCallback last_failure_callback;
+  };
+
+  explicit FakeAgentLauncher(Record* record);
+  ~FakeAgentLauncher() override;
+
+  // AgentLauncher overrides:
+  void Launch(LaunchFailureCallback failure_callback) override;
+
+ private:
+  const raw_ptr<Record> record_;
+};
+
+}  // namespace brave_vpn::v2
+
+#endif  // BRAVE_COMPONENTS_BRAVE_VPN_BROWSER_V2_AGENT_TEST_FAKE_AGENT_LAUNCHER_H_

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.cc
@@ -66,6 +66,7 @@ BraveVpnServiceImpl::BraveVpnServiceImpl(
 #if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
   agent_client_ = std::make_unique<AgentClient>();
   agent_client_->AddObserver(this);
+  agent_launcher_ = std::make_unique<AgentLauncher>();
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
   purchased_state_manager_ = std::make_unique<PurchasedStateManager>(
       local_prefs, api_client_.get(), skus_client_.get(),
@@ -121,7 +122,9 @@ void BraveVpnServiceImpl::GetAllRegions(GetAllRegionsCallback callback) {
 }
 
 void BraveVpnServiceImpl::Shutdown() {
+  weak_factory_.InvalidateWeakPtrs();
 #if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
+  agent_launcher_.reset();
   agent_client_.reset();
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
   purchased_state_manager_.reset();
@@ -202,11 +205,27 @@ void BraveVpnServiceImpl::OnAgentNotRunning() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   LOG(ERROR) << "Agent is not running";
 
-  // TODO(https://github.com/brave/brave-browser/issues/58243)
   // The agent process is apparently not running. While the agent client will
-  // retry on its own, check if the agent is running and start it if not. This
-  // is a workaround for the case where the agent is not started by the
-  // privileged helper.
+  // retry on its own, launch the agent process. This is a workaround for the
+  // case where the agent is not started by the privileged helper.
+  if (agent_launcher_) {
+    agent_launcher_->Launch(base::BindOnce(
+        &BraveVpnServiceImpl::OnAgentLaunchFailed, weak_factory_.GetWeakPtr()));
+  }
+}
+
+void BraveVpnServiceImpl::OnAgentLaunchFailed(
+    AgentLauncher::LaunchError error) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  LOG(ERROR) << "Failed to launch agent: "
+             << AgentLauncher::ErrorToString(error);
+
+  // Purchased state is untouched - the subscription is valid and the UI stays
+  // fully enabled. Just stop the retry loop; the next user-initiated connect
+  // starts a fresh sequence.
+  if (agent_client_) {
+    agent_client_->Reset();
+  }
 }
 
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl.h
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "base/memory/raw_ref.h"
+#include "base/memory/weak_ptr.h"
 #include "brave/components/brave_vpn/browser/brave_vpn_service.h"
 #include "brave/components/brave_vpn/browser/v2/skus_service_client.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
@@ -19,6 +20,7 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
 #include "brave/components/brave_vpn/browser/v2/agent/agent_client.h"
+#include "brave/components/brave_vpn/browser/v2/agent/agent_launcher.h"
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
 
 namespace network {
@@ -149,6 +151,9 @@ class BraveVpnServiceImpl : public BraveVpnService
   void OnAgentUnavailable(
       std::optional<mojom::BrowserAuthResult> result) override;
   void OnAgentNotRunning() override;
+
+  // Called when the agent process fails to launch.
+  void OnAgentLaunchFailed(AgentLauncher::LaunchError error);
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
 
 #if !BUILDFLAG(IS_ANDROID)
@@ -166,10 +171,12 @@ class BraveVpnServiceImpl : public BraveVpnService
   std::unique_ptr<SkusServiceClient> skus_client_;
 #if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
   std::unique_ptr<AgentClient> agent_client_;
+  std::unique_ptr<AgentLauncher> agent_launcher_;
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
   std::unique_ptr<PurchasedStateManager> purchased_state_manager_;
 
   [[maybe_unused]] mojom::ConnectionState connection_state_;
+  base::WeakPtrFactory<BraveVpnServiceImpl> weak_factory_{this};
 };
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/browser/v2/brave_vpn_service_impl_unittest.cc
+++ b/components/brave_vpn/browser/v2/brave_vpn_service_impl_unittest.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 
 #include "base/functional/bind.h"
 #include "base/task/thread_pool/thread_pool_instance.h"
@@ -35,6 +36,7 @@
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
 #include "brave/components/brave_vpn/browser/v2/agent/test/fake_agent.h"
+#include "brave/components/brave_vpn/browser/v2/agent/test/fake_agent_launcher.h"
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
 
 namespace brave_vpn::v2 {
@@ -80,6 +82,9 @@ class BraveVpnServiceImplTest : public testing::Test {
     ASSERT_EQ(service_->agent_client_->state(),
               AgentClient::State::kDisconnected);
     ReplaceAgentClientWithFake();
+    // Replace the real agent launcher with one that does not launch anything
+    // but captures a callback and counts launch attempts.
+    ReplaceAgentLauncherWithFake();
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
   }
 
@@ -102,8 +107,21 @@ class BraveVpnServiceImplTest : public testing::Test {
     service_->agent_client_->AddObserver(service_.get());
   }
 
+  void ReplaceAgentLauncherWithFake() {
+    service_->agent_launcher_ =
+        std::make_unique<FakeAgentLauncher>(&launch_record_);
+  }
+
   void UpdateAgentConnection(mojom::PurchasedState state) {
     service_->UpdateAgentConnection(state);
+  }
+  void NotifyAgentNotRunning() { service_->OnAgentNotRunning(); }
+  void NotifyAgentDisconnected() { service_->OnAgentDisconnected(); }
+  void NotifyAgentUnavailable(mojom::BrowserAuthResult result) {
+    service_->OnAgentUnavailable(result);
+  }
+  void NotifyAgentLaunchFailed(AgentLauncher::LaunchError error) {
+    service_->OnAgentLaunchFailed(error);
   }
 
   AgentClient* agent_client() { return service_->agent_client_.get(); }
@@ -119,6 +137,7 @@ class BraveVpnServiceImplTest : public testing::Test {
   int skus_bind_count_ = 0;
 #if BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
   FakeAgent fake_agent_;
+  FakeAgentLauncher::Record launch_record_;
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
   // Declared last so it is destroyed before the prefs, the fake SKUS
   // service, and the fake agent it points at.
@@ -174,6 +193,12 @@ TEST_F(BraveVpnServiceImplTest, SafeDefaultsAfterShutdown) {
   // The agent client is gone; the mapping must not dereference it.
   UpdateAgentConnection(mojom::PurchasedState::PURCHASED);
   UpdateAgentConnection(mojom::PurchasedState::NOT_PURCHASED);
+
+  NotifyAgentNotRunning();
+  NotifyAgentDisconnected();
+  NotifyAgentUnavailable(mojom::BrowserAuthResult::kInconclusive);
+  NotifyAgentLaunchFailed(AgentLauncher::LaunchError::kLaunchFailed);
+  EXPECT_EQ(launch_record_.launch_count, 0);
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)
 
 #if !BUILDFLAG(IS_ANDROID)
@@ -218,6 +243,61 @@ TEST_F(BraveVpnServiceImplTest, PolicyDisabledKeepsAgentDisconnected) {
   CreateService();
   UpdateAgentConnection(mojom::PurchasedState::PURCHASED);
   EXPECT_EQ(agent_client()->state(), AgentClient::State::kDisconnected);
+}
+
+TEST_F(BraveVpnServiceImplTest, AgentNotRunningLaunchesAgent) {
+  CreateService();
+  ASSERT_EQ(launch_record_.launch_count, 0);
+
+  NotifyAgentNotRunning();
+
+  EXPECT_EQ(launch_record_.launch_count, 1);
+  EXPECT_TRUE(launch_record_.last_failure_callback);
+}
+
+// Only a missing agent justifies a launch. A refusal means the agent is right
+// there and said no; a disconnect means it was there a moment ago. Starting a
+// second instance in either case would be wrong.
+TEST_F(BraveVpnServiceImplTest, OnlyMissingAgentTriggersLaunch) {
+  CreateService();
+  UpdateAgentConnection(mojom::PurchasedState::PURCHASED);
+
+  NotifyAgentDisconnected();
+  NotifyAgentUnavailable(mojom::BrowserAuthResult::kRejected);
+
+  EXPECT_EQ(launch_record_.launch_count, 0);
+}
+
+// A launch that never happened leaves nothing to connect to, so the retry loop
+// stops. The next user-initiated connect starts a fresh sequence, which is the
+// only way back.
+TEST_F(BraveVpnServiceImplTest, AgentLaunchFailureStopsRetrying) {
+  CreateService();
+  UpdateAgentConnection(mojom::PurchasedState::PURCHASED);
+  ASSERT_EQ(agent_client()->state(), AgentClient::State::kConnecting);
+
+  NotifyAgentNotRunning();
+  ASSERT_TRUE(launch_record_.last_failure_callback);
+  std::move(launch_record_.last_failure_callback)
+      .Run(AgentLauncher::LaunchError::kAppNotFound);
+
+  EXPECT_EQ(agent_client()->state(), AgentClient::State::kDisconnected);
+}
+
+// The launcher is gone after Shutdown(), but the failure callback is bound to
+// the still-live service, so it can arrive afterwards and must not dereference
+// the agent client.
+TEST_F(BraveVpnServiceImplTest, LaunchFailureAfterShutdownDoesNotCrash) {
+  CreateService();
+  UpdateAgentConnection(mojom::PurchasedState::PURCHASED);
+  NotifyAgentNotRunning();
+  ASSERT_TRUE(launch_record_.last_failure_callback);
+
+  ShutdownService();
+
+  // Must not crash.
+  std::move(launch_record_.last_failure_callback)
+      .Run(AgentLauncher::LaunchError::kLaunchFailed);
 }
 
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN_V2_APPS)


### PR DESCRIPTION
The browser needs to be able to start the agent itself: the privileged helper cannot, since it has no way to know whether the browser is eligible until the agent brokers for it.

AgentLauncher does that and nothing else: it resolves the agent path on a blocking sequence, creates a detached process, and reports only that process creation failed.A failed launch stops the retry loop but leaves purchased state alone, so the UI stays enabled and the next connect starts a fresh attempt.

Platform implementations are stubbed and land separately. Gated on enable_brave_vpn_v2_apps.

Implements part of https://github.com/brave/brave-browser/issues/58243

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
