### PR TITLE
[iOS] Remove autofill data manager feature flag gate

### DIFF
--- a/ios/browser/api/web_view/brave_web_view_configuration.mm
+++ b/ios/browser/api/web_view/brave_web_view_configuration.mm
@@ -50,10 +50,6 @@
   // Reimplements CWVWebViewConfiguration's `autofillDataManager` method to
   // instead create a CWVAutofillDataManager using Chrome factories instead
   // of `//ios/web_view` specific factories.
-  if (!base::FeatureList::IsEnabled(
-          brave::features::kUseChromiumWebViewsAutofill)) {
-    return nil;
-  }
   if (!_autofillDataManager && self.persistent) {
     ProfileIOS* profile = ProfileIOS::FromBrowserState(self.browserState);
     autofill::PersonalDataManager* personalDataManager =


### PR DESCRIPTION
Access to the underlying stored autofill data doesn't necessarily require the autofill web view integrations
