### PR TITLE
Auto-fix checkouts that point to non-existent git cache dirs.

### DIFF
--- a/build/commands/lib/staleCheckoutUtils.ts
+++ b/build/commands/lib/staleCheckoutUtils.ts
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import config from './config.ts'
+import * as Log from './log.ts'
+import util from './util.js'
+
+// Matches `'<entry>': '<url>',` and `'<entry>': None,` lines.
+const kEntryRegex =
+  /^\s*['"](?<entry>[^'"]+)['"]\s*:\s*(?:['"](?<url>[^'"]*)['"]|None)\s*,?\s*$/gm
+
+function readGclientEntries(): string[] {
+  const entriesFile = path.join(config.rootDir, '.gclient_entries')
+  if (!fs.existsSync(entriesFile)) {
+    return []
+  }
+
+  const content = fs.readFileSync(entriesFile, 'utf8')
+  const entries: string[] = []
+  for (const match of content.matchAll(kEntryRegex)) {
+    const { entry, url } = match.groups ?? {}
+    if (entry && url) {
+      entries.push(entry)
+    }
+  }
+  return entries
+}
+
+// Resolves the actual .git directory, handling the `gitdir:` indirection used
+// by worktrees and submodules.
+function resolveGitDir(checkoutDir: string): string | null {
+  const dotGit = path.join(checkoutDir, '.git')
+  let stat
+  try {
+    stat = fs.statSync(dotGit)
+  } catch {
+    return null
+  }
+
+  if (stat.isDirectory()) {
+    return dotGit
+  }
+
+  const gitDir = /^gitdir:\s*(.+)$/m.exec(fs.readFileSync(dotGit, 'utf8'))?.[1]
+  if (!gitDir) {
+    return null
+  }
+  return path.resolve(checkoutDir, gitDir.trim())
+}
+
+function isLocalPath(url: string): boolean {
+  return url.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(url)
+}
+
+// Returns a reason string if the checkout references a local git cache that no
+// longer exists on disk, otherwise null.
+function getMissingGitCacheReason(checkoutDir: string): string | null {
+  const gitDir = resolveGitDir(checkoutDir)
+  if (!gitDir) {
+    return null
+  }
+
+  const originUrl = util.runGit(
+    checkoutDir,
+    ['config', '--get', 'remote.origin.url'],
+    true,
+    { stdio: 'pipe', skipLogging: true },
+  )
+  if (originUrl && isLocalPath(originUrl) && !fs.existsSync(originUrl)) {
+    return `origin ${originUrl} is missing`
+  }
+
+  const alternatesFile = path.join(gitDir, 'objects', 'info', 'alternates')
+  if (fs.existsSync(alternatesFile)) {
+    const missingAlternate = fs
+      .readFileSync(alternatesFile, 'utf8')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((objectsDir) => path.resolve(gitDir, objectsDir))
+      .find((objectsDir) => !fs.existsSync(objectsDir))
+    if (missingAlternate) {
+      return `alternate ${missingAlternate} is missing`
+    }
+  }
+
+  return null
+}
+
+// Removes checkouts listed in .gclient_entries that point at a git cache which
+// has been deleted. Such checkouts make gclient fail with errors like
+// "unable to normalize alternate object path" and "fatal: bad object <sha>",
+// and the only way to recover is to re-clone them from scratch.
+export function removeStaleCheckouts(): void {
+  let removedCount = 0
+  for (const entry of readGclientEntries()) {
+    // Entries may be in the `<path>:<cipd package>` form.
+    const checkoutDir = path.resolve(config.rootDir, entry.replace(/:.*$/, ''))
+    if (!fs.existsSync(checkoutDir)) {
+      continue
+    }
+
+    // The main Chromium and brave-core checkouts are never removed, they hold
+    // local state that must not be lost.
+    if (
+      checkoutDir === path.resolve(config.srcDir)
+      || checkoutDir === path.resolve(config.braveCoreDir)
+    ) {
+      continue
+    }
+
+    const reason = getMissingGitCacheReason(checkoutDir)
+    if (!reason) {
+      continue
+    }
+
+    Log.warn(`Removing stale checkout ${checkoutDir}: ${reason}`)
+    fs.rmSync(checkoutDir, { recursive: true, force: true })
+    removedCount++
+  }
+
+  if (removedCount > 0) {
+    Log.status(
+      `Removed ${removedCount} stale checkout(s), they will be re-cloned`,
+    )
+  }
+}

--- a/build/commands/scripts/sync.ts
+++ b/build/commands/scripts/sync.ts
@@ -15,6 +15,7 @@ import * as Log from '../lib/log.ts'
 import depotTools from '../lib/depotTools.js'
 import { isCI } from '../lib/ciDetect.ts'
 import syncUtil from '../lib/syncUtils.js'
+import { removeStaleCheckouts } from '../lib/staleCheckoutUtils.ts'
 import sisoUtils from '../lib/sisoUtils.js'
 
 program
@@ -120,6 +121,10 @@ async function sync(options) {
   if (isCI) {
     options.delete_unused_deps = true
   }
+
+  Log.progressScope('check stale checkouts', () => {
+    removeStaleCheckouts()
+  })
 
   Log.progressScope('gclient sync', () => {
     const didSyncChromium = syncUtil.syncChromium(options)


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Fix rare, but annoying issue like
```
Error: Command 'git -c core.quotePath=false diff --name-status d06d2a6d42baf6c0c91cacc28df2542a911d05fe' returned non-zero exit status 128 in /Users/user/brave/5/src/third_party/libgifcodec
error: unable to normalize alternate object path: /Users/user/.gitcache/skia.googlesource.com-libgifcodec/objects
error: unable to normalize alternate object path: /Users/user/.gitcache/skia.googlesource.com-libgifcodec/objects
error: unable to normalize alternate object path: /Users/user/.gitcache/skia.googlesource.com-libgifcodec/objects
error: unable to normalize alternate object path: /Users/user/.gitcache/skia.googlesource.com-libgifcodec/objects
fatal: bad object d06d2a6d42baf6c0c91cacc28df2542a911d05fe
```

that happens when a gitcache was re-created and old checkout can't find the directories in it that existed before. Such checkout cannot be sync-ed without removing those stale directories.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
