### PR TITLE
[ai_chat] Serve Leo workspace files from a service worker

### DIFF
--- a/browser/ui/webui/ai_chat/leo_workspace_ui.cc
+++ b/browser/ui/webui/ai_chat/leo_workspace_ui.cc
@@ -33,13 +33,18 @@ void CreateAndAddWorkspaceDataSource(content::BrowserContext* browser_context) {
   webui::SetupWebUIDataSource(source, kAiChatUiGenerated,
                               IDR_AI_CHAT_LEO_WORKSPACE_HTML);
 
+  // Not bundled, so it is not in |kAiChatUiGenerated|, and it has to keep the
+  // path the worker is registered for.
+  source->AddResourcePath(kAIChatLeoWorkspaceServiceWorkerScript,
+                          IDR_AI_CHAT_LEO_WORKSPACE_SERVICE_WORKER_JS);
+
   // This page runs its own first-party module bundle only. No network, no
   // frames, no embedding by other pages. The FileSystemDirectoryHandle it will
   // operate on is delivered out-of-band (launchQueue), not fetched.
   //
-  // A service worker registered for this host is not served by this data
-  // source and does not get this policy: its responses carry headers of their
-  // own.
+  // This is the whole policy for this data source, and the folder's files do
+  // not get it: they are served by the service worker, whose responses carry
+  // headers of their own. See workspace_service_worker.h.
   source->OverrideContentSecurityPolicy(
       network::mojom::CSPDirectiveName::DefaultSrc, "default-src 'none';");
   source->OverrideContentSecurityPolicy(

--- a/components/ai_chat/content/browser/BUILD.gn
+++ b/components/ai_chat/content/browser/BUILD.gn
@@ -31,6 +31,8 @@ static_library("browser") {
     "page_content_fetcher.h",
     "workspace_associated_content.cc",
     "workspace_associated_content.h",
+    "workspace_service_worker.cc",
+    "workspace_service_worker.h",
   ]
 
   if (enable_pdf) {

--- a/components/ai_chat/content/browser/DEPS
+++ b/components/ai_chat/content/browser/DEPS
@@ -28,6 +28,7 @@ include_rules = [
   "+third_party/blink/public/mojom/content_extraction",
   "+third_party/blink/public/mojom/file_system_access",
   "+third_party/blink/public/mojom/permissions",
+  "+third_party/blink/public/mojom/service_worker",
   "+third_party/blink/public/mojom/web_launch",
   "+third_party/skia/include",
   "+ui/base",

--- a/components/ai_chat/content/browser/workspace_associated_content.cc
+++ b/components/ai_chat/content/browser/workspace_associated_content.cc
@@ -14,6 +14,7 @@
 #include "base/time/time.h"
 #include "base/uuid.h"
 #include "brave/components/ai_chat/content/browser/content_tool.h"
+#include "brave/components/ai_chat/content/browser/workspace_service_worker.h"
 #include "brave/components/ai_chat/core/common/constants.h"
 #include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "components/content_settings/core/common/content_settings.h"
@@ -51,6 +52,11 @@ WorkspaceAssociatedContent::WorkspaceAssociatedContent(
   set_uuid(uuid);
   set_url(url);
   SetTitle(u"Workspace");
+
+  // Serves this folder's files at <this url>/files/, by asking the page below
+  // to read them. Registered per workspace, but scoped to the whole host, so
+  // this is a no-op after the first one.
+  RegisterWorkspaceServiceWorker(browser_context);
 
   // Hidden, headless background WebContents that hosts the workspace page.
   content::WebContents::CreateParams params(browser_context);

--- a/components/ai_chat/content/browser/workspace_service_worker.cc
+++ b/components/ai_chat/content/browser/workspace_service_worker.cc
@@ -1,0 +1,57 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/ai_chat/content/browser/workspace_service_worker.h"
+
+#include "base/functional/bind.h"
+#include "base/logging.h"
+#include "base/strings/strcat.h"
+#include "brave/components/ai_chat/core/common/constants.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/global_routing_id.h"
+#include "content/public/browser/service_worker_context.h"
+#include "content/public/browser/storage_partition.h"
+#include "third_party/blink/public/common/storage_key/storage_key.h"
+#include "third_party/blink/public/mojom/service_worker/service_worker_registration_options.mojom.h"
+#include "url/gurl.h"
+#include "url/origin.h"
+
+namespace ai_chat {
+
+namespace {
+
+void OnRegistered(blink::ServiceWorkerStatusCode status) {
+  if (status != blink::ServiceWorkerStatusCode::kOk) {
+    LOG(ERROR) << "Leo workspace service worker registration failed: "
+               << blink::ServiceWorkerStatusToString(status);
+  }
+}
+
+}  // namespace
+
+void RegisterWorkspaceServiceWorker(content::BrowserContext* browser_context) {
+  CHECK(browser_context);
+
+  const GURL scope(kAIChatLeoWorkspaceUIURL);
+  blink::mojom::ServiceWorkerRegistrationOptions options;
+  options.scope = scope;
+  // The script is shipped as a resource of the same data source that serves the
+  // workspace page, and is not bundled, so it needs no module resolution.
+  options.type = blink::mojom::ScriptType::kClassic;
+  // The script only ever changes with the browser, and there is no network to
+  // revalidate against.
+  options.update_via_cache =
+      blink::mojom::ServiceWorkerUpdateViaCache::kImports;
+
+  content::ServiceWorkerContext* service_worker_context =
+      browser_context->GetDefaultStoragePartition()->GetServiceWorkerContext();
+  service_worker_context->RegisterServiceWorker(
+      GURL(base::StrCat(
+          {kAIChatLeoWorkspaceUIURL, kAIChatLeoWorkspaceServiceWorkerScript})),
+      blink::StorageKey::CreateFirstParty(url::Origin::Create(scope)), options,
+      content::GlobalRenderFrameHostId(), base::BindOnce(&OnRegistered));
+}
+
+}  // namespace ai_chat

--- a/components/ai_chat/content/browser/workspace_service_worker.h
+++ b/components/ai_chat/content/browser/workspace_service_worker.h
@@ -1,0 +1,43 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_WORKSPACE_SERVICE_WORKER_H_
+#define BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_WORKSPACE_SERVICE_WORKER_H_
+
+namespace content {
+class BrowserContext;
+}
+
+namespace ai_chat {
+
+// Registers the service worker that serves workspace folders, scoped to the
+// whole leo-workspace host. It answers requests under
+// chrome-untrusted://leo-workspace/<uuid>/files/ by asking that workspace's
+// page for the file, so the folder is read through the page's
+// FileSystemDirectoryHandle rather than by path in the browser.
+//
+// Serving from a worker is what lets a folder's files be given a response of
+// their own: the worker sets each one's Content-Type, and scopes each one's CSP
+// to the folder it came from. A WebUI data source can do neither - its MIME
+// types come from a fixed list that answers "text/html" for anything else, and
+// its CSP is per-source, so it is shared with the page.
+//
+// SECURITY: served files share this origin with the workspace pages, which are
+// auto-granted File System Access read/write and are the only origin allowed
+// navigator.modelContext, so model-authored script served from here runs with
+// the latter. Sandboxing the response is not the answer: an opaque origin
+// cannot be controlled by a service worker, so a sandboxed page's own
+// subresources would never reach this worker.
+// TODO(https://github.com/brave/brave-browser/issues/58792): Support dynamic
+// origins from WebUI, so each workspace's files get an origin of their own.
+//
+// Registration is idempotent, and browser-side because
+// OriginCanRegisterServiceWorkerFromJavascript() refuses WebUI schemes: the
+// page cannot register (or unregister) a worker of its own.
+void RegisterWorkspaceServiceWorker(content::BrowserContext* browser_context);
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_WORKSPACE_SERVICE_WORKER_H_

--- a/components/ai_chat/core/common/constants.h
+++ b/components/ai_chat/core/common/constants.h
@@ -58,6 +58,14 @@ inline constexpr char kAIChatLeoWorkspaceUIHost[] = "leo-workspace";
 inline constexpr char kAIChatLeoWorkspaceUIURL[] =
     "chrome-untrusted://leo-workspace/";
 
+// The service worker that serves each workspace's folder, and its script.
+// Files sit under a reserved segment so that model-authored names cannot
+// collide with a workspace page at /<uuid>:
+// chrome-untrusted://leo-workspace/<uuid>/files/<path relative to the folder>.
+inline constexpr char kAIChatLeoWorkspaceServiceWorkerScript[] =
+    "leo_workspace_service_worker.js";
+inline constexpr char kAIChatLeoWorkspaceFilesSegment[] = "files";
+
 }  // namespace ai_chat
 
 #endif  // BRAVE_COMPONENTS_AI_CHAT_CORE_COMMON_CONSTANTS_H_

--- a/components/ai_chat/resources/ai_chat_ui_resources.grdp
+++ b/components/ai_chat/resources/ai_chat_ui_resources.grdp
@@ -23,4 +23,6 @@
     type="BINDATA" />
   <include name="IDR_AI_CHAT_INTERFACE_REMOVAL_JS" file="../ai_chat/resources/code_sandbox/interface_removal.js"
     type="BINDATA" />
+  <include name="IDR_AI_CHAT_LEO_WORKSPACE_SERVICE_WORKER_JS" file="../ai_chat/resources/leo_workspace/leo_workspace_service_worker.js"
+    type="BINDATA" />
 </grit-part>

--- a/components/ai_chat/resources/leo_workspace/file_ops.ts
+++ b/components/ai_chat/resources/leo_workspace/file_ops.ts
@@ -93,6 +93,23 @@ async function readText(
   return (await fh.getFile()).text()
 }
 
+// Throws if |rel| is not a file in the workspace, or is larger than
+// |maxBytes|. Safe to call with a path from outside: splitPath() rejects '..',
+// and getFileHandle() rejects separators, so nothing resolves out of |root|.
+export async function readBytes(
+  root: FileSystemDirectoryHandle,
+  rel: string,
+  maxBytes: number,
+): Promise<Uint8Array> {
+  const fh = await getFile(root, rel)
+  const file = await fh.getFile()
+  // Checked before reading, so an oversized file costs a stat, not its size.
+  if (file.size > maxBytes) {
+    throw new Error(`file is too large to serve: ${rel} (${file.size} bytes)`)
+  }
+  return new Uint8Array(await file.arrayBuffer())
+}
+
 async function writeText(
   root: FileSystemDirectoryHandle,
   rel: string,

--- a/components/ai_chat/resources/leo_workspace/file_server.test.ts
+++ b/components/ai_chat/resources/leo_workspace/file_server.test.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { serveFiles } from './file_server'
+import { createFakeWorkspace } from './test_file_system'
+
+// Stands in for navigator.serviceWorker: keeps the listener so a test can play
+// the part of the worker and post a request to the page.
+class FakeContainer {
+  listener: ((event: MessageEvent) => void) | null = null
+  startMessages = jest.fn()
+
+  addEventListener(type: string, listener: (event: MessageEvent) => void) {
+    if (type === 'message') {
+      this.listener = listener
+    }
+  }
+
+  /** Sends |data| with a reply port, and resolves with what comes back. */
+  request(data: unknown): Promise<any> {
+    return new Promise((resolve) => {
+      const port = { postMessage: (reply: unknown) => resolve(reply) }
+      this.listener!({
+        data,
+        ports: [port],
+      } as unknown as MessageEvent)
+    })
+  }
+}
+
+let container: FakeContainer
+
+function serve(files: Record<string, string>) {
+  serveFiles(createFakeWorkspace(files) as FileSystemDirectoryHandle)
+}
+
+beforeEach(() => {
+  container = new FakeContainer()
+  Object.defineProperty(navigator, 'serviceWorker', {
+    configurable: true,
+    writable: true,
+    value: container,
+  })
+  jest.spyOn(console, 'warn').mockImplementation(() => {})
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  // @ts-expect-error - reset the stand-in.
+  delete navigator.serviceWorker
+})
+
+describe('workspace file server', () => {
+  it('starts the queued messages the worker has already sent', () => {
+    serve({ 'a.txt': 'hi' })
+    expect(container.startMessages).toHaveBeenCalledTimes(1)
+  })
+
+  it('replies with the bytes of a file in the folder', async () => {
+    serve({ 'docs/report.html': '<h1>hi</h1>' })
+    const reply = await container.request({
+      type: 'leo-workspace-read-file',
+      path: 'docs/report.html',
+    })
+    expect(new TextDecoder().decode(reply.bytes)).toBe('<h1>hi</h1>')
+  })
+
+  it('replies without bytes for a file that is not there', async () => {
+    serve({ 'a.txt': 'hi' })
+    const reply = await container.request({
+      type: 'leo-workspace-read-file',
+      path: 'nope.txt',
+    })
+    expect(reply.bytes).toBeUndefined()
+  })
+
+  it('replies without bytes for a path that leaves the folder', async () => {
+    serve({ 'a.txt': 'hi' })
+    const reply = await container.request({
+      type: 'leo-workspace-read-file',
+      path: '../outside.txt',
+    })
+    expect(reply.bytes).toBeUndefined()
+  })
+
+  it('ignores a message that is not a file request', async () => {
+    serve({ 'a.txt': 'hi' })
+    const port = { postMessage: jest.fn() }
+    container.listener!({
+      data: { type: 'something-else' },
+      ports: [port],
+    } as unknown as MessageEvent)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(port.postMessage).not.toHaveBeenCalled()
+  })
+})
+
+describe('workspace file server size cap', () => {
+  it('replies without bytes for a file too large to serve', async () => {
+    serve({ 'huge.bin': 'x'.repeat(64 * 1024 * 1024 + 1) })
+    const reply = await container.request({
+      type: 'leo-workspace-read-file',
+      path: 'huge.bin',
+    })
+    expect(reply.bytes).toBeUndefined()
+  })
+})

--- a/components/ai_chat/resources/leo_workspace/file_server.ts
+++ b/components/ai_chat/resources/leo_workspace/file_server.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Answers the service worker's requests for files in this workspace's folder,
+// so that a folder is served through the same FileSystemDirectoryHandle the
+// tools use. See leo_workspace_service_worker.js.
+
+import { readBytes } from './file_ops'
+
+// A reply is one transferred buffer, so nothing streams and an oversized file
+// would sit in the page's memory entire. Refused instead.
+const kMaxServedFileSize = 64 * 1024 * 1024
+
+interface ReadFileRequest {
+  type: 'leo-workspace-read-file'
+  path: string
+}
+
+function isReadFileRequest(data: unknown): data is ReadFileRequest {
+  return (
+    typeof data === 'object'
+    && data !== null
+    && (data as ReadFileRequest).type === 'leo-workspace-read-file'
+    && typeof (data as ReadFileRequest).path === 'string'
+  )
+}
+
+async function onMessage(root: FileSystemDirectoryHandle, event: MessageEvent) {
+  // The worker replies down a port of its own, so a request without one did not
+  // come from it.
+  const port = event.ports[0]
+  if (!port || !isReadFileRequest(event.data)) {
+    return
+  }
+
+  try {
+    const bytes = await readBytes(root, event.data.path, kMaxServedFileSize)
+    port.postMessage({ bytes }, [bytes.buffer])
+  } catch (error) {
+    // A missing file is the common case here, and the worker turns an empty
+    // reply into a 404.
+    console.warn('[leo-workspace] could not serve', event.data.path, error)
+    port.postMessage({})
+  }
+}
+
+// Serves |root| for as long as this page lives. Nothing persists: with the page
+// gone the worker has no one to ask, so the folder stops being readable over
+// its URLs.
+export function serveFiles(root: FileSystemDirectoryHandle) {
+  const container = navigator.serviceWorker
+  if (!container) {
+    console.error('[leo-workspace] no service worker container to serve files')
+    return
+  }
+  container.addEventListener('message', (event) => {
+    void onMessage(root, event)
+  })
+  // Messages from the worker are queued until the page asks for them, and
+  // addEventListener() alone does not (only assigning onmessage would).
+  container.startMessages()
+}

--- a/components/ai_chat/resources/leo_workspace/index.test.tsx
+++ b/components/ai_chat/resources/leo_workspace/index.test.tsx
@@ -49,6 +49,13 @@ beforeEach(() => {
     },
   })
 
+  // serveFiles() listens for the service worker's file requests.
+  Object.defineProperty(navigator, 'serviceWorker', {
+    configurable: true,
+    writable: true,
+    value: { addEventListener: jest.fn(), startMessages: jest.fn() },
+  })
+
   jest.spyOn(console, 'log').mockImplementation(() => {})
   jest.spyOn(console, 'error').mockImplementation(() => {})
 })
@@ -56,6 +63,8 @@ beforeEach(() => {
 afterEach(() => {
   delete document.modelContext
   delete window.launchQueue
+  // @ts-expect-error - remove the stand-in container.
+  delete navigator.serviceWorker
 })
 
 describe('leo workspace entry point', () => {

--- a/components/ai_chat/resources/leo_workspace/index.tsx
+++ b/components/ai_chat/resources/leo_workspace/index.tsx
@@ -13,6 +13,7 @@
 // The handle is delivered via launchQueue; once captured, the file tools are
 // registered with Leo via WebMCP (see tools.ts / file_ops.ts).
 
+import { serveFiles } from './file_server'
 import { registerTools } from './tools'
 
 // launchQueue is not in the default TS DOM lib; declare the minimal surface we
@@ -42,6 +43,7 @@ function onLaunch(params: LaunchParams) {
   }
   rootHandle = entry as FileSystemDirectoryHandle
   console.log('[leo-workspace] received directory handle:', rootHandle.name)
+  serveFiles(rootHandle)
   void registerTools(rootHandle)
 }
 

--- a/components/ai_chat/resources/leo_workspace/leo_workspace_service_worker.js
+++ b/components/ai_chat/resources/leo_workspace/leo_workspace_service_worker.js
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Service worker for chrome-untrusted://leo-workspace/. Serves a workspace's
+// folder at /<uuid>/files/<path> by asking that workspace's page to read the
+// file with its FileSystemDirectoryHandle, and leaves every other request to
+// the WebUI data source.
+//
+// Registered browser-side (see workspace_service_worker.h), because a WebUI
+// origin cannot register a worker from JavaScript.
+//
+// Plain JS on purpose: it is shipped as a resource rather than bundled, so it
+// stays a classic worker script with no module resolution to arrange.
+
+'use strict'
+
+// Keep in sync with kAIChatLeoWorkspaceFilesSegment.
+const kFilesSegment = 'files'
+
+// A page that has not answered by now is treated as gone. The read itself is
+// local, so this only has to cover a page that is wedged or shutting down.
+const kRequestTimeoutMs = 10000
+
+// Extensions we are prepared to name a type for. Anything else is served as an
+// attachment instead of being guessed at: the alternative is a wrong
+// Content-Type, and for text/html that would mean markup in a data file being
+// parsed as a document.
+const kMimeTypes = new Map([
+  ['html', 'text/html'],
+  ['htm', 'text/html'],
+  ['css', 'text/css'],
+  ['js', 'text/javascript'],
+  ['mjs', 'text/javascript'],
+  ['json', 'application/json'],
+  ['txt', 'text/plain'],
+  ['md', 'text/markdown'],
+  ['csv', 'text/csv'],
+  ['xml', 'text/xml'],
+  ['svg', 'image/svg+xml'],
+  ['png', 'image/png'],
+  ['jpg', 'image/jpeg'],
+  ['jpeg', 'image/jpeg'],
+  ['gif', 'image/gif'],
+  ['webp', 'image/webp'],
+  ['avif', 'image/avif'],
+  ['ico', 'image/x-icon'],
+  ['woff2', 'font/woff2'],
+  ['woff', 'font/woff'],
+  ['ttf', 'font/ttf'],
+  ['mp3', 'audio/mpeg'],
+  ['wav', 'audio/wav'],
+  ['ogg', 'audio/ogg'],
+  ['mp4', 'video/mp4'],
+  ['webm', 'video/webm'],
+  ['pdf', 'application/pdf'],
+])
+
+// What a served file is allowed to do. Deliberately not sandboxed: a sandboxed
+// response gets an opaque origin, and an opaque origin cannot be controlled by
+// a service worker, so a served page's own subresources would not reach this
+// worker and nothing beyond a self-contained file could be served. Keeping
+// model-authored content off the workspace page's origin is left to giving each
+// workspace an origin of its own. See workspace_service_worker.h.
+//
+// The sources are this workspace's own files root, so a served page can load
+// the rest of its folder and nothing else: not another workspace's files, and
+// not the workspace page or its bundle. A source with a path matches the URL
+// being requested, which is what makes that expressible.
+function fileCSP(uuid) {
+  const filesRoot = `${self.location.origin}/${uuid}/${kFilesSegment}/`
+  return [
+    `default-src ${filesRoot} 'unsafe-inline' 'unsafe-eval' data: blob:`,
+    // No network at all, so a served file cannot send a folder's contents
+    // anywhere.
+    "connect-src 'none'",
+    "form-action 'none'",
+    "base-uri 'none'",
+  ].join('; ')
+}
+
+// Splits "/<uuid>/files/<path>", or returns null when the request is not for a
+// workspace file. Path traversal is not a concern here: the segments are handed
+// to the page, which resolves them with getDirectoryHandle()/getFileHandle(),
+// and those reject separators and '..' and cannot leave the folder.
+function decodeSegment(segment) {
+  try {
+    return decodeURIComponent(segment)
+  } catch {
+    // Not something a browser produces, and not worth failing the request over:
+    // a name that does not decode simply will not be found in the folder.
+    return segment
+  }
+}
+
+function parseFileRequest(url) {
+  const segments = url.pathname.split('/').filter((s) => s !== '')
+  if (segments.length < 3 || segments[1] !== kFilesSegment) {
+    return null
+  }
+  return {
+    uuid: segments[0],
+    path: segments.slice(2).map(decodeSegment).join('/'),
+  }
+}
+
+function mimeTypeFor(path) {
+  const name = path.slice(path.lastIndexOf('/') + 1)
+  const dot = name.lastIndexOf('.')
+  return dot > 0 ? kMimeTypes.get(name.slice(dot + 1).toLowerCase()) : undefined
+}
+
+// The window clients that might hold a handle for workspace |uuid|: its page,
+// but also any other tab opened on the same URL, which has no handle and will
+// never answer. Uncontrolled clients count, since the page is loaded once, when
+// the workspace is created, and may well predate this worker.
+async function findWorkspaceClients(uuid) {
+  const clients = await self.clients.matchAll({
+    type: 'window',
+    includeUncontrolled: true,
+  })
+  return clients.filter((client) => {
+    const path = new URL(client.url).pathname
+    return path === `/${uuid}` || path === `/${uuid}/`
+  })
+}
+
+// Asks |client| for |path| over a private channel, so the reply cannot be
+// spoofed by anything else that can postMessage to this worker.
+function requestFile(client, path) {
+  return new Promise((resolve) => {
+    const channel = new MessageChannel()
+    const timer = setTimeout(() => {
+      channel.port1.close()
+      resolve(null)
+    }, kRequestTimeoutMs)
+
+    channel.port1.onmessage = (event) => {
+      clearTimeout(timer)
+      channel.port1.close()
+      resolve(event.data && event.data.bytes ? event.data : null)
+    }
+    client.postMessage({ type: 'leo-workspace-read-file', path }, [
+      channel.port2,
+    ])
+  })
+}
+
+// Asks every candidate at once and answers with the first real reply, so a tab
+// sitting on the workspace URL without a handle cannot swallow a request, nor
+// make it wait out its timeout.
+function readFromAnyClient(clients, path) {
+  return new Promise((resolve) => {
+    let pending = clients.length
+    for (const client of clients) {
+      void requestFile(client, path).then((reply) => {
+        if (reply) {
+          resolve(reply)
+        } else if (--pending === 0) {
+          resolve(null)
+        }
+      })
+    }
+  })
+}
+
+// Says which stage failed, because an empty response looks exactly like a
+// navigation that never reached this worker.
+function notFound(reason) {
+  console.warn('[leo-workspace-sw]', reason)
+  return new Response(`Leo workspace: ${reason}\n`, {
+    status: 404,
+    headers: new Headers({
+      'Content-Type': 'text/plain',
+      'Content-Security-Policy': "sandbox; default-src 'none'",
+    }),
+  })
+}
+
+async function serveWorkspaceFile(request) {
+  const parsed = parseFileRequest(new URL(request.url))
+  if (!parsed) {
+    return null
+  }
+  // Only reads: a folder is not writable over its own URLs.
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return new Response(null, { status: 405 })
+  }
+
+  // Fails closed once the workspace is gone, rather than answering from
+  // whichever folder happens to be open now.
+  const clients = await findWorkspaceClients(parsed.uuid)
+  if (clients.length === 0) {
+    return notFound(`no page open for workspace ${parsed.uuid}`)
+  }
+
+  const file = await readFromAnyClient(clients, parsed.path)
+  if (!file) {
+    return notFound(`no workspace page could read ${parsed.path}`)
+  }
+
+  const type = mimeTypeFor(parsed.path)
+  const headers = new Headers({
+    'Content-Security-Policy': fileCSP(parsed.uuid),
+    'Content-Type': type || 'application/octet-stream',
+    'X-Content-Type-Options': 'nosniff',
+    // The folder changes underneath us as the model writes to it.
+    'Cache-Control': 'no-store',
+  })
+  if (!type) {
+    // Unknown type: let the user save it rather than rendering a guess.
+    headers.set('Content-Disposition', 'attachment')
+  }
+  return new Response(request.method === 'HEAD' ? null : file.bytes, {
+    status: 200,
+    headers,
+  })
+}
+
+self.addEventListener('install', () => {
+  // Serve as soon as this version is installed: the pages that need it are
+  // already open.
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url)
+  if (!parseFileRequest(url)) {
+    // Everything else on this host is the workspace page and its bundle, which
+    // the WebUI data source serves.
+    return
+  }
+  event.respondWith(
+    serveWorkspaceFile(event.request).then(
+      (response) => response || notFound(`could not serve ${url.pathname}`),
+    ),
+  )
+})

--- a/components/ai_chat/resources/leo_workspace/test_file_system.ts
+++ b/components/ai_chat/resources/leo_workspace/test_file_system.ts
@@ -45,6 +45,8 @@ class FakeFileHandle {
       name: this.name,
       size: this.contents.length,
       text: async () => this.contents,
+      arrayBuffer: async () =>
+        new TextEncoder().encode(this.contents).buffer as ArrayBuffer,
     }
   }
 


### PR DESCRIPTION
- Resolves https://github.com/brave/brave-browser/issues/57388 (series)

Stacked on brave/brave-core#39722 — review that first.

Serves each workspace's folder at
`chrome-untrusted://leo-workspace/<uuid>/files/<path>` from a service worker,
which reads it through the workspace page's `FileSystemDirectoryHandle`.

Serving from a worker is what lets a folder's files carry headers of their own:
the worker names each file's type, and scopes each file's CSP to the folder it
came from, so a served page can load the rest of its own folder and nothing else
— not another workspace's files, not the workspace page or its bundle — with no
network to exfiltrate over. A WebUI data source can do neither: its MIME types
come from a fixed list that answers `text/html` for everything else (so a
model-written `notes.txt` or `data.csv` would be parsed as a document), and its
CSP is per-source, so it is shared with the page.

Path confinement also stops being ours to get right. The page resolves each
request with `getDirectoryHandle()`/`getFileHandle()`, which reject separators
and `..` and cannot leave the folder, so there is no C++ path parsing to defend.

Nothing outlives the workspace: with the page gone the worker has no one to ask,
so a folder stops being readable over its URLs.

## Points for review

- **Served files are not sandboxed, so they share the workspace pages' origin.**
  A `sandbox` response gets an opaque origin, and an opaque origin cannot be
  controlled by a service worker — so a sandboxed page's own subresources never
  reach the worker and nothing beyond a self-contained single file can be served.
  Isolation is therefore left to giving each workspace an origin of its own,
  tracked in https://github.com/brave/brave-browser/issues/58792. In the
  meantime a served file is same-origin with the workspace page, which means it
  can reach `navigator.modelContext` (gated on scheme+host, not path) and so
  register tools into the user's Leo session. The File System Access grant is
  *not* reachable, since grants ride on handles and a served page has none.
- **The files root fails open.** `/<uuid>/files` and `/<uuid>/files/` are only
  two segments, so the worker does not claim them and the data source answers
  with the workspace page's HTML. It should 404. Not fixed here.
- Directory URLs 404: there is no `index.html` resolution and no listing.
- The worker's registration is origin-wide and persists across restarts; nothing
  unregisters it when the last workspace goes away. It is inert without a page.

## Verification

`pnpm run build`, `pnpm run gn_check`, `pnpm run presubmit`, and
`pnpm run test-unit leo_workspace` (103 tests) pass. Manually verified end to
end: an `index.html` in a workspace folder loads in a tab, along with its
relative subresources.