### PR TITLE
[plaster] Deploying `ast-grep-0.45.3`

### DIFF
--- a/EXTRA_DEPS
+++ b/EXTRA_DEPS
@@ -112,9 +112,9 @@ extra_deps = {
         'condition': 'host_os == "linux"',
         'objects': [
             {
-                'object_name': 'ast-grep-0.44.1-linux-x64.tar.gz',
-                'sha256sum': 'e2d0696358940a5c09a54ef1266b369036717293d9f9312513da6edf98a13176',
-                'size_bytes': 7935160,
+                'object_name': 'ast-grep-0.45.3-linux-x64.tar.gz',
+                'sha256sum': '31e5c1d736d22fb6c0a4ca22558570465f040a0f33d76ee280570d12b2572a6b',
+                'size_bytes': 7916969,
             },
         ],
     },
@@ -123,9 +123,9 @@ extra_deps = {
         'condition': 'host_os == "mac" and host_cpu == "x64"',
         'objects': [
             {
-                'object_name': 'ast-grep-0.44.1-mac.tar.gz',
-                'sha256sum': '38e9259845066f0fc6b2a947f1760305add3c52a8d53d198bd1ae830e12569dc',
-                'size_bytes': 7775908,
+                'object_name': 'ast-grep-0.45.3-mac.tar.gz',
+                'sha256sum': 'ec3683172ab0dc17aef447891c5ad488586b899494af1145e97a1b47e8c9c3ab',
+                'size_bytes': 7680568,
             },
         ],
     },
@@ -134,9 +134,9 @@ extra_deps = {
         'condition': 'host_os == "mac" and host_cpu == "arm64"',
         'objects': [
             {
-                'object_name': 'ast-grep-0.44.1-mac-arm64.tar.gz',
-                'sha256sum': 'ef1cf3f749796c0318c3f6badd75df3e5090ce4cf07c0e7cf89f34c0db452e75',
-                'size_bytes': 7774326,
+                'object_name': 'ast-grep-0.45.3-mac-arm64.tar.gz',
+                'sha256sum': 'b6ba00ff2fdbb10f27ca7534a60d01022ad64b889c4b55eec0de501864d6c99b',
+                'size_bytes': 7674690,
             },
         ],
     },
@@ -145,9 +145,9 @@ extra_deps = {
         'condition': 'host_os == "win"',
         'objects': [
             {
-                'object_name': 'ast-grep-0.44.1-win.tar.gz',
-                'sha256sum': 'c1e06394908573ddf334f41809b63e9b80122b11048412c41c2b66c52106ea47',
-                'size_bytes': 7667559,
+                'object_name': 'ast-grep-0.45.3-win.tar.gz',
+                'sha256sum': 'd423ec0d24ec7e310b4b7136d8e11bd4a8440ca16ecbe9d37ca1e30414835967',
+                'size_bytes': 7757317,
             },
         ],
     },


### PR DESCRIPTION
This update also rolls out the tree-sitter for `gn`.

Bug: https://github.com/brave/brave-browser/issues/58378
