### PR TITLE
[Android] Fix renderer kill on WebOTP requests with kWebOTP disabled

### DIFF
--- a/browser/test/BUILD.gn
+++ b/browser/test/BUILD.gn
@@ -4,9 +4,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 # These use `InProcessBrowserTest`, which does not exist on Android, and nor
-# does `//chrome/test:test_support_ui`. They should move to
-# `PlatformBrowserTest` and join `platform_browser_tests` below, so that the
-# features they cover are checked on Android too.
+# does `//chrome/test:test_support_ui`.
 if (!is_android) {
   source_set("browser_tests") {
     testonly = true
@@ -46,8 +44,8 @@ if (!is_android) {
   }
 }
 
-# Unlike `browser_tests` above, these use `PlatformBrowserTest`, so they also
-# build and run on Android.
+# Unlike `browser_tests`, these use `PlatformBrowserTest`, so they also build
+# and run on Android.
 source_set("platform_browser_tests") {
   testonly = true
   defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]

--- a/browser/test/BUILD.gn
+++ b/browser/test/BUILD.gn
@@ -3,39 +3,64 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-source_set("browser_tests") {
+# These use `InProcessBrowserTest`, which does not exist on Android, and nor
+# does `//chrome/test:test_support_ui`. They should move to
+# `PlatformBrowserTest` and join `platform_browser_tests` below, so that the
+# features they cover are checked on Android too.
+if (!is_android) {
+  source_set("browser_tests") {
+    testonly = true
+    defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+
+    sources = [
+      "disabled_features/disable_client_hints_browsertest.cc",
+      "disabled_features/fenced_frame_browsertest.cc",
+      "disabled_features/navigator_battery_browsertest.cc",
+      "disabled_features/navigator_bluetooth_browsertest.cc",
+      "disabled_features/navigator_storage_browsertest.cc",
+      "disabled_features/reporting_observer_browsertest.cc",
+      "disabled_features/window_name_browsertest.cc",
+      "document_location_browsertest.cc",
+    ]
+
+    deps = [
+      "//base",
+      "//brave/browser",
+      "//brave/common",
+      "//chrome/browser",
+      "//chrome/browser/content_settings:content_settings_factory",
+      "//chrome/browser/ui",
+      "//chrome/common",
+      "//chrome/test:test_support",
+      "//chrome/test:test_support_ui",
+      "//content/public/browser",
+      "//content/test:test_support",
+      "//ui/webui:test_support",
+    ]
+
+    if (is_mac) {
+      sources += [ "os_crypt/keychain_password_mac_browsertest.mm" ]
+
+      deps += [ "//components/os_crypt/common:keychain_password_mac" ]
+    }
+  }
+}
+
+# Unlike `browser_tests` above, these use `PlatformBrowserTest`, so they also
+# build and run on Android.
+source_set("platform_browser_tests") {
   testonly = true
   defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
 
-  sources = [
-    "disabled_features/disable_client_hints_browsertest.cc",
-    "disabled_features/fenced_frame_browsertest.cc",
-    "disabled_features/navigator_battery_browsertest.cc",
-    "disabled_features/navigator_bluetooth_browsertest.cc",
-    "disabled_features/navigator_storage_browsertest.cc",
-    "disabled_features/reporting_observer_browsertest.cc",
-    "disabled_features/window_name_browsertest.cc",
-    "document_location_browsertest.cc",
-  ]
+  sources = [ "disabled_features/web_otp_browsertest.cc" ]
 
   deps = [
     "//base",
-    "//brave/browser",
-    "//brave/common",
-    "//chrome/browser",
-    "//chrome/browser/content_settings:content_settings_factory",
-    "//chrome/browser/ui",
-    "//chrome/common",
     "//chrome/test:test_support",
-    "//chrome/test:test_support_ui",
     "//content/public/browser",
     "//content/test:test_support",
-    "//ui/webui:test_support",
+    "//net:test_support",
+    "//testing/gtest",
+    "//url",
   ]
-
-  if (is_mac) {
-    sources += [ "os_crypt/keychain_password_mac_browsertest.mm" ]
-
-    deps += [ "//components/os_crypt/common:keychain_password_mac" ]
-  }
 }

--- a/browser/test/disabled_features/web_otp_browsertest.cc
+++ b/browser/test/disabled_features/web_otp_browsertest.cc
@@ -58,12 +58,12 @@ IN_PROC_BROWSER_TEST_F(WebOtpDisabledTest, ApiIsNotExposed) {
 // so a renderer that still exposes WebOTP asks for a binder that is not there,
 // which is a bad message and terminates the renderer.
 IN_PROC_BROWSER_TEST_F(WebOtpDisabledTest, RequestingOtpDoesNotKillTab) {
-  // Resolving means the renderer was still running a second after the request.
-  EXPECT_EQ(true, content::EvalJs(web_contents(),
-                                  "new Promise(resolve => {"
-                                  "  navigator.credentials"
-                                  "      .get({otp: {transport: ['sms']}})"
-                                  "      .catch(() => {});"
-                                  "  setTimeout(() => resolve(true), 1000);"
-                                  "})"));
+  // With WebOTP disabled the `otp` member is not recognized, so no credential
+  // type is requested and the promise rejects without the renderer ever asking
+  // for the binder.
+  EXPECT_EQ("NotSupportedError", content::EvalJs(web_contents(), R"(
+      navigator.credentials.get({otp: {transport: ['sms']}})
+          .then(() => 'resolved', e => e.name)
+  )"));
+  EXPECT_FALSE(web_contents()->IsCrashed());
 }

--- a/browser/test/disabled_features/web_otp_browsertest.cc
+++ b/browser/test/disabled_features/web_otp_browsertest.cc
@@ -1,0 +1,69 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+
+#include "base/functional/bind.h"
+#include "chrome/test/base/chrome_test_utils.h"
+#include "chrome/test/base/platform_browser_test.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "net/test/embedded_test_server/http_request.h"
+#include "net/test/embedded_test_server/http_response.h"
+#include "url/gurl.h"
+
+namespace {
+
+std::unique_ptr<net::test_server::HttpResponse> HandleRequest(
+    const net::test_server::HttpRequest& request) {
+  auto response = std::make_unique<net::test_server::BasicHttpResponse>();
+  response->set_content_type("text/html");
+  response->set_content("<html><body></body></html>");
+  return response;
+}
+
+}  // namespace
+
+// navigator.credentials is [SecureContext], so these navigate to the embedded
+// test server rather than a data: URL, which is an opaque origin.
+class WebOtpDisabledTest : public PlatformBrowserTest {
+ public:
+  void SetUpOnMainThread() override {
+    PlatformBrowserTest::SetUpOnMainThread();
+    embedded_test_server()->RegisterDefaultHandler(
+        base::BindRepeating(&HandleRequest));
+    ASSERT_TRUE(embedded_test_server()->Start());
+    ASSERT_TRUE(content::NavigateToURL(web_contents(),
+                                       embedded_test_server()->GetURL("/")));
+  }
+
+ protected:
+  content::WebContents* web_contents() {
+    return chrome_test_utils::GetActiveWebContents(this);
+  }
+};
+
+// features::kWebOTP is shipped disabled, so the renderer must not expose the
+// API either.
+IN_PROC_BROWSER_TEST_F(WebOtpDisabledTest, ApiIsNotExposed) {
+  EXPECT_EQ(false,
+            content::EvalJs(web_contents(), "'OTPCredential' in window"));
+}
+
+// blink.mojom.WebOTPService is bound only while features::kWebOTP is enabled,
+// so a renderer that still exposes WebOTP asks for a binder that is not there,
+// which is a bad message and terminates the renderer.
+IN_PROC_BROWSER_TEST_F(WebOtpDisabledTest, RequestingOtpDoesNotKillTab) {
+  // Resolving means the renderer was still running a second after the request.
+  EXPECT_EQ(true, content::EvalJs(web_contents(),
+                                  "new Promise(resolve => {"
+                                  "  navigator.credentials"
+                                  "      .get({otp: {transport: ['sms']}})"
+                                  "      .catch(() => {});"
+                                  "  setTimeout(() => resolve(true), 1000);"
+                                  "})"));
+}

--- a/renderer/brave_content_renderer_client.cc
+++ b/renderer/brave_content_renderer_client.cc
@@ -131,6 +131,16 @@ void BraveContentRendererClient::
   blink::WebRuntimeFeatures::EnableWebGPUExperimentalFeatures(false);
   blink::WebRuntimeFeatures::EnableWebNFC(false);
 
+  // Disable the WebOTP API; kWebOTP is disabled browser-side, and
+  // content/child/runtime_features.cc forwards that state to Blink only when
+  // the feature is overridden by a field trial or the command line - a
+  // plastered default is not an override. Without this the renderer requests
+  // blink.mojom.WebOTPService, whose binder is registered only while the
+  // feature is on, and the missing binder is a bad message that kills the
+  // renderer. Upstream syncs UserMediaElement the same way; see
+  // runtime_features.cc.
+  blink::WebRuntimeFeatures::EnableWebOTP(false);
+
   // These features don't have dedicated WebRuntimeFeatures wrappers.
   blink::WebRuntimeFeatures::EnableFeatureFromString("AdTagging", false);
   blink::WebRuntimeFeatures::EnableFeatureFromString("AIClassifierAPI", false);

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1033,6 +1033,7 @@ test("brave_browser_tests") {
     "//brave/browser/skus/test:browser_tests",
     "//brave/browser/storage_access_api:browser_tests",
     "//brave/browser/test:browser_tests",
+    "//brave/browser/test:platform_browser_tests",
     "//brave/browser/themes",
     "//brave/browser/ui:browser_tests",
     "//brave/browser/ui/tabs:tabs_public",


### PR DESCRIPTION
Any page that calls navigator.credentials.get({otp: ...}) killed the renderer with RESULT_CODE_KILLED_BAD_MESSAGE (bad_message reason 123, RPH_MOJO_PROCESS_ERROR, "No binder found for interface blink.mojom.WebOTPService for the frame/document scope"). amazon.com's sign-in page is one of them.

Brave disables features::kWebOTP, and the WebOTPService binder is registered only while that feature is enabled. content/child/runtime_features.cc forwards the state to Blink only when the feature is overridden by a field trial or the command line, and the OVERRIDE_FEATURE_DEFAULT_STATES plaster migration (v1.96.9, brave-core@2f817e26463) turned the pin into a plain default, which is not an override. The renderer kept exposing OTPCredential and asked for a binder that was not there. Same failure mode as brave/brave-core#39491.

Fix: disable the Blink runtime flag explicitly, as we already do for Fledge/FencedFrames/TopicsAPI, and as upstream does for UserMediaElement and AttributionReporting in runtime_features.cc.

Adds a browser test. It uses PlatformBrowserTest so it also runs on Android; the existing browser/test/disabled_features tests are InProcessBrowserTest based and desktop only, so they move under an is_android guard to keep the Android GN graph resolvable.

Resolves: https://github.com/brave/brave-browser/issues/58817

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
