### PR TITLE
[iOS] [P3A] Use correct max value for enum & bucket-based histograms

### DIFF
--- a/ios/brave-ios/Sources/Growth/P3AUmaExtensions.swift
+++ b/ios/brave-ios/Sources/Growth/P3AUmaExtensions.swift
@@ -14,7 +14,8 @@ public func UmaHistogramEnumeration<E: RawRepresentable & CaseIterable>(
   _ name: String,
   sample: E
 ) where E.RawValue == Int {
-  UmaHistogramExactLinear(name, sample.rawValue, E.allCases.count + 1)
+  assert(!E.allCases.isEmpty)
+  UmaHistogramExactLinear(name, sample.rawValue, E.allCases.map(\.rawValue).max()! + 1)
 }
 
 /// A bucket that may span a single value or a range of values
@@ -53,7 +54,7 @@ public func UmaHistogramRecordValueToBucket(
     Logger.module.warning("Value (\(value)) not found in any bucket for histogram \(name)")
     return
   }
-  UmaHistogramExactLinear(name, answer, buckets.count + 1)
+  UmaHistogramExactLinear(name, answer, buckets.count)
 }
 
 // swift-format-ignore


### PR DESCRIPTION
We were off-by-one for both enum and bucket-based histograms. Enums were not using the raw value for their max value calculations. Buckets were adding one to match desktop but the bucket construction differ so this was incorrect (iOS already includes bucket ranges rather than just upper bounds)

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58733
