### PR TITLE
Android password sync profile store

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -497,12 +497,24 @@ const char* const kBraveSyncImplLink[1] = {"https://github.com/brave/go-sync"};
       kOsAndroid,                                                    \
       FEATURE_VALUE_TYPE(features::kBraveAndroidTabGroupsSettings),  \
   })
+#define BRAVE_ANDROID_SYNC_PASSWORDS_IN_PROFILE_STORE                      \
+  EXPAND_FEATURE_ENTRIES({                                                 \
+      "brave-android-sync-passwords-in-profile-store",                     \
+      "Sync passwords in profile store",                                   \
+      "Sync passwords via the profile store (like desktop) instead of "    \
+      "the account store, migrating existing passwords on startup. Not "   \
+      "cleanly reversible once enabled.",                                  \
+      kOsAndroid,                                                          \
+      FEATURE_VALUE_TYPE(                                                  \
+          brave_sync::features::kBraveAndroidSyncPasswordsInProfileStore), \
+  })
 #else
 #define BRAVE_BACKGROUND_VIDEO_PLAYBACK_ANDROID
 #define BRAVE_SAFE_BROWSING_ANDROID
 #define BRAVE_ADAPTIVE_BUTTON_IN_TOOLBAR_ANDROID
 #define BRAVE_CUSTOM_SEARCH_ENGINES
 #define BRAVE_ANDROID_TAB_GROUPS_SETTINGS
+#define BRAVE_ANDROID_SYNC_PASSWORDS_IN_PROFILE_STORE
 #endif  // BUILDFLAG(IS_ANDROID)
 
 #if !BUILDFLAG(IS_ANDROID)
@@ -1578,6 +1590,7 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
   BRAVE_SAFE_BROWSING_ANDROID                                                  \
   BRAVE_ADAPTIVE_BUTTON_IN_TOOLBAR_ANDROID                                     \
   BRAVE_ANDROID_TAB_GROUPS_SETTINGS                                            \
+  BRAVE_ANDROID_SYNC_PASSWORDS_IN_PROFILE_STORE                                \
   BRAVE_CUSTOM_PROFILE_IMAGE_FEATURE_ENTRY                                     \
   BRAVE_CUSTOM_SEARCH_ENGINES                                                  \
   BRAVE_CHANGE_ACTIVE_TAB_ON_SCROLL_EVENT_FEATURE_ENTRIES                      \

--- a/browser/password_manager/android/BUILD.gn
+++ b/browser/password_manager/android/BUILD.gn
@@ -5,6 +5,22 @@
 
 import("//build/config/android/rules.gni")
 
