### PR TITLE
[ads] Add verbose mode flag for brave://ads-internals

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -12,6 +12,7 @@
 #include "brave/browser/ui/brave_ui_features.h"
 #include "brave/browser/updater/buildflags.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_ads/buildflags/buildflags.h"
 #include "brave/components/brave_component_updater/browser/features.h"
 #include "brave/components/brave_education/buildflags.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
@@ -60,6 +61,10 @@
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/common/features.h"
+#endif
+
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+#include "brave/components/brave_ads/core/public/ads_internals/ads_internals_verbose_mode_feature.h"
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_NEWS)
@@ -380,6 +385,18 @@ const char* const kBraveSyncImplLink[1] = {"https://github.com/brave/go-sync"};
                    kOsAll,                                             \
                    FEATURE_VALUE_TYPE(psst::features::kEnablePsst),    \
                }))
+
+#define ADS_INTERNALS_VERBOSE_MODE_FEATURE_ENTRIES                        \
+  IF_BUILDFLAG(                                                           \
+      ENABLE_BRAVE_ADS,                                                   \
+      EXPAND_FEATURE_ENTRIES({                                            \
+          "ads-internals-verbose-mode",                                   \
+          "Enable brave://ads-internals verbose mode",                    \
+          "Shows extra debugging tabs and tools on brave://ads-"          \
+          "internals.",                                                   \
+          kOsDesktop | kOsAndroid,                                        \
+          FEATURE_VALUE_TYPE(brave_ads::kAdsInternalsVerboseModeFeature), \
+      }))
 
 #if !BUILDFLAG(IS_ANDROID)
 #define BRAVE_COMMANDS_FEATURE_ENTRIES                                      \
@@ -1578,6 +1595,7 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
   BRAVE_NEWS_FEATURE_ENTRIES                                                   \
   SPEEDREADER_FEATURE_ENTRIES                                                  \
   REQUEST_OTR_FEATURE_ENTRIES                                                  \
+  ADS_INTERNALS_VERBOSE_MODE_FEATURE_ENTRIES                                   \
   BRAVE_MODULE_FILENAME_PATCH                                                  \
   PLAYLIST_FEATURE_ENTRIES                                                     \
   BRAVE_COMMANDS_FEATURE_ENTRIES                                               \

--- a/browser/ui/webui/ads_internals/ads_internals_ui.cc
+++ b/browser/ui/webui/ads_internals/ads_internals_ui.cc
@@ -7,9 +7,11 @@
 
 #include <utility>
 
+#include "base/feature_list.h"
 #include "brave/browser/brave_ads/ads_service_factory.h"
 #include "brave/browser/ui/webui/brave_webui_source.h"
 #include "brave/components/brave_ads/browser/resources/grit/ads_internals_generated_map.h"
+#include "brave/components/brave_ads/core/public/ads_internals/ads_internals_verbose_mode_feature.h"
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/core/pref_names.h"
 #include "chrome/browser/browser_process.h"
@@ -81,6 +83,9 @@ AdsInternalsUI::AdsInternalsUI(content::WebUI* web_ui)
       IDR_ADS_INTERNALS_HTML);
   source->AddBoolean("logsSupported", rewards_service_ != nullptr);
   source->AddBoolean("verboseLoggingEnabled", IsVerboseLoggingEnabled());
+  source->AddBoolean(
+      "adsInternalsVerboseModeEnabled",
+      base::FeatureList::IsEnabled(brave_ads::kAdsInternalsVerboseModeFeature));
 }
 
 AdsInternalsUI::~AdsInternalsUI() = default;

