### PR TITLE
Enable vertical tabs glass effect

### DIFF
--- a/browser/ui/views/frame/BUILD.gn
+++ b/browser/ui/views/frame/BUILD.gn
@@ -30,6 +30,7 @@ source_set("frame") {
     "//chrome/browser/ui/exclusive_access",
     "//chrome/browser/ui/views/bookmarks",
     "//chrome/browser/ui/views/infobars",
+    "//ui/base:features",
     "//ui/compositor",
   ]
 }

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <memory>
 #include <utility>
 
 #include "base/check.h"
@@ -16,6 +17,7 @@
 #include "brave/browser/ui/views/sidebar/sidebar_container_view.h"
 #include "build/build_config.h"
 #include "chrome/browser/ui/browser_window/public/browser_window_features.h"
+#include "chrome/browser/ui/color/chrome_color_id.h"
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
 #include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
 #include "chrome/browser/ui/layout_constants.h"
@@ -26,11 +28,15 @@
 #include "chrome/browser/ui/views/frame/custom_corners_background.h"
 #include "chrome/browser/ui/views/frame/layout/browser_view_layout_delegate.h"
 #include "chrome/browser/ui/views/frame/multi_contents_view.h"
+#include "chrome/browser/ui/views/frame/themed_background.h"
 #include "chrome/browser/ui/views/infobars/infobar_container_view.h"
 #include "chrome/browser/ui/views/side_panel/side_panel.h"
+#include "ui/base/ui_base_features.h"
+#include "ui/views/background.h"
 #include "ui/views/border.h"
 #include "ui/views/layout/layout_provider.h"
 #include "ui/views/view_class_properties.h"