+source_set("password_migration") {
+  sources = [
+    "brave_account_to_profile_password_migration.cc",
+    "brave_account_to_profile_password_migration.h",
+  ]
+
+  deps = [
+    "//base",
+    "//brave/components/brave_sync:features",
+    "//chrome/browser/password_manager/factories",
+    "//components/keyed_service/core",
+    "//components/password_manager/core/browser:password_form",
+    "//components/password_manager/core/browser/password_store:password_store_interface",
+  ]
+}
+
 source_set("unit_tests") {
   testonly = true
   sources = [
@@ -14,6 +30,7 @@ source_set("unit_tests") {
   ]
 
   deps = [
+    ":password_migration",
     "//base",
     "//base/test:test_support",
     "//brave/components/brave_sync:features",

--- a/browser/password_manager/android/BUILD.gn
+++ b/browser/password_manager/android/BUILD.gn
@@ -7,14 +7,23 @@ import("//build/config/android/rules.gni")
 
 source_set("unit_tests") {
   testonly = true
-  sources = [ "password_ui_view_android_unittest.cc" ]
+  sources = [
+    "brave_account_storage_flag_unittest.cc",
+    "brave_account_to_profile_password_migration_unittest.cc",
+    "password_ui_view_android_unittest.cc",
+  ]
 
   deps = [
     "//base",
     "//base/test:test_support",
+    "//brave/components/brave_sync:features",
     "//chrome/browser/password_manager:test_support",
     "//chrome/test:test_support",
     "//components/password_manager/core/browser/export",
+    "//components/password_manager/core/browser/features:utils",
+    "//components/signin/public/identity_manager",
+    "//components/sync:test_support",
+    "//components/sync/service",
     "//testing/gmock",
     "//testing/gtest",
   ]

--- a/browser/password_manager/android/brave_account_storage_flag_unittest.cc
+++ b/browser/password_manager/android/brave_account_storage_flag_unittest.cc
@@ -1,0 +1,57 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/test/scoped_feature_list.h"
+#include "base/test/task_environment.h"
+#include "brave/components/brave_sync/features.h"
+#include "components/password_manager/core/browser/features/password_manager_features_util.h"
+#include "components/signin/public/base/consent_level.h"
+#include "components/sync/service/sync_service.h"
+#include "components/sync/test/test_sync_service.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_password_manager {
+
+// Verifies the Brave override in features_util::IsAccountStorageActive: on
+// Android, a syncing user should stay eligible for the account store when the
+// flag is off (upstream behavior) and become ineligible when it is on (so
+// passwords route to the profile store like desktop).
+class BraveAccountStorageFlagTest : public ::testing::Test {
+ protected:
+  // A signed-in, syncing user with a healthy, active transport.
+  syncer::TestSyncService& SyncingUser() {
+    // Brave Sync users are legacy sync-feature (kSync) users, so this test must
+    // set up that state to exercise the flag path in IsAccountStorageActive.
+    // The crbug.com/40066949 deprecation intentionally does not apply here.
+    sync_service_.SetSignedIn(signin::ConsentLevel::kSync);  // nocheck
+    sync_service_.SetMaxTransportState(
+        syncer::SyncService::TransportState::ACTIVE);
+    return sync_service_;
+  }
+
+  base::test::TaskEnvironment task_environment_;
+  syncer::TestSyncService sync_service_;
+};
+
+TEST_F(BraveAccountStorageFlagTest, FlagOffKeepsAccountStorageActive) {
+  base::test::ScopedFeatureList features;
+  features.InitAndDisableFeature(
+      brave_sync::features::kBraveAndroidSyncPasswordsInProfileStore);
+
+  EXPECT_TRUE(
+      password_manager::features_util::IsAccountStorageActive(&SyncingUser()));
+}
+
+TEST_F(BraveAccountStorageFlagTest,
+       FlagOnDisablesAccountStorageForSyncingUser) {
+  base::test::ScopedFeatureList features;
+  features.InitAndEnableFeature(
+      brave_sync::features::kBraveAndroidSyncPasswordsInProfileStore);
+
+  EXPECT_FALSE(
+      password_manager::features_util::IsAccountStorageActive(&SyncingUser()));
+}
+
+}  // namespace brave_password_manager

--- a/browser/password_manager/android/brave_account_to_profile_password_migration.cc
+++ b/browser/password_manager/android/brave_account_to_profile_password_migration.cc
@@ -22,7 +22,6 @@
 #include "brave/components/brave_sync/features.h"
 #include "chrome/browser/password_manager/factories/account_password_store_factory.h"
 #include "chrome/browser/password_manager/factories/profile_password_store_factory.h"
-#include "chrome/browser/profiles/profile.h"
 #include "components/keyed_service/core/service_access_type.h"
 #include "components/password_manager/core/browser/password_form.h"
 #include "components/password_manager/core/browser/password_store/password_form_converters.h"

--- a/browser/password_manager/android/brave_account_to_profile_password_migration.cc
+++ b/browser/password_manager/android/brave_account_to_profile_password_migration.cc
@@ -1,0 +1,264 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/password_manager/android/brave_account_to_profile_password_migration.h"
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "base/barrier_closure.h"
+#include "base/feature_list.h"
+#include "base/functional/bind.h"
+#include "base/functional/callback.h"
+#include "base/location.h"
+#include "base/memory/ref_counted.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/memory/weak_ptr.h"
+#include "base/time/time.h"
+#include "brave/components/brave_sync/features.h"
+#include "chrome/browser/password_manager/factories/account_password_store_factory.h"
+#include "chrome/browser/password_manager/factories/profile_password_store_factory.h"
+#include "chrome/browser/profiles/profile.h"
+#include "components/keyed_service/core/service_access_type.h"
+#include "components/password_manager/core/browser/password_form.h"
+#include "components/password_manager/core/browser/password_store/password_form_converters.h"
+#include "components/password_manager/core/browser/password_store/password_store_consumer.h"
+#include "components/password_manager/core/browser/password_store/password_store_interface.h"
+
+namespace brave_password_manager {
+
+namespace {
+
+using password_manager::LoginsResult;
+using password_manager::LoginsResultOrError;
+using password_manager::PasswordForm;
+using password_manager::PasswordStoreBackendError;
+using password_manager::PasswordStoreInterface;
+using password_manager::StoredCredential;
+
+// The most recent of a form's last-used, password-modified and creation times.
+// Used to decide which side wins when the same credential exists in both
+// stores with different passwords (mirrors the logic in
+// PasswordLocalDataBatchUploader).
+base::Time LatestTimestamp(const PasswordForm& form) {
+  return std::ranges::max(
+      {form.date_last_used, form.date_password_modified, form.date_created});
+}
+
+// Reads all logins from a single store and runs `done_callback` when finished.
+// Keeps itself alive by being moved into that callback, and is destroyed once
+// it runs. Mirrors PasswordLocalDataBatchUploader::PasswordFetchRequest. On a
+// read error the results are left empty (the migrator treats that as "nothing
+// to copy / nothing verified", so it never deletes unverified data).
+class PasswordFetchRequest : public password_manager::PasswordStoreConsumer {
+ public:
+  PasswordFetchRequest() = default;
+  PasswordFetchRequest(const PasswordFetchRequest&) = delete;
+  PasswordFetchRequest& operator=(const PasswordFetchRequest&) = delete;
+  ~PasswordFetchRequest() override = default;
+
+  void Run(PasswordStoreInterface* store, base::OnceClosure done_callback) {
+    done_callback_ = std::move(done_callback);
+    store->GetAllLogins(weak_ptr_factory_.GetWeakPtr());
+  }
+
+  std::vector<PasswordForm> TakeResults() { return std::move(results_); }
+
+ private:
+  // PasswordStoreConsumer:
+  void OnGetPasswordStoreResultsOrErrorFrom(
+      PasswordStoreInterface* store,
+      LoginsResultOrError results_or_error) override {
+    if (!std::holds_alternative<PasswordStoreBackendError>(results_or_error)) {
+      results_ = password_manager::ToPasswordForms(
+          std::get<LoginsResult>(std::move(results_or_error)));
+    }
+    std::move(done_callback_).Run();
+    // `this` may be deleted now; do not touch any member below.
+  }
+
+  std::vector<PasswordForm> results_;
+  base::OnceClosure done_callback_;
+  base::WeakPtrFactory<PasswordFetchRequest> weak_ptr_factory_{this};
+};
+
+// Moves passwords from the account store to the profile store. A credential is
+// removed from the account store only after it is confirmed present in the
+// profile store (copy/merge -> verify -> delete). All logins are migrated,
+// including blocklisted ("never save") entries. When the same credential
+// exists in both stores with different passwords, the most recently changed
+// one wins, so an account-only newer password is never dropped.
+//
+// Ref-counted so it outlives the async store operations: each step binds a
+// reference into its completion callback, and the object is destroyed once the
+// last step finishes.
+class AccountToProfilePasswordMigrator
+    : public base::RefCounted<AccountToProfilePasswordMigrator> {
+ public:
+  AccountToProfilePasswordMigrator(
+      scoped_refptr<PasswordStoreInterface> account_store,
+      scoped_refptr<PasswordStoreInterface> profile_store,
+      base::OnceClosure on_complete)
+      : account_store_(std::move(account_store)),
+        profile_store_(std::move(profile_store)),
+        on_complete_(std::move(on_complete)) {}
+
+  AccountToProfilePasswordMigrator(const AccountToProfilePasswordMigrator&) =
+      delete;
+  AccountToProfilePasswordMigrator& operator=(
+      const AccountToProfilePasswordMigrator&) = delete;
+
+  void Start() {
+    // Step 1: read the account store.
+    ReadStore(account_store_.get(),
+              base::BindOnce(&AccountToProfilePasswordMigrator::OnAccountLogins,
+                             this));
+  }
+
+ private:
+  friend class base::RefCounted<AccountToProfilePasswordMigrator>;
+  ~AccountToProfilePasswordMigrator() = default;
+
+  // Reads all logins from `store`, passing the (owned) fetch request to
+  // `on_results` when done.
+  void ReadStore(PasswordStoreInterface* store,
+                 base::OnceCallback<void(std::unique_ptr<PasswordFetchRequest>)>
+                     on_results) {
+    auto request = std::make_unique<PasswordFetchRequest>();
+    PasswordFetchRequest* request_ptr = request.get();
+    request_ptr->Run(store,
+                     base::BindOnce(std::move(on_results), std::move(request)));
+  }
+
+  void OnAccountLogins(std::unique_ptr<PasswordFetchRequest> request) {
+    account_forms_ = request->TakeResults();
+    if (account_forms_.empty()) {
+      std::move(on_complete_).Run();  // Nothing to migrate.
+      return;
+    }
+    // Step 2: read the profile store before deciding how to merge each
+    // credential.
+    ReadStore(
+        profile_store_.get(),
+        base::BindOnce(
+            &AccountToProfilePasswordMigrator::OnProfileLoginsForMerge, this));
+  }
+
+  void OnProfileLoginsForMerge(std::unique_ptr<PasswordFetchRequest> request) {
+    std::vector<PasswordForm> profile_forms = request->TakeResults();
+
+    // Copy/merge: add credentials missing from the profile store, and overwrite
+    // ones whose account copy has a newer, different password.
+    std::vector<StoredCredential> to_add;
+    std::vector<StoredCredential> to_update;
+    for (const PasswordForm& account_form : account_forms_) {
+      auto it = std::ranges::find_if(
+          profile_forms, [&account_form](const PasswordForm& profile_form) {
+            return password_manager::ArePasswordFormUniqueKeysEqual(
+                profile_form, account_form);
+          });
+      if (it == profile_forms.end()) {
+        to_add.push_back(password_manager::FromPasswordForm(account_form));
+      } else if (it->password_value != account_form.password_value &&
+                 LatestTimestamp(*it) < LatestTimestamp(account_form)) {
+        to_update.push_back(password_manager::FromPasswordForm(account_form));
+      }
+      // Otherwise the profile copy already wins; it will still be drained from
+      // the account store in the verify step below.
+    }
+
+    if (to_add.empty() && to_update.empty()) {
+      // Every account credential already has an equal-or-newer copy in the
+      // profile store; skip straight to draining the account store.
+      VerifyAndDrainAccountStore();
+      return;
+    }
+
+    const int barrier_count =
+        (to_add.empty() ? 0 : 1) + (to_update.empty() ? 0 : 1);
+    base::RepeatingClosure barrier = base::BarrierClosure(
+        barrier_count,
+        base::BindOnce(
+            &AccountToProfilePasswordMigrator::VerifyAndDrainAccountStore,
+            this));
+    if (!to_add.empty()) {
+      profile_store_->AddLogins(std::move(to_add), barrier);
+    }
+    if (!to_update.empty()) {
+      profile_store_->UpdateLogins(std::move(to_update), barrier);
+    }
+  }
+
+  void VerifyAndDrainAccountStore() {
+    // Step 3: re-read the profile store to confirm the writes landed before
+    // deleting anything from the account store.
+    ReadStore(
+        profile_store_.get(),
+        base::BindOnce(
+            &AccountToProfilePasswordMigrator::OnProfileLoginsForVerify, this));
+  }
+
+  void OnProfileLoginsForVerify(std::unique_ptr<PasswordFetchRequest> request) {
+    std::vector<PasswordForm> profile_forms = request->TakeResults();
+    // Remove from the account store only the credentials that are now confirmed
+    // present in the profile store.
+    for (const PasswordForm& account_form : account_forms_) {
+      const bool present_in_profile = std::ranges::any_of(
+          profile_forms, [&account_form](const PasswordForm& profile_form) {
+            return password_manager::ArePasswordFormUniqueKeysEqual(
+                profile_form, account_form);
+          });
+      if (present_in_profile) {
+        account_store_->RemoveLogin(
+            FROM_HERE, password_manager::FromPasswordForm(account_form));
+      }
+    }
+    // Finish only after the removals above have been processed. RemoveLogin has
+    // no completion callback, but store operations run in order, so a trailing
+    // read completes after them (and keeps `this` alive until then).
+    ReadStore(
+        account_store_.get(),
+        base::BindOnce(&AccountToProfilePasswordMigrator::OnFinished, this));
+  }
+
+  void OnFinished(std::unique_ptr<PasswordFetchRequest> request) {
+    std::move(on_complete_).Run();
+  }
+
+  const scoped_refptr<PasswordStoreInterface> account_store_;
+  const scoped_refptr<PasswordStoreInterface> profile_store_;
+  std::vector<PasswordForm> account_forms_;
+  base::OnceClosure on_complete_;
+};
+
+}  // namespace
+
+void MaybeMigrateAccountPasswordsToProfileStore(Profile* profile,
+                                                base::OnceClosure on_complete) {
+  if (!base::FeatureList::IsEnabled(
+          brave_sync::features::kBraveAndroidSyncPasswordsInProfileStore)) {
+    std::move(on_complete).Run();
+    return;
+  }
+  scoped_refptr<PasswordStoreInterface> account_store =
+      AccountPasswordStoreFactory::GetForProfile(
+          profile, ServiceAccessType::EXPLICIT_ACCESS);
+  scoped_refptr<PasswordStoreInterface> profile_store =
+      ProfilePasswordStoreFactory::GetForProfile(
+          profile, ServiceAccessType::EXPLICIT_ACCESS);
+  if (!account_store || !profile_store) {
+    std::move(on_complete).Run();
+    return;
+  }
+  base::MakeRefCounted<AccountToProfilePasswordMigrator>(
+      std::move(account_store), std::move(profile_store),
+      std::move(on_complete))
+      ->Start();
+}
+
+}  // namespace brave_password_manager

--- a/browser/password_manager/android/brave_account_to_profile_password_migration.cc
+++ b/browser/password_manager/android/brave_account_to_profile_password_migration.cc
@@ -16,7 +16,6 @@
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/location.h"
-#include "base/memory/ref_counted.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/time/time.h"
@@ -94,11 +93,11 @@ class PasswordFetchRequest : public password_manager::PasswordStoreConsumer {
 // exists in both stores with different passwords, the most recently changed
 // one wins, so an account-only newer password is never dropped.
 //
-// Ref-counted so it outlives the async store operations: each step binds a
-// reference into its completion callback, and the object is destroyed once the
-// last step finishes.
-class AccountToProfilePasswordMigrator
-    : public base::RefCounted<AccountToProfilePasswordMigrator> {
+// Self-owned: it holds its own `unique_ptr` (`self_`) so it outlives the async
+// store operations, and drops it to delete itself once the last step finishes.
+// Callbacks are bound with weak pointers, so an in-flight step that is dropped
+// (e.g. the store shuts down) simply stops the chain.
+class AccountToProfilePasswordMigrator {
  public:
   AccountToProfilePasswordMigrator(
       scoped_refptr<PasswordStoreInterface> account_store,
@@ -113,17 +112,16 @@ class AccountToProfilePasswordMigrator
   AccountToProfilePasswordMigrator& operator=(
       const AccountToProfilePasswordMigrator&) = delete;
 
-  void Start() {
+  // Takes ownership of itself via `self` and starts the migration.
+  void Start(std::unique_ptr<AccountToProfilePasswordMigrator> self) {
+    self_ = std::move(self);
     // Step 1: read the account store.
     ReadStore(account_store_.get(),
               base::BindOnce(&AccountToProfilePasswordMigrator::OnAccountLogins,
-                             this));
+                             weak_factory_.GetWeakPtr()));
   }
 
  private:
-  friend class base::RefCounted<AccountToProfilePasswordMigrator>;
-  ~AccountToProfilePasswordMigrator() = default;
-
   // Reads all logins from `store`, passing the (owned) fetch request to
   // `on_results` when done.
   void ReadStore(PasswordStoreInterface* store,
@@ -138,15 +136,15 @@ class AccountToProfilePasswordMigrator
   void OnAccountLogins(std::unique_ptr<PasswordFetchRequest> request) {
     account_forms_ = request->TakeResults();
     if (account_forms_.empty()) {
-      std::move(on_complete_).Run();  // Nothing to migrate.
+      Finish();  // Nothing to migrate.
       return;
     }
     // Step 2: read the profile store before deciding how to merge each
     // credential.
-    ReadStore(
-        profile_store_.get(),
-        base::BindOnce(
-            &AccountToProfilePasswordMigrator::OnProfileLoginsForMerge, this));
+    ReadStore(profile_store_.get(),
+              base::BindOnce(
+                  &AccountToProfilePasswordMigrator::OnProfileLoginsForMerge,
+                  weak_factory_.GetWeakPtr()));
   }
 
   void OnProfileLoginsForMerge(std::unique_ptr<PasswordFetchRequest> request) {
@@ -185,7 +183,7 @@ class AccountToProfilePasswordMigrator
         barrier_count,
         base::BindOnce(
             &AccountToProfilePasswordMigrator::VerifyAndDrainAccountStore,
-            this));
+            weak_factory_.GetWeakPtr()));
     if (!to_add.empty()) {
       profile_store_->AddLogins(std::move(to_add), barrier);
     }
@@ -197,10 +195,10 @@ class AccountToProfilePasswordMigrator
   void VerifyAndDrainAccountStore() {
     // Step 3: re-read the profile store to confirm the writes landed before
     // deleting anything from the account store.
-    ReadStore(
-        profile_store_.get(),
-        base::BindOnce(
-            &AccountToProfilePasswordMigrator::OnProfileLoginsForVerify, this));
+    ReadStore(profile_store_.get(),
+              base::BindOnce(
+                  &AccountToProfilePasswordMigrator::OnProfileLoginsForVerify,
+                  weak_factory_.GetWeakPtr()));
   }
 
   void OnProfileLoginsForVerify(std::unique_ptr<PasswordFetchRequest> request) {
@@ -220,13 +218,19 @@ class AccountToProfilePasswordMigrator
     }
     // Finish only after the removals above have been processed. RemoveLogin has
     // no completion callback, but store operations run in order, so a trailing
-    // read completes after them (and keeps `this` alive until then).
-    ReadStore(
-        account_store_.get(),
-        base::BindOnce(&AccountToProfilePasswordMigrator::OnFinished, this));
+    // read completes after them.
+    ReadStore(account_store_.get(),
+              base::BindOnce(&AccountToProfilePasswordMigrator::OnFinished,
+                             weak_factory_.GetWeakPtr()));
   }
 
-  void OnFinished(std::unique_ptr<PasswordFetchRequest> request) {
+  void OnFinished(std::unique_ptr<PasswordFetchRequest> request) { Finish(); }
+
+  // Runs the completion callback and deletes `this`. `self_` is moved into a
+  // local first so `this` stays alive during the callback and is destroyed when
+  // the local goes out of scope.
+  void Finish() {
+    std::unique_ptr<AccountToProfilePasswordMigrator> self = std::move(self_);
     std::move(on_complete_).Run();
   }
 
@@ -234,6 +238,8 @@ class AccountToProfilePasswordMigrator
   const scoped_refptr<PasswordStoreInterface> profile_store_;
   std::vector<PasswordForm> account_forms_;
   base::OnceClosure on_complete_;
+  std::unique_ptr<AccountToProfilePasswordMigrator> self_;
+  base::WeakPtrFactory<AccountToProfilePasswordMigrator> weak_factory_{this};
 };
 
 }  // namespace
@@ -255,10 +261,11 @@ void MaybeMigrateAccountPasswordsToProfileStore(Profile* profile,
     std::move(on_complete).Run();
     return;
   }
-  base::MakeRefCounted<AccountToProfilePasswordMigrator>(
+  auto migrator = std::make_unique<AccountToProfilePasswordMigrator>(
       std::move(account_store), std::move(profile_store),
-      std::move(on_complete))
-      ->Start();
+      std::move(on_complete));
+  AccountToProfilePasswordMigrator* migrator_ptr = migrator.get();
+  migrator_ptr->Start(std::move(migrator));
 }
 
 }  // namespace brave_password_manager

--- a/browser/password_manager/android/brave_account_to_profile_password_migration.h
+++ b/browser/password_manager/android/brave_account_to_profile_password_migration.h
@@ -1,0 +1,28 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_PASSWORD_MANAGER_ANDROID_BRAVE_ACCOUNT_TO_PROFILE_PASSWORD_MIGRATION_H_
+#define BRAVE_BROWSER_PASSWORD_MANAGER_ANDROID_BRAVE_ACCOUNT_TO_PROFILE_PASSWORD_MIGRATION_H_
+
+#include "base/functional/callback.h"
+#include "base/functional/callback_helpers.h"
+
+class Profile;
+
+namespace brave_password_manager {
+
+// When kBraveAndroidSyncPasswordsInProfileStore is enabled, moves passwords
+// from the account store into the profile store (which becomes the synced
+// store under the flag). Copy -> verify present in profile -> delete from
+// account, so nothing is deleted before it is confirmed copied. No-op when the
+// flag is off or the account store is empty; safe to call on every startup.
+// `on_complete` runs once the migration has finished, including no-op cases.
+void MaybeMigrateAccountPasswordsToProfileStore(
+    Profile* profile,
+    base::OnceClosure on_complete = base::DoNothing());
+
+}  // namespace brave_password_manager
+
+#endif  // BRAVE_BROWSER_PASSWORD_MANAGER_ANDROID_BRAVE_ACCOUNT_TO_PROFILE_PASSWORD_MIGRATION_H_

--- a/browser/password_manager/android/brave_account_to_profile_password_migration_unittest.cc
+++ b/browser/password_manager/android/brave_account_to_profile_password_migration_unittest.cc
@@ -1,0 +1,205 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/password_manager/android/brave_account_to_profile_password_migration.h"
+
+#include <string>
+#include <vector>
+
+#include "base/memory/raw_ptr.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/test/scoped_feature_list.h"
+#include "base/test/test_future.h"
+#include "base/time/time.h"
+#include "brave/components/brave_sync/features.h"
+#include "chrome/browser/password_manager/password_manager_test_util.h"
+#include "chrome/test/base/testing_browser_process.h"
+#include "chrome/test/base/testing_profile.h"
+#include "chrome/test/base/testing_profile_manager.h"
+#include "components/password_manager/core/browser/password_form.h"
+#include "components/password_manager/core/browser/password_store/password_form_converters.h"
+#include "components/password_manager/core/browser/password_store/test_password_store.h"
+#include "content/public/test/browser_task_environment.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace brave_password_manager {
+
+namespace {
+
+using password_manager::PasswordForm;
+using password_manager::TestPasswordStore;
+
+}  // namespace
+
+class BraveAccountToProfilePasswordMigrationTest : public ::testing::Test {
+ protected:
+  BraveAccountToProfilePasswordMigrationTest()
+      : testing_profile_manager_(TestingBrowserProcess::GetGlobal()) {}
+
+  void SetUp() override {
+    ASSERT_TRUE(testing_profile_manager_.SetUp());
+    profile_ = testing_profile_manager_.CreateTestingProfile("TestProfile");
+    profile_store_ = CreateAndUseTestPasswordStore(profile_);
+    account_store_ = CreateAndUseTestAccountPasswordStore(profile_);
+    profile_store_->Init();
+    account_store_->Init();
+  }
+
+  void TearDown() override {
+    account_store_->ShutdownOnUIThread();
+    profile_store_->ShutdownOnUIThread();
+  }
+
+  void EnableFeature() {
+    feature_list_.InitAndEnableFeature(
+        brave_sync::features::kBraveAndroidSyncPasswordsInProfileStore);
+  }
+
+  void DisableFeature() {
+    feature_list_.InitAndDisableFeature(
+        brave_sync::features::kBraveAndroidSyncPasswordsInProfileStore);
+  }
+
+  PasswordForm MakeForm(const std::string& signon_realm,
+                        const std::string& username,
+                        const std::string& password,
+                        bool blocked = false,
+                        base::Time modified = base::Time()) {
+    PasswordForm form;
+    form.url = GURL(signon_realm);
+    form.signon_realm = signon_realm;
+    form.username_value = base::ASCIIToUTF16(username);
+    form.password_value = base::ASCIIToUTF16(password);
+    form.blocked_by_user = blocked;
+    form.date_created = modified;
+    form.date_password_modified = modified;
+    return form;
+  }
+
+  void AddLogin(TestPasswordStore* store, const PasswordForm& form) {
+    base::test::TestFuture<void> future;
+    store->AddLogin(password_manager::FromPasswordForm(form),
+                    future.GetCallback());
+    EXPECT_TRUE(future.Wait());
+  }
+
+  std::vector<PasswordForm> GetLogins(TestPasswordStore* store) {
+    std::vector<PasswordForm> logins;
+    for (const auto& [realm, forms] :
+         password_manager::GetAllLoginsSync(store)) {
+      logins.insert(logins.end(), forms.begin(), forms.end());
+    }
+    return logins;
+  }
+
+  void RunMigration() {
+    base::test::TestFuture<void> future;
+    MaybeMigrateAccountPasswordsToProfileStore(profile_, future.GetCallback());
+    EXPECT_TRUE(future.Wait());
+  }
+
+  content::BrowserTaskEnvironment task_environment_;
+  base::test::ScopedFeatureList feature_list_;
+  TestingProfileManager testing_profile_manager_;
+  raw_ptr<TestingProfile> profile_ = nullptr;
+  scoped_refptr<TestPasswordStore> profile_store_;
+  scoped_refptr<TestPasswordStore> account_store_;
+};
+
+TEST_F(BraveAccountToProfilePasswordMigrationTest, MigratesAccountToProfile) {
+  EnableFeature();
+  AddLogin(account_store_.get(), MakeForm("https://a.com/", "u1", "p1"));
+  AddLogin(account_store_.get(), MakeForm("https://b.com/", "u2", "p2"));
+
+  RunMigration();
+
+  EXPECT_EQ(2u, GetLogins(profile_store_.get()).size());
+  EXPECT_EQ(0u, GetLogins(account_store_.get()).size());
+}
+
+TEST_F(BraveAccountToProfilePasswordMigrationTest, MigratesBlocklistEntry) {
+  EnableFeature();
+  AddLogin(account_store_.get(),
+           MakeForm("https://blocked.com/", "", "", /*blocked=*/true));
+
+  RunMigration();
+
+  std::vector<PasswordForm> profile_logins = GetLogins(profile_store_.get());
+  ASSERT_EQ(1u, profile_logins.size());
+  EXPECT_TRUE(profile_logins[0].blocked_by_user);
+  EXPECT_EQ(0u, GetLogins(account_store_.get()).size());
+}
+
+TEST_F(BraveAccountToProfilePasswordMigrationTest, NewerAccountPasswordWins) {
+  EnableFeature();
+  const base::Time older = base::Time::Now();
+  const base::Time newer = older + base::Hours(1);
+  AddLogin(profile_store_.get(),
+           MakeForm("https://a.com/", "u", "old", /*blocked=*/false, older));
+  AddLogin(account_store_.get(),
+           MakeForm("https://a.com/", "u", "new", /*blocked=*/false, newer));
+
+  RunMigration();
+
+  std::vector<PasswordForm> profile_logins = GetLogins(profile_store_.get());
+  ASSERT_EQ(1u, profile_logins.size());
+  EXPECT_EQ(u"new", profile_logins[0].password_value);
+  EXPECT_EQ(0u, GetLogins(account_store_.get()).size());
+}
+
+TEST_F(BraveAccountToProfilePasswordMigrationTest,
+       OlderAccountPasswordDoesNotOverwrite) {
+  EnableFeature();
+  const base::Time older = base::Time::Now();
+  const base::Time newer = older + base::Hours(1);
+  AddLogin(profile_store_.get(), MakeForm("https://a.com/", "u", "profilenew",
+                                          /*blocked=*/false, newer));
+  AddLogin(account_store_.get(), MakeForm("https://a.com/", "u", "accountold",
+                                          /*blocked=*/false, older));
+
+  RunMigration();
+
+  std::vector<PasswordForm> profile_logins = GetLogins(profile_store_.get());
+  ASSERT_EQ(1u, profile_logins.size());
+  EXPECT_EQ(u"profilenew", profile_logins[0].password_value);
+  EXPECT_EQ(0u, GetLogins(account_store_.get()).size());
+}
+
+TEST_F(BraveAccountToProfilePasswordMigrationTest, IdenticalCredentialDedups) {
+  EnableFeature();
+  AddLogin(profile_store_.get(), MakeForm("https://a.com/", "u", "same"));
+  AddLogin(account_store_.get(), MakeForm("https://a.com/", "u", "same"));
+
+  RunMigration();
+
+  EXPECT_EQ(1u, GetLogins(profile_store_.get()).size());
+  EXPECT_EQ(0u, GetLogins(account_store_.get()).size());
+}
+
+TEST_F(BraveAccountToProfilePasswordMigrationTest, NoOpWhenAccountEmpty) {
+  EnableFeature();
+  AddLogin(profile_store_.get(), MakeForm("https://a.com/", "u", "p"));
+
+  RunMigration();
+
+  EXPECT_EQ(1u, GetLogins(profile_store_.get()).size());
+  EXPECT_EQ(0u, GetLogins(account_store_.get()).size());
+}
+
+TEST_F(BraveAccountToProfilePasswordMigrationTest,
+       DoesNotMigrateWhenFlagDisabled) {
+  DisableFeature();
+  AddLogin(account_store_.get(), MakeForm("https://a.com/", "u1", "p1"));
+  AddLogin(account_store_.get(), MakeForm("https://b.com/", "u2", "p2"));
+
+  RunMigration();
+
+  EXPECT_EQ(0u, GetLogins(profile_store_.get()).size());
+  EXPECT_EQ(2u, GetLogins(account_store_.get()).size());
+}
+
+}  // namespace brave_password_manager