--- a/components/brave_ads/browser/resources/lib/app_store.ts
+++ b/components/brave_ads/browser/resources/lib/app_store.ts
@@ -166,6 +166,7 @@ export interface AppState {
   variationsCountryCode: string
   logsSupported: boolean
   verboseLoggingEnabled: boolean
+  adsInternalsVerboseModeEnabled: boolean
   log: string
   autoRefreshEnabled: boolean
   errorsOnlyEnabled: boolean
@@ -225,6 +226,7 @@ export function defaultAppStore() {
     variationsCountryCode: '',
     logsSupported: false,
     verboseLoggingEnabled: false,
+    adsInternalsVerboseModeEnabled: false,
     log: '',
     autoRefreshEnabled: false,
     errorsOnlyEnabled: true,

--- a/components/brave_ads/browser/resources/lib/browser_app_store.ts
+++ b/components/brave_ads/browser/resources/lib/browser_app_store.ts
@@ -20,6 +20,8 @@ export function createAppStore(): AppStore {
   store.update({
     logsSupported,
     verboseLoggingEnabled: loadTimeData.getBoolean('verboseLoggingEnabled'),
+    adsInternalsVerboseModeEnabled:
+      loadTimeData.getBoolean('adsInternalsVerboseModeEnabled'),
   })
 
   // Rewards enabled/wallet connected can change from another tab (e.g.

--- a/components/brave_ads/core/browser/internals/ads_internals_handler_unittest.cc
+++ b/components/brave_ads/core/browser/internals/ads_internals_handler_unittest.cc
@@ -74,6 +74,7 @@ TEST_F(BraveAdsInternalsHandlerTest,
       /*get_language_resource_component_id_callback=*/
       AdsInternalsHandler::GetComponentIdCallback(),
       AdsInternalsHandler::GetIsSponsoredImagesLoadedCallback(),
+      /*get_ntp_sponsored_images_manifest_version_callback=*/
       AdsInternalsHandler::GetComponentIdCallback());
 
   mojo::Remote<bat_ads::mojom::AdsInternals> ads_internals_remote;
@@ -102,6 +103,7 @@ TEST_F(BraveAdsInternalsHandlerTest,
       /*get_language_resource_component_id_callback=*/
       AdsInternalsHandler::GetComponentIdCallback(),
       AdsInternalsHandler::GetIsSponsoredImagesLoadedCallback(),
+      /*get_ntp_sponsored_images_manifest_version_callback=*/
       AdsInternalsHandler::GetComponentIdCallback());
 
   mojo::Remote<bat_ads::mojom::AdsInternals> ads_internals_remote;
@@ -135,6 +137,7 @@ TEST_F(BraveAdsInternalsHandlerTest,
       /*get_language_resource_component_id_callback=*/
       AdsInternalsHandler::GetComponentIdCallback(),
       AdsInternalsHandler::GetIsSponsoredImagesLoadedCallback(),
+      /*get_ntp_sponsored_images_manifest_version_callback=*/
       AdsInternalsHandler::GetComponentIdCallback());
 
   mojo::Remote<bat_ads::mojom::AdsInternals> ads_internals_remote;
@@ -168,6 +171,7 @@ TEST_F(BraveAdsInternalsHandlerTest,
       /*get_language_resource_component_id_callback=*/
       AdsInternalsHandler::GetComponentIdCallback(),
       AdsInternalsHandler::GetIsSponsoredImagesLoadedCallback(),
+      /*get_ntp_sponsored_images_manifest_version_callback=*/
       AdsInternalsHandler::GetComponentIdCallback());
 
   mojo::Remote<bat_ads::mojom::AdsInternals> ads_internals_remote;
@@ -195,6 +199,7 @@ TEST_F(BraveAdsInternalsHandlerTest,
       /*get_language_resource_component_id_callback=*/
       AdsInternalsHandler::GetComponentIdCallback(),
       AdsInternalsHandler::GetIsSponsoredImagesLoadedCallback(),
+      /*get_ntp_sponsored_images_manifest_version_callback=*/
       AdsInternalsHandler::GetComponentIdCallback());
 
   mojo::Remote<bat_ads::mojom::AdsInternals> ads_internals_remote;
@@ -227,6 +232,7 @@ TEST_F(BraveAdsInternalsHandlerTest,
       /*get_language_resource_component_id_callback=*/
       AdsInternalsHandler::GetComponentIdCallback(),
       AdsInternalsHandler::GetIsSponsoredImagesLoadedCallback(),
+      /*get_ntp_sponsored_images_manifest_version_callback=*/
       AdsInternalsHandler::GetComponentIdCallback());
 
   mojo::Remote<bat_ads::mojom::AdsInternals> ads_internals_remote;
@@ -261,6 +267,7 @@ TEST_F(BraveAdsInternalsHandlerTest,
       /*get_language_resource_component_id_callback=*/
       AdsInternalsHandler::GetComponentIdCallback(),
       AdsInternalsHandler::GetIsSponsoredImagesLoadedCallback(),
+      /*get_ntp_sponsored_images_manifest_version_callback=*/
       AdsInternalsHandler::GetComponentIdCallback());
 
   mojo::Remote<bat_ads::mojom::AdsInternals> ads_internals_remote;
@@ -299,6 +306,7 @@ TEST_F(BraveAdsInternalsHandlerTest,
       /*get_language_resource_component_id_callback=*/
       AdsInternalsHandler::GetComponentIdCallback(),
       AdsInternalsHandler::GetIsSponsoredImagesLoadedCallback(),
+      /*get_ntp_sponsored_images_manifest_version_callback=*/
       AdsInternalsHandler::GetComponentIdCallback());
 
   mojo::Remote<bat_ads::mojom::AdsInternals> ads_internals_remote;
@@ -347,6 +355,7 @@ TEST_F(BraveAdsInternalsHandlerTest,
       /*get_language_resource_component_id_callback=*/
       AdsInternalsHandler::GetComponentIdCallback(),
       AdsInternalsHandler::GetIsSponsoredImagesLoadedCallback(),
+      /*get_ntp_sponsored_images_manifest_version_callback=*/
       AdsInternalsHandler::GetComponentIdCallback());
 
   mojo::Remote<bat_ads::mojom::AdsInternals> ads_internals_remote;
@@ -387,6 +396,7 @@ TEST_F(BraveAdsInternalsHandlerTest, SetDiagnosticIdUpdatesPrefWithValidUuid) {
       /*get_language_resource_component_id_callback=*/
       AdsInternalsHandler::GetComponentIdCallback(),
       AdsInternalsHandler::GetIsSponsoredImagesLoadedCallback(),
+      /*get_ntp_sponsored_images_manifest_version_callback=*/
       AdsInternalsHandler::GetComponentIdCallback());
 
   mojo::Remote<bat_ads::mojom::AdsInternals> ads_internals_remote;
@@ -418,6 +428,7 @@ TEST_F(BraveAdsInternalsHandlerTest,
       /*get_language_resource_component_id_callback=*/
       AdsInternalsHandler::GetComponentIdCallback(),
       AdsInternalsHandler::GetIsSponsoredImagesLoadedCallback(),
+      /*get_ntp_sponsored_images_manifest_version_callback=*/
       AdsInternalsHandler::GetComponentIdCallback());
 
   mojo::Remote<bat_ads::mojom::AdsInternals> ads_internals_remote;
@@ -445,6 +456,7 @@ TEST_F(BraveAdsInternalsHandlerTest, SetDiagnosticIdClearsPrefWithEmptyValue) {
       /*get_language_resource_component_id_callback=*/
       AdsInternalsHandler::GetComponentIdCallback(),
       AdsInternalsHandler::GetIsSponsoredImagesLoadedCallback(),
+      /*get_ntp_sponsored_images_manifest_version_callback=*/
       AdsInternalsHandler::GetComponentIdCallback());
 
   mojo::Remote<bat_ads::mojom::AdsInternals> ads_internals_remote;
@@ -507,6 +519,7 @@ TEST_F(BraveAdsInternalsHandlerTest,
       /*get_language_resource_component_id_callback=*/
       AdsInternalsHandler::GetComponentIdCallback(),
       AdsInternalsHandler::GetIsSponsoredImagesLoadedCallback(),
+      /*get_ntp_sponsored_images_manifest_version_callback=*/
       AdsInternalsHandler::GetComponentIdCallback());
 
   mojo::Remote<bat_ads::mojom::AdsInternals> ads_internals_remote;
@@ -536,6 +549,7 @@ TEST_F(BraveAdsInternalsHandlerTest,
       /*get_language_resource_component_id_callback=*/
       AdsInternalsHandler::GetComponentIdCallback(),
       AdsInternalsHandler::GetIsSponsoredImagesLoadedCallback(),
+      /*get_ntp_sponsored_images_manifest_version_callback=*/
       AdsInternalsHandler::GetComponentIdCallback());
 
   mojo::Remote<bat_ads::mojom::AdsInternals> ads_internals_remote;

--- a/components/brave_ads/core/internal/BUILD.gn
+++ b/components/brave_ads/core/internal/BUILD.gn
@@ -320,6 +320,7 @@ static_library("internal") {
     "ads_internals/ads_internals_info.h",
     "ads_internals/ads_internals_util.cc",
     "ads_internals/ads_internals_util.h",
+    "ads_internals/ads_internals_verbose_mode_feature.cc",
     "ads_notifier_manager.cc",
     "ads_notifier_manager.h",
     "ads_util.cc",

--- a/components/brave_ads/core/internal/ads_internals/ads_internals_verbose_mode_feature.cc
+++ b/components/brave_ads/core/internal/ads_internals/ads_internals_verbose_mode_feature.cc
@@ -1,0 +1,13 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/core/public/ads_internals/ads_internals_verbose_mode_feature.h"
+
+namespace brave_ads {
+
+BASE_FEATURE(kAdsInternalsVerboseModeFeature,
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
+}  // namespace brave_ads

--- a/components/brave_ads/core/internal/ads_internals/ads_internals_verbose_mode_feature_unittest.cc
+++ b/components/brave_ads/core/internal/ads_internals/ads_internals_verbose_mode_feature_unittest.cc
@@ -1,0 +1,25 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/core/public/ads_internals/ads_internals_verbose_mode_feature.h"
+
+#include "base/test/scoped_feature_list.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+// npm run test -- brave_unit_tests --filter=BraveAds*
+
+namespace brave_ads {
+
+TEST(BraveAdsAdsInternalsVerboseModeFeatureTest, IsDisabledByDefault) {
+  // Arrange
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitWithFeatures(/*enabled_features=*/{},
+                                       /*disabled_features=*/{});
+
+  // Act & Assert
+  EXPECT_FALSE(base::FeatureList::IsEnabled(kAdsInternalsVerboseModeFeature));
+}
+
+}  // namespace brave_ads

--- a/components/brave_ads/core/public/BUILD.gn
+++ b/components/brave_ads/core/public/BUILD.gn
@@ -26,6 +26,7 @@ source_set("headers") {
     "ads_client/ads_client_notifier.h",
     "ads_client/ads_client_notifier_observer.h",
     "ads_constants.h",
+    "ads_internals/ads_internals_verbose_mode_feature.h",
     "ads_observer.h",
     "ads_util.h",
     "command_line_switches/command_line_switches_util.h",

--- a/components/brave_ads/core/public/ads_internals/ads_internals_verbose_mode_feature.h
+++ b/components/brave_ads/core/public/ads_internals/ads_internals_verbose_mode_feature.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_PUBLIC_ADS_INTERNALS_ADS_INTERNALS_VERBOSE_MODE_FEATURE_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_CORE_PUBLIC_ADS_INTERNALS_ADS_INTERNALS_VERBOSE_MODE_FEATURE_H_
+
+#include "base/feature_list.h"
+#include "brave/components/brave_ads/buildflags/buildflags.h"
+
+static_assert(BUILDFLAG(ENABLE_BRAVE_ADS));
+
+namespace brave_ads {
+
+// Enables additional low-level debugging UI on brave://ads-internals.
+// Off by default since it exposes ad-serving internals that are only useful for
+// debugging.
+BASE_DECLARE_FEATURE(kAdsInternalsVerboseModeFeature);
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_CORE_PUBLIC_ADS_INTERNALS_ADS_INTERNALS_VERBOSE_MODE_FEATURE_H_

--- a/components/brave_ads/core/test/BUILD.gn
+++ b/components/brave_ads/core/test/BUILD.gn
@@ -204,6 +204,7 @@ source_set("brave_ads_unit_tests") {
     "//brave/components/brave_ads/core/internal/ads_client/test/ads_client_notifier_observer_mock.h",
     "//brave/components/brave_ads/core/internal/ads_impl_unittest.cc",
     "//brave/components/brave_ads/core/internal/ads_internals/ads_internals_util_unittest.cc",
+    "//brave/components/brave_ads/core/internal/ads_internals/ads_internals_verbose_mode_feature_unittest.cc",
     "//brave/components/brave_ads/core/internal/ads_util_unittest.cc",
     "//brave/components/brave_ads/core/internal/application_state/browser_manager_unittest.cc",
     "//brave/components/brave_ads/core/internal/application_state/browser_util_unittest.cc",

--- a/ios/browser/flags/DEPS
+++ b/ios/browser/flags/DEPS
@@ -1,5 +1,7 @@
 include_rules = [
   "+brave/components/ai_chat/core/common/features.h",
+  "+brave/components/brave_ads/buildflags/buildflags.h",
+  "+brave/components/brave_ads/core/public/ads_internals/ads_internals_verbose_mode_feature.h",
   "+brave/components/brave_component_updater/browser/features.h",
   "+brave/components/brave_origin/features.h",
   "+brave/components/brave_rewards/core/features.h",

--- a/ios/browser/flags/about_flags.mm
+++ b/ios/browser/flags/about_flags.mm
@@ -6,6 +6,7 @@
 // This file is included into //ios/chrome/browser/flags/about_flags.mm
 
 #include "brave/components/ai_chat/core/common/features.h"
+#include "brave/components/brave_ads/buildflags/buildflags.h"
 #include "brave/components/brave_component_updater/browser/features.h"
 #include "brave/components/brave_origin/features.h"
 #include "brave/components/brave_rewards/core/features.h"
@@ -26,6 +27,10 @@
 #include "components/webui/flags/feature_entry_macros.h"
 #include "components/webui/flags/flags_state.h"
 #include "net/base/features.h"
+
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+#include "brave/components/brave_ads/core/public/ads_internals/ads_internals_verbose_mode_feature.h"
+#endif
 
 #if BUILDFLAG(ENABLE_BRAVE_WALLET)
 #include "brave/components/brave_wallet/common/features.h"
@@ -266,6 +271,19 @@ const flags_ui::FeatureEntry::FeatureVariation
 #define BRAVE_WALLET_FEATURE_ENTRIES
 #endif
 
+#if BUILDFLAG(ENABLE_BRAVE_ADS)
+#define ADS_INTERNALS_VERBOSE_MODE_FEATURE_ENTRIES                      \
+  EXPAND_FEATURE_ENTRIES({                                              \
+      "ads-internals-verbose-mode",                                     \
+      "Enable brave://ads-internals verbose mode",                      \
+      "Shows extra debugging tabs and tools on brave://ads-internals.", \
+      flags_ui::kOsIos,                                                 \
+      FEATURE_VALUE_TYPE(brave_ads::kAdsInternalsVerboseModeFeature),   \
+  })
+#else
+#define ADS_INTERNALS_VERBOSE_MODE_FEATURE_ENTRIES
+#endif
+
 #define BRAVE_PLAYLIST_FEATURE_ENTRIES                   \
   EXPAND_FEATURE_ENTRIES({                               \
       "brave-playlist",                                  \
@@ -391,6 +409,7 @@ const flags_ui::FeatureEntry::FeatureVariation
           FEATURE_VALUE_TYPE(brave_origin::features::kBraveOrigin),            \
       })                                                                       \
   BRAVE_SHIELDS_FEATURE_ENTRIES                                                \
+  ADS_INTERNALS_VERBOSE_MODE_FEATURE_ENTRIES                                   \
   BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                          \
   BRAVE_SKU_SDK_FEATURE_ENTRIES                                                \
   BRAVE_AI_CHAT_FEATURE_ENTRIES                                                \

--- a/ios/browser/ui/webui/ads/ads_internals_ui.mm
+++ b/ios/browser/ui/webui/ads/ads_internals_ui.mm
@@ -11,8 +11,10 @@
 
 #include "base/check.h"
 #include "base/containers/span.h"
+#include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "brave/components/brave_ads/browser/resources/grit/ads_internals_generated_map.h"
+#include "brave/components/brave_ads/core/public/ads_internals/ads_internals_verbose_mode_feature.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/ios/browser/brave_ads/ads_service_factory_ios.h"
 #include "brave/ios/browser/brave_ads/ads_service_impl_ios.h"
@@ -45,6 +47,9 @@ AdsInternalsUI::AdsInternalsUI(web::WebUIIOS* web_ui, const GURL& url)
   // LoadDiagnosticLog`, so the Logs tab has nothing to show here.
   source->AddBoolean("logsSupported", false);
   source->AddBoolean("verboseLoggingEnabled", false);
+  source->AddBoolean(
+      "adsInternalsVerboseModeEnabled",
+      base::FeatureList::IsEnabled(brave_ads::kAdsInternalsVerboseModeFeature));
 
   // Bind Mojom Interface
   web_ui->GetWebState()->GetInterfaceBinderForMainFrame()->AddInterface(


### PR DESCRIPTION
Gates low-level debugging tabs behind a flag, off by default, on desktop, Android, and iOS.

Part of https://github.com/brave/brave-browser/issues/58803

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
