### PR TITLE
[plaster] Fix `set_blink_runtime_enabled_feature_state`

### DIFF
--- a/app/BUILD.gn
+++ b/app/BUILD.gn
@@ -120,6 +120,7 @@ source_set("browser_tests") {
 source_set("unit_tests") {
   testonly = true
   sources = [
+    "blink_runtime_feature_defaults_unittest.cc",
     "brave_main_delegate_unittest.cc",
     "feature_defaults_unittest.cc",
   ]
@@ -198,6 +199,7 @@ source_set("unit_tests") {
     "//services/device/public/cpp:device_features",
     "//services/network/public/cpp",
     "//testing/gtest",
+    "//third_party/blink/public:blink",
     "//ui/base",
   ]
   if (is_android) {

--- a/app/DEPS
+++ b/app/DEPS
@@ -78,6 +78,9 @@ specific_include_rules = {
     "+chrome/test/base",
     "+content/public/test",
   ],
+  "blink_runtime_feature_defaults_unittest\.cc": [
+    "+third_party/blink/public/platform/web_runtime_features.h",
+  ],
   "feature_defaults_unittest\.cc": [
     "+android_webview/common/aw_features.h",
     "+components/browser_actuator/internal/features.h",

--- a/app/blink_runtime_feature_defaults_unittest.cc
+++ b/app/blink_runtime_feature_defaults_unittest.cc
@@ -1,0 +1,61 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <string_view>
+
+#include "base/containers/fixed_flat_set.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/blink/public/platform/web_runtime_features.h"
+
+namespace {
+
+constexpr auto kDisabledRuntimeFeatures =
+    base::MakeFixedFlatSet<std::string_view>({
+        "AdInterestGroupAPI",
+        "AIPromptAPI",
+        "AIPromptAPIMultimodalInput",
+        "AIProofreadingAPI",
+        "AIRewriterAPI",
+        "AISummarizationAPI",
+        "AIWriterAPI",
+        "ControlledFrame",
+        "FencedFrames",
+        "Fledge",
+        "LanguageDetectionAPI",
+        "Parakeet",
+        "Prerender2",
+        "TranslationAPI",
+        "UserMediaElement",
+    });
+
+constexpr auto kEnabledRuntimeFeatures =
+    base::MakeFixedFlatSet<std::string_view>({
+        "ReduceUserAgentMinorVersion",
+    });
+
+bool IsEnabled(std::string_view name) {
+  return blink::WebRuntimeFeatures::IsFeatureEnabledFromStringForTesting(name);
+}
+
+void ExpectTheForcedState() {
+  for (std::string_view name : kDisabledRuntimeFeatures) {
+    EXPECT_FALSE(IsEnabled(name)) << name;
+  }
+  for (std::string_view name : kEnabledRuntimeFeatures) {
+    EXPECT_TRUE(IsEnabled(name)) << name;
+  }
+}
+
+TEST(BlinkRuntimeFeatureDefaultsTest, ForcedRuntimeFeatureDefaults) {
+  ExpectTheForcedState();
+}
+
+TEST(BlinkRuntimeFeatureDefaultsTest, BaseFeatureSyncPreservesTheDefaults) {
+  blink::WebRuntimeFeatures::UpdateStatusFromBaseFeatures();
+
+  ExpectTheForcedState();
+}
+
+}  // namespace

--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -3,7 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "base/debug/debugging_buildflags.h"
 #include "base/feature_list.h"
 #include "base/features.h"
 #include "chrome/browser/browser_features.h"

--- a/chromium_src/third_party/blink/renderer/platform/exported/web_runtime_features.cc
+++ b/chromium_src/third_party/blink/renderer/platform/exported/web_runtime_features.cc
@@ -1,0 +1,17 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <third_party/blink/renderer/platform/exported/web_runtime_features.cc>
+
+namespace blink {
+
+// The reader for `EnableFeatureFromString`, declared by the plaster on
+// web_runtime_features.h. See it for why this exists.
+bool WebRuntimeFeatures::IsFeatureEnabledFromStringForTesting(
+    std::string_view name) {
+  return RuntimeEnabledFeatures::IsFeatureEnabledFromStringForTesting(name);
+}
+
+}  // namespace blink

--- a/patches/third_party-blink-public-platform-web_runtime_features.h.patch
+++ b/patches/third_party-blink-public-platform-web_runtime_features.h.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/blink/public/platform/web_runtime_features.h b/third_party/blink/public/platform/web_runtime_features.h
+index d7584122c0b89e646cec244febbaeb9df57877dc..395fa110a480712d0139783db11382e74a031de8 100644
+--- a/third_party/blink/public/platform/web_runtime_features.h
++++ b/third_party/blink/public/platform/web_runtime_features.h
+@@ -71,6 +71,7 @@ class BLINK_PLATFORM_EXPORT WebRuntimeFeatures : public WebRuntimeFeaturesBase {
+   static void EnableLocalNetworkAccessWebRTC(bool);
+ 
+   WebRuntimeFeatures() = delete;
++  static bool IsFeatureEnabledFromStringForTesting(std::string_view);
+ };
+ 
+ }  // namespace blink

--- a/patches/third_party-blink-renderer-build-scripts-templates-runtime_enabled_features.cc.tmpl.patch
+++ b/patches/third_party-blink-renderer-build-scripts-templates-runtime_enabled_features.cc.tmpl.patch
@@ -1,0 +1,20 @@
+diff --git a/third_party/blink/renderer/build/scripts/templates/runtime_enabled_features.cc.tmpl b/third_party/blink/renderer/build/scripts/templates/runtime_enabled_features.cc.tmpl
+index 3fdcb18fadcf364a6c8d2bfe5c1c1042a0386a4d..a63414fc19879139bf71c6423ae3b0fead6c2e60 100644
+--- a/third_party/blink/renderer/build/scripts/templates/runtime_enabled_features.cc.tmpl
++++ b/third_party/blink/renderer/build/scripts/templates/runtime_enabled_features.cc.tmpl
+@@ -178,6 +178,15 @@ bool RuntimeEnabledFeaturesBase::IsFeatureEnabledFromString(
+   }
+ }
+ 
++// static
++bool RuntimeEnabledFeaturesBase::IsFeatureEnabledFromStringForTesting(
++    std::string_view name) {
++  std::optional<uint16_t> flag_index = FindFeatureFlagIndex(name);
++  CHECK(flag_index.has_value())
++      << "RuntimeEnabledFeature not recognized: " << name;
++  return feature_states_[*flag_index];
++}
++
+ // static
+ void RuntimeEnabledFeaturesBase::UpdateStatusFromBaseFeatures() {
+   // Parallel arrays rather than an array-of-structs avoid per-entry padding.

--- a/patches/third_party-blink-renderer-build-scripts-templates-runtime_enabled_features.h.tmpl.patch
+++ b/patches/third_party-blink-renderer-build-scripts-templates-runtime_enabled_features.h.tmpl.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/blink/renderer/build/scripts/templates/runtime_enabled_features.h.tmpl b/third_party/blink/renderer/build/scripts/templates/runtime_enabled_features.h.tmpl
+index e2e96bad04e6d620b5054d645ee785d3cec9c756..ff1dae0d099e486c7e94599acb6d641305653f2a 100644
+--- a/third_party/blink/renderer/build/scripts/templates/runtime_enabled_features.h.tmpl
++++ b/third_party/blink/renderer/build/scripts/templates/runtime_enabled_features.h.tmpl
+@@ -111,6 +111,7 @@ class PLATFORM_EXPORT RuntimeEnabledFeaturesBase {
+   {% endfor %}
+ 
+   static bool IsFeatureEnabledFromString(std::string_view name);
++  static bool IsFeatureEnabledFromStringForTesting(std::string_view name);
+ 
+  protected:
+   // See the comment in RuntimeEnabledFeatures for why these are protected.

--- a/patches/third_party-blink-renderer-platform-runtime_enabled_features.json5.patch
+++ b/patches/third_party-blink-renderer-platform-runtime_enabled_features.json5.patch
@@ -1,32 +1,58 @@
 diff --git a/third_party/blink/renderer/platform/runtime_enabled_features.json5 b/third_party/blink/renderer/platform/runtime_enabled_features.json5
-index 22bb1b8232d1028dc9c74472d0df3fd334df1929..444b3b836b228068eaf9c05fb6a356e24f0a9b1e 100644
+index 22bb1b8232d1028dc9c74472d0df3fd334df1929..d1ec427a9714bc563f92d24d12a3f42e2a4450d7 100644
 --- a/third_party/blink/renderer/platform/runtime_enabled_features.json5
 +++ b/third_party/blink/renderer/platform/runtime_enabled_features.json5
-@@ -297,6 +297,7 @@
+@@ -297,7 +297,7 @@
      {
        // Interest Group JS API/runtimeflag.
        name: "AdInterestGroupAPI",
+-      status: "stable",
 +      base_feature_status: "disabled",  // feature state is enforced via plaster rewrite.
-       status: "stable",
        origin_trial_feature_name: "AdInterestGroupAPI",
        implied_by: ["Fledge", "Parakeet"],
-@@ -407,6 +408,7 @@
+       public: true,
+@@ -407,14 +407,8 @@
      },
      {
        name: "AIPromptAPI",
 +      base_feature_status: "disabled",  // feature state is enforced via plaster rewrite.
        public: true,
-       status: {
-         "Win": "stable",
-@@ -434,6 +436,7 @@
+-      status: {
+-        "Win": "stable",
+-        "Mac": "stable",
+-        "Linux": "stable",
+-        "ChromeOS": "stable",
+-        "default": "",
+-      },
+     },
+     {
+       name: "AIPromptAPIForWorkers",
+@@ -434,13 +428,7 @@
      },
      {
        name: "AIPromptAPIMultimodalInput",
+-      status: {
+-        "Win": "stable",
+-        "Mac": "stable",
+-        "Linux": "stable",
+-        "ChromeOS": "stable",
+-        "default": "",
+-      },
 +      base_feature_status: "disabled",  // feature state is enforced via plaster rewrite.
-       status: {
-         "Win": "stable",
-         "Mac": "stable",
-@@ -488,7 +491,7 @@
+     },
+     {
+       // Gates access to inference parameter enhancements for "AIPromptAPI".
+@@ -478,32 +466,18 @@
+     },
+     {
+       name: "AIProofreadingAPI",
+-      status: {
+-        "Win": "experimental",
+-        "Mac": "experimental",
+-        "Linux": "experimental",
+-        "ChromeOS": "experimental",
+-        "default": "",
+-      },
        origin_trial_feature_name: "AIProofreaderAPI",
        origin_trial_os: ["win", "mac", "linux", "chromeos"],
        origin_trial_allows_third_party: true,
@@ -35,7 +61,14 @@ index 22bb1b8232d1028dc9c74472d0df3fd334df1929..444b3b836b228068eaf9c05fb6a356e2
        copied_from_base_feature_if: "overridden",
      },
      {
-@@ -503,7 +506,7 @@
+       name: "AIRewriterAPI",
+-      status: {
+-        "Win": "experimental",
+-        "Mac": "experimental",
+-        "Linux": "experimental",
+-        "ChromeOS": "experimental",
+-        "default": "",
+-      },
        origin_trial_feature_name: "AIRewriterAPI",
        origin_trial_os: ["win", "mac", "linux", "chromeos"],
        origin_trial_allows_third_party: true,
@@ -44,15 +77,32 @@ index 22bb1b8232d1028dc9c74472d0df3fd334df1929..444b3b836b228068eaf9c05fb6a356e2
        copied_from_base_feature_if: "overridden",
      },
      {
-@@ -512,6 +515,7 @@
+@@ -512,13 +486,7 @@
      },
      {
        name: "AISummarizationAPI",
+-      status: {
+-        "Win": "stable",
+-        "Mac": "stable",
+-        "Linux": "stable",
+-        "ChromeOS": "stable",
+-        "default": "",
+-      },
 +      base_feature_status: "disabled",  // feature state is enforced via plaster rewrite.
-       status: {
-         "Win": "stable",
-         "Mac": "stable",
-@@ -539,7 +543,7 @@
+     },
+     {
+       name: "AISummarizationAPIForWorkers",
+@@ -529,17 +497,10 @@
+     },
+     {
+       name: "AIWriterAPI",
+-      status: {
+-        "Win": "experimental",
+-        "Mac": "experimental",
+-        "Linux": "experimental",
+-        "ChromeOS": "experimental",
+-        "default": "",
+-      },
        origin_trial_feature_name: "AIWriterAPI",
        origin_trial_os: ["win", "mac", "linux", "chromeos"],
        origin_trial_allows_third_party: true,
@@ -61,7 +111,7 @@ index 22bb1b8232d1028dc9c74472d0df3fd334df1929..444b3b836b228068eaf9c05fb6a356e2
        copied_from_base_feature_if: "overridden",
      },
      {
-@@ -1292,7 +1296,7 @@
+@@ -1292,7 +1253,7 @@
        // objects that live on the compositor thread.
        // [1] https://drafts.csswg.org/css-animations-2/#timeline-triggers
        name: "CompositorTimelineTrigger",
@@ -70,25 +120,32 @@ index 22bb1b8232d1028dc9c74472d0df3fd334df1929..444b3b836b228068eaf9c05fb6a356e2
      },
      {
        name: "CompressionDictionaryTransport",
-@@ -1375,6 +1379,7 @@
+@@ -1375,8 +1336,8 @@
        // https://github.com/WICG/controlled-frame/blob/main/README.md for more
        // info.
        name: "ControlledFrame",
 +      base_feature_status: "disabled",  // feature state is enforced via plaster rewrite.
        public: true,
-       status: "stable",
+-      status: "stable",
      },
-@@ -2847,7 +2852,8 @@
+     {
+       // Enable support for requesting SecurityInfo in WebRequest API
+@@ -2847,13 +2808,13 @@
      },
      {
        name: "FencedFrames",
--      base_feature: "none",
 +      base_feature_status: "disabled",  // feature state is enforced via plaster rewrite.
-+      base_feature: "FencedFramesRuntime",
+       base_feature: "none",
        // This helps enable and expose the <fencedframe> element, but note that
        // blink::features::kFencedFrames must be enabled as well, as we require
        // the support of the browser process to fully enable the feature.
-@@ -2948,6 +2954,7 @@
+       // Enabling this runtime enabled feature alone has no effect.
+       public: true,
+-      status: "stable",
+     },
+     {
+       name: "FencedFramesAPIChanges",
+@@ -2948,6 +2909,7 @@
      {
        // In-development features for the File System Access API.
        name: "FileSystemAccessAPIExperimental",
@@ -96,7 +153,7 @@ index 22bb1b8232d1028dc9c74472d0df3fd334df1929..444b3b836b228068eaf9c05fb6a356e2
        status: "experimental",
      },
      {
-@@ -2962,6 +2969,7 @@
+@@ -2962,6 +2924,7 @@
      {
        // Non-OPFS File System Access API.
        name: "FileSystemAccessLocal",
@@ -104,24 +161,33 @@ index 22bb1b8232d1028dc9c74472d0df3fd334df1929..444b3b836b228068eaf9c05fb6a356e2
        status: {"default": "stable"},
      },
      {
-@@ -3085,6 +3093,7 @@
+@@ -3085,7 +3048,7 @@
      },
      {
        name: "Fledge",
+-      status: "stable",
 +      base_feature_status: "disabled",  // feature state is enforced via plaster rewrite.
-       status: "stable",
        public: true,
      },
-@@ -3796,7 +3805,7 @@
-         "Android": "test",
-         "default": "",
-       },
+     {
+@@ -3788,15 +3751,7 @@
+     },
+     {
+       name: "LanguageDetectionAPI",
+-      status: {
+-        "Win": "stable",
+-        "Mac": "stable",
+-        "Linux": "stable",
+-        "ChromeOS": "stable",
+-        "Android": "test",
+-        "default": "",
+-      },
 -      base_feature_status: "enabled",
 +      base_feature_status: "disabled",  // feature state is enforced via plaster rewrite.
        copied_from_base_feature_if: "overridden",
      },
      {
-@@ -4154,6 +4163,7 @@
+@@ -4154,6 +4109,7 @@
      // "experimental" is the support on other platforms.
      {
        name: "MiddleClickAutoscroll",
@@ -129,7 +195,7 @@ index 22bb1b8232d1028dc9c74472d0df3fd334df1929..444b3b836b228068eaf9c05fb6a356e2
        status: "test",
      },
      // Killswitch for crbug.com/40062462 fix.
-@@ -4625,6 +4635,7 @@
+@@ -4625,6 +4581,7 @@
      {
        // PARAKEET ad serving runtime flag/JS API.
        name: "Parakeet",
@@ -137,15 +203,16 @@ index 22bb1b8232d1028dc9c74472d0df3fd334df1929..444b3b836b228068eaf9c05fb6a356e2
        origin_trial_feature_name: "Parakeet",
      },
      {
-@@ -4797,6 +4808,7 @@
+@@ -4797,7 +4754,7 @@
        //
        // It also has some feature params defined throughout the codebase.
        name: "Prerender2",
+-      status: "stable",
 +      base_feature_status: "disabled",  // feature state is enforced via plaster rewrite.
-       status: "stable",
      },
      {
-@@ -5028,6 +5040,7 @@
+       // Used to allow prerender cross-origin iframes with an opt-in response
+@@ -5028,6 +4985,7 @@
      // but we still keep this flag for future phase tests.
      {
        name: "ReduceUserAgentMinorVersion",
@@ -153,24 +220,32 @@ index 22bb1b8232d1028dc9c74472d0df3fd334df1929..444b3b836b228068eaf9c05fb6a356e2
        status: "stable",
      },
      {
-@@ -6445,7 +6458,7 @@
-         "ChromeOS": "stable",
-         "default": "",
-       },
+@@ -6438,14 +6396,7 @@
+     },
+     {
+       name: "TranslationAPI",
+-      status: {
+-        "Win": "stable",
+-        "Mac": "stable",
+-        "Linux": "stable",
+-        "ChromeOS": "stable",
+-        "default": "",
+-      },
 -      base_feature_status: "enabled",
 +      base_feature_status: "disabled",  // feature state is enforced via plaster rewrite.
        copied_from_base_feature_if: "overridden",
      },
      {
-@@ -6620,6 +6633,7 @@
+@@ -6620,7 +6571,7 @@
      },
      {
        name: "UserMediaElement",
+-      status: "stable",
 +      base_feature_status: "disabled",  // feature state is enforced via plaster rewrite.
-       status: "stable",
        public: true,
      },
-@@ -7425,5 +7439,10 @@
+     {
+@@ -7425,5 +7376,10 @@
        // crbug.com/435623334.
        name: "XSLTSpecialTrial",
      },

--- a/renderer/brave_content_renderer_client.cc
+++ b/renderer/brave_content_renderer_client.cc
@@ -123,9 +123,6 @@ void BraveContentRendererClient::
   ChromeContentRendererClient::
       SetRuntimeFeaturesDefaultsBeforeBlinkInitialization();
 
-  blink::WebRuntimeFeatures::EnableFledge(false);
-  // Disable the fenced frames API; kFencedFrames is disabled browser-side.
-  blink::WebRuntimeFeatures::EnableFencedFrames(false);
   // Disable topics APIs because kBrowsingTopics feature is disabled
   blink::WebRuntimeFeatures::EnableTopicsAPI(false);
   blink::WebRuntimeFeatures::EnableWebGPUExperimentalFeatures(false);

--- a/rewrite/third_party/blink/public/platform/web_runtime_features.h.yaml
+++ b/rewrite/third_party/blink/public/platform/web_runtime_features.h.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+blank_macros_for_ast_parsing: true
+
+substitutions:
+  - description: |-
+      Expose a runtime flag reader taking a feature name.
+
+      This is used by tests to confirm that the flag has been disabled.
+    add_to_public:
+      class_name: WebRuntimeFeatures
+      code:
+        'static bool IsFeatureEnabledFromStringForTesting(std::string_view);'

--- a/rewrite/third_party/blink/renderer/build/scripts/templates/runtime_enabled_features.cc.tmpl.yaml
+++ b/rewrite/third_party/blink/renderer/build/scripts/templates/runtime_enabled_features.cc.tmpl.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |-
+      Define the runtime flag reader declared on the generated class.
+
+      The same lookup `IsFeatureEnabledFromString` runs, without the
+      origin-trial filter that makes it refuse those features: the flag is a
+      real value for every feature.
+    regex:
+      pattern: |2-
+        // static
+        void RuntimeEnabledFeaturesBase::UpdateStatusFromBaseFeatures() {
+      replace: |2-
+        // static
+        bool RuntimeEnabledFeaturesBase::IsFeatureEnabledFromStringForTesting(
+            std::string_view name) {
+          std::optional<uint16_t> flag_index = FindFeatureFlagIndex(name);
+          CHECK(flag_index.has_value())
+              << "RuntimeEnabledFeature not recognized: " << name;
+          return feature_states_[*flag_index];
+        }
+
+        // static
+        void RuntimeEnabledFeaturesBase::UpdateStatusFromBaseFeatures() {

--- a/rewrite/third_party/blink/renderer/build/scripts/templates/runtime_enabled_features.h.tmpl.yaml
+++ b/rewrite/third_party/blink/renderer/build/scripts/templates/runtime_enabled_features.h.tmpl.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |-
+      Declare a runtime flag reader that answers for every feature.
+
+      `IsFeatureEnabledFromString` refuses an origin-trial controlled
+      feature, since what such a feature is enabled for is a question about a
+      context rather than the flag. The flag is still the state a page
+      without a token gets, and forcing it is how Brave ships a good number
+      of features disabled, so a test needs to read it back for those
+      features too — by name, so that one test covers the whole set rather
+      than the features that happen to declare `public: true`.
+    regex:
+      pattern: |2-
+          static bool IsFeatureEnabledFromString(std::string_view name);
+      replace: |2-
+          static bool IsFeatureEnabledFromString(std::string_view name);
+          static bool IsFeatureEnabledFromStringForTesting(std::string_view name);

--- a/rewrite/third_party/blink/renderer/platform/runtime_enabled_features.json5.yaml
+++ b/rewrite/third_party/blink/renderer/platform/runtime_enabled_features.json5.yaml
@@ -53,49 +53,40 @@ substitutions:
       re_flags: [MULTILINE]
       replace: '\1\2\n\1base_feature: "none",'
 
-  # FencedFrames declares `base_feature: "none"` upstream, so the runtime flag
-  # has no backing `base::Feature` and its state cannot be forced. Give it one
-  # (a generated `kFencedFramesRuntime`, not the manual `kFencedFrames` in
-  # third_party/blink/common/features.cc, which would collide) so the disabled
-  # state below is synced into the runtime flag at startup.
-  - description: 'Give FencedFrames a backing base::Feature.'
-    regex:
-      re_pattern: '(name: "FencedFrames",\n *)base_feature: "none",'
-      replace: '\1base_feature: "FencedFramesRuntime",'
-
-  # These plaster override the `base::Feature` value for the blink runtime
-  # features. Keep them in alphabetical order.
+  # These plaster force the state the blink runtime features ship in, both
+  # the `base::Feature` default and the runtime flag's own. Keep them in
+  # alphabetical order.
   - description: 'Ship the interest-group ad-targeting API disabled.'
     set_blink_runtime_enabled_feature_state:
       feature_name: AdInterestGroupAPI
       value: disabled
 
-  - description: "Ship the Prompt API's base feature disabled."
+  - description: 'Ship the Prompt API disabled.'
     set_blink_runtime_enabled_feature_state:
       feature_name: AIPromptAPI
       value: disabled
 
-  - description: "Ship the Prompt API's multimodal input base feature disabled."
+  - description: "Ship the Prompt API's multimodal input disabled."
     set_blink_runtime_enabled_feature_state:
       feature_name: AIPromptAPIMultimodalInput
       value: disabled
 
-  - description: "Ship the Proofreader API's base feature disabled."
+  - description: 'Ship the Proofreader API disabled.'
     set_blink_runtime_enabled_feature_state:
       feature_name: AIProofreadingAPI
       value: disabled
 
-  - description: "Ship the Rewriter API's base feature disabled."
+  - description: 'Ship the Rewriter API disabled.'
     set_blink_runtime_enabled_feature_state:
       feature_name: AIRewriterAPI
       value: disabled
 
-  - description: "Ship the Summarizer API's base feature disabled."
+  - description: 'Ship the Summarizer API disabled.'
     set_blink_runtime_enabled_feature_state:
       feature_name: AISummarizationAPI
       value: disabled
 
-  - description: "Ship the Writer API's base feature disabled."
+  - description: 'Ship the Writer API disabled.'
     set_blink_runtime_enabled_feature_state:
       feature_name: AIWriterAPI
       value: disabled
@@ -105,17 +96,17 @@ substitutions:
       feature_name: ControlledFrame
       value: disabled
 
-  - description: 'Ship the Protected Audience ad auction API disabled.'
-    set_blink_runtime_enabled_feature_state:
-      feature_name: Fledge
-      value: disabled
-
   - description: 'Ship the fenced frames API disabled.'
     set_blink_runtime_enabled_feature_state:
       feature_name: FencedFrames
       value: disabled
 
-  - description: "Ship the Language Detection API's base feature disabled."
+  - description: 'Ship the Protected Audience ad auction API disabled.'
+    set_blink_runtime_enabled_feature_state:
+      feature_name: Fledge
+      value: disabled
+
+  - description: 'Ship the Language Detection API disabled.'
     set_blink_runtime_enabled_feature_state:
       feature_name: LanguageDetectionAPI
       value: disabled
@@ -140,12 +131,12 @@ substitutions:
       feature_name: ReduceUserAgentMinorVersion
       value: enabled
 
-  - description: "Ship the Translation API's base feature disabled."
+  - description: 'Ship the Translation API disabled.'
     set_blink_runtime_enabled_feature_state:
       feature_name: TranslationAPI
       value: disabled
 
-  - description: 'Ship the user media element base feature disabled.'
+  - description: 'Ship the user media element disabled.'
     set_blink_runtime_enabled_feature_state:
       feature_name: UserMediaElement
       value: disabled

--- a/tools/cr/plaster.py
+++ b/tools/cr/plaster.py
@@ -2129,27 +2129,40 @@ class CxxAddEnumEntriesRewriter(_AstGrepRewriter):
 
 
 class JsSetBlinkRuntimeEnabledFeatureStateRewriter(_AstGrepRewriter):
-    """Override a value `base::Feature` for a `runtime_enabled_features.json5`.
+    """Force the shipped state of a `runtime_enabled_features.json5` feature.
 
     This rewriter has the same purpose as the one used for C++,
     `CxxSetFeatureFlagDefaultStateRewriter`, which is override the default state
     of a particular flag. It is named for the field it sets rather than after
     that rewriter, since the flag it overrides is one Blink generates from
     this file rather than one declared in C++.
+
+    An entry declares two defaults, and shipping a feature in a given state
+    means stating both. `base_feature_status` fixes the default of the
+    `base::Feature` the entry generates, and `status` fixes the default of the
+    Blink runtime flag of the same name. The two are independent: Blink copies
+    the `base::Feature` value into the runtime flag only when that feature is
+    enabled or has been overridden on the command line or by a field trial, so
+    a `base_feature_status: "disabled"` on its own leaves a `status: "stable"`
+    runtime flag on, and the web-exposed API with it.
     """
 
     NAME: Final = 'set_blink_runtime_enabled_feature_state'
 
-    # Two ops share the work (see `apply`); this names the namespace and a
+    # Several ops share the work (see `apply`); this names the namespace and a
     # representative op for the base's helpers.
     OP_ID: Final = 'js.set_blink_runtime_enabled_feature_state'
 
-    SUMMARY: Final = "Force a runtime feature's `base::Feature` default state."
+    SUMMARY: Final = "Force a runtime feature's shipped default state."
 
     # Authored in Markdown; `Help` renders it with rich.
     HELP: Final = r"""
-        Sets `base_feature_status` on a `runtime_enabled_features.json5`
-        feature entry, overriding it.
+        Sets `base_feature_status` and `status` on a
+        `runtime_enabled_features.json5` feature entry.
+
+        This rewriter disables the feature by rewriting both `status` and
+        `base_feature_status` to `disabled`. At the same time, It enables the
+        feature by rewriting both to `enabled` and `stable`.
 
         Fields:
 
@@ -2160,7 +2173,7 @@ class JsSetBlinkRuntimeEnabledFeatureStateRewriter(_AstGrepRewriter):
 
         ```yaml
         substitutions:
-          - description: Ship MyFeature's base feature disabled.
+          - description: Ship MyFeature disabled.
             set_blink_runtime_enabled_feature_state:
               feature_name: MyFeature
               value: disabled
@@ -2170,7 +2183,7 @@ class JsSetBlinkRuntimeEnabledFeatureStateRewriter(_AstGrepRewriter):
          {
            name: "MyFeature",
         +  base_feature_status: "disabled",  // feature state is enforced via plaster rewrite.
-           status: "stable",
+        -  status: "stable",
          },
         ```
     """
@@ -2180,6 +2193,16 @@ class JsSetBlinkRuntimeEnabledFeatureStateRewriter(_AstGrepRewriter):
 
     # Adds the field to an entry that lacks it.
     _ADD_NEW: Final = 'js.add_blink_runtime_enabled_feature_state'
+
+    # Drops the entry's own `status`, whatever shape it takes.
+    _CLEAR_STATUS: Final = 'js.clear_blink_runtime_feature_status'
+
+    # States the `status` an `enabled` value needs, once cleared.
+    _ADD_STATUS: Final = 'js.add_blink_runtime_feature_status'
+
+    # The `status` each value ships the runtime flag with. `disabled` wants no
+    # status at all, so it names none and only the clearing op runs.
+    _STATUS_FOR_VALUE: Final = {'enabled': 'stable'}
 
     @classmethod
     def validate_count(cls, count: int, description: str) -> None:
@@ -2197,24 +2220,41 @@ class JsSetBlinkRuntimeEnabledFeatureStateRewriter(_AstGrepRewriter):
         description: str,
         blank_for_parse: BlankForParseOptions = BlankForParseOptions()
     ) -> tuple[str, list[str]]:
-        # Which op applies turns on whether the entry already declares the
-        # field, so `count` -- already validated as 1 -- says nothing here.
         del count, description
         engine = AstRewriter(RewritersEval.load(),
                              contents,
                              blank_for_parse=blank_for_parse)
-        # Locating the entry first is what tells the two apart. A missing
-        # entry leaves `has_field` False, and the add op then reports the
-        # shortfall through the usual count check.
+
+        # Let's look up for `base_feature_status` first
         entry = engine.first_match(Operation(self.OP_ID, self._inputs))
         source = contents.encode('utf-8')
         has_field = (entry is not None and b'base_feature_status:'
                      in source[entry.start:entry.end])
-        op = Operation(self._SET_EXISTING if has_field else self._ADD_NEW,
-                       self._inputs, MatchExpectation.exactly(1))
-        changes = engine.run(op)
-        error = op.expectation.error_for(changes)
-        return engine.content, [error] if error else []
+
+        operations = [
+            # SET or ADD depending on the result of the previous matcher.
+            Operation(self._SET_EXISTING if has_field else self._ADD_NEW,
+                      self._inputs, MatchExpectation.exactly(1)),
+
+            # Optional: Looks up for where `status` is. For `disable` we do not
+            # need to to do anthing else if nothing is found, as disabling means
+            # deleting `status`.
+            Operation(self._CLEAR_STATUS, self._inputs,
+                      MatchExpectation.optional()),
+        ]
+
+        status = self._STATUS_FOR_VALUE.get(self._inputs['value'])
+        if status:
+            operations.append(
+                Operation(self._ADD_STATUS, self._inputs | {'status': status},
+                          MatchExpectation.exactly(1)))
+
+        errors = []
+        for operation in operations:
+            error = operation.expectation.error_for(engine.run(operation))
+            if error:
+                errors.append(f'{operation.op_id}: {error}')
+        return engine.content, errors
 
 
 # The hand-written rewriters. `_REWRITERS` is assembled from these plus the

--- a/tools/cr/plaster_test.py
+++ b/tools/cr/plaster_test.py
@@ -3866,7 +3866,16 @@ class RewriterFormsTest(unittest.TestCase):
                      '      feature_name: MyFeature\n'
                      '      value: disabled\n')
 
+    _ENABLED_FEATURE_YAML = ('substitutions:\n'
+                             '  - description: Ship MyFeature enabled.\n'
+                             '    set_blink_runtime_enabled_feature_state:\n'
+                             '      feature_name: MyFeature\n'
+                             '      value: enabled\n')
+
     def test_blink_runtime_enabled_feature_state_adds_a_missing_field(self):
+        # `status` goes with the disable: left as upstream had it, the runtime
+        # flag -- and the web-exposed API behind it -- would stay on, since
+        # only an enabled or overridden `base::Feature` reaches the flag.
         result = self._apply(
             'runtime_enabled_features.json5', '[\n'
             '  {\n'
@@ -3880,7 +3889,81 @@ class RewriterFormsTest(unittest.TestCase):
             '    name: "MyFeature",\n'
             '    base_feature_status: "disabled",  '
             '// feature state is enforced via plaster rewrite.\n'
+            '  },\n'
+            '];\n')
+
+    def test_blink_runtime_enabled_feature_state_clears_a_dict_status(self):
+        # The per-platform form spans several lines and has to go whole.
+        result = self._apply(
+            'runtime_enabled_features.json5', '[\n'
+            '  {\n'
+            '    name: "MyFeature",\n'
+            '    status: {\n'
+            '      "Win": "stable",\n'
+            '      "default": "",\n'
+            '    },\n'
+            '    public: true,\n'
+            '  },\n'
+            '];\n', self._FEATURE_YAML)
+        self.assertEqual(
+            result, '[\n'
+            '  {\n'
+            '    name: "MyFeature",\n'
+            '    base_feature_status: "disabled",  '
+            '// feature state is enforced via plaster rewrite.\n'
+            '    public: true,\n'
+            '  },\n'
+            '];\n')
+
+    def test_blink_runtime_enabled_feature_state_enabled_states_a_status(self):
+        # `enabled` has to restate the status it cleared, or the value would
+        # disable the runtime flag it means to keep on.
+        result = self._apply(
+            'runtime_enabled_features.json5', '[\n'
+            '  {\n'
+            '    name: "MyFeature",\n'
+            '    status: "experimental",\n'
+            '  },\n'
+            '];\n', self._ENABLED_FEATURE_YAML)
+        self.assertEqual(
+            result, '[\n'
+            '  {\n'
+            '    name: "MyFeature",\n'
+            '    base_feature_status: "enabled",  '
+            '// feature state is enforced via plaster rewrite.\n'
             '    status: "stable",\n'
+            '  },\n'
+            '];\n')
+
+    def test_blink_runtime_enabled_feature_state_enabled_reapplies_unchanged(
+            self):
+        once = self._apply(
+            'runtime_enabled_features.json5', '[\n'
+            '  {\n'
+            '    name: "MyFeature",\n'
+            '    status: "experimental",\n'
+            '  },\n'
+            '];\n', self._ENABLED_FEATURE_YAML)
+        twice = self._apply('runtime_enabled_features.json5', once,
+                            self._ENABLED_FEATURE_YAML)
+        self.assertEqual(once, twice)
+
+    def test_blink_runtime_enabled_feature_state_accepts_a_status_less_entry(
+            self):
+        # Nothing to clear is not a shortfall: the entry already ships the way
+        # a `disabled` value wants it.
+        result = self._apply(
+            'runtime_enabled_features.json5', '[\n'
+            '  {\n'
+            '    name: "MyFeature",\n'
+            '  },\n'
+            '];\n', self._FEATURE_YAML)
+        self.assertEqual(
+            result, '[\n'
+            '  {\n'
+            '    name: "MyFeature",\n'
+            '    base_feature_status: "disabled",  '
+            '// feature state is enforced via plaster rewrite.\n'
             '  },\n'
             '];\n')
 
@@ -3970,7 +4053,6 @@ class RewriterFormsTest(unittest.TestCase):
             '    name: "MyFeature",\n'
             '    base_feature_status: "disabled",  '
             '// feature state is enforced via plaster rewrite.\n'
-            '    status: "stable",\n'
             '  },\n'
             '];\n')
 

--- a/tools/cr/rewriters.pyl
+++ b/tools/cr/rewriters.pyl
@@ -662,15 +662,12 @@ has:
             },
         },
 
-        # Both ops below set a feature entry's `base_feature_status`, which is
-        # what forces the default state of the `base::Feature` the entry
-        # generates. Which one applies depends on whether the entry already
-        # declares the field, so the two are paired and chosen between by
-        # `js.set_blink_runtime_enabled_feature_state`'s frontend rewriter.
-        #
-        # We leave a trailing comment on the field, so the substitution always
-        # produces a diff even when upstream's own value already agrees with
-        # ours, as feature flags are preemtively overridden most of the time.
+        # The four ops below force a feature entry's shipped state, and are
+        # driven together by `js.set_blink_runtime_enabled_feature_state`'s
+        # frontend rewriter. Two fields decide that state and both have to be
+        # stated: `base_feature_status` fixes the default of the
+        # `base::Feature` the entry generates, and `status` fixes the default
+        # of the Blink runtime flag itself.
 
         # The field is absent, so it is inserted directly after `name`. The
         # negative lookahead is what establishes absence; with the field
@@ -707,6 +704,43 @@ has:
                 "replace":
                     "\\1{value}\\2  "
                     "// feature state is enforced via plaster rewrite.",
+            },
+            "result": {
+                "node": "object",
+            },
+        },
+
+        # Drops whatever `status` the entry declares, which is what leaves the
+        # runtime flag off: a feature with no status is enabled nowhere by
+        # default. It runs for either value, since stating a status means
+        # clearing the one already there first. An entry that declares none is
+        # already in the wanted shape, so this op is allowed to match nothing.
+        "js.clear_blink_runtime_feature_status": {
+            "matcher": "js.find_runtime_feature_entry",
+            "inputs": ["feature_name"],
+            "replace": {
+                "re_pattern":
+                    "\\n[ \\t]*status:\\s*(?:\"[^\"]*\"|\\{[^{}]*\\})\\s*,"
+                    "(?:[ \\t]*//[^\\n]*)?",
+                "replace": "",
+            },
+            "result": {
+                "node": "object",
+            },
+        },
+
+        # States the `status` an `enabled` value wants, the entry having been
+        # cleared of its own by the op above. It anchors on
+        # `base_feature_status`, which the ops above guarantee is present by
+        # the time this runs, so the two fields end up stated together.
+        "js.add_blink_runtime_feature_status": {
+            "matcher": "js.find_runtime_feature_entry",
+            "inputs": ["feature_name", "status"],
+            "replace": {
+                "re_pattern":
+                    "([ \\t]*)(base_feature_status:\\s*\"[^\"]*\","
+                    "(?:[ \\t]*//[^\\n]*)?)",
+                "replace": "\\1\\2\\n\\1status: \"{status}\",",
             },
             "result": {
                 "node": "object",


### PR DESCRIPTION
There is a bug in this rewriter, as the feature flag value is being set,
however that has no effect on how blink runtime treats those flags.

This PR corrects this issue by adding handling into
`set_blink_runtime_enabled_feature_state` to permit disabling the flag
in the runtime too. Additionally, this PR introduces a test confirm we
have these flags disabled at runtime.
