### PR TITLE
[cr155][brockit] Improve toolchain recovery

### DIFF
--- a/tools/cr/install_extra_deps.py
+++ b/tools/cr/install_extra_deps.py
@@ -47,6 +47,10 @@ from tarball_installer import (  # pylint: disable=wrong-import-position
 # normal runs, to avoid cluttering the sync output.
 _LOG = logging.getLogger('install_extra_deps')
 
+# Level defaults to WARNING for users of this file that import it. For the
+# application mode, the CLI determines that based on the presence of `--quiet`.
+_LOG.setLevel(logging.WARNING)
+
 
 def _select_object(objects: list[dict],
                    variables: dict[str, object]) -> dict | None:
@@ -357,18 +361,26 @@ class ExtraDepsRunner:
 def main() -> int:
     # The gclient machinery used to resolve DEPS conditions logs very verbosely
     # on the root logger (every dependency's `verify_validity`, recursedeps,
-    # etc.). Keep the root at ERROR to silence that chatter, and emit this
-    # script's own messages through `_LOG` (at INFO) so they still surface.
+    # etc.). Keep the root at ERROR to silence that chatter; this script's own
+    # messages go through `_LOG`, whose level is set from `--quiet` below.
     logging.basicConfig(level=logging.ERROR, format='%(message)s')
-    _LOG.setLevel(logging.INFO)
 
     parser = argparse.ArgumentParser(
         description='Download and install the bucket-hosted archive(s) for the '
         'given EXTRA_DEPS entries.')
     subparsers = parser.add_subparsers(dest='command', required=True)
 
+    # Shared by every subcommand, so `--quiet` is accepted after the command
+    # name rather than only ahead of it.
+    common_parser = argparse.ArgumentParser(add_help=False)
+    common_parser.add_argument('-q',
+                               '--quiet',
+                               action='store_true',
+                               help='Report nothing but warnings and errors.')
+
     sync_parser = subparsers.add_parser(
         'sync',
+        parents=[common_parser],
         help='Download and install the bucket-hosted archive(s) for the given '
         'EXTRA_DEPS entries.')
     sync_parser.add_argument(
@@ -382,6 +394,7 @@ def main() -> int:
 
     setdep_parser = subparsers.add_parser(
         'setdep',
+        parents=[common_parser],
         help='Repin EXTRA_DEPS entries in place, preserving comments and '
         'formatting (like `gclient setdep`).')
     setdep_parser.add_argument(
@@ -399,6 +412,8 @@ def main() -> int:
         'invocation.')
 
     args = parser.parse_args()
+    if not args.quiet:
+        _LOG.setLevel(logging.INFO)
 
     if args.command == 'setdep':
         setdep(args.revisions)

--- a/tools/cr/install_extra_deps_test.py
+++ b/tools/cr/install_extra_deps_test.py
@@ -463,6 +463,23 @@ class MainTest(unittest.TestCase):
         },
     }
 
+    def setUp(self):
+        # `main()` sets the module logger's level, which outlives the call, so
+        # restore it or these tests leak into each other (and into the rest of
+        # the file) depending on execution order.
+        level = m._LOG.level
+        self.addCleanup(m._LOG.setLevel, level)
+
+    def _run_setdep(self, *extra_argv: str) -> None:
+        """Runs `main()` on a stubbed `setdep`, with `extra_argv` appended."""
+        argv = [
+            'install_extra_deps', 'setdep', '-r',
+            'src/path/to/dep@pkg.tar.gz,abc,1', *extra_argv
+        ]
+        with mock.patch.object(m, 'setdep'):
+            with mock.patch.object(sys, 'argv', argv):
+                self.assertEqual(m.main(), 0)
+
     def test_dispatches_selected_dep_to_runner(self):
         """A valid dep key resolves a runner and installs that entry's spec."""
         runner = mock.Mock()
@@ -520,6 +537,22 @@ class MainTest(unittest.TestCase):
                     self.assertEqual(m.main(), 0)
         setdep.assert_called_once_with([revision])
         checkout.assert_not_called()
+
+    def test_reporting_is_off_until_main_enables_it(self):
+        """At import the logger sits above INFO, so in-process consumers (see
+        `toolchain.RustToolchain.repin`) don't inherit the root logger's INFO
+        and print this script's reporting inside their own."""
+        self.assertGreater(m._LOG.level, logging.INFO)
+
+    def test_cli_enables_reporting(self):
+        """A plain CLI run opts into INFO, so `Repinned ...` surfaces."""
+        self._run_setdep()
+        self.assertEqual(m._LOG.level, logging.INFO)
+
+    def test_quiet_leaves_reporting_off(self):
+        """`--quiet` skips that opt-in, leaving the import-time level."""
+        self._run_setdep('--quiet')
+        self.assertGreater(m._LOG.level, logging.INFO)
 
     def test_setdep_requires_a_revision(self):
         """`setdep` with no `-r` is rejected by argparse before any work."""
