### PR TITLE
Fixed pin to taskbar on Windows

### DIFF
--- a/browser/brave_shell_integration_win.cc
+++ b/browser/brave_shell_integration_win.cc
@@ -20,12 +20,14 @@
 #include "base/strings/string_util.h"
 #include "base/task/thread_pool.h"
 #include "base/win/shortcut.h"
+#include "base/win/windows_version.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/profiles/profile_attributes_entry.h"
 #include "chrome/browser/profiles/profile_manager.h"
 #include "chrome/browser/profiles/profile_shortcut_manager_win.h"
 #include "chrome/browser/shell_integration_win.h"
+#include "chrome/browser/win/taskbar_manager.h"
 #include "chrome/installer/util/install_util.h"
 #include "chrome/installer/util/shell_util.h"
 #include "chrome/installer/util/taskbar_util.h"
@@ -145,6 +147,22 @@ bool PinToTaskbarImpl(const base::FilePath& profile_path,
   return PinShortcutToTaskbar(shortcut_path->file_path());
 }
 
+// Microsoft blocked pinning via IPinnedList3 in Windows 11 24H2. From that
+// version on, the TaskbarManager limited access feature is the only way to pin,
+// and it's what shows the OS system notification.
+bool ShouldUseLimitedAccessFeature() {
+  return base::win::GetVersion() >= base::win::Version::WIN11_24H2;
+}
+
+void DoPinToTaskbarWithLimitedAccessFeature(
+    base::OnceCallback<void(bool)> callback) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  browser_util::PinAppToTaskbar(
+      ShellUtil::GetBrowserModelId(InstallUtil::IsPerUserInstall()),
+      browser_util::PinAppToTaskbarChannel::kSettingsPage, std::move(callback));
+}
+
 void DoPinToTaskbar(const base::FilePath& profile_path,
                     base::OnceCallback<void(bool)> callback) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
@@ -191,6 +209,10 @@ void PinToTaskbar(Profile* profile,
         if (succeeded && is_pinned_to_taskbar) {
           // Early return. Already pinned.
           std::move(result_callback).Run(true);
+          return;
+        }
+        if (ShouldUseLimitedAccessFeature()) {
+          DoPinToTaskbarWithLimitedAccessFeature(std::move(result_callback));
           return;
         }
         DoPinToTaskbar(profile_path, std::move(result_callback));

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -752,6 +752,7 @@ if (is_win) {
 
   brave_chrome_browser_deps += [
     "//brave/components/windows_recall",
+    "//chrome/browser/win",
     "//chrome/install_static:install_static_util",
     "//chrome/installer/util:with_no_strings",
   ]


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58830

Our approach(using `IPinnedList3`) was broken since Windows 11 24H2.
Used `browser_util::PinAppToTaskbar()` for affected Windows version.

Didn't add test as its simply called upstream api and it's difficult to test because pinning only works for installed one.
Verified with official test build from https://ci.brave.com/job/test-brave-browser-build-windows-x64/2001/


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
