### PR TITLE
[Android] Media playback pause bug

### DIFF
--- a/android/javatests/BUILD.gn
+++ b/android/javatests/BUILD.gn
@@ -134,7 +134,10 @@ android_library("brave_test_java_org.chromium.components.browser_ui.media") {
   deps = [
     ":brave_test_java_helper",
     "//brave/components/browser_ui/media/android:java",
+    "//components/browser_ui/media/android:java",
+    "//content/public/android:content_full_java",
     "//content/public/android:content_java",
+    "//content/public/test/android:content_java_test_support",
     "//third_party/android_deps:org_mockito_mockito_core_java",
     "//third_party/mockito:mockito_java",
     "//ui/android:ui_no_recycler_view_java",

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -3168,6 +3168,7 @@ public class BytecodeTest {
         List<String> methods =
                 Arrays.asList(
                         "mediaSessionDestroyed",
+                        "mediaSessionDocumentChanged",
                         "mediaSessionStateChanged",
                         "mediaSessionMetadataChanged",
                         "mediaSessionActionsChanged",

--- a/android/javatests/org/chromium/components/browser_ui/media/BraveMediaSessionHelperTest.java
+++ b/android/javatests/org/chromium/components/browser_ui/media/BraveMediaSessionHelperTest.java
@@ -6,7 +6,13 @@
 package org.chromium.components.browser_ui.media;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
@@ -22,18 +28,20 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import org.chromium.base.CommandLine;
+import org.chromium.base.ThreadUtils;
 import org.chromium.base.test.util.Batch;
 import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
+import org.chromium.content.browser.MediaSessionImpl;
+import org.chromium.content_public.browser.NavigationHandle;
 import org.chromium.content_public.browser.WebContents;
+import org.chromium.content_public.browser.WebContentsObserver;
+import org.chromium.content_public.browser.test.NativeLibraryTestUtils;
 import org.chromium.ui.base.WindowAndroid;
 import org.chromium.url.GURL;
 
 import java.lang.ref.WeakReference;
 
-/**
- * Unit tests for the YouTube-aware predicates that {@link BraveMediaSessionHelper} uses to decide
- * whether to suppress media-session pause events.
- */
+/** Tests for media pause suppression and notification lifetime. */
 @Batch(Batch.PER_CLASS)
 @RunWith(ChromeJUnit4ClassRunner.class)
 public class BraveMediaSessionHelperTest {
@@ -44,7 +52,9 @@ public class BraveMediaSessionHelperTest {
 
     @Rule public MockitoRule mMockitoRule = MockitoJUnit.rule();
 
-    @Mock private WebContents mWebContents;
+    @Mock(extraInterfaces = WebContentsObserver.Observable.class)
+    private WebContents mWebContents;
+
     @Mock private WebContents mOtherWebContents;
     @Mock private WindowAndroid mWindowAndroid;
     @Mock private Activity mActivity;
@@ -203,5 +213,115 @@ public class BraveMediaSessionHelperTest {
         mockUrl("https://m.youtube.com/watch?v=dQw4w9WgXcQ");
 
         assertFalse(mHelper.shouldSuppressMediaPause(mWebContents));
+    }
+
+    @Test
+    @SmallTest
+    public void reloadClearsPreservedMediaNotification() {
+        NativeLibraryTestUtils.loadNativeLibraryNoBrowserProcess();
+        ThreadUtils.runOnUiThreadBlocking(
+                () -> {
+                    // Set up a YouTube Music page with background playback enabled.
+                    CommandLine.getInstance().appendSwitch(DISABLE_BACKGROUND_MEDIA_SUSPEND);
+                    MediaSessionHelper.Delegate delegate = mock(MediaSessionHelper.Delegate.class);
+                    MediaSessionHelper helper =
+                            createMediaSessionHelper(
+                                    "https://music.youtube.com/watch?v=qrZhOZyXc-I", delegate);
+                    try {
+                        // Simulate the initial page load.
+                        NavigationHandle navigation = mock(NavigationHandle.class);
+                        when(navigation.hasCommitted()).thenReturn(true);
+                        helper.mWebContentsObserver.didFinishNavigationInPrimaryMainFrame(
+                                navigation);
+
+                        // Start playback, then preserve controls when it becomes uncontrollable.
+                        helper.mMediaSessionObserver.mediaSessionStateChanged(true, false);
+                        helper.mMediaSessionObserver.mediaSessionStateChanged(false, true);
+                        assertFalse(helper.mNotificationInfoBuilder.build().isPaused);
+
+                        // A playlist URL change must keep the existing background controls.
+                        when(navigation.isSameDocument()).thenReturn(true);
+                        helper.mWebContentsObserver.didFinishNavigationInPrimaryMainFrame(
+                                navigation);
+                        assertFalse(helper.mNotificationInfoBuilder.build().isPaused);
+                        clearInvocations(delegate);
+
+                        // A navigation that does not commit must leave the current controls intact.
+                        when(navigation.isSameDocument()).thenReturn(false);
+                        when(navigation.hasCommitted()).thenReturn(false);
+                        helper.mWebContentsObserver.didFinishNavigationInPrimaryMainFrame(
+                                navigation);
+                        assertFalse(helper.mNotificationInfoBuilder.build().isPaused);
+
+                        // Later session updates must still preserve those controls.
+                        helper.mMediaSessionObserver.mediaSessionStateChanged(false, true);
+                        assertFalse(helper.mNotificationInfoBuilder.build().isPaused);
+                        clearInvocations(delegate);
+
+                        // A committed reload must clear the preserved controls.
+                        when(navigation.hasCommitted()).thenReturn(true);
+                        helper.mWebContentsObserver.didFinishNavigationInPrimaryMainFrame(
+                                navigation);
+                        assertNull(helper.mNotificationInfoBuilder);
+
+                        // A stale session update must not bring the old controls back.
+                        helper.mMediaSessionObserver.mediaSessionStateChanged(false, true);
+                        assertNull(helper.mNotificationInfoBuilder);
+                        verify(delegate, never()).showMediaNotification(any());
+                    } finally {
+                        helper.destroy();
+                        MediaSessionHelper.setOverriddenMediaSessionForTesting(null);
+                    }
+                });
+    }
+
+    @Test
+    @SmallTest
+    public void reloadKeepsBraveTalkMediaNotification() {
+        NativeLibraryTestUtils.loadNativeLibraryNoBrowserProcess();
+        ThreadUtils.runOnUiThreadBlocking(
+                () -> {
+                    // Brave Talk keeps controls even with background playback disabled.
+                    CommandLine.getInstance().removeSwitch(DISABLE_BACKGROUND_MEDIA_SUSPEND);
+                    MediaSessionHelper.Delegate delegate = mock(MediaSessionHelper.Delegate.class);
+                    MediaSessionHelper helper =
+                            createMediaSessionHelper("https://talk.brave.com/room", delegate);
+                    try {
+                        NavigationHandle navigation = mock(NavigationHandle.class);
+                        when(navigation.hasCommitted()).thenReturn(true);
+                        helper.mWebContentsObserver.didFinishNavigationInPrimaryMainFrame(
+                                navigation);
+
+                        // Talk does not require a prior controllable session to keep controls.
+                        helper.mMediaSessionObserver.mediaSessionStateChanged(false, true);
+                        assertFalse(helper.mNotificationInfoBuilder.build().isPaused);
+                        clearInvocations(delegate);
+
+                        // Reloading Talk must keep its controls, unlike the YouTube case.
+                        helper.mWebContentsObserver.didFinishNavigationInPrimaryMainFrame(
+                                navigation);
+                        assertFalse(helper.mNotificationInfoBuilder.build().isPaused);
+
+                        helper.mMediaSessionObserver.mediaSessionStateChanged(false, true);
+                        assertFalse(helper.mNotificationInfoBuilder.build().isPaused);
+                        verify(delegate, never()).hideMediaNotification();
+                    } finally {
+                        helper.destroy();
+                        MediaSessionHelper.setOverriddenMediaSessionForTesting(null);
+                    }
+                });
+    }
+
+    private MediaSessionHelper createMediaSessionHelper(
+            String url, MediaSessionHelper.Delegate delegate) {
+        mockUrl(url);
+        when(mWebContents.getVisibleUrl()).thenReturn(new GURL(url));
+        when(delegate.createMediaNotificationInfoBuilder())
+                .thenAnswer(
+                        invocation ->
+                                new MediaNotificationInfo.Builder().setInstanceId(1).setId(1));
+        // The Brave wrapper only handles MediaSessionImpl instances.
+        MediaSessionHelper.setOverriddenMediaSessionForTesting(mock(MediaSessionImpl.class));
+        return new MediaSessionHelper(mWebContents, delegate);
     }
 }

--- a/components/browser_ui/media/android/java/src/org/chromium/components/browser_ui/media/BraveMediaSessionHelper.java
+++ b/components/browser_ui/media/android/java/src/org/chromium/components/browser_ui/media/BraveMediaSessionHelper.java
@@ -229,6 +229,25 @@ public class BraveMediaSessionHelper implements MediaImageCallback {
         }
         ((MediaSessionImpl) mediaSession).removeObserver(mediaSessionObserver);
         return new MediaSessionObserver(mediaSession) {
+            // "Controllable" means Chromium can resume or suspend the session. Remember whether
+            // this document had such a session so stale updates after reload cannot create
+            // controls.
+            private boolean mHasControllableSession;
+
+            // True when Brave kept controls that Chromium would otherwise hide. A new document
+            // must clear these old controls, except for the existing Brave Talk behavior.
+            private boolean mIsPreservingMediaSession;
+
+            @Override
+            public void mediaSessionDocumentChanged() {
+                boolean wasPreservingMediaSession = mIsPreservingMediaSession;
+                mHasControllableSession = false;
+                mIsPreservingMediaSession = false;
+                if (wasPreservingMediaSession && !isBraveTalk(getMediaSessionWebContents())) {
+                    mediaSessionObserver.mediaSessionStateChanged(false, true);
+                }
+            }
+
             @Override
             public void mediaSessionDestroyed() {
                 mediaSessionObserver.mediaSessionDestroyed();
@@ -236,6 +255,8 @@ public class BraveMediaSessionHelper implements MediaImageCallback {
 
             @Override
             public void mediaSessionStateChanged(boolean isControllable, boolean isPaused) {
+                if (isControllable) mHasControllableSession = true;
+                mIsPreservingMediaSession = false;
                 // Keep the Android media controls alive for Brave Talk, background YouTube audio,
                 // and the active Brave-managed YouTube PiP session when the page transiently
                 // reports itself as not controllable. For Brave Talk and background playback the
@@ -245,7 +266,9 @@ public class BraveMediaSessionHelper implements MediaImageCallback {
                 // right command after wake/restore transitions.
                 if (!isControllable) {
                     WebContents webContents = getMediaSessionWebContents();
-                    if (shouldSuppressMediaPause(webContents)) {
+                    if (shouldSuppressMediaPause(webContents)
+                            && (mHasControllableSession || isBraveTalk(webContents))) {
+                        mIsPreservingMediaSession = true;
                         isControllable = true;
                         if (shouldForcePlayingState(webContents)) {
                             isPaused = false;

--- a/patches/components-browser_ui-media-android-java-src-org-chromium-components-browser_ui-media-MediaSessionHelper.java.patch
+++ b/patches/components-browser_ui-media-android-java-src-org-chromium-components-browser_ui-media-MediaSessionHelper.java.patch
@@ -1,0 +1,12 @@
+diff --git a/components/browser_ui/media/android/java/src/org/chromium/components/browser_ui/media/MediaSessionHelper.java b/components/browser_ui/media/android/java/src/org/chromium/components/browser_ui/media/MediaSessionHelper.java
+index 9a0909b16a5730c0f1d4d100813f299c764a5bfd..a6c34c1da666a9d4438eee0e975df255eff89373 100644
+--- a/components/browser_ui/media/android/java/src/org/chromium/components/browser_ui/media/MediaSessionHelper.java
++++ b/components/browser_ui/media/android/java/src/org/chromium/components/browser_ui/media/MediaSessionHelper.java
+@@ -438,6 +438,7 @@ public class MediaSessionHelper implements MediaImageCallback {
+                 new WebContentsObserver(webContents) {
+                     @Override
+                     public void didFinishNavigationInPrimaryMainFrame(NavigationHandle navigation) {
++                        if (navigation.hasCommitted() && !navigation.isSameDocument() && mMediaSessionObserver != null) mMediaSessionObserver.mediaSessionDocumentChanged();
+                         if (!navigation.hasCommitted() || navigation.isSameDocument()) {
+                             return;
+                         }

--- a/patches/content-public-android-java-src-org-chromium-content_public-browser-MediaSessionObserver.java.patch
+++ b/patches/content-public-android-java-src-org-chromium-content_public-browser-MediaSessionObserver.java.patch
@@ -1,0 +1,13 @@
+diff --git a/content/public/android/java/src/org/chromium/content_public/browser/MediaSessionObserver.java b/content/public/android/java/src/org/chromium/content_public/browser/MediaSessionObserver.java
+index f54849ba460cde8a99d84273b5c529808b724dec..eacba4f202709afcb54eff049bd5af9fa2772998 100644
+--- a/content/public/android/java/src/org/chromium/content_public/browser/MediaSessionObserver.java
++++ b/content/public/android/java/src/org/chromium/content_public/browser/MediaSessionObserver.java
+@@ -20,6 +20,8 @@ import java.util.Set;
+  */
+ @NullMarked
+ public abstract class MediaSessionObserver {
++    /** Called only when a new document commits in the primary main frame. */
++    public void mediaSessionDocumentChanged() {}
+     private @Nullable MediaSession mMediaSession;
+ 
+     /** Construct a MediaSessionObserver and start observing |mediaSession|. */

--- a/rewrite/components/browser_ui/media/android/java/src/org/chromium/components/browser_ui/media/MediaSessionHelper.java.yaml
+++ b/rewrite/components/browser_ui/media/android/java/src/org/chromium/components/browser_ui/media/MediaSessionHelper.java.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Notify the media observer when a new document commits.
+
+      Allows Brave clear stale media controls after a reload or navigation.
+      Same-document playlist changes and cancelled navigations keep their controls.
+    regex:
+      re_pattern:
+        '(public void didFinishNavigationInPrimaryMainFrame\([^)]*\) \{)'
+      replace: |-
+        \1
+                                if (navigation.hasCommitted() && !navigation.isSameDocument() && mMediaSessionObserver != null) mMediaSessionObserver.mediaSessionDocumentChanged();

--- a/rewrite/content/public/android/java/src/org/chromium/content_public/browser/MediaSessionObserver.java.yaml
+++ b/rewrite/content/public/android/java/src/org/chromium/content_public/browser/MediaSessionObserver.java.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Add a document-change callback.
+
+      This callback is used to reset playback state from the previous document.
+    regex:
+      re_pattern: '(public abstract class MediaSessionObserver \{)'
+      replace: |-
+        \1
+            /** Called only when a new document commits in the primary main frame. */
+            public void mediaSessionDocumentChanged() {}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/54893.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

## Overview

Reloading a YouTube Music page stops playback but can leave a stale Android media notification. Brave keeps media controls during temporary session changes to support background playback, PiP, and Brave Talk. Those controls can outlive the document they belong to.

This PR clears preserved controls when a new document commits, and prevents later stale session updates from bringing them back. Same-document and uncommitted navigations keep the current controls. 

Much of the existing Brave-specific media playback code ensures Brave Talk audio and microphone access work when the browser is in the background or the phone is locked, even with background playback disabled. I tested these cases, including two-way audio after five minutes locked, and this PR preserves the existing behavior in my testing.

## Commits

**Add media session tests (Commit 1):**

- `reloadClearsPreservedMediaNotification()`: a red 🔴 test demonstrating the current issue with a stale media playback notification persisting when reloading the page. This test will turn green as the fix is applied in Commit 2.
- `reloadKeepsBraveTalkMediaNotification()`: a green 🟢 test covering Talk's notification preservation across reload.

**Clear stale Android media controls on navigation (Commit 2):**

- `MediaSessionObserver`: add `mediaSessionDocumentChanged()`.
- `MediaSessionHelper`: call it when a different document commits in the primary main frame.
- `BraveMediaSessionHelper`: clear the previous document's preserved controls and reject stale updates, except for Brave Talk.
- `BytecodeTest`: add the callback to the allowed method list.

Commit 2 turns the red 🔴 test green 🟢.

## Testing

This was manually tested on my Pixel 10 Pro / Android 17, branch debug build `1.97.0` / Chromium `153.0.8010.28`. I manually verified audio and microphone results.

- 🟢 YouTube Music reload clears audio/notification; fresh playback works.
- 🟢 Brave Talk two-way audio works in foreground, background, and after five minutes the Android device locked with background playback disabled. Reload/rejoin restores audio as expected.
🟢 Selecting another playlist item starts the new track. Cancelling the browser’s reload confirmation leaves the current track playing.
- 🟢 Background playlist advances while locked; Android notification Pause/Play works.
- 🟢 With background playback off, locking the phone pauses PiP playback. After unlocking, the Android notification’s Play button resumes it
- 🟢 PiP with background playback enabled resumes through ADB media Play while locked, then advances to the next track.

Note: during this testing, this issue was discovered: [[Android] PiP playback pauses on lock screen under Chromium 153](https://github.com/brave/brave-browser/issues/58827). I will look at this in a separate PR, and IMO it should not block this PR from being merged.

## Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/eb0c3e9b-782e-4f42-8551-7f6e4546f423" controls></video> | <video src="https://github.com/user-attachments/assets/7596c42e-5aa7-4384-9a33-b7a153b61f04" controls></video> |