@@ -676,6 +709,14 @@ extra_deps = {
                       result)
         self.assertIn("'overlayed_on': 'upstream/old.tar.gz',", result)
         self.assertIn("'bucket': 'https://downloads.invalid/',", result)
+
+    def test_reports_each_entry_repinned(self):
+        """Every repinned entry is reported, for the CLI's benefit."""
+        with self.assertLogs(m._LOG, level='INFO') as logs:
+            m.setdep(['src/path/to/dep@new.tar.gz,newsha,222'],
+                     extra_deps_file=self._path)
+        self.assertEqual(logs.output,
+                         ['INFO:install_extra_deps:Repinned src/path/to/dep'])
 
     def test_updates_overlayed_on_when_given(self):
         """A fourth field rewrites `overlayed_on` alongside the other three."""

--- a/tools/cr/toolchain.py
+++ b/tools/cr/toolchain.py
@@ -37,7 +37,8 @@ from versioning import Version
 #              `properties` tuple (the field names the job reads from a JSON
 #              PROPERTIES payload).
 #   publish -- (optional) `{revision}`-templated URL of the published artifact,
-#              used to tell whether CI already built this toolchain.
+#              used to tell whether CI already built this toolchain, and so
+#              whether `recover` can skip straight to repinning.
 #   repin   -- (optional) the in-tree pin the `repin` command rewrites and any
 #              upstream file it mirrors. Absent when there is no automated
 #              repin.
@@ -45,6 +46,9 @@ from versioning import Version
 #
 # `ToolchainSpec` is a thin typed view over one entry.
 # ---------------------------------------------------------------------------
