### PR TITLE
[ads] Fix AdsInternalsHandler dangling pointer to shut-down AdsService

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -487,6 +487,10 @@ void AdsServiceImpl::InitializeBatAdsCallback(bool success) {
   NotifyDidInitializeAdsService();
 }
 
+base::WeakPtr<AdsService> AdsServiceImpl::GetWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
+}
+
 bool AdsServiceImpl::IsIneligibleToStart() const {
   return is_ineligible_to_start_;
 }

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -133,6 +133,7 @@ class AdsServiceImpl : public AdsService,
   ~AdsServiceImpl() override;
 
   // AdsService:
+  base::WeakPtr<AdsService> GetWeakPtr() override;
   bool IsIneligibleToStart() const override;
   bool IsInitialized() const override;
 

--- a/components/brave_ads/core/browser/internals/ads_internals_handler.cc
+++ b/components/brave_ads/core/browser/internals/ads_internals_handler.cc
@@ -44,7 +44,7 @@ AdsInternalsHandler::AdsInternalsHandler(
     GetComponentIdCallback get_language_resource_component_id_callback,
     GetIsSponsoredImagesLoadedCallback get_is_sponsored_images_loaded_callback,
     GetComponentIdCallback get_ntp_sponsored_images_manifest_version_callback)
-    : ads_service_(ads_service),
+    : ads_service_(ads_service ? ads_service->GetWeakPtr() : nullptr),
       prefs_(prefs),
       variations_service_(variations_service),
       get_ntp_sponsored_images_component_id_callback_(

--- a/components/brave_ads/core/browser/internals/ads_internals_handler.h
+++ b/components/brave_ads/core/browser/internals/ads_internals_handler.h
@@ -104,7 +104,7 @@ class AdsInternalsHandler final : public bat_ads::mojom::AdsInternals,
   // brave_ads::AdsServiceObserver:
   void OnDidInitializeAdsService() override;
 
-  const raw_ptr<brave_ads::AdsService> ads_service_;  // Not owned.
+  base::WeakPtr<brave_ads::AdsService> ads_service_;
 
   const raw_ref<PrefService> prefs_;
 

--- a/components/brave_ads/core/browser/internals/ads_internals_handler_unittest.cc
+++ b/components/brave_ads/core/browser/internals/ads_internals_handler_unittest.cc
@@ -519,8 +519,80 @@ TEST_F(BraveAdsInternalsHandlerTest,
   page.FlushForTesting();
 
   // Assert
-  EXPECT_EQ(true, page.last_rewards_enabled);
-  EXPECT_EQ(true, page.last_wallet_connected);
+  EXPECT_THAT(page.last_rewards_enabled, ::testing::Optional(true));
+  EXPECT_THAT(page.last_wallet_connected, ::testing::Optional(true));
+}
+
+TEST_F(BraveAdsInternalsHandlerTest,
+       GetAdsInternalsReturnsEmptyJsonAfterAdsServiceIsDestroyed) {
+  // Arrange
+  auto owned_ads_service_mock = std::make_unique<AdsServiceMock>();
+
+  AdsInternalsHandler handler(
+      owned_ads_service_mock.get(), profile_prefs_,
+      /*variations_service=*/nullptr,
+      /*get_ntp_sponsored_images_component_id_callback=*/
+      AdsInternalsHandler::GetComponentIdCallback(),
+      /*get_country_resource_component_id_callback=*/
+      AdsInternalsHandler::GetComponentIdCallback(),
+      /*get_language_resource_component_id_callback=*/
+      AdsInternalsHandler::GetComponentIdCallback(),
+      AdsInternalsHandler::GetIsSponsoredImagesLoadedCallback(),
+      AdsInternalsHandler::GetComponentIdCallback());
+
+  mojo::Remote<bat_ads::mojom::AdsInternals> ads_internals_remote;
+  handler.BindInterface(ads_internals_remote.BindNewPipeAndPassReceiver());
+
+  // Simulates the real `AdsService` object being destroyed before this
+  // handler, e.g. during profile shutdown, while the handler is still alive.
+  owned_ads_service_mock.reset();
+
+  base::test::TestFuture<std::string> test_future;
+
+  // Act
+  ads_internals_remote->GetAdsInternals(base::BindLambdaForTesting(
+      [&test_future](const std::string& json) { test_future.SetValue(json); }));
+
+  // Assert
+  EXPECT_EQ("{}", test_future.Get());
+}
+
+TEST_F(BraveAdsInternalsHandlerTest,
+       GetAdsInternalsStillWorksAfterReversibleAdsServiceRestart) {
+  // Arrange
+  AdsInternalsHandler handler(
+      &ads_service_mock_, profile_prefs_,
+      /*variations_service=*/nullptr,
+      /*get_ntp_sponsored_images_component_id_callback=*/
+      AdsInternalsHandler::GetComponentIdCallback(),
+      /*get_country_resource_component_id_callback=*/
+      AdsInternalsHandler::GetComponentIdCallback(),
+      /*get_language_resource_component_id_callback=*/
+      AdsInternalsHandler::GetComponentIdCallback(),
+      AdsInternalsHandler::GetIsSponsoredImagesLoadedCallback(),
+      AdsInternalsHandler::GetComponentIdCallback());
+
+  mojo::Remote<bat_ads::mojom::AdsInternals> ads_internals_remote;
+  handler.BindInterface(ads_internals_remote.BindNewPipeAndPassReceiver());
+
+  // Simulates a reversible bat-ads-only restart, e.g. a Brave Rewards pref
+  // toggle, which shuts down and later reinitializes bat ads without
+  // destroying the `AdsService` object itself.
+  ads_service_mock_.NotifyObserversOnDidShutdownAdsServiceForTesting();
+  ads_service_mock_.NotifyObserversOnDidInitializeAdsServiceForTesting();
+
+  base::test::TestFuture<std::string> test_future;
+  EXPECT_CALL(ads_service_mock_, GetInternals)
+      .WillOnce([](GetInternalsCallback callback) {
+        std::move(callback).Run(base::DictValue());
+      });
+
+  // Act
+  ads_internals_remote->GetAdsInternals(base::BindLambdaForTesting(
+      [&test_future](const std::string& json) { test_future.SetValue(json); }));
+
+  // Assert
+  EXPECT_EQ("{}", test_future.Get());
 }
 
 TEST_F(BraveAdsInternalsHandlerTest,
@@ -544,14 +616,14 @@ TEST_F(BraveAdsInternalsHandlerTest,
   FakeAdsInternalsPage page;
   ads_internals_remote->CreateAdsInternalsPageHandler(page.BindNewPipe());
   page.FlushForTesting();
-  ASSERT_EQ(false, page.last_wallet_connected);
+  ASSERT_THAT(page.last_wallet_connected, ::testing::Optional(false));
 
   // Act
   profile_prefs_.SetString(brave_rewards::prefs::kExternalWalletType, "uphold");
   page.FlushForTesting();
 
   // Assert
-  EXPECT_EQ(true, page.last_wallet_connected);
+  EXPECT_THAT(page.last_wallet_connected, ::testing::Optional(true));
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/browser/service/ads_service.h
+++ b/components/brave_ads/core/browser/service/ads_service.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/browser/service/ads_service_callback.h"
@@ -63,6 +64,12 @@ class AdsService : public KeyedService {
   ~AdsService() override;
 
   AdsService::Delegate* delegate() { return delegate_.get(); }
+
+  // Returns a `WeakPtr` that becomes invalid once this object is destroyed,
+  // regardless of any bat-ads-only shutdown/restart cycles it goes through in
+  // the meantime. Consumers that outlive the profile's `AdsService`, e.g.
+  // WebUI handlers, should hold this instead of a raw pointer.
+  virtual base::WeakPtr<AdsService> GetWeakPtr() = 0;
 
   void AddObserver(AdsServiceObserver* observer);
   void RemoveObserver(AdsServiceObserver* observer);

--- a/components/brave_ads/core/browser/service/test/ads_service_mock.cc
+++ b/components/brave_ads/core/browser/service/test/ads_service_mock.cc
@@ -5,10 +5,24 @@
 
 #include "brave/components/brave_ads/core/browser/service/test/ads_service_mock.h"
 
+#include "brave/components/brave_ads/core/browser/service/ads_service_observer.h"
+
 namespace brave_ads {
 
 AdsServiceMock::AdsServiceMock() : AdsService(/*delegate=*/nullptr) {}
 
 AdsServiceMock::~AdsServiceMock() = default;
+
+base::WeakPtr<AdsService> AdsServiceMock::GetWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
+}
+
+void AdsServiceMock::NotifyObserversOnDidShutdownAdsServiceForTesting() {
+  observers_.Notify(&AdsServiceObserver::OnDidShutdownAdsService);
+}
+
+void AdsServiceMock::NotifyObserversOnDidInitializeAdsServiceForTesting() {
+  observers_.Notify(&AdsServiceObserver::OnDidInitializeAdsService);
+}
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/browser/service/test/ads_service_mock.h
+++ b/components/brave_ads/core/browser/service/test/ads_service_mock.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/weak_ptr.h"
 #include "brave/components/brave_ads/core/browser/service/ads_service.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "testing/gmock/include/gmock/gmock.h"
@@ -25,6 +26,11 @@ class AdsServiceMock : public AdsService {
   AdsServiceMock& operator=(const AdsServiceMock&) = delete;
 
   ~AdsServiceMock() override;
+
+  base::WeakPtr<AdsService> GetWeakPtr() override;
+
+  void NotifyObserversOnDidShutdownAdsServiceForTesting();
+  void NotifyObserversOnDidInitializeAdsServiceForTesting();
 
   MOCK_METHOD(void,
               AddBatAdsObserver,
@@ -116,6 +122,9 @@ class AdsServiceMock : public AdsService {
   MOCK_METHOD(void, NotifyBrowserDidResignActive, ());
 
   MOCK_METHOD(void, NotifyDidSolveAdaptiveCaptcha, ());
+
+ private:
+  base::WeakPtrFactory<AdsServiceMock> weak_ptr_factory_{this};
 };
 
 }  // namespace brave_ads

--- a/ios/browser/brave_ads/ads_service_impl_ios.h
+++ b/ios/browser/brave_ads/ads_service_impl_ios.h
@@ -62,6 +62,7 @@ class AdsServiceImplIOS : public AdsService {
   void NotifyDidClearAdsServiceData() const;
 
   // AdsService:
+  base::WeakPtr<AdsService> GetWeakPtr() override;
   bool IsIneligibleToStart() const override;
   bool IsInitialized() const override;
 

--- a/ios/browser/brave_ads/ads_service_impl_ios.mm
+++ b/ios/browser/brave_ads/ads_service_impl_ios.mm
@@ -58,6 +58,10 @@ AdsClientNotifier* AdsServiceImplIOS::GetAdsClientNotifier() {
   return ads_client_notifier_.get();
 }
 
+base::WeakPtr<AdsService> AdsServiceImplIOS::GetWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
+}
+
 bool AdsServiceImplIOS::IsIneligibleToStart() const {
   // iOS has no eligibility gate; the service is never ineligible to start.
   return false;


### PR DESCRIPTION
Uses a `base::WeakPtr<AdsService>` instead of a `raw_ptr` for `ads_service_`, so it is only invalidated when `AdsService` is actually destroyed.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
