### PR TITLE
[Android] Fix renderer kill on WebOTP requests with kWebOTP disabled (uplift to 1.96.x)

### DIFF
--- a/browser/test/BUILD.gn
+++ b/browser/test/BUILD.gn
@@ -3,39 +3,62 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-source_set("browser_tests") {
+# These use `InProcessBrowserTest`, which does not exist on Android, and nor
+# does `//chrome/test:test_support_ui`.
+if (!is_android) {
+  source_set("browser_tests") {
+    testonly = true
+    defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+
+    sources = [
+      "disabled_features/disable_client_hints_browsertest.cc",
+      "disabled_features/fenced_frame_browsertest.cc",
+      "disabled_features/navigator_battery_browsertest.cc",
+      "disabled_features/navigator_bluetooth_browsertest.cc",
+      "disabled_features/navigator_storage_browsertest.cc",
+      "disabled_features/reporting_observer_browsertest.cc",
+      "disabled_features/window_name_browsertest.cc",
+      "document_location_browsertest.cc",
+    ]
+
+    deps = [
+      "//base",
+      "//brave/browser",
+      "//brave/common",
+      "//chrome/browser",
+      "//chrome/browser/content_settings:content_settings_factory",
+      "//chrome/browser/ui",
+      "//chrome/common",
+      "//chrome/test:test_support",
+      "//chrome/test:test_support_ui",
+      "//content/public/browser",
+      "//content/test:test_support",
+      "//ui/webui:test_support",
+    ]
+
+    if (is_mac) {
+      sources += [ "os_crypt/keychain_password_mac_browsertest.mm" ]
+
+      deps += [ "//components/os_crypt/common:keychain_password_mac" ]
+    }
+  }
+}
+
+# Unlike `browser_tests`, these use `PlatformBrowserTest`, so they also build
+# and run on Android.
+source_set("platform_browser_tests") {
   testonly = true
   defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
 
-  sources = [
-    "disabled_features/disable_client_hints_browsertest.cc",
-    "disabled_features/fenced_frame_browsertest.cc",
-    "disabled_features/navigator_battery_browsertest.cc",
-    "disabled_features/navigator_bluetooth_browsertest.cc",
-    "disabled_features/navigator_storage_browsertest.cc",
-    "disabled_features/reporting_observer_browsertest.cc",
-    "disabled_features/window_name_browsertest.cc",
-    "document_location_browsertest.cc",
-  ]
+  sources = [ "disabled_features/web_otp_browsertest.cc" ]
 
   deps = [
     "//base",
-    "//brave/browser",
-    "//brave/common",
-    "//chrome/browser",
-    "//chrome/browser/content_settings:content_settings_factory",
-    "//chrome/browser/ui",
-    "//chrome/common",
     "//chrome/test:test_support",
-    "//chrome/test:test_support_ui",
     "//content/public/browser",
     "//content/test:test_support",
-    "//ui/webui:test_support",
+    "//net:test_support",
+    "//testing/gtest",
+    "//url",
   ]
-
-  if (is_mac) {
-    sources += [ "os_crypt/keychain_password_mac_browsertest.mm" ]
-
-    deps += [ "//components/os_crypt/common:keychain_password_mac" ]
-  }
 }

--- a/browser/test/disabled_features/web_otp_browsertest.cc
+++ b/browser/test/disabled_features/web_otp_browsertest.cc
@@ -1,0 +1,69 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+
+#include "base/functional/bind.h"
+#include "chrome/test/base/chrome_test_utils.h"
+#include "chrome/test/base/platform_browser_test.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "net/test/embedded_test_server/http_request.h"
+#include "net/test/embedded_test_server/http_response.h"
+#include "url/gurl.h"
+
+namespace {
+
+std::unique_ptr<net::test_server::HttpResponse> HandleRequest(
+    const net::test_server::HttpRequest& request) {
+  auto response = std::make_unique<net::test_server::BasicHttpResponse>();
+  response->set_content_type("text/html");
+  response->set_content("<html><body></body></html>");
+  return response;
+}
+
+}  // namespace
+
+// navigator.credentials is [SecureContext], so these navigate to the embedded
+// test server rather than a data: URL, which is an opaque origin.
+class WebOtpDisabledTest : public PlatformBrowserTest {
+ public:
+  void SetUpOnMainThread() override {
+    PlatformBrowserTest::SetUpOnMainThread();
+    embedded_test_server()->RegisterDefaultHandler(
+        base::BindRepeating(&HandleRequest));
+    ASSERT_TRUE(embedded_test_server()->Start());
+    ASSERT_TRUE(content::NavigateToURL(web_contents(),
+                                       embedded_test_server()->GetURL("/")));
+  }
+
+ protected:
+  content::WebContents* web_contents() {
+    return chrome_test_utils::GetActiveWebContents(this);
+  }
+};
+
+// features::kWebOTP is shipped disabled, so the renderer must not expose the
+// API either.
+IN_PROC_BROWSER_TEST_F(WebOtpDisabledTest, ApiIsNotExposed) {
+  EXPECT_EQ(false,
+            content::EvalJs(web_contents(), "'OTPCredential' in window"));
+}
+
+// blink.mojom.WebOTPService is bound only while features::kWebOTP is enabled,
+// so a renderer that still exposes WebOTP asks for a binder that is not there,
+// which is a bad message and terminates the renderer.
+IN_PROC_BROWSER_TEST_F(WebOtpDisabledTest, RequestingOtpDoesNotKillTab) {
+  // With WebOTP disabled the `otp` member is not recognized, so no credential
+  // type is requested and the promise rejects without the renderer ever asking
+  // for the binder.
+  EXPECT_EQ("NotSupportedError", content::EvalJs(web_contents(), R"(
+      navigator.credentials.get({otp: {transport: ['sms']}})
+          .then(() => 'resolved', e => e.name)
+  )"));
+  EXPECT_FALSE(web_contents()->IsCrashed());
+}

--- a/renderer/brave_content_renderer_client.cc
+++ b/renderer/brave_content_renderer_client.cc
@@ -131,6 +131,16 @@ void BraveContentRendererClient::
   blink::WebRuntimeFeatures::EnableWebGPUExperimentalFeatures(false);
   blink::WebRuntimeFeatures::EnableWebNFC(false);
 
+  // Disable the WebOTP API; kWebOTP is disabled browser-side, and
+  // content/child/runtime_features.cc forwards that state to Blink only when
+  // the feature is overridden by a field trial or the command line - a
+  // plastered default is not an override. Without this the renderer requests
+  // blink.mojom.WebOTPService, whose binder is registered only while the
+  // feature is on, and the missing binder is a bad message that kills the
+  // renderer. Upstream syncs UserMediaElement the same way; see
+  // runtime_features.cc.
+  blink::WebRuntimeFeatures::EnableWebOTP(false);
+
   // These features don't have dedicated WebRuntimeFeatures wrappers.
   blink::WebRuntimeFeatures::EnableFeatureFromString("AdTagging", false);
   blink::WebRuntimeFeatures::EnableFeatureFromString("AIClassifierAPI", false);

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1032,6 +1032,7 @@ test("brave_browser_tests") {
     "//brave/browser/skus/test:browser_tests",
     "//brave/browser/storage_access_api:browser_tests",
     "//brave/browser/test:browser_tests",
+    "//brave/browser/test:platform_browser_tests",
     "//brave/browser/themes",
     "//brave/browser/ui:browser_tests",
     "//brave/browser/ui/tabs:tabs_public",


### PR DESCRIPTION
Uplift of #39700
Resolves https://github.com/brave/brave-browser/issues/58817

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.