### PR TITLE
[VPN 2.0] Implement AgentLauncher on Windows

### DIFF
--- a/components/brave_vpn/browser/v2/agent/BUILD.gn
+++ b/components/brave_vpn/browser/v2/agent/BUILD.gn
@@ -69,6 +69,8 @@ source_set("unit_tests") {
 
   if (is_mac) {
     sources += [ "agent_launcher_mac_unittest.mm" ]
+  } else if (is_win) {
+    sources += [ "agent_launcher_win_unittest.cc" ]
   }
 
   deps = [

--- a/components/brave_vpn/browser/v2/agent/agent_launcher_win.cc
+++ b/components/brave_vpn/browser/v2/agent/agent_launcher_win.cc
@@ -3,27 +3,99 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <windows.h>
+
+#include <optional>
+#include <utility>
+
+#include "base/command_line.h"
 #include "base/files/file_path.h"
-#include "base/notimplemented.h"
+#include "base/files/file_util.h"
+#include "base/functional/bind.h"
+#include "base/logging.h"
+#include "base/path_service.h"
+#include "base/process/launch.h"
+#include "base/process/process.h"
+#include "base/task/task_traits.h"
+#include "base/task/thread_pool.h"
+#include "base/win/access_token.h"
+#include "brave/components/brave_vpn/app/v2/agent/branding_buildflags.h"
 #include "brave/components/brave_vpn/browser/v2/agent/agent_launcher_internal.h"
 
 namespace brave_vpn::v2::internal {
+namespace {
+
+// The filtered, medium integrity token of an elevated browser; empty when the
+// browser is not elevated, or when the session has no lower integrity level to
+// drop to.
+std::optional<base::win::AccessToken> GetDeElevatedToken() {
+  std::optional<base::win::AccessToken> token =
+      base::win::AccessToken::FromCurrentProcess(
+          /*impersonation=*/false, TOKEN_DUPLICATE | TOKEN_QUERY);
+  if (!token || !token->IsElevated()) {
+    return std::nullopt;
+  }
+
+  std::optional<base::win::AccessToken> filtered_token = token->LinkedToken();
+  if (!filtered_token) {
+    return std::nullopt;
+  }
+  return filtered_token->DuplicatePrimary(TOKEN_QUERY | TOKEN_DUPLICATE |
+                                          TOKEN_ASSIGN_PRIMARY);
+}
+
+bool LaunchDetached(const base::CommandLine& command_line, HANDLE as_user) {
+  base::LaunchOptions options;
+  options.as_user = as_user;
+  options.start_hidden = true;
+
+  // The browser may itself sit inside a job object with "kill on close",
+  // which would take the agent down with it. Try to breakaway first, though
+  // it may fail due to lack of the necessary job object permissions.
+  options.force_breakaway_from_job_ = true;
+  if (base::LaunchProcess(command_line, options).IsValid()) {
+    return true;
+  }
+  options.force_breakaway_from_job_ = false;
+  return base::LaunchProcess(command_line, options).IsValid();
+}
+
+void CreateAgentProcess(AgentLauncher::LaunchFailureCallback failure_callback,
+                        const base::FilePath& agent_path) {
+  // The agent needs no elevated privileges, so it must not get them just
+  // because the browser happens to be running elevated. Launching with the
+  // filtered token puts it at the integrity level the rest of the session uses.
+  const std::optional<base::win::AccessToken> token = GetDeElevatedToken();
+  if (!LaunchDetached(base::CommandLine(agent_path),
+                      token ? token->get() : nullptr)) {
+    std::move(failure_callback).Run(AgentLauncher::LaunchError::kLaunchFailed);
+  }
+}
+
+}  // namespace
 
 base::FilePath GetValidAgentPath() {
-  // TODO(https://github.com/brave/brave-browser/issues/58243)
-  // Implement agent path building and validation logic for Windows.
-  // Empty path means there is no valid agent executable found.
-  NOTIMPLEMENTED_LOG_ONCE()
-      << "GetValidAgentPath() is not yet implemented on Windows";
-  return {};
+  const base::FilePath agent_path =
+      base::PathService::CheckedGet(base::DIR_EXE)
+          .AppendASCII(BUILDFLAG(VPN_AGENT_EXE_NAME));
+  if (!base::PathExists(agent_path)) {
+    LOG(ERROR) << "VPN agent not found at " << agent_path;
+    return {};
+  }
+  return agent_path;
 }
 
 void LaunchAgentProcess(AgentLauncher::LaunchFailureCallback failure_callback,
                         const base::FilePath& agent_path) {
-  // TODO(https://github.com/brave/brave-browser/issues/58243)
-  // Implement agent launch logic for Windows using appropriate Windows APIs.
-  NOTIMPLEMENTED_LOG_ONCE()
-      << "LaunchAgentProcess() is not yet implemented on Windows";
+  // Process creation blocks, so it cannot run on the calling (UI) sequence. The
+  // failure callback is already bound to the caller's sequence, so the task can
+  // run it directly.
+  base::ThreadPool::PostTask(
+      FROM_HERE,
+      {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
+       base::TaskShutdownBehavior::CONTINUE_ON_SHUTDOWN},
+      base::BindOnce(&CreateAgentProcess, std::move(failure_callback),
+                     agent_path));
 }
 
 }  // namespace brave_vpn::v2::internal

--- a/components/brave_vpn/browser/v2/agent/agent_launcher_win_unittest.cc
+++ b/components/brave_vpn/browser/v2/agent/agent_launcher_win_unittest.cc
@@ -1,0 +1,59 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <optional>
+
+#include "base/base_paths.h"
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/test/scoped_path_override.h"
+#include "brave/components/brave_vpn/app/v2/agent/branding_buildflags.h"
+#include "brave/components/brave_vpn/browser/v2/agent/agent_launcher_internal.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_vpn::v2::internal {
+
+// Overriding DIR_EXE keeps this hermetic: the result must not depend on
+// whether the build directory happens to hold a built agent.
+class AgentLauncherWinTest : public testing::Test {
+ public:
+  AgentLauncherWinTest() {
+    CHECK(exe_dir_.CreateUniqueTempDir());
+    exe_override_.emplace(base::DIR_EXE, exe_dir_.GetPath());
+  }
+
+  base::FilePath ExpectedAgentPath() const {
+    return exe_dir_.GetPath().AppendASCII(BUILDFLAG(VPN_AGENT_EXE_NAME));
+  }
+
+ protected:
+  base::ScopedTempDir exe_dir_;
+  std::optional<base::ScopedPathOverride> exe_override_;
+};
+
+// Locks the install layout the browser relies on. If the installer stops
+// placing the agent next to the executable, or renames it independently of
+// VPN_AGENT_EXE_NAME, this is what should fail.
+TEST_F(AgentLauncherWinTest, FindsAgentNextToModule) {
+  const base::FilePath agent_path = ExpectedAgentPath();
+  ASSERT_TRUE(base::WriteFile(agent_path, ""));
+
+  const base::FilePath found_path = GetValidAgentPath();
+  ASSERT_FALSE(found_path.empty());
+  EXPECT_EQ(found_path, agent_path);
+
+  // Independent of the constants above.
+  EXPECT_EQ(found_path.Extension(), L".exe");
+  EXPECT_EQ(found_path.DirName(), exe_dir_.GetPath());
+}
+
+// An empty result is the only signal the shared layer has for reporting
+// kAppNotFound, so a missing executable must not come back as a usable path.
+TEST_F(AgentLauncherWinTest, EmptyWhenAgentMissing) {
+  EXPECT_TRUE(GetValidAgentPath().empty());
+}
+
+}  // namespace brave_vpn::v2::internal


### PR DESCRIPTION
Locate the agent next to the browser executable and create it detached, with the executable name coming from the same GN variable that names it at build time.

The agent needs no elevated privileges, so it must not inherit them when the browser itself happens to run elevated: an elevated browser launches it with the filtered token instead, putting the agent at the integrity level the rest of the session uses.

Implements part of https://github.com/brave/brave-browser/issues/58243