### PR TITLE
[ai_chat] Have the Leo workspace WebUI serve itself from a service worker

### DIFF
--- a/browser/ui/webui/ai_chat/leo_workspace_ui.cc
+++ b/browser/ui/webui/ai_chat/leo_workspace_ui.cc
@@ -22,6 +22,53 @@
 
 namespace ai_chat {
 
+namespace {
+
+// Also called without a WebUIController, to fetch a service worker script for
+// this host. See LeoWorkspaceUIConfig::RegisterURLDataSource().
+void CreateAndAddWorkspaceDataSource(content::BrowserContext* browser_context) {
+  content::WebUIDataSource* source = content::WebUIDataSource::CreateAndAdd(
+      browser_context, kAIChatLeoWorkspaceUIURL);
+
+  webui::SetupWebUIDataSource(source, kAiChatUiGenerated,
+                              IDR_AI_CHAT_LEO_WORKSPACE_HTML);
+
+  // This page runs its own first-party module bundle only. No network, no
+  // frames, no embedding by other pages. The FileSystemDirectoryHandle it will
+  // operate on is delivered out-of-band (launchQueue), not fetched.
+  //
+  // A service worker registered for this host is not served by this data
+  // source and does not get this policy: its responses carry headers of their
+  // own.
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::DefaultSrc, "default-src 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::ScriptSrc,
+      "script-src 'self' chrome-untrusted://resources;");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::StyleSrc,
+      "style-src 'self' chrome-untrusted://resources;");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::ConnectSrc, "connect-src 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::ObjectSrc, "object-src 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::FrameSrc, "frame-src 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::FrameAncestors,
+      "frame-ancestors 'none';");
+  // Only this origin's own worker. Registration is browser-side, so this does
+  // not gate it, but the page has no business creating workers of its own.
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::WorkerSrc, "worker-src 'self';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::FormAction, "form-action 'none';");
+  source->OverrideContentSecurityPolicy(
+      network::mojom::CSPDirectiveName::BaseURI, "base-uri 'none';");
+}
+
+}  // namespace
+
 bool LeoWorkspaceUIConfig::IsWebUIEnabled(
     content::BrowserContext* browser_context) {
   return IsAIChatEnabled(user_prefs::UserPrefs::Get(browser_context)) &&
@@ -40,41 +87,19 @@ LeoWorkspaceUIConfig::LeoWorkspaceUIConfig()
 
 LeoWorkspaceUIConfig::~LeoWorkspaceUIConfig() = default;
 
+void LeoWorkspaceUIConfig::RegisterURLDataSource(
+    content::BrowserContext* browser_context) {
+  CreateAndAddWorkspaceDataSource(browser_context);
+}
+
+bool LeoWorkspaceUIConfig::ShouldInterceptNavigationsWithServiceWorker() {
+  return true;
+}
+
 LeoWorkspaceUI::LeoWorkspaceUI(content::WebUI* web_ui)
     : ui::UntrustedWebUIController(web_ui) {
-  auto* browser_context = web_ui->GetWebContents()->GetBrowserContext();
-  auto* source = content::WebUIDataSource::CreateAndAdd(
-      browser_context, kAIChatLeoWorkspaceUIURL);
-
-  webui::SetupWebUIDataSource(source, kAiChatUiGenerated,
-                              IDR_AI_CHAT_LEO_WORKSPACE_HTML);
-
-  // This page runs its own first-party module bundle only. No network, no
-  // frames, no embedding by other pages. The FileSystemDirectoryHandle it will
-  // operate on is delivered out-of-band (launchQueue), not fetched.
-  source->OverrideContentSecurityPolicy(
-      network::mojom::CSPDirectiveName::DefaultSrc, "default-src 'none';");
-  source->OverrideContentSecurityPolicy(
-      network::mojom::CSPDirectiveName::ScriptSrc,
-      "script-src 'self' chrome-untrusted://resources;");
-  source->OverrideContentSecurityPolicy(
-      network::mojom::CSPDirectiveName::StyleSrc,
-      "style-src 'self' chrome-untrusted://resources;");
-  source->OverrideContentSecurityPolicy(
-      network::mojom::CSPDirectiveName::ConnectSrc, "connect-src 'none';");
-  source->OverrideContentSecurityPolicy(
-      network::mojom::CSPDirectiveName::ObjectSrc, "object-src 'none';");
-  source->OverrideContentSecurityPolicy(
-      network::mojom::CSPDirectiveName::FrameSrc, "frame-src 'none';");
-  source->OverrideContentSecurityPolicy(
-      network::mojom::CSPDirectiveName::FrameAncestors,
-      "frame-ancestors 'none';");
-  source->OverrideContentSecurityPolicy(
-      network::mojom::CSPDirectiveName::WorkerSrc, "worker-src 'none';");
-  source->OverrideContentSecurityPolicy(
-      network::mojom::CSPDirectiveName::FormAction, "form-action 'none';");
-  source->OverrideContentSecurityPolicy(
-      network::mojom::CSPDirectiveName::BaseURI, "base-uri 'none';");
+  CreateAndAddWorkspaceDataSource(
+      web_ui->GetWebContents()->GetBrowserContext());
 }
 
 LeoWorkspaceUI::~LeoWorkspaceUI() = default;

--- a/browser/ui/webui/ai_chat/leo_workspace_ui.h
+++ b/browser/ui/webui/ai_chat/leo_workspace_ui.h
@@ -23,6 +23,10 @@ class LeoWorkspaceUIConfig : public content::WebUIConfig {
   std::unique_ptr<content::WebUIController> CreateWebUIController(
       content::WebUI* web_ui,
       const GURL& url) override;
+  void RegisterURLDataSource(content::BrowserContext* browser_context) override;
+  // The folder of each workspace is served by a service worker, so navigations
+  // to this host must reach it rather than taking the WebUI shortcut.
+  bool ShouldInterceptNavigationsWithServiceWorker() override;
 };
 
 // Hidden, headless Untrusted WebUI that hosts the Leo "workspace" tools. The

--- a/chromium_src/content/browser/loader/navigation_url_loader_impl.cc
+++ b/chromium_src/content/browser/loader/navigation_url_loader_impl.cc
@@ -1,0 +1,60 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "content/browser/webui/url_data_manager_backend.h"
+#include "content/public/browser/web_ui_url_loader_factory.h"
+#include "content/public/browser/webui_config.h"
+#include "content/public/browser/webui_config_map.h"
+#include "url/gurl.h"
+
+namespace content {
+
+class BrowserContext;
+class FrameTreeNode;
+
+namespace {
+
+// Whether |url| is a WebUI that has asked to be reachable by a service worker,
+// and so must not take the shortcut in NavigationURLLoaderImpl::Start() that
+// loads WebUI without consulting any interceptor.
+//
+// Hosts that have not asked keep the shortcut, so this changes the way a
+// navigation is loaded only where a WebUI opted in.
+bool ShouldInterceptWebUINavigation(BrowserContext* browser_context,
+                                    const GURL& url) {
+  WebUIConfig* config =
+      WebUIConfigMap::GetInstance().GetConfig(browser_context, url);
+  return config && config->ShouldInterceptNavigationsWithServiceWorker();
+}
+
+// The factory the shortcut would have used, for an opted-in host whose service
+// worker did not serve the navigation after all. Reached through
+// CreateTerminalNonNetworkLoaderFactory(), which knows every other non-network
+// scheme but not WebUI, because until now WebUI never got that far.
+mojo::PendingRemote<network::mojom::URLLoaderFactory>
+MaybeCreateWebUILoaderFactory(FrameTreeNode* frame_tree_node, const GURL& url);
+
+}  // namespace
+
+}  // namespace content
+
+#include <content/browser/loader/navigation_url_loader_impl.cc>
+
+namespace content {
+namespace {
+
+mojo::PendingRemote<network::mojom::URLLoaderFactory>
+MaybeCreateWebUILoaderFactory(FrameTreeNode* frame_tree_node, const GURL& url) {
+  const std::string scheme = url.GetScheme();
+  if (!std::ranges::contains(URLDataManagerBackend::GetWebUISchemes(),
+                             scheme)) {
+    return {};
+  }
+  return CreateWebUIURLLoaderFactory(frame_tree_node->current_frame_host(),
+                                     scheme, /*allowed_hosts=*/{});
+}
+
+}  // namespace
+}  // namespace content

--- a/chromium_src/content/browser/service_worker/service_worker_context_wrapper.cc
+++ b/chromium_src/content/browser/service_worker/service_worker_context_wrapper.cc
@@ -1,0 +1,55 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/containers/flat_set.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/web_ui_url_loader_factory.h"
+#include "content/public/browser/webui_config.h"
+#include "content/public/browser/webui_config_map.h"
+#include "content/public/common/url_constants.h"
+#include "third_party/blink/public/common/loader/url_loader_factory_bundle.h"
+#include "url/gurl.h"
+
+namespace content {
+
+namespace {
+
+// Gives |bundle_info| a factory that can serve |scope|'s WebUI resources, so
+// that the script of a chrome-untrusted:// service worker can be fetched.
+//
+// The fetch is browser-initiated, so it reaches neither the frame nor the
+// worker ContentBrowserClient factory hooks, and it happens without a
+// WebUIController - which is what would ordinarily register the data source
+// the script has to come from. See WebUIConfig::RegisterURLDataSource().
+void MaybeAddUntrustedWebUIScriptFactory(
+    BrowserContext* browser_context,
+    const GURL& scope,
+    network::PendingSharedURLLoaderFactory* bundle_info) {
+  if (!scope.SchemeIs(kChromeUIUntrustedScheme)) {
+    return;
+  }
+
+  // Fail closed for a scope with no WebUI behind it: without a config there is
+  // no data source to register, and nothing legitimate to serve.
+  WebUIConfig* config =
+      WebUIConfigMap::GetInstance().GetConfig(browser_context, scope);
+  if (!config) {
+    return;
+  }
+  config->RegisterURLDataSource(browser_context);
+
+  static_cast<blink::PendingURLLoaderFactoryBundle*>(bundle_info)
+      ->pending_scheme_specific_factories()
+      .emplace(kChromeUIUntrustedScheme,
+               CreateWebUIURLLoaderFactoryForWorker(
+                   browser_context, kChromeUIUntrustedScheme,
+                   /*allowed_hosts=*/base::flat_set<std::string>()));
+}
+
+}  // namespace
+
+}  // namespace content
+
+#include <content/browser/service_worker/service_worker_context_wrapper.cc>

--- a/chromium_src/content/public/browser/webui_config.cc
+++ b/chromium_src/content/public/browser/webui_config.cc
@@ -1,0 +1,23 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <content/public/browser/webui_config.cc>
+
+namespace content {
+
+// Whether navigations to this WebUI should go through the
+// NavigationURLLoaderImpl interceptors, so that a service worker registered for
+// this host can serve them.
+//
+// WebUI navigations otherwise take a shortcut that returns before any
+// interceptor is consulted, which leaves such a worker unreachable - for a
+// document's subresources as much as for the navigation itself, since the
+// document never gets a service worker client either. Only a host that serves
+// its own content from a worker has any reason to leave that shortcut.
+bool WebUIConfig::ShouldInterceptNavigationsWithServiceWorker() {
+  return false;
+}
+
+}  // namespace content

--- a/patches/content-browser-loader-navigation_url_loader_impl.cc.patch
+++ b/patches/content-browser-loader-navigation_url_loader_impl.cc.patch
@@ -1,0 +1,27 @@
+diff --git a/content/browser/loader/navigation_url_loader_impl.cc b/content/browser/loader/navigation_url_loader_impl.cc
+index bf56800508aa5b6f66282e74e396b98379f0ffe6..832ed3efe61d3047f673d4021a80ea3a64374801 100644
+--- a/content/browser/loader/navigation_url_loader_impl.cc
++++ b/content/browser/loader/navigation_url_loader_impl.cc
+@@ -700,7 +700,9 @@ void NavigationURLLoaderImpl::Start() {
+     // or be intercepted, so we just let it go here.
+     std::string scheme = request_info_->common_params->url.GetScheme();
+     if (std::ranges::contains(URLDataManagerBackend::GetWebUISchemes(),
+-                              scheme)) {
++                              scheme) &&
++        !ShouldInterceptWebUINavigation(
++            browser_context_, request_info_->common_params->url)) {
+       FrameTreeNode* frame_tree_node =
+           FrameTreeNode::GloballyFindByID(frame_tree_node_id_);
+       CHECK(frame_tree_node);
+@@ -2198,6 +2200,11 @@ NavigationURLLoaderImpl::CreateTerminalNonNetworkLoaderFactory(
+     return factory_from_client;
+   }
+ 
++  if (mojo::PendingRemote<network::mojom::URLLoaderFactory> webui =
++          MaybeCreateWebUILoaderFactory(frame_tree_node, url)) {
++    return webui;
++  }
++
+   if (url.GetScheme() == url::kFileSystemScheme) {
+     bool is_nav_allowed =
+         GetContentClient()->browser()->IsFileSystemURLNavigationAllowed(

--- a/patches/content-browser-service_worker-service_worker_context_wrapper.cc.patch
+++ b/patches/content-browser-service_worker-service_worker_context_wrapper.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/content/browser/service_worker/service_worker_context_wrapper.cc b/content/browser/service_worker/service_worker_context_wrapper.cc
+index 6f44260b0ed2548f542cc12370aefcb4bc583ba5..4e32f45d70e4e23d6f1384c0389032b3206b6e5f 100644
+--- a/content/browser/service_worker/service_worker_context_wrapper.cc
++++ b/content/browser/service_worker/service_worker_context_wrapper.cc
+@@ -2054,6 +2054,8 @@ ServiceWorkerContextWrapper::GetLoaderFactoryForBrowserInitiatedRequest(
+       loader_factory_bundle_info =
+           context()->loader_factory_bundle_for_update_check()->Clone();
+ 
++  MaybeAddUntrustedWebUIScriptFactory(browser_context(), scope,
++                                      loader_factory_bundle_info.get());
+ 
+   static_cast<blink::PendingURLLoaderFactoryBundle*>(
+       loader_factory_bundle_info.get())

--- a/patches/content-public-browser-webui_config.h.patch
+++ b/patches/content-public-browser-webui_config.h.patch
@@ -1,0 +1,13 @@
+diff --git a/content/public/browser/webui_config.h b/content/public/browser/webui_config.h
+index 0e32041a05b114f8fc55c307116a954fd7447885..471bb5e2f64eaf654cb9f4e1462cf1e016c52016 100644
+--- a/content/public/browser/webui_config.h
++++ b/content/public/browser/webui_config.h
+@@ -84,6 +84,8 @@ class CONTENT_EXPORT WebUIConfig {
+   // the WebUIController or resources will fail to load.
+   virtual void RegisterURLDataSource(BrowserContext* browser_context) {}
+ 
++  virtual bool ShouldInterceptNavigationsWithServiceWorker();
++
+  private:
+   const std::string scheme_;
+   const std::string host_;

--- a/rewrite/content/browser/loader/navigation_url_loader_impl.cc.yaml
+++ b/rewrite/content/browser/loader/navigation_url_loader_impl.cc.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |-
+      Let a WebUI opt its navigations out of the interceptor-skipping shortcut.
+
+      The shortcut returns before CreateInterceptors(), so a WebUI navigation
+      reaches no interceptor and its document never gets a service worker
+      client, which leaves a worker registered for the host unreachable - for
+      the document's subresources as much as for the navigation itself. Hosts
+      that have not opted in (see
+      WebUIConfig::ShouldInterceptNavigationsWithServiceWorker()) keep taking
+      it.
+    regex:
+      re_pattern: |-
+        (contains\(URLDataManagerBackend::GetWebUISchemes\(\),\s+scheme\))(\) \{)
+      replace: |-
+        \1 &&
+                !ShouldInterceptWebUINavigation(
+                    browser_context_, request_info_->common_params->url)\2
+
+  - description: |-
+      Serve WebUI from the non-network navigation factories as well.
+
+      Only the shortcut in Start() ever created a WebUI factory for a
+      navigation, so a host that has left that shortcut, and whose service
+      worker does not answer, would have nothing left to load it. This sits
+      after the embedder's override, so a factory from the embedder still wins.
+    regex:
+      re_pattern: |-
+        (return factory_from_client;\s+\})
+      replace: |-
+        \1
+
+          if (mojo::PendingRemote<network::mojom::URLLoaderFactory> webui =
+                  MaybeCreateWebUILoaderFactory(frame_tree_node, url)) {
+            return webui;
+          }

--- a/rewrite/content/browser/service_worker/service_worker_context_wrapper.cc.yaml
+++ b/rewrite/content/browser/service_worker/service_worker_context_wrapper.cc.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |-
+      Fetch a WebUI service worker's script from its data source.
+
+      The fetch is browser-initiated, so it reaches none of the
+      ContentBrowserClient factory hooks that would otherwise supply a factory
+      for the scheme, and it runs without a WebUIController, which is what would
+      ordinarily have registered the data source it comes from.
+    regex:
+      re_pattern: '(loader_factory_bundle_for_update_check\(\)->Clone\(\);\n)'
+      replace: |-
+        \1
+          MaybeAddUntrustedWebUIScriptFactory(browser_context(), scope,
+                                              loader_factory_bundle_info.get());

--- a/rewrite/content/public/browser/webui_config.h.yaml
+++ b/rewrite/content/public/browser/webui_config.h.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# WebUIConfig's class head carries CONTENT_EXPORT.
+blank_macros_for_ast_parsing: true
+
+substitutions:
+  - description: |-
+      Let a WebUI ask for its navigations to reach the loader interceptors.
+
+      WebUI navigations take a shortcut in NavigationURLLoaderImpl::Start()
+      that returns before any interceptor is consulted, so a service worker
+      registered for a WebUI host can never serve one, for subresources as much
+      as for the navigation itself. A host that serves its own content from a
+      worker overrides this to leave that shortcut.
+    add_to_public:
+      class_name: WebUIConfig
+      code: 'virtual bool ShouldInterceptNavigationsWithServiceWorker();'


### PR DESCRIPTION
- Resolves https://github.com/brave/brave-browser/issues/57388 (series)

Stacked on https://github.com/brave/brave-core/pull/39756 — review that first.

Opts `chrome-untrusted://leo-workspace` into being served by a service worker
registered for its host, so that the PR stacked on this one can serve each
workspace's folder from one. Nothing registers a worker yet.

Two consequences of that, both here:

- Registering a worker fetches its script without a `WebUIController`, so the
  data source has to be created for that path too —
  `LeoWorkspaceUIConfig::RegisterURLDataSource()`, sharing one helper with the
  controller so the two cannot drift.
- Navigations to this host now leave the WebUI shortcut that would otherwise
  skip the worker entirely
  (`ShouldInterceptNavigationsWithServiceWorker()` → true).

`worker-src` moves from `'none'` to `'self'`. Registration is browser-side so the
directive does not gate it, but `'none'` would contradict the fact that this
origin has a worker.

## Verification

`pnpm run build`, `pnpm run gn_check`, `pnpm run presubmit` pass. Behaviour is
exercised by the PR stacked on this one.

<sub>Recreated from #39722, which GitHub would not let me re-base onto the new
bottom of the stack.</sub>