+
+# The default starting point for rust/wasm brave subrevisions.
+FIRST_BRAVE_SUBREVISION = 1
 
 TOOLCHAINS = {
     'windows': {
@@ -83,13 +87,11 @@ TOOLCHAINS = {
             'script': 'build/mac/download_hermetic_xcode.py',
             'upstream_min_os_file': 'build/mac_toolchain.py',
         },
-        'advice': (
-            'Contact DevOps to ask for an updated macOS toolchain node to '
-            'be used to generate a new toolchain, then generate the new '
-            'toolchain in https://ci.brave.com/view/toolchains/. Once the '
-            'new toolchain is published, call '
-            '`brockit.py update-xcode-toolchain --to=<chromium-ref>` to '
-            'repin it.'),
+        'advice': ('Generate the new toolchain in '
+                   'https://ci.brave.com/view/toolchains/ (or via '
+                   '`brockit.py gen-xcode-toolchain`), then call '
+                   '`brockit.py update-xcode-toolchain --to=<chromium-ref>` '
+                   'to repin it.'),
     },
     'rust': {
         'label': 'Rust toolchain',
@@ -109,16 +111,9 @@ TOOLCHAINS = {
                 'https://ci.brave.com/view/toolchains/job/'
                 'brave-browser-rust-toolchain-aux-build-windows-x64/',
             ),
-            # The Rust jobs take no build parameter; they read a JSON
-            # PROPERTIES payload with these fields instead. `chromium_ref` is
-            # filled from the triggered version; the rest are supplied by the
-            # caller of `trigger`.
             'properties': ('brave_subrevision', 'chromium_ref'),
         },
         'publish': {
-            # `-1` is the first brave sub-revision: if any toolchain exists for
-            # a revision, this archive does. `{revision}` is the Rust/Clang
-            # triple `is_published` fills in.
             'url': ('https://brave-build-deps-public.s3.brave.com/'
                     'rust-toolchain-aux/'
                     'linux-x64-rust-toolchain-{revision}-1.tar.xz'),
@@ -167,9 +162,7 @@ class ToolchainSpec:
     build_param: str | None = None
     properties: tuple[str, ...] | None = None
 
-    # Availability probe: a `{revision}`-templated URL for the published
-    # artifact, letting `is_published` suppress the advisory once CI uploads it.
-    # None when no probe exists (the advisory then always fires).
+    # A url template for the published toolchain.
     published_url: str | None = None
 
     # Repin particulars (absent for toolchains with no automated repin):
@@ -369,12 +362,10 @@ class Toolchain:
               target: Version | str) -> ToolchainAdvisory | None:
         """Returns an advisory when a new toolchain is needed, else None.
 
-        A new toolchain is needed when a detection constant changed across the
-        range and no built artifact is already published for `target`.
+        The advisory is only produced if a change is detected for the current
+        version upgrade range.
         """
         if not self.was_updated(working, target):
-            return None
-        if self.is_published(target):
             return None
 
         commit_hash, subject = self._pickaxe(target, since=working)
@@ -397,9 +388,9 @@ class Toolchain:
 
         Toolchains with a `build_param` carry the tag there and take no
         `properties`. Toolchains that declare `spec.properties` instead receive
-        a JSON `PROPERTIES` payload: `chromium_ref` (when declared) defaults to
-        the triggered version, and every other declared field must be supplied
-        here as a keyword argument.
+        a JSON `PROPERTIES` payload, which `_properties_payload` builds:
+        declared fields it can default are filled in, and any it cannot must be
+        supplied here as a keyword argument.
 
         Returns whether the pipelines finished successfully (see
         `ci.JenkinsCi.trigger`): always True when not watching.
@@ -419,12 +410,6 @@ class Toolchain:
     def _properties_payload(self, version: Version | str,
                             provided: dict) -> dict | None:
         """Builds the `PROPERTIES` payload, checking every field is provided.
-
-        `chromium_ref`/`chromium_tag` (whichever the toolchain declares)
-        defaults to the triggered version; all other declared fields must come
-        from `provided`. Raises if a toolchain that takes no properties is
-        given any, or if the supplied fields don't match exactly what the
-        toolchain declares.
         """
         if self.spec.properties is None:
             if provided:
@@ -437,6 +422,8 @@ class Toolchain:
             payload.setdefault('chromium_ref', str(version))
         if 'chromium_tag' in self.spec.properties:
             payload.setdefault('chromium_tag', str(version))
+        if 'brave_subrevision' in self.spec.properties:
+            payload.setdefault('brave_subrevision', FIRST_BRAVE_SUBREVISION)
         if set(payload) != set(self.spec.properties):
             raise InvalidInputException(
                 f'The {self.spec.label} toolchain requires the properties '
@@ -448,15 +435,21 @@ class Toolchain:
     def recover(self, target: Version, culprit: str) -> bool:
         """Best-effort auto-resolution of a needed toolchain during a lift.
 
-        The idea is to close the loop without the user: kick off the CI job(s),
-        wait for them, and repin the freshly published result. Returns True when
-        fully recovered (nothing left for the user), so the caller can drop the
-        advisory.
+        This method basically builds the toolchain if nobody has, then repins
+        the published result. A toolchain that is already published is just
+        used with no need for a CI job.
 
-        The base class cannot recover automatically and returns False.
+        Returns True when fully recovered (nothing left for the user), so the
+        caller can drop the advisory.
         """
-        del target, culprit
-        return False
+        try:
+            if not self.is_published(target) and not self.trigger(target,
+                                                                  watch=True):
+                return False
+            self.repin(target, culprit)
+        except (InvalidInputException, BadOutcomeException):
+            return False
+        return True
 
     # -- repin (in-tree pin + commit), overridden where applicable ----------
 
@@ -506,10 +499,6 @@ class ToolchainAdvisory:
 class RustToolchain(Toolchain):
     """The Rust/WASM toolchain, pinned in `EXTRA_DEPS`."""
 
-    # A recovery is the first build for a revision, so it triggers (and probes,
-    # via the `publish` URL) brave sub-revision 1.
-    _FIRST_BRAVE_SUBREVISION = 1
-
     def __init__(self) -> None:
         super().__init__(ToolchainSpec.from_entry('rust', TOOLCHAINS['rust']))
 
@@ -525,25 +514,6 @@ class RustToolchain(Toolchain):
         except requests.RequestException:
             # Assume the toolchain is not available if the request fails.
             return False
-
-    def recover(self, target: Version, culprit: str) -> bool:
-        """Trigger the Rust jobs, watch them, and repin on success.
-
-        Any failure returns False so the caller keeps the advisory for the user
-        to resolve.
-        """
-        try:
-            if not self.trigger(
-                    target,
-                    watch=True,
-                    brave_subrevision=self._FIRST_BRAVE_SUBREVISION):
-                return False
-            self.repin(target,
-                       culprit,
-                       brave_subrevision=self._FIRST_BRAVE_SUBREVISION)
-        except (InvalidInputException, BadOutcomeException):
-            return False
-        return True
 
     @staticmethod
     def _upstream_stem(text: str) -> str:
@@ -595,24 +565,13 @@ class RustToolchain(Toolchain):
         return (f'Rust/WASM toolchain ({match["rust"][:12]}-{match["sub"]}, '
                 f'{match["clang"]}, sub {match["sub"]})')
 
-    # `brave_subrevision` is required here (unlike the base's `**kwargs`
-    # catch-all) since this toolchain has no side index to auto-discover it
-    # from; see the base `repin`'s docstring.
     # pylint: disable=arguments-differ
     def repin(self,
               version: Version,
               culprit: str | None = None,
               *,
-              brave_subrevision: int) -> None:
+              brave_subrevision: int = FIRST_BRAVE_SUBREVISION) -> None:
         """Repins the Rust/WASM `EXTRA_DEPS` entry and commits it.
-
-        `brave_subrevision` must name the exact respin already published for
-        this Chromium tag's Rust+Clang revision (e.g. `1` for a fresh
-        Chromium-version bump, or whatever `gen-rust-toolchain
-        --brave-subrevision` last built) -- there is no side index to
-        auto-discover it from; every platform's object is read straight from
-        its sibling index (see
-        `build_rust_toolchain.rust_toolchain_extra_dep`).
         """
         self._require_no_staged_files()
 
@@ -676,6 +635,18 @@ class XcodeToolchain(Toolchain):
     def __init__(self) -> None:
         super().__init__(ToolchainSpec.from_entry('xcode',
                                                   TOOLCHAINS['xcode']))
+
+    def is_published(self, target: Version | str) -> bool:
+        """Whether a published Xcode toolchain index exists for `target`.
+        """
+        try:
+            mac_sdk_gni = repository.chromium.read_file(self.spec.files[0],
+                                                        commit=str(target))
+            sdk_info = build_xcode_toolchain.MacSdkInfo.from_gni(mac_sdk_gni)
+            build_xcode_toolchain.fetch_published_index(sdk_info)
+        except (RuntimeError, OSError):
+            return False
+        return True
 
     @staticmethod
     def _provenance_comment(sdk_info: build_xcode_toolchain.MacSdkInfo,
@@ -777,9 +748,9 @@ class XcodeToolchain(Toolchain):
 
         if not self._rewrite_hermetic_xcode_script(sdk_info, index,
                                                    mac_toolchain_py):
-            raise InvalidInputException(
-                f'{self.spec.script} is already pinned to these values; '
-                'nothing to commit.')
+            terminal.log_task(f'{self.spec.script} is already pinned to these '
+                              'values; nothing to commit.')
+            return
 
         commit_hash = self.find_culprit(ref, culprit)
         title = (f'Switch to Xcode {index["xcode_version"]} '
@@ -807,14 +778,16 @@ class WindowsToolchain(Toolchain):
         super().__init__(
             ToolchainSpec.from_entry('windows', TOOLCHAINS['windows']))
 
-    def recover(self, target: Version, culprit: str) -> bool:
-        """Trigger the Windows toolchain job, watch it, and repin on success.
+    def is_published(self, target: Version | str) -> bool:
+        """Whether a published Windows toolchain index exists for `target`.
         """
         try:
-            if not self.trigger(target, watch=True):
-                return False
-            self.repin(target, culprit)
-        except (InvalidInputException, BadOutcomeException):
+            vs_toolchain_py = repository.chromium.read_file(self.spec.files[0],
+                                                            commit=str(target))
+            sdk_info = (build_windows_toolchain.WinSdkInfo.
+                        from_vs_toolchain_py(vs_toolchain_py))
+            build_windows_toolchain.fetch_published_index(sdk_info)
+        except (RuntimeError, OSError):
             return False
         return True
 
@@ -871,9 +844,9 @@ class WindowsToolchain(Toolchain):
             raise BadOutcomeException(str(e)) from e
 
         if not self._rewrite_config_ts(sdk_info, index):
-            raise InvalidInputException(
-                f'{self.spec.script} is already pinned to these values; '
-                'nothing to commit.')
+            terminal.log_task(f'{self.spec.script} is already pinned to these '
+                              'values; nothing to commit.')
+            return
 
         commit_hash = self.find_culprit(ref, culprit)
         title = f'Switch to Windows SDK {sdk_info.sdk_version_in_comment}'

--- a/tools/cr/toolchain_test.py
+++ b/tools/cr/toolchain_test.py
@@ -14,6 +14,9 @@ Layers:
   `Toolchain.find_culprit`, `RustToolchain.is_published`, and `Toolchain.check`,
   driven against a `FakeChromiumRepo`.
 
+* Recovery -- `recover` across all three toolchains: `is_published` decides
+  whether CI has to build before the repin.
+
 * Repin -- `RustToolchain.repin` and `XcodeToolchain.repin` end-to-end against a
   `FakeChromiumRepo` with the commit-msg hook installed (builders faked, so no
   network), validating the file rewrite *and* the `tags=toolchain` /
@@ -221,12 +224,25 @@ class TriggerTest(unittest.TestCase):
             'chromium_ref': CHROMIUM_TAG,
         })
 
-    def test_rust_requires_its_properties(self):
+    def test_rust_defaults_its_brave_subrevision(self):
+        # `brave_subrevision` is not derivable from the version, but a build
+        # nobody has made is always the first one -- which is what lets
+        # `recover` trigger without supplying it.
+        rust = toolchain.RustToolchain()
+        launcher = self._trigger(rust)
+        _, kwargs = launcher.trigger.call_args
+        self.assertEqual(
+            kwargs['properties'], {
+                'brave_subrevision': toolchain.FIRST_BRAVE_SUBREVISION,
+                'chromium_ref': CHROMIUM_TAG,
+            })
+
+    def test_rust_rejects_undeclared_properties(self):
         launcher = MagicMock()
         with patch('toolchain.JenkinsCi.from_config', return_value=launcher):
-            # `brave_subrevision` is not auto-derivable, so it must be supplied.
             with self.assertRaises(toolchain.InvalidInputException):
-                toolchain.RustToolchain().trigger(Version(CHROMIUM_TAG))
+                toolchain.RustToolchain().trigger(Version(CHROMIUM_TAG),
+                                                  not_a_field=1)
         launcher.trigger.assert_not_called()
 
     def test_xcode_codifies_properties_and_no_build_param(self):
@@ -607,14 +623,17 @@ class XcodeRepinTest(_FakeRepoTest):
         self.assertIn('Unrelated chromium change', message)
         self.assertNotIn(autodetect, message)
 
-    def test_already_pinned_second_run_raises(self):
+    def test_already_pinned_second_run_is_a_no_op(self):
+        # Repinning is idempotent: a second run over the same values commits
+        # nothing and does not raise, so `recover` re-running the pre-run
+        # checks (e.g. under `--continue`) can't manufacture an advisory for a
+        # pin that is already correct.
         self._seed_mac_sdk_bump()
 
         self.xcode.repin(Version(CHROMIUM_TAG), culprit=None)
         head_after_first = self._brave_head()
 
-        with self.assertRaises(toolchain.InvalidInputException):
-            self.xcode.repin(Version(CHROMIUM_TAG), culprit=None)
+        self.xcode.repin(Version(CHROMIUM_TAG), culprit=None)
         self.assertEqual(self._brave_head(), head_after_first)
 
     def test_index_fetch_failure_raises(self):
@@ -625,6 +644,21 @@ class XcodeRepinTest(_FakeRepoTest):
         with self.assertRaises(toolchain.BadOutcomeException):
             self.xcode.repin(Version(CHROMIUM_TAG), culprit=None)
         self.assertEqual(self._brave_head(), head_before)
+
+    def test_is_published_true_when_index_resolves(self):
+        self._seed_mac_sdk_bump()
+        self.assertTrue(self.xcode.is_published(CHROMIUM_TAG))
+
+    def test_is_published_false_when_index_missing(self):
+        self._seed_mac_sdk_bump()
+        self.fetch_index.side_effect = RuntimeError('index not found')
+        self.assertFalse(self.xcode.is_published(CHROMIUM_TAG))
+
+    def test_is_published_false_on_network_error(self):
+        # A probe that cannot answer must not take the lift down with it.
+        self._seed_mac_sdk_bump()
+        self.fetch_index.side_effect = TimeoutError('timed out')
+        self.assertFalse(self.xcode.is_published(CHROMIUM_TAG))
 
     def test_missing_upstream_min_os_block_raises(self):
         self._seed_mac_sdk_bump(
@@ -789,14 +823,14 @@ class WindowsRepinTest(_FakeRepoTest):
         self.assertIn('Unrelated chromium change', message)
         self.assertNotIn(autodetect, message)
 
-    def test_already_pinned_second_run_raises(self):
+    def test_already_pinned_second_run_is_a_no_op(self):
+        # See `XcodeRepinTest.test_already_pinned_second_run_is_a_no_op`.
         self._seed_vs_toolchain_bump()
 
         self.windows.repin(Version(CHROMIUM_TAG), culprit=None)
         head_after_first = self._brave_head()
 
-        with self.assertRaises(toolchain.InvalidInputException):
-            self.windows.repin(Version(CHROMIUM_TAG), culprit=None)
+        self.windows.repin(Version(CHROMIUM_TAG), culprit=None)
         self.assertEqual(self._brave_head(), head_after_first)
 
     def test_index_fetch_failure_raises(self):
@@ -807,6 +841,21 @@ class WindowsRepinTest(_FakeRepoTest):
         with self.assertRaises(toolchain.BadOutcomeException):
             self.windows.repin(Version(CHROMIUM_TAG), culprit=None)
         self.assertEqual(self._brave_head(), head_before)
+
+    def test_is_published_true_when_index_resolves(self):
+        self._seed_vs_toolchain_bump()
+        self.assertTrue(self.windows.is_published(CHROMIUM_TAG))
+
+    def test_is_published_false_when_index_missing(self):
+        self._seed_vs_toolchain_bump()
+        self.fetch_index.side_effect = RuntimeError('index not found')
+        self.assertFalse(self.windows.is_published(CHROMIUM_TAG))
+
+    def test_is_published_false_on_network_error(self):
+        # See `XcodeRepinTest.test_is_published_false_on_network_error`.
+        self._seed_vs_toolchain_bump()
+        self.fetch_index.side_effect = TimeoutError('timed out')
+        self.assertFalse(self.windows.is_published(CHROMIUM_TAG))
 
     def test_malformed_vs_toolchain_py_raises(self):
         vs_toolchain = self.repo.chromium / 'build' / 'vs_toolchain.py'
@@ -894,19 +943,22 @@ class DetectionTest(_FakeRepoTest):
             with self.assertRaises(toolchain.InvalidInputException):
                 self.rust.find_culprit(CHROMIUM_TAG)
 
-    def test_check_reports_advisory_when_not_published(self):
+    def test_check_reports_advisory_on_change(self):
         base, culprit = self._seed_rust_range()
-        with patch.object(self.rust, 'is_published', return_value=False):
-            advisory = self.rust.check(base, CHROMIUM_TAG)
+        advisory = self.rust.check(base, CHROMIUM_TAG)
         self.assertIsNotNone(advisory)
         self.assertIn('Rust toolchain', advisory.description)
         self.assertEqual(advisory.commit_hash, culprit)
         self.assertIn('Roll rust revision', advisory.commit_message)
 
-    def test_check_suppressed_when_published(self):
+    def test_check_reports_advisory_even_when_published(self):
+        # An already-published artifact is not a reason to stay quiet: the
+        # in-tree pin still has to move to it. This is the roll-then-revert
+        # case, where the target lands back on a revision an earlier cycle
+        # built while the pin sits on the rolled-forward one.
         base, _ = self._seed_rust_range()
         with patch.object(self.rust, 'is_published', return_value=True):
-            self.assertIsNone(self.rust.check(base, CHROMIUM_TAG))
+            self.assertIsNotNone(self.rust.check(base, CHROMIUM_TAG))
 
     def test_check_none_without_change(self):
         base, _ = self._seed_rust_range()
@@ -946,80 +998,82 @@ class IsPublishedTest(unittest.TestCase):
 
 
 class RecoverTest(unittest.TestCase):
-    """`recover` closes the loop for Rust/Windows and is a no-op for Xcode."""
+    """`recover` builds only when needed, then repins.
+
+    One inherited implementation serves every toolchain, so each case runs
+    across all three. `is_published` is pinned explicitly throughout: False is
+    the plain forward roll (build, then repin), True is the revert onto an
+    already-built revision (repin only, no CI).
+    """
 
     def setUp(self):
-        self.rust = toolchain.RustToolchain()
-        self.windows = toolchain.WindowsToolchain()
         self.version = Version(CHROMIUM_TAG)
+        self.toolchains = (toolchain.RustToolchain(),
+                           toolchain.XcodeToolchain(),
+                           toolchain.WindowsToolchain())
 
     def test_success_triggers_watches_and_repins(self):
-        with patch.object(self.rust, 'trigger', return_value=True) as trigger, \
-                patch.object(self.rust, 'repin') as repin:
-            recovered = self.rust.recover(self.version, 'culprithash')
+        for tc in self.toolchains:
+            with self.subTest(toolchain=tc.spec.key), \
+                    patch.object(tc, 'is_published', return_value=False), \
+                    patch.object(tc, 'trigger', return_value=True) as trigger, \
+                    patch.object(tc, 'repin') as repin:
+                self.assertTrue(tc.recover(self.version, 'culprithash'))
+                # No toolchain-specific arguments: `brave_subrevision` reaches
+                # the Rust job through the PROPERTIES payload, and its pin
+                # through `repin`'s default.
+                trigger.assert_called_once_with(self.version, watch=True)
+                repin.assert_called_once_with(self.version, 'culprithash')
 
-        self.assertTrue(recovered)
-        trigger.assert_called_once_with(self.version,
-                                        watch=True,
-                                        brave_subrevision=1)
-        repin.assert_called_once_with(self.version,
-                                      'culprithash',
-                                      brave_subrevision=1)
+    def test_published_repins_without_building(self):
+        for tc in self.toolchains:
+            with self.subTest(toolchain=tc.spec.key), \
+                    patch.object(tc, 'is_published', return_value=True), \
+                    patch.object(tc, 'trigger') as trigger, \
+                    patch.object(tc, 'repin') as repin:
+                self.assertTrue(tc.recover(self.version, 'culprithash'))
+                trigger.assert_not_called()
+                repin.assert_called_once_with(self.version, 'culprithash')
 
     def test_failed_build_keeps_advisory(self):
-        with patch.object(self.rust, 'trigger', return_value=False), \
-                patch.object(self.rust, 'repin') as repin:
-            self.assertFalse(self.rust.recover(self.version, 'h'))
-        repin.assert_not_called()
+        for tc in self.toolchains:
+            with self.subTest(toolchain=tc.spec.key), \
+                    patch.object(tc, 'is_published', return_value=False), \
+                    patch.object(tc, 'trigger', return_value=False), \
+                    patch.object(tc, 'repin') as repin:
+                self.assertFalse(tc.recover(self.version, 'h'))
+                repin.assert_not_called()
 
     def test_missing_credentials_keeps_advisory(self):
-        with patch.object(
-                self.rust,
-                'trigger',
-                side_effect=toolchain.InvalidInputException('creds')):
-            self.assertFalse(self.rust.recover(self.version, 'h'))
+        for tc in self.toolchains:
+            with self.subTest(toolchain=tc.spec.key), \
+                    patch.object(tc, 'is_published', return_value=False), \
+                    patch.object(
+                        tc,
+                        'trigger',
+                        side_effect=toolchain.InvalidInputException('creds')), \
+                    patch.object(tc, 'repin') as repin:
+                self.assertFalse(tc.recover(self.version, 'h'))
+                repin.assert_not_called()
 
     def test_repin_failure_keeps_advisory(self):
-        with patch.object(self.rust, 'trigger', return_value=True), \
-                patch.object(self.rust,
-                             'repin',
-                             side_effect=toolchain.BadOutcomeException('boom')):
-            self.assertFalse(self.rust.recover(self.version, 'h'))
+        for tc in self.toolchains:
+            with self.subTest(toolchain=tc.spec.key), \
+                    patch.object(tc, 'is_published', return_value=True), \
+                    patch.object(
+                        tc,
+                        'repin',
+                        side_effect=toolchain.BadOutcomeException('boom')):
+                self.assertFalse(tc.recover(self.version, 'h'))
 
-    def test_base_toolchain_cannot_recover(self):
-        # A toolchain without an override never recovers, so its advisory
-        # always survives for the user.
-        self.assertFalse(toolchain.XcodeToolchain().recover(self.version, 'h'))
-
-    def test_windows_success_triggers_watches_and_repins(self):
-        with patch.object(self.windows, 'trigger',
-                          return_value=True) as trigger, \
-                patch.object(self.windows, 'repin') as repin:
-            recovered = self.windows.recover(self.version, 'culprithash')
-
-        self.assertTrue(recovered)
-        trigger.assert_called_once_with(self.version, watch=True)
-        repin.assert_called_once_with(self.version, 'culprithash')
-
-    def test_windows_failed_build_keeps_advisory(self):
-        with patch.object(self.windows, 'trigger', return_value=False), \
-                patch.object(self.windows, 'repin') as repin:
-            self.assertFalse(self.windows.recover(self.version, 'h'))
-        repin.assert_not_called()
-
-    def test_windows_missing_credentials_keeps_advisory(self):
-        with patch.object(
-                self.windows,
-                'trigger',
-                side_effect=toolchain.InvalidInputException('creds')):
-            self.assertFalse(self.windows.recover(self.version, 'h'))
-
-    def test_windows_repin_failure_keeps_advisory(self):
-        with patch.object(self.windows, 'trigger', return_value=True), \
-                patch.object(self.windows,
-                             'repin',
-                             side_effect=toolchain.BadOutcomeException('boom')):
-            self.assertFalse(self.windows.recover(self.version, 'h'))
+    def test_toolchain_without_automated_repin_keeps_advisory(self):
+        # The base `repin` raises, so a spec with no automated repin still
+        # leaves the advisory for the user even once CI has published.
+        base = toolchain.Toolchain(
+            toolchain.ToolchainSpec.from_entry('rust',
+                                               toolchain.TOOLCHAINS['rust']))
+        with patch.object(base, 'is_published', return_value=True):
+            self.assertFalse(base.recover(self.version, 'h'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This change rolls out toolchain update detection and recovery for all
toolchain types. The recovery system has been improved too, and it now
verifies if a toolchain is published, and if not, then it runs CI. This
will help with cases where we already have the toolchain in our buckets,
and brockit can just pin to that toolchain, rather than silently not
letting the user know that the toolchain has changed.

Chromium changes:
https://chromium.googlesource.com/chromium/src/+/05067bb3411c4bec611552f85985258f309331c2

commit 05067bb3411c4bec611552f85985258f309331c2
Author: Hans Wennborg <hans@chromium.org>
Date:   Mon Sep 7 06:24:16 2026 -0700

    Revert "Roll clang+rust llvmorg-24-init-3796-g20e97c4b-5 : llvmorg-24-init-7283-g640ab6c4-1 / 0913b18e489ac1011b580e31fa5559654be12bfc-2 : c33d8f3b5a50b56466998e8c5ed8a077d2caed84-1"

    This reverts commit b26ae1eb6b4881ee444f718764e0d604204d161a.

    Reason for revert:
    This caused assertion failures on mac64-dcheck (2nd bug).

    Failure Link:
    https://ci.chromium.org/ui/p/chrome/builders/official/mac64-dcheck/3022/infra

    Original change's description:
    > Roll clang+rust llvmorg-24-init-3796-g20e97c4b-5 : llvmorg-24-init-7283-g640ab6c4-1 / 0913b18e489ac1011b580e31fa5559654be12bfc-2 : c33d8f3b5a50b56466998e8c5ed8a077d2caed84-1
    >
    > https://chromium.googlesource.com/external/github.com/llvm/llvm-project/+log/20e97c4b..640ab6c4
    >
    > https://chromium.googlesource.com/external/github.com/rust-lang/rust/+log/0913b18e489a..c33d8f3b5a50
    >
    > Ran: ./tools/clang/scripts/upload_revision.py 640ab6c44d94fbec679b3314e50468bb0c5a8f05
    >
    > Bug: 549080734
    > Change-Id: I83ac68d087e63ce136d6a1197d135e59572d53e7
    > Include-Ci-Only-Tests: true
    > Cq-Include-Trybots: chromium/try:android-16-x64-dbg
    > Cq-Include-Trybots: chromium/try:android-cronet-riscv64-dbg
    > Cq-Include-Trybots: chromium/try:android-cronet-riscv64-rel
    > Cq-Include-Trybots: chromium/try:chromeos-amd64-generic-cfi-thin-lto-rel
    > Cq-Include-Trybots: chromium/try:dawn-win10-x86-deps-rel
    > Cq-Include-Trybots: chromium/try:fuchsia-arm64-cast-receiver-rel
    > Cq-Include-Trybots: chromium/try:ios-catalyst,android-official
    > Cq-Include-Trybots: chromium/try:linux-cast-x64-rel
    > Cq-Include-Trybots: chromium/try:linux-chromeos-dbg
    > Cq-Include-Trybots: chromium/try:linux-swangle-try-x64,win-swangle-try-x86
    > Cq-Include-Trybots: chromium/try:linux-v4l2-codec-rel
    > Cq-Include-Trybots: chromium/try:linux-wayland-mutter-rel
    > Cq-Include-Trybots: chromium/try:linux_chromium_cfi_rel_ng
    > Cq-Include-Trybots: chromium/try:linux_chromium_chromeos_msan_rel_ng
    > Cq-Include-Trybots: chromium/try:linux_chromium_msan_rel_ng
    > Cq-Include-Trybots: chromium/try:mac-official,linux-official
    > Cq-Include-Trybots: chromium/try:mac13-arm64-rel,mac_chromium_asan_rel_ng
    > Cq-Include-Trybots: chromium/try:mac15-x64-rel-tests
    > Cq-Include-Trybots: chromium/try:win-arm64-rel
    > Cq-Include-Trybots: chromium/try:win-official,win32-official
    > Cq-Include-Trybots: chrome/try:android-arm32-pgo,android-arm64-pgo
    > Cq-Include-Trybots: chrome/try:android-x64-rel-ready
    > Cq-Include-Trybots: chrome/try:chromeos-brya-chrome,chromeos-eve-chrome
    > Cq-Include-Trybots: chrome/try:chromeos-volteer-chrome
    > Cq-Include-Trybots: chrome/try:linux-chromeos-chrome
    > Cq-Include-Trybots: chrome/try:linux-pgo,mac-pgo,win64-pgo
    > Cq-Include-Trybots: chrome/try:win-chrome,win64-chrome,linux-chrome,mac-chrome
    > Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8351507
    > Reviewed-by: Nico Weber <thakis@chromium.org>
    > Commit-Queue: Hans Wennborg <hans@chromium.org>
    > Cr-Commit-Position: refs/heads/main@{#1692916}

    Bug: 549080734, 558234942
    Bug: 549080734
    Change-Id: I3645d38eb76ec09f774011f1d2d26d981043762b
    Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/8366586
    Bot-Commit: rubber-stamper@appspot.gserviceaccount.com <rubber-stamper@appspot.gserviceaccount.com>
    Cr-Commit-Position: refs/heads/main@{#1693314}
