### PR TITLE
[iOS] Follow appearance for night mode

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
@@ -336,6 +336,14 @@ extension SceneDelegate {
       }
       .store(in: &cancellables)
 
+    Preferences.General.nightModeFollowsAppearance.objectWillChange
+      .receive(on: RunLoop.main)
+      .sink { [weak self, weak windowScene] _ in
+        guard let self = self, let windowScene else { return }
+        self.updateTheme(for: windowScene)
+      }
+      .store(in: &cancellables)
+
     browserViewController.privateBrowsingManager.$isPrivateBrowsing
       .removeDuplicates()
       .receive(on: RunLoop.main)
@@ -686,7 +694,7 @@ extension SceneDelegate {
 
     // The expected appearance theme should be dark mode when night mode is enabled for websites
     let themeValue =
-      Preferences.General.nightModeEnabled.value
+      Preferences.General.nightModeSetting == .on
       ? DefaultTheme.dark.rawValue : Preferences.General.themeNormalMode.value
 
     let themeOverride =

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Menu.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Menu.swift
@@ -234,11 +234,12 @@ extension BrowserViewController {
       },
       .init(
         id: .toggleNightMode,
-        state: Preferences.General.nightModeEnabled.value
+        state: tab?.nightMode?.isEnabled ?? false
       ) { @MainActor action in
         var actionCopy = action
-        Preferences.General.nightModeEnabled.value.toggle()
-        actionCopy.state = Preferences.General.nightModeEnabled.value
+        let isEnabled = !(action.state ?? false)
+        Preferences.General.nightModeSetting = isEnabled ? .on : .off
+        actionCopy.state = isEnabled
         return .updateAction(actionCopy)
       },
     ]

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -106,7 +106,12 @@ extension BrowserViewController: TabManagerDelegate {
     tab.cosmeticFilteringTabHelper = .init(tab: tab)
     tab.logins = .init(tab: tab, passwordAPI: profileController.passwordAPI)
     tab.protectionStats = .init(tab: tab)
-    tab.nightMode = .init(tab: tab)
+    tab.nightMode = .init(
+      tab: tab,
+      isDarkAppearance: { [weak self] in
+        self?.traitCollection.userInterfaceStyle == .dark
+      }
+    )
     // reader mode
     tab.readerMode = .init(tab: tab, readerModeCache: ReaderModeScriptHandler.cache(for: tab))
     tab.readerMode?.onStateChanged = { [weak self, weak tab] in

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -971,6 +971,11 @@ public class BrowserViewController: UIViewController {
     super.viewDidLoad()
     view.backgroundColor = UIColor(braveSystemName: .containerBackground)
 
+    registerForTraitChanges([UITraitUserInterfaceStyle.self]) {
+      (self: BrowserViewController, _: UITraitCollection) in
+      self.tabManager.selectedTab?.nightMode?.refreshNightMode()
+    }
+
     // Add layout guides
     view.addLayoutGuide(pageOverlayLayoutGuide)
     view.addLayoutGuide(headerHeightLayoutGuide)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/NightModeTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/NightModeTabHelper.swift
@@ -20,15 +20,18 @@ extension TabDataValues {
 
 class NightModeTabHelper: TabObserver {
   private weak var tab: (any TabState)?
+  private let isDarkAppearance: () -> Bool
   private var prefObserver: PrefObserver?
 
-  init(tab: some TabState) {
+  init(tab: some TabState, isDarkAppearance: @escaping () -> Bool) {
     self.tab = tab
+    self.isDarkAppearance = isDarkAppearance
 
     let prefObserver = PrefObserver { [weak self] in
-      self?.isEnabled = Preferences.General.nightModeEnabled.value
+      self?.refreshNightMode()
     }
     Preferences.General.nightModeEnabled.observe(from: prefObserver)
+    Preferences.General.nightModeFollowsAppearance.observe(from: prefObserver)
     self.prefObserver = prefObserver
 
     tab.addObserver(self)
@@ -38,15 +41,10 @@ class NightModeTabHelper: TabObserver {
     tab?.removeObserver(self)
   }
 
-  private var isEnabled: Bool = Preferences.General.nightModeEnabled.value {
-    didSet {
-      guard let url = tab?.visibleURL else { return }
-      if isEnabled, !Self.isNightModeBlockedURL(url) {
-        enable()
-      } else {
-        disable()
-      }
-    }
+  var isEnabled: Bool {
+    return Preferences.General.nightModeSetting.isEnabled(
+      whenAppearanceIsDark: isDarkAppearance()
+    )
   }
 
   private func enable() {
@@ -88,13 +86,22 @@ class NightModeTabHelper: TabObserver {
     return siteList.contains(domainName)
   }
 
-  private func refreshNightMode() {
-    isEnabled = Preferences.General.nightModeEnabled.value
+  func refreshNightMode() {
+    guard let url = tab?.visibleURL else { return }
+    if isEnabled, !Self.isNightModeBlockedURL(url) {
+      enable()
+    } else {
+      disable()
+    }
   }
 
   // MARK: - TabObserver
 
   func tabDidCommitNavigation(_ tab: some TabState) {
+    refreshNightMode()
+  }
+
+  func tabWasShown(_ tab: some TabState) {
     refreshNightMode()
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
@@ -72,6 +72,31 @@ extension Preferences {
       key: "general.night-mode-enabled",
       default: false
     )
+    /// Whether Night Mode follows the effective browser appearance
+    public static let nightModeFollowsAppearance = Option<Bool>(
+      key: "general.night-mode-follows-appearance",
+      default: false
+    )
+    public static var nightModeSetting: NightModeSetting {
+      get {
+        NightModeSetting(
+          isEnabled: nightModeEnabled.value,
+          followsAppearance: nightModeFollowsAppearance.value
+        )
+      }
+      set {
+        switch newValue {
+        case .off:
+          nightModeEnabled.value = false
+          nightModeFollowsAppearance.value = false
+        case .on:
+          nightModeEnabled.value = true
+          nightModeFollowsAppearance.value = false
+        case .followAppearance:
+          nightModeFollowsAppearance.value = true
+        }
+      }
+    }
     /// Specifies whether the bookmark button is present on toolbar
     public static let toolbarShortcutButton = Option<Int?>(
       key: "general.show-bookmark-toolbar-shortcut",

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -1326,17 +1326,44 @@ class SettingsViewController: TableViewController, BraveAccountAuthenticationObs
       optionsViewController.headerText = Strings.themesDisplayBrightness
       optionsViewController.navigationItem.title = Strings.themesDisplayBrightness
 
+      let nightModeSectionUUID = UUID().uuidString
+      let nightModeRowUUID = UUID().uuidString
+      var nightModeRow = Row(
+        text: Strings.NightMode.settingsTitle,
+        detailText: Preferences.General.nightModeSetting.displayString,
+        image: UIImage(braveSystemNamed: "leo.theme.dark"),
+        accessory: .disclosureIndicator,
+        cellClass: MultilineSubtitleCell.self,
+        uuid: nightModeRowUUID
+      )
+      nightModeRow.selection = { [unowned optionsViewController] in
+        let nightModeOptionsViewController = OptionSelectionViewController<NightModeSetting>(
+          options: NightModeSetting.allCases,
+          selectedOption: Preferences.General.nightModeSetting,
+          optionChanged: { _, option in
+            Preferences.General.nightModeSetting = option
+            if let indexPath = optionsViewController.dataSource.indexPath(
+              rowUUID: nightModeRowUUID,
+              sectionUUID: nightModeSectionUUID
+            ) {
+              optionsViewController.dataSource.sections[indexPath.section].rows[indexPath.row]
+                .detailText = option.displayString
+            }
+          }
+        )
+        nightModeOptionsViewController.headerText = Strings.NightMode.settingsTitle
+        nightModeOptionsViewController.footerText = Strings.NightMode.sectionDescription
+        nightModeOptionsViewController.navigationItem.title = Strings.NightMode.settingsTitle
+        optionsViewController.navigationController?.pushViewController(
+          nightModeOptionsViewController,
+          animated: true
+        )
+      }
+
       let nightModeSection = Section(
         header: .title(Strings.NightMode.sectionTitle),
-        rows: [
-          .boolRow(
-            title: Strings.NightMode.settingsTitle,
-            detailText: Strings.NightMode.settingsDescription,
-            option: Preferences.General.nightModeEnabled,
-            image: UIImage(braveSystemNamed: "leo.theme.dark")
-          )
-        ],
-        footer: .title(Strings.NightMode.sectionDescription)
+        rows: [nightModeRow],
+        uuid: nightModeSectionUUID
       )
 
       optionsViewController.dataSource.sections.append(nightModeSection)

--- a/ios/brave-ios/Sources/Brave/Frontend/Widgets/Themes/Theme.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Widgets/Themes/Theme.swift
@@ -39,3 +39,33 @@ public enum DefaultTheme: String, RepresentableOptionType {
     }
   }
 }
+
+public enum NightModeSetting: String, CaseIterable, RepresentableOptionType {
+  case off
+  case on
+  case followAppearance
+
+  init(isEnabled: Bool, followsAppearance: Bool) {
+    if followsAppearance {
+      self = .followAppearance
+    } else {
+      self = isEnabled ? .on : .off
+    }
+  }
+
+  func isEnabled(whenAppearanceIsDark appearanceIsDark: Bool) -> Bool {
+    switch self {
+    case .off: return false
+    case .on: return true
+    case .followAppearance: return appearanceIsDark
+    }
+  }
+
+  public var displayString: String {
+    switch self {
+    case .off: return Strings.NightMode.offOption
+    case .on: return Strings.NightMode.onOption
+    case .followAppearance: return Strings.NightMode.followAppearanceOption
+    }
+  }
+}

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -7798,12 +7798,33 @@ extension Strings {
       comment:
         "A table cell subtitle for Night Mode - explanatory element for the toggle preference"
     )
+    public static let offOption = NSLocalizedString(
+      "nightMode.offOption",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Off",
+      comment: "Selection that disables Night Mode"
+    )
+    public static let onOption = NSLocalizedString(
+      "nightMode.onOption",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "On",
+      comment: "Selection that always enables Night Mode"
+    )
+    public static let followAppearanceOption = NSLocalizedString(
+      "nightMode.followAppearanceOption",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Follow Appearance",
+      comment: "Selection that enables Night Mode when the browser appearance is dark"
+    )
     public static let sectionDescription = NSLocalizedString(
       "nightMode.sectionDescription",
       tableName: "BraveShared",
       bundle: .module,
       value:
-        "Night mode will affect website appearance and general system appearance at the same time.",
+        "Follow Appearance enables Night Mode whenever the browser appearance is dark. When Appearance is Automatic, it follows the iOS appearance.",
       comment:
         "A table cell subtitle for Night Mode - explanatory element for the toggle preference"
     )

--- a/ios/brave-ios/Tests/ClientTests/DarkModeTests.swift
+++ b/ios/brave-ios/Tests/ClientTests/DarkModeTests.swift
@@ -10,6 +10,28 @@ import XCTest
 
 class DarkModeTests: XCTestCase {
 
+  func testNightModeSettingFromStoredPreferences() {
+    XCTAssertEqual(NightModeSetting(isEnabled: false, followsAppearance: false), .off)
+    XCTAssertEqual(NightModeSetting(isEnabled: true, followsAppearance: false), .on)
+    XCTAssertEqual(
+      NightModeSetting(isEnabled: false, followsAppearance: true),
+      .followAppearance
+    )
+    XCTAssertEqual(
+      NightModeSetting(isEnabled: true, followsAppearance: true),
+      .followAppearance
+    )
+  }
+
+  func testNightModeSettingEffectiveState() {
+    XCTAssertFalse(NightModeSetting.off.isEnabled(whenAppearanceIsDark: false))
+    XCTAssertFalse(NightModeSetting.off.isEnabled(whenAppearanceIsDark: true))
+    XCTAssertTrue(NightModeSetting.on.isEnabled(whenAppearanceIsDark: false))
+    XCTAssertTrue(NightModeSetting.on.isEnabled(whenAppearanceIsDark: true))
+    XCTAssertFalse(NightModeSetting.followAppearance.isEnabled(whenAppearanceIsDark: false))
+    XCTAssertTrue(NightModeSetting.followAppearance.isEnabled(whenAppearanceIsDark: true))
+  }
+
   func testNightModeBlockedURL() {
     let blockList = [
       "twitter.com",


### PR DESCRIPTION
Adds a "Follow Appearance" for Night Mode on iOS. When selected, Night Mode follows Brave’s Light, Dark, or Automatic appearance, including changes to the system appearance. The browser-menu toggle continues to force Night Mode on or off globally.

Addresses the request in https://github.com/brave/brave-browser/issues/42012