+#include "ui/views/view_utils.h"
 
 BraveBrowserViewTabbedLayoutImpl::BraveBrowserViewTabbedLayoutImpl(
     std::unique_ptr<BrowserViewLayoutDelegate> delegate,
@@ -308,6 +314,7 @@ void BraveBrowserViewTabbedLayoutImpl::DoPostLayoutVisualAdjustments(
   BrowserViewTabbedLayoutImpl::DoPostLayoutVisualAdjustments(params);
   UpdateInsetsForVerticalTabStrip();
   delegate().UpdateContentsCornerRadii(CalculateContentsCornerRadii());
+  UpdateBackgroundsForGlassFrame();
 
   if (delegate().ShouldDrawVerticalTabStrip()) {
     return;
@@ -618,6 +625,75 @@ void BraveBrowserViewTabbedLayoutImpl::UpdateInsetsForVerticalTabStrip() {
 
   views().vertical_tab_strip_host->SetBorder(
       insets.IsEmpty() ? nullptr : views::CreateEmptyBorder(insets));
+}
+
+bool BraveBrowserViewTabbedLayoutImpl::IsFullWindowGlassFrameActive() const {
+  // The chrome only paints over glass while this window is the one holding the
+  // glass frame, and never in fullscreen, where upstream keeps the frame
+  // opaque. Both vertical tab implementations qualify; they are mutually
+  // exclusive.
+  return in_glass_mode() &&
+         !is_fullscreen(delegate().GetBrowserWindowState()) &&
+         (delegate().ShouldDrawVerticalTabStrip() ||
+          delegate().ShouldShowVerticalTabs());
+}
+
+void BraveBrowserViewTabbedLayoutImpl::UpdateBackgroundsForGlassFrame() {
+  if (!features::IsGlassFrameEnabled()) {
+    return;
+  }
+
+  const bool use_glass = IsFullWindowGlassFrameActive();
+  const CustomCornersBackground::ColorChoiceWithAlpha primary_color(
+      CustomCornersBackground::ToolbarTheme(), use_glass ? 0.0f : 1.0f);
+
+  auto set_primary_color = [&primary_color](views::View* view) {
+    if (!view || !view->background()) {
+      return;
+    }
+    if (auto* const background =
+            view->background()->AsA<CustomCornersBackground>()) {
+      background->SetPrimaryColor(primary_color);
+    }
+  };
+
+  // The toolbar and main area colors are only set when those views are built,
+  // so they have to be restored here as well.
+  set_primary_color(views().toolbar);
+  set_primary_color(views().main_background_region);
+
+  // ConfigureTopContainerBackground() runs on every layout pass and resets the
+  // top container color, so only override it while the glass is showing.
+  if (use_glass) {
+    set_primary_color(views().top_container);
+  }
+
+  // The remaining surfaces have to have their background swapped out rather
+  // than recolored. Whether `view` still needs that swap: in glass mode it
+  // should end up with no background, otherwise with its opaque one back.
+  // Comparing against the current background rather than tracking transitions
+  // also covers the bookmark bar, which is created lazily.
+  const auto needs_swap = [use_glass](views::View* view) {
+    return view && static_cast<bool>(view->background()) == use_glass;
+  };
+
+  // The host sits behind the vertical tab strip, which floats above it in its
+  // own layer, so both have to let the glass through.
+  if (needs_swap(views().vertical_tab_strip_host)) {
+    views().vertical_tab_strip_host->SetBackground(
+        use_glass ? nullptr : views::CreateSolidBackground(kColorToolbar));
+  }
+
+  if (needs_swap(views().bookmark_bar)) {
+    views().bookmark_bar->SetBackground(
+        use_glass ? nullptr
+                  : std::make_unique<ThemedBackground>(
+                        views::AsViewClass<BrowserView>(views().browser_view)));
+  }
+
+  if (views().sidebar_container) {
+    views().sidebar_container->SetUseGlassBackground(use_glass);
+  }
 }
 
 gfx::Insets BraveBrowserViewTabbedLayoutImpl::GetContentsMargins() const {

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.cc
@@ -345,6 +345,21 @@ void BraveBrowserViewTabbedLayoutImpl::DoPostLayoutVisualAdjustments(
   toolbar_background->SetCorners(toolbar_corners);
 }
 
+void BraveBrowserViewTabbedLayoutImpl::OnGlassModeChanged() {
+  BrowserViewTabbedLayoutImpl::OnGlassModeChanged();
+
+  // Upstream only invalidates its own tab strip region views here, and with
+  // Brave's vertical tabs neither of them is laid out by the browser view. The
+  // backgrounds that follow the glass state are updated from
+  // DoPostLayoutVisualAdjustments(), so without a layout pass the chrome stays
+  // opaque and hides the glass until something else happens to relayout. The
+  // first window of the session hits this, as it only becomes glass eligible
+  // once it activates, which is after its initial layout.
+  if (views().browser_view) {
+    views().browser_view->InvalidateLayout();
+  }
+}
+
 int BraveBrowserViewTabbedLayoutImpl::GetHorizontalTabStripLeadingMargin(
     const BrowserLayoutParams& params) const {
   // Compact, with no leading exclusion padding (i.e. not an alternate

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
@@ -79,6 +79,7 @@ class BraveBrowserViewTabbedLayoutImpl : public BrowserViewTabbedLayoutImpl {
   void DoPreLayoutComputations(const BrowserLayoutParams& params) override;
   void DoPostLayoutVisualAdjustments(
       const BrowserLayoutParams& params) override;
+  void OnGlassModeChanged() override;
   // SeparatorInfo is the upstream's private nested type. Friend access (added
   // via the chromium_src .h shadow) lets this subclass name it here; the body
   // of the override lives in

--- a/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
+++ b/browser/ui/views/frame/layout/brave_browser_view_tabbed_layout_impl.h
@@ -121,6 +121,16 @@ class BraveBrowserViewTabbedLayoutImpl : public BrowserViewTabbedLayoutImpl {
 
   void UpdateInsetsForVerticalTabStrip();
 
+  // Whether the macOS glass frame is showing behind the entire window, which
+  // Brave does with vertical tabs. See the glass frame width/height hooks in
+  // chromium_src/chrome/browser/ui/views/frame/browser_native_widget_mac.mm.
+  bool IsFullWindowGlassFrameActive() const;
+
+  // Makes the chrome surfaces sitting on top of the glass frame paint
+  // transparent, so the glass shows through all of them, and restores their
+  // opaque color once the glass frame goes away.
+  void UpdateBackgroundsForGlassFrame();
+
   gfx::Insets GetContentsMargins() const;
 
   // Whether the contents area reaches the top edge of the window, which happens

--- a/browser/ui/views/frame/vertical_tabs/BUILD.gn
+++ b/browser/ui/views/frame/vertical_tabs/BUILD.gn
@@ -37,9 +37,11 @@ source_set("vertical_tabs") {
     "//chrome/browser/ui/frame",
     "//chrome/browser/ui/tabs",
     "//chrome/browser/ui/views:layout_provider",
+    "//chrome/browser/ui/views/frame:glass_frame_service",
     "//chrome/browser/ui/views/toolbar",
     "//chrome/common:constants",
     "//components/prefs",
+    "//ui/compositor",
     "//ui/views",
   ]
 }

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_container_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_container_view.cc
@@ -15,6 +15,7 @@
 #include "brave/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/compositor/layer.h"
 #include "ui/views/layout/fill_layout.h"
 #include "ui/views/view_utils.h"
 
@@ -36,6 +37,9 @@ BraveVerticalTabStripContainerView::BraveVerticalTabStripContainerView(
                   browser_view_->tab_strip_view())))) {
   // Needs layer to render this over the webview.
   SetPaintToLayer();
+  // Layers fill their bounds opaquely by default, which paints black wherever
+  // the strip doesn't. It drops its background with the macOS glass frame.
+  layer()->SetFillsBoundsOpaquely(false);
 
   // As we follow user's choice for vertical tab alignment,
   // we don't need to mirror this view.

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.cc
@@ -46,6 +46,7 @@
 #include "chrome/browser/ui/ui_features.h"
 #include "chrome/browser/ui/views/chrome_layout_provider.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/frame/glass_frame_service.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_ink_drop_util.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_view.h"
 #include "chrome/common/pref_names.h"
@@ -328,7 +329,17 @@ BraveVerticalTabStripRegionView::BraveVerticalTabStripRegionView(
       GetShortcutTextForNewTabButton(browser_view), browser_));
 
   resize_area_ = AddChildView(std::make_unique<ResettableResizeArea>(this));
-  SetBackground(views::CreateSolidBackground(kColorToolbar));
+
+  if (auto* const glass_frame_service = GlassFrameService::GetInstance()) {
+    is_glass_frame_eligible_ =
+        glass_frame_service->IsBrowserWindowEligible(browser_);
+    glass_frame_subscription_ =
+        glass_frame_service->RegisterGlassFrameEligibilityChangedCallback(
+            browser_, base::BindRepeating(&BraveVerticalTabStripRegionView::
+                                              OnGlassFrameEligibilityChanged,
+                                          base::Unretained(this)));
+  }
+  UpdateBackground();
 
   auto* prefs = browser_->GetProfile()->GetPrefs();
 
@@ -530,6 +541,7 @@ void BraveVerticalTabStripRegionView::SetState(State state) {
 
   last_state_ = std::exchange(state_, state);
   resize_area_->SetEnabled(state == State::kExpanded);
+  UpdateBackground();
 
   if (!VerticalTabController::FromBrowser(browser_)
            ->ShouldShowBraveVerticalTabs()) {
@@ -772,6 +784,26 @@ void BraveVerticalTabStripRegionView::OnThemeChanged() {
   View::OnThemeChanged();
 
   UpdateBorder();
+}
+
+void BraveVerticalTabStripRegionView::OnGlassFrameEligibilityChanged(
+    bool is_eligible) {
+  if (is_glass_frame_eligible_ == is_eligible) {
+    return;
+  }
+
+  is_glass_frame_eligible_ = is_eligible;
+  UpdateBackground();
+}
+
+void BraveVerticalTabStripRegionView::UpdateBackground() {
+  // With the glass frame, the window is one continuous glass surface and the
+  // tab strip lets it show through. While floating, the strip sits on top of
+  // the web contents instead of the window frame, so it stays opaque.
+  const bool show_glass =
+      is_glass_frame_eligible_ && state_ != State::kFloating;
+  SetBackground(show_glass ? nullptr
+                           : views::CreateSolidBackground(kColorToolbar));
 }
 
 void BraveVerticalTabStripRegionView::OnMouseExited(

--- a/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tabs/vertical_tab_strip_region_view.h
@@ -214,6 +214,12 @@ class BraveVerticalTabStripRegionView : public views::View,
   // of this view if it's needed
   void OnCollapseAnimationEnded();
 
+  void OnGlassFrameEligibilityChanged(bool is_eligible);
+
+  // Picks between the opaque toolbar background and no background at all, so
+  // the macOS glass frame can show through the tab strip.
+  void UpdateBackground();
+
   raw_ptr<BrowserView> browser_view_ = nullptr;
   raw_ptr<Browser> browser_ = nullptr;
   raw_ptr<HorizontalTabStripRegionView> original_region_view_ = nullptr;
@@ -257,6 +263,9 @@ class BraveVerticalTabStripRegionView : public views::View,
   base::OneShotTimer mouse_exit_timer_;
 
   bool mouse_events_for_test_ = false;
+
+  bool is_glass_frame_eligible_ = false;
+  base::CallbackListSubscription glass_frame_subscription_;
 
   gfx::SlideAnimation width_animation_{this};
 

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -51,6 +51,7 @@
 #include "ui/events/event_observer.h"
 #include "ui/events/types/event_type.h"
 #include "ui/gfx/geometry/point.h"
+#include "ui/views/background.h"
 #include "ui/views/border.h"
 #include "ui/views/controls/webview/webview.h"
 #include "ui/views/event_monitor.h"
@@ -155,6 +156,32 @@ void SidebarContainerView::SetSidebarControlViewVisibilityChangedCallback(
   sidebar_control_view_visibility_changed_callback_ = std::move(callback);
 }
 
+void SidebarContainerView::SetUseGlassBackground(bool use_glass) {
+  if (use_glass_background_ == use_glass) {
+    return;
+  }
+
+  use_glass_background_ = use_glass;
+  ApplyGlassBackground();
+}
+
+void SidebarContainerView::ApplyGlassBackground() {
+  auto background = [this]() -> std::unique_ptr<views::Background> {
+    return use_glass_background_ ? nullptr
+                                 : views::CreateSolidBackground(kColorToolbar);
+  };
+
+  SetBackground(background());
+
+  if (sidebar_control_view_) {
+    sidebar_control_view_->SetBackground(background());
+    // Layers fill their bounds opaquely by default, which would paint black
+    // wherever the control view no longer paints.
+    sidebar_control_view_->layer()->SetFillsBoundsOpaquely(
+        !use_glass_background_);
+  }
+}
+
 void SidebarContainerView::ChildVisibilityChanged(views::View* child) {
   if (child == sidebar_control_view_ &&
       sidebar_control_view_visibility_changed_callback_) {
@@ -242,6 +269,9 @@ void SidebarContainerView::AddChildViews() {
 
   // To prevent showing layered-children while its bounds is invisible.
   sidebar_control_view_->layer()->SetMasksToBounds(true);
+
+  // The control view is created after the glass frame state is first applied.
+  ApplyGlassBackground();
 
   // Hide by default. Visibility will be controlled by show options callback
   // later.

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -73,6 +73,11 @@ class SidebarContainerView : public sidebar::Sidebar,
   void SetSidebarControlViewVisibilityChangedCallback(
       base::RepeatingClosure callback);
 
+  // Drops the opaque backgrounds of this view and the control view so the
+  // macOS glass frame shows through the sidebar, and restores them when the
+  // glass frame goes away.
+  void SetUseGlassBackground(bool use_glass);
+
   // Sidebar overrides:
   void SetSidebarShowOption(
       sidebar::SidebarService::ShowSidebarOption show_option) override;
@@ -132,6 +137,8 @@ class SidebarContainerView : public sidebar::Sidebar,
   void StartBrowserWindowEventMonitoring();
   void StopBrowserWindowEventMonitoring();
 
+  void ApplyGlassBackground();
+
   // Casts |browser_| to BraveBrowser, as storing it as BraveBrowser would cause
   // a precocious downcast.
   BraveBrowser* GetBraveBrowser() const;
@@ -140,6 +147,7 @@ class SidebarContainerView : public sidebar::Sidebar,
   raw_ptr<SidebarControlView> sidebar_control_view_ = nullptr;
   bool initialized_ = false;
   bool sidebar_on_left_ = true;
+  bool use_glass_background_ = false;
   base::OneShotTimer sidebar_hide_timer_;
   sidebar::SidebarService::ShowSidebarOption show_sidebar_option_ =
       sidebar::SidebarService::ShowSidebarOption::kShowAlways;

--- a/chromium_src/chrome/browser/ui/views/frame/browser_native_widget_mac.mm
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_native_widget_mac.mm
@@ -1,0 +1,37 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/tabs/public/vertical_tab_controller.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+
+namespace {
+
+// Upstream sizes the glass effect view to a single region: top chrome with a
+// horizontal tab strip, or the tab strip column with vertical tabs. Brave
+// extends it over the whole window when vertical tabs are in use, so the glass
+// shows through every part of the browser chrome. Covers both the upstream
+// vertical tab strip and Brave's own, which are mutually exclusive.
+bool BraveShouldUseFullWindowGlassFrame(BrowserView* browser_view) {
+  if (!browser_view) {
+    return false;
+  }
+  if (browser_view->ShouldDrawVerticalTabStrip()) {
+    return true;
+  }
+  auto* const controller =
+      VerticalTabController::FromBrowser(browser_view->browser());
+  return controller && controller->ShouldShowBraveVerticalTabs();
+}
+
+}  // namespace
+
+#define BRAVE_BROWSER_NATIVE_WIDGET_MAC_FULL_WINDOW_GLASS_FRAME \
+  if (BraveShouldUseFullWindowGlassFrame(browser_view_)) {      \
+    return std::nullopt;                                        \
+  }
+
+#include <chrome/browser/ui/views/frame/browser_native_widget_mac.mm>
+
+#undef BRAVE_BROWSER_NATIVE_WIDGET_MAC_FULL_WINDOW_GLASS_FRAME

--- a/patches/chrome-browser-ui-views-frame-browser_native_widget_mac.mm.patch
+++ b/patches/chrome-browser-ui-views-frame-browser_native_widget_mac.mm.patch
@@ -1,0 +1,20 @@
+diff --git a/chrome/browser/ui/views/frame/browser_native_widget_mac.mm b/chrome/browser/ui/views/frame/browser_native_widget_mac.mm
+index fd63fdec82640fdb42de8388dfd691900f706674..d9025e63e8ddf8fd2a1f8f57f8fa7da07a36b2e5 100644
+--- a/chrome/browser/ui/views/frame/browser_native_widget_mac.mm
++++ b/chrome/browser/ui/views/frame/browser_native_widget_mac.mm
+@@ -271,6 +271,7 @@ void BrowserNativeWidgetMac::GetWindowFrameTitlebarHeight(
+ }
+ 
+ std::optional<int> BrowserNativeWidgetMac::GetGlassFrameHeight() const {
++  BRAVE_BROWSER_NATIVE_WIDGET_MAC_FULL_WINDOW_GLASS_FRAME
+   // If vertical tabs are being drawn, the glass effect view is not restricted
+   // vertically to top chrome (it spans full height).
+   if (!browser_view_ || browser_view_->ShouldDrawVerticalTabStrip()) {
+@@ -294,6 +295,7 @@ std::optional<int> BrowserNativeWidgetMac::GetGlassFrameHeight() const {
+ }
+ 
+ std::optional<int> BrowserNativeWidgetMac::GetGlassFrameWidth() const {
++  BRAVE_BROWSER_NATIVE_WIDGET_MAC_FULL_WINDOW_GLASS_FRAME
+   // If vertical tabs are not being drawn (e.g. horizontal tab strip mode,
+   // popup/app windows, or window too narrow to render vertical tabs), the glass
+   // effect view spans the full window width without horizontal restriction.


### PR DESCRIPTION
Chromium's glass frame is sized to one region: top chrome with horizontal tabs, or the tab-strip column with upstream vertical tabs. Brave's vertical tabs leave the rest of the chrome opaque, so the window does not look like one glass surface.

Returning `std::nullopt` from `GetGlassFrameHeight`/`GetGlassFrameWidth` when Brave (or upstream) vertical tabs are showing lets the glass cover the whole window. Layout then makes the chrome that sits on that surface transparent (toolbar, top container, bookmark bar, vertical tab strip, sidebar) and restores the opaque backgrounds when glass is not active (fullscreen, floating strip, glass ineligible). Layered views also stop filling their bounds opaquely so they do not paint black over the glass.

macOS only. Horizontal tabs are unchanged.

## Test plan

- [ ] macOS 26+ with the glass frame enabled: enable **Use vertical tabs**. The tab strip, toolbar, bookmark bar, and sidebar should all show the same glass as the window frame (no opaque chrome slabs).
- [ ] Collapse and expand the vertical tab strip. Glass should remain; no black fill behind the strip.
- [ ] Switch the strip to floating / overlay over web contents. The strip should go back to the opaque toolbar color while it sits over the page.
- [ ] Enter and exit fullscreen. Chrome should be opaque in fullscreen and glass again after exit.
- [ ] Toggle the bookmark bar and sidebar on/off. Glass should show through when they are visible; no leftover opaque backgrounds.
- [ ] Turn vertical tabs off (horizontal tabs). Glass should be limited to top chrome again, matching Chromium.
- [ ] Light and dark appearance, and inactive window: glass and restored opaque colors should both look correct.
- [ ] Linux/Windows: vertical tabs still use the opaque toolbar background (no glass).

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->