--- a/browser/profiles/brave_profile_manager.cc
+++ b/browser/profiles/brave_profile_manager.cc
@@ -12,6 +12,7 @@
 #include "base/check.h"
 #include "base/path_service.h"
 #include "brave/browser/misc_metrics/profile_misc_metrics_service_factory.h"
+#include "brave/browser/password_manager/android/brave_account_to_profile_password_migration.h"
 #include "brave/browser/perf/brave_perf_features_processor.h"
 #include "brave/browser/profiles/profile_util.h"
 #include "brave/browser/request_otr/request_otr_service_factory.h"
@@ -29,6 +30,7 @@
 #include "brave/components/ntp_background_images/common/pref_names.h"
 #include "brave/components/request_otr/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
+#include "build/build_config.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 #include "chrome/browser/profiles/profile_attributes_entry.h"
@@ -202,6 +204,10 @@ void BraveProfileManager::DoFinalInitForServices(Profile* profile,
   // TODO(https://github.com/brave/brave-browser/issues/50823)
   // Move MigrateHttpsUpgradeSettings from here as well
   MigrateHttpsUpgradeSettings(profile);
+
+#if BUILDFLAG(IS_ANDROID)
+  brave_password_manager::MaybeMigrateAccountPasswordsToProfileStore(profile);
+#endif
 
   ProfileManager::DoFinalInitForServices(profile, go_off_the_record);
   // Mirror the upstream guard so Brave services aren't created for profiles

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -619,8 +619,6 @@ if (enable_brave_vpn_v2) {
 if (is_android) {
   brave_chrome_browser_sources += [
     "//brave/browser/android/brave_init_android.cc",
-    "//brave/browser/password_manager/android/brave_account_to_profile_password_migration.cc",
-    "//brave/browser/password_manager/android/brave_account_to_profile_password_migration.h",
     "//brave/browser/password_manager/android/password_ui_view_android.cc",
     "//brave/browser/password_manager/android/password_ui_view_android.h",
     "//brave/browser/sync/brave_sync_devices_android.cc",
@@ -655,21 +653,19 @@ if (is_android) {
     "//brave/browser/download/android:jni_headers",
     "//brave/browser/ntp_background/android",
     "//brave/browser/password_entry_edit/android",
+    "//brave/browser/password_manager/android:password_migration",
     "//brave/browser/ui/webui/new_tab_takeover/android:new_tab_takeover",
     "//brave/build/android:jni_headers",
-    "//brave/components/brave_sync:features",
     "//brave/components/brave_sync:sync_service_impl_helper",
     "//chrome/android:jni_headers",
     "//chrome/browser/affiliations",
     "//chrome/browser/password_manager/android:password_manager_android",
     "//chrome/browser/password_manager/factories",
     "//chrome/browser/webdata_services",
-    "//components/password_manager/core/browser:password_form",
     "//components/password_manager/core/browser/export",
     "//components/password_manager/core/browser/form_parsing",
     "//components/password_manager/core/browser/import:importer",
     "//components/password_manager/core/browser/leak_detection",
-    "//components/password_manager/core/browser/password_store:password_store_interface",
     "//components/sync_device_info",
   ]
 

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -619,6 +619,8 @@ if (enable_brave_vpn_v2) {
 if (is_android) {
   brave_chrome_browser_sources += [
     "//brave/browser/android/brave_init_android.cc",
+    "//brave/browser/password_manager/android/brave_account_to_profile_password_migration.cc",
+    "//brave/browser/password_manager/android/brave_account_to_profile_password_migration.h",
     "//brave/browser/password_manager/android/password_ui_view_android.cc",
     "//brave/browser/password_manager/android/password_ui_view_android.h",
     "//brave/browser/sync/brave_sync_devices_android.cc",
@@ -655,16 +657,19 @@ if (is_android) {
     "//brave/browser/password_entry_edit/android",
     "//brave/browser/ui/webui/new_tab_takeover/android:new_tab_takeover",
     "//brave/build/android:jni_headers",
+    "//brave/components/brave_sync:features",
     "//brave/components/brave_sync:sync_service_impl_helper",
     "//chrome/android:jni_headers",
     "//chrome/browser/affiliations",
     "//chrome/browser/password_manager/android:password_manager_android",
     "//chrome/browser/password_manager/factories",
     "//chrome/browser/webdata_services",
+    "//components/password_manager/core/browser:password_form",
     "//components/password_manager/core/browser/export",
     "//components/password_manager/core/browser/form_parsing",
     "//components/password_manager/core/browser/import:importer",
     "//components/password_manager/core/browser/leak_detection",
+    "//components/password_manager/core/browser/password_store:password_store_interface",
     "//components/sync_device_info",
   ]
 

--- a/chromium_src/components/password_manager/core/browser/features/DEPS
+++ b/chromium_src/components/password_manager/core/browser/features/DEPS
@@ -1,0 +1,3 @@
+include_rules = [
+  "+brave/components/brave_sync/features.h",
+]

--- a/chromium_src/components/password_manager/core/browser/features/password_manager_features_util.cc
+++ b/chromium_src/components/password_manager/core/browser/features/password_manager_features_util.cc
@@ -1,0 +1,9 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/feature_list.h"
+#include "brave/components/brave_sync/features.h"
+
+#include <components/password_manager/core/browser/features/password_manager_features_util.cc>

--- a/chromium_src/components/password_manager/core/browser/sync/DEPS
+++ b/chromium_src/components/password_manager/core/browser/sync/DEPS
@@ -1,0 +1,3 @@
+include_rules = [
+  "+brave/components/brave_sync/features.h",
+]

--- a/chromium_src/components/password_manager/core/browser/sync/password_data_type_controller.cc
+++ b/chromium_src/components/password_manager/core/browser/sync/password_data_type_controller.cc
@@ -1,0 +1,9 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/feature_list.h"
+#include "brave/components/brave_sync/features.h"
+
+#include <components/password_manager/core/browser/sync/password_data_type_controller.cc>

--- a/chromium_src/components/password_manager/core/browser/sync/password_sync_bridge.cc
+++ b/chromium_src/components/password_manager/core/browser/sync/password_sync_bridge.cc
@@ -1,0 +1,9 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/feature_list.h"
+#include "brave/components/brave_sync/features.h"
+
+#include <components/password_manager/core/browser/sync/password_sync_bridge.cc>

--- a/components/brave_sync/features.cc
+++ b/components/brave_sync/features.cc
@@ -12,5 +12,7 @@ namespace brave_sync::features {
 BASE_FEATURE(kBraveSync, base::FEATURE_ENABLED_BY_DEFAULT);
 BASE_FEATURE(kBraveSyncDefaultPasswords,
              base::FEATURE_ENABLED_BY_DEFAULT);
+BASE_FEATURE(kBraveAndroidSyncPasswordsInProfileStore,
+             base::FEATURE_DISABLED_BY_DEFAULT);
 
 }  // namespace brave_sync::features

--- a/components/brave_sync/features.h
+++ b/components/brave_sync/features.h
@@ -13,6 +13,10 @@ namespace features {
 
 BASE_DECLARE_FEATURE(kBraveSync);
 BASE_DECLARE_FEATURE(kBraveSyncDefaultPasswords);
+// Android only: sync passwords via the profile store (like desktop) instead of
+// the account store, migrating existing account-store passwords to the profile
+// store on startup. Staged rollout; not cleanly reversible once migrated.
+BASE_DECLARE_FEATURE(kBraveAndroidSyncPasswordsInProfileStore);
 
 }  // namespace features
 }  // namespace brave_sync

--- a/components/password_manager/core/browser/features/sources.gni
+++ b/components/password_manager/core/browser/features/sources.gni
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+brave_components_password_manager_core_browser_features_deps =
+    [ "//brave/components/brave_sync:features" ]

--- a/components/password_manager/core/browser/sync/sources.gni
+++ b/components/password_manager/core/browser/sync/sources.gni
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+brave_components_password_manager_core_browser_sync_deps =
+    [ "//brave/components/brave_sync:features" ]

--- a/patches/components-password_manager-core-browser-features-BUILD.gn.patch
+++ b/patches/components-password_manager-core-browser-features-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/components/password_manager/core/browser/features/BUILD.gn b/components/password_manager/core/browser/features/BUILD.gn
+index 8ab1adfdaf728ea37fdd72466813b84a3c371c36..e673a50e1a2484b7da671a520cf26860ae42f6c0 100644
+--- a/components/password_manager/core/browser/features/BUILD.gn
++++ b/components/password_manager/core/browser/features/BUILD.gn
+@@ -30,6 +30,7 @@ source_set("utils") {
+   ]
+ 
+   configs += [ "//build/config/compiler:wexit_time_destructors" ]
++  import("//brave/components/password_manager/core/browser/features/sources.gni") deps += brave_components_password_manager_core_browser_features_deps
+ }
+ 
+ source_set("unit_tests") {

--- a/patches/components-password_manager-core-browser-features-password_manager_features_util.cc.patch
+++ b/patches/components-password_manager-core-browser-features-password_manager_features_util.cc.patch
@@ -1,0 +1,18 @@
+diff --git a/components/password_manager/core/browser/features/password_manager_features_util.cc b/components/password_manager/core/browser/features/password_manager_features_util.cc
+index c62394b4991ee546f806daccc327b16836a6d27b..00ad797b6549e0234b23f2ab7987fa7dd989afe2 100644
+--- a/components/password_manager/core/browser/features/password_manager_features_util.cc
++++ b/components/password_manager/core/browser/features/password_manager_features_util.cc
+@@ -13,6 +13,13 @@
+ namespace password_manager::features_util {
+ 
+ bool IsAccountStorageActive(const syncer::SyncService* sync_service) {
++  #if BUILDFLAG(IS_ANDROID)
++    if (base::FeatureList::IsEnabled(
++          brave_sync::features::kBraveAndroidSyncPasswordsInProfileStore) &&
++          sync_service && sync_service->IsSyncFeatureEnabled()) {
++      return false;
++    }
++  #endif
+   if (!sync_service) {
+     return false;
+   }

--- a/patches/components-password_manager-core-browser-sync-BUILD.gn.patch
+++ b/patches/components-password_manager-core-browser-sync-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/components/password_manager/core/browser/sync/BUILD.gn b/components/password_manager/core/browser/sync/BUILD.gn
+index 5eb1c87d3fe72acf282f047dcd63c62e37af95c8..e208606dbdc6f0c80f1a4c0ccdd6ec9693d98aa5 100644
+--- a/components/password_manager/core/browser/sync/BUILD.gn
++++ b/components/password_manager/core/browser/sync/BUILD.gn
+@@ -32,6 +32,7 @@ source_set("sync") {
+     "//sql",
+     "//url",
+   ]
++  import("//brave/components/password_manager/core/browser/sync/sources.gni") deps += brave_components_password_manager_core_browser_sync_deps
+ }
+ 
+ source_set("unit_tests") {

--- a/patches/components-password_manager-core-browser-sync-password_data_type_controller.cc.patch
+++ b/patches/components-password_manager-core-browser-sync-password_data_type_controller.cc.patch
@@ -1,0 +1,16 @@
+diff --git a/components/password_manager/core/browser/sync/password_data_type_controller.cc b/components/password_manager/core/browser/sync/password_data_type_controller.cc
+index e86fe3c2a2f1d0add6d862ca0dff7994c7e4624b..62c3982a6a4335ec2bb035e4c34fbc3e24fbeb9d 100644
+--- a/components/password_manager/core/browser/sync/password_data_type_controller.cc
++++ b/components/password_manager/core/browser/sync/password_data_type_controller.cc
+@@ -39,7 +39,10 @@ void PasswordDataTypeController::LoadModels(
+   // Make syncing users behave like signed-in users, storage-wise.
+   // TODO(crbug.com/40067058): Drop when kForceMigrateSyncingUserToSignedIn
+   // is launched on Android, since there won't be syncing users anymore.
+-  overridden_context.sync_mode = syncer::SyncMode::kTransportOnly;
++  if (!base::FeatureList::IsEnabled(
++          brave_sync::features::kBraveAndroidSyncPasswordsInProfileStore)) {
++    overridden_context.sync_mode = syncer::SyncMode::kTransportOnly;
++  }
+ #endif
+   sync_mode_ = overridden_context.sync_mode;
+   DataTypeController::LoadModels(overridden_context, model_load_callback);

--- a/patches/components-password_manager-core-browser-sync-password_sync_bridge.cc.patch
+++ b/patches/components-password_manager-core-browser-sync-password_sync_bridge.cc.patch
@@ -1,0 +1,25 @@
+diff --git a/components/password_manager/core/browser/sync/password_sync_bridge.cc b/components/password_manager/core/browser/sync/password_sync_bridge.cc
+index c757b03336058f9ce48798165a855041d99a2474..3762c57d0e9cec8e686aba4023bebb16d932c68e 100644
+--- a/components/password_manager/core/browser/sync/password_sync_bridge.cc
++++ b/components/password_manager/core/browser/sync/password_sync_bridge.cc
+@@ -896,6 +896,20 @@ bool PasswordSyncBridge::SupportsGetStorageKey() const {
+ 
+ void PasswordSyncBridge::ApplyDisableSyncChanges(
+     std::unique_ptr<syncer::MetadataChangeList> delete_metadata_change_list) {
++  if (wipe_model_upon_sync_disabled_behavior_ ==
++          syncer::WipeModelUponSyncDisabledBehavior::kAlways &&
++      base::FeatureList::IsEnabled(
++          brave_sync::features::kBraveAndroidSyncPasswordsInProfileStore)) {
++    CHECK(password_store_sync_->IsAccountStore());
++
++    delete_metadata_change_list->DropAllChanges();
++    delete_metadata_change_list.reset();
++
++    password_store_sync_->GetMetadataStore()->DeleteAllSyncMetadata(
++        syncer::PASSWORDS);
++    sync_enabled_or_disabled_cb_.Run();
++    return;
++  }
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+   CHECK(password_store_sync_);
+ 

--- a/rewrite/components/password_manager/core/browser/features/password_manager_features_util.cc.yaml
+++ b/rewrite/components/password_manager/core/browser/features/password_manager_features_util.cc.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      IsAccountStorageActive looks on kBraveAndroidSyncPasswordsInProfileStore flag
+
+      Brave: apply the syncing-user disqualifier on desktop (unchanged) and on
+      Android only when the profile-store flag is enabled, so saves route to the
+      profile store, consistent with the active sync delegate.
+    preempt_function_impl:
+      function_name: IsAccountStorageActive
+      code: |-
+        #if BUILDFLAG(IS_ANDROID)
+          if (base::FeatureList::IsEnabled(
+                brave_sync::features::kBraveAndroidSyncPasswordsInProfileStore) &&
+                sync_service && sync_service->IsSyncFeatureEnabled()) {
+            return false;
+          }
+        #endif

--- a/rewrite/components/password_manager/core/browser/sync/password_data_type_controller.cc.yaml
+++ b/rewrite/components/password_manager/core/browser/sync/password_data_type_controller.cc.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      Wrap kTransportOnly mode with kBraveAndroidSyncPasswordsInProfileStore flag
+
+      Brave: only force transport-only (account store) when the flag is off;
+      when on, keep the incoming sync mode (kFull) so sync uses the profile
+      store for passwords like desktop.
+    regex:
+      re_pattern:
+        '(overridden_context\.sync_mode = syncer::SyncMode::kTransportOnly;)'
+      replace: |-
+        if (!base::FeatureList::IsEnabled(
+                  brave_sync::features::kBraveAndroidSyncPasswordsInProfileStore)) {
+            \1
+          }

--- a/rewrite/components/password_manager/core/browser/sync/password_sync_bridge.cc.yaml
+++ b/rewrite/components/password_manager/core/browser/sync/password_sync_bridge.cc.yaml
@@ -1,0 +1,32 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |
+      ApplyDisableSyncChanges looks on kBraveAndroidSyncPasswordsInProfileStore flag
+
+      When the flag is enabled, then account store should not be wiped
+      to preserve records till the migration at startup.
+      Under the profile-store flag the account store is drained to
+      the profile store by a startup migrator. Do NOT delete its data here
+      (that would race the migrator and lose any credentials not yet on
+      the sync server); wipe only the metadata, like the kNever case.
+    preempt_function_impl:
+      function_name: PasswordSyncBridge::ApplyDisableSyncChanges
+      code: |-
+        if (wipe_model_upon_sync_disabled_behavior_ ==
+                syncer::WipeModelUponSyncDisabledBehavior::kAlways &&
+            base::FeatureList::IsEnabled(
+                brave_sync::features::kBraveAndroidSyncPasswordsInProfileStore)) {
+          CHECK(password_store_sync_->IsAccountStore());
+
+          delete_metadata_change_list->DropAllChanges();
+          delete_metadata_change_list.reset();
+
+          password_store_sync_->GetMetadataStore()->DeleteAllSyncMetadata(
+              syncer::PASSWORDS);
+          sync_enabled_or_disabled_cb_.Run();
+          return;
+        }


### PR DESCRIPTION
This PR switches store for synced passwords  from account store to profile store on Android to match the way how it is done on desktop and does a migration of passwords from account store to password store if required.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58845

### Test plan

#### I. Switch of store and migration of passwords
  1. Flag is off, sync is off, create password u1
  2. Flag off, enable sync, save a password u3
  3. Open page fill.dev, do login u5, do not press save password, go offline (airplane mode, WiFI is off) - then press save password u5
  4. Still offline, enable `Sync passwords in profile store` flag, restart
  5. Switch device to online mode
  6. Exit the sync chain - ensure all the passwords are at Password Manager
  
#### II. Plan for blocklist migration
  1. Enable sync (flag off)
  2. Open the site online, do login u5, do not press anything in popup, go offline (airplane mode, WiFI is off) - then press "never save"
  3. Enable `Sync passwords in profile store` flag, restart, still offline
  4. Open password manager, ensure the blocklist entry survived and migrated


<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
