### PR TITLE
[ads] Fix uneven round-robin ad distribution

### DIFF
--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/new_tab_page_ads/eligible_new_tab_page_ads_v2_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/new_tab_page_ads/eligible_new_tab_page_ads_v2_unittest.cc
@@ -213,11 +213,12 @@ TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
 
   ASSERT_NE(creative_ads_1, creative_ads_2);
 
-  // Assert: `creative_ads_1` is served again because `creative_ads_2` was
-  // served last and is not served immediately after all ads have been seen.
+  // Assert: both ads have now been seen so the rotation resets, making
+  // either ad eligible again.
   base::test::TestFuture<CreativeNewTabPageAdList> test_future_3;
   eligible_ads_->GetForUserModel(user_model, test_future_3.GetCallback());
-  EXPECT_EQ(test_future_3.Take(), creative_ads_1);
+  EXPECT_THAT(test_future_3.Take(),
+              ::testing::AnyOfArray({creative_ads_1, creative_ads_2}));
 }
 
 TEST_F(BraveAdsEligibleNewTabPageAdsV2Test, ZeroPriorityAdIsNeverServed) {
@@ -377,12 +378,14 @@ TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,
   ASSERT_NE(first_served_creative_ads, second_served_creative_ads);
   SimulateServeAd(second_served_creative_ads);
 
-  // Assert: all priority 1 ads have been seen so the bucket resets.
-  // `second_served_creative_ads` is excluded; `first_served_creative_ads` comes
-  // back. The lower-priority `creative_ad_3` is never reached.
+  // Assert: all priority 1 ads have been seen so the bucket resets, making
+  // both `creative_ad_1` and `creative_ad_2` eligible again. The lower
+  // priority `creative_ad_3` is never reached.
   base::test::TestFuture<CreativeNewTabPageAdList> test_future_3;
   eligible_ads_->GetForUserModel(user_model, test_future_3.GetCallback());
-  EXPECT_EQ(test_future_3.Take(), first_served_creative_ads);
+  EXPECT_THAT(test_future_3.Take(),
+              ::testing::AnyOfArray(
+                  {first_served_creative_ads, second_served_creative_ads}));
 }
 
 TEST_F(BraveAdsEligibleNewTabPageAdsV2Test,

--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/notification_ads/eligible_notification_ads_v2_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/notification_ads/eligible_notification_ads_v2_unittest.cc
@@ -198,12 +198,13 @@ TEST_F(BraveAdsEligibleNotificationAdsV2Test,
 
   ASSERT_NE(first_served_creative_ads, second_served_creative_ads);
 
-  // Assert: `first_served_creative_ads` is served again because
-  // `second_served_creative_ads` was served last and is not served immediately
-  // after all ads have been seen.
+  // Assert: both ads have now been seen so the rotation resets, making
+  // either ad eligible again.
   base::test::TestFuture<CreativeNotificationAdList> test_future_3;
   eligible_ads_->GetForUserModel(user_model, test_future_3.GetCallback());
-  EXPECT_EQ(test_future_3.Take(), first_served_creative_ads);
+  EXPECT_THAT(test_future_3.Take(),
+              ::testing::AnyOfArray(
+                  {first_served_creative_ads, second_served_creative_ads}));
 }
 
 TEST_F(BraveAdsEligibleNotificationAdsV2Test, ZeroPriorityAdIsNeverServed) {
@@ -352,12 +353,14 @@ TEST_F(BraveAdsEligibleNotificationAdsV2Test,
   ASSERT_NE(first_served_creative_ads, second_served_creative_ads);
   SimulateServeAd(second_served_creative_ads);
 
-  // Assert: all priority 1 ads have been seen so the bucket resets.
-  // The second-served ad is excluded; the first-served ad comes back.
-  // The lower-priority `creative_ad_3` is never reached.
+  // Assert: all priority 1 ads have been seen so the bucket resets, making
+  // both `creative_ad_1` and `creative_ad_2` eligible again. The lower
+  // priority `creative_ad_3` is never reached.
   base::test::TestFuture<CreativeNotificationAdList> test_future_3;
   eligible_ads_->GetForUserModel(user_model, test_future_3.GetCallback());
-  EXPECT_EQ(test_future_3.Take(), first_served_creative_ads);
+  EXPECT_THAT(test_future_3.Take(),
+              ::testing::AnyOfArray(
+                  {first_served_creative_ads, second_served_creative_ads}));
 }
 
 TEST_F(BraveAdsEligibleNotificationAdsV2Test,

--- a/components/brave_ads/core/internal/serving/eligible_ads/round_robin/creative_ad_round_robin.h
+++ b/components/brave_ads/core/internal/serving/eligible_ads/round_robin/creative_ad_round_robin.h
@@ -7,18 +7,19 @@
 #define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_SERVING_ELIGIBLE_ADS_ROUND_ROBIN_CREATIVE_AD_ROUND_ROBIN_H_
 
 #include <algorithm>
-#include <optional>
 #include <string>
 #include <vector>
 
 #include "brave/components/brave_ads/core/internal/serving/eligible_ads/eligible_ads_feature.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 #include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
 
 namespace brave_ads {
 
-// Ensures every ad is served once per rotation before any repeats, and prevents
-// the most recently served ad from being the first served in the next rotation
-// when possible. State is intentionally kept in memory only and not persisted.
+// Ensures every ad within a priority bucket is served once per rotation
+// before any repeats. Each priority bucket rotates independently so that a
+// higher priority bucket's rotation cannot affect a lower priority bucket's
+// eligibility. State is intentionally kept in memory only and not persisted.
 class CreativeAdRoundRobin final {
  public:
   CreativeAdRoundRobin();
@@ -28,64 +29,54 @@ class CreativeAdRoundRobin final {
 
   ~CreativeAdRoundRobin();
 
-  // Filters out served `creative_ads`, resetting the rotation when all
-  // creatives in the current set have been served. On reset, excludes the last
-  // served creative to avoid an immediate repeat unless it would leave no ads
-  // to serve.
+  // Filters out served `creative_ads`, resetting the rotation for their
+  // priority bucket when all creatives in the current set have been served.
+  // `creative_ads` must all share the same `priority`, as is the case when
+  // called with a single bucket from `PrioritizedCreativeAdBuckets`.
   template <typename T>
   void Filter(std::vector<T>& creative_ads) {
-    if (!kShouldRoundRobin.Get()) {
+    if (!kShouldRoundRobin.Get() || creative_ads.empty()) {
       return;
     }
 
-    if (creative_ads.empty()) {
-      // Filtering an empty ad list indicates that no campaigns are active, so
-      // the round-robin state should reset.
-      served_creative_instance_ids_.clear();
-      return;
-    }
+    absl::flat_hash_set<std::string>& served_creative_instance_ids =
+        served_creative_instance_ids_by_priority_[creative_ads.front()
+                                                      .priority];
 
     // Check if all creative ads have been served.
-    if (std::ranges::all_of(creative_ads, [this](const T& creative_ad) {
-          return served_creative_instance_ids_.contains(
+    if (std::ranges::all_of(creative_ads, [&served_creative_instance_ids](
+                                              const T& creative_ad) {
+          return served_creative_instance_ids.contains(
               creative_ad.creative_instance_id);
         })) {
       // All ads have been served, so reset for the next round, including any
       // creative instance IDs from removed campaigns.
-      served_creative_instance_ids_.clear();
-
-      if (last_served_creative_instance_id_ && creative_ads.size() > 1) {
-        // Exclude the last served creative ad to avoid an immediate repeat if
-        // there is more than one ad. `last_served_creative_instance_id_` may
-        // refer to a creative no longer in the candidate set; inserting it is
-        // safe because `erase_if` only removes creative instance IDs present in
-        // `creative_ads`.
-        served_creative_instance_ids_.insert(
-            *last_served_creative_instance_id_);
-      }
+      served_creative_instance_ids.clear();
     }
 
     // Remove served ads from the eligible ads for this serving round.
-    std::erase_if(creative_ads, [this](const T& creative_ad) {
-      return served_creative_instance_ids_.contains(
-          creative_ad.creative_instance_id);
-    });
+    std::erase_if(creative_ads,
+                  [&served_creative_instance_ids](const T& creative_ad) {
+                    return served_creative_instance_ids.contains(
+                        creative_ad.creative_instance_id);
+                  });
   }
 
-  // Marks a creative ad as served to avoid repeats within a rotation.
+  // Marks a creative ad as served within its priority bucket to avoid
+  // repeats within a rotation.
   template <typename T>
   void MarkAsServed(const T& creative_ad) {
     if (!kShouldRoundRobin.Get()) {
       return;
     }
 
-    served_creative_instance_ids_.insert(creative_ad.creative_instance_id);
-    last_served_creative_instance_id_ = creative_ad.creative_instance_id;
+    served_creative_instance_ids_by_priority_[creative_ad.priority].insert(
+        creative_ad.creative_instance_id);
   }
 
  private:
-  absl::flat_hash_set<std::string> served_creative_instance_ids_;
-  std::optional<std::string> last_served_creative_instance_id_;
+  absl::flat_hash_map<int, absl::flat_hash_set<std::string>>
+      served_creative_instance_ids_by_priority_;
 };
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/serving/eligible_ads/round_robin/creative_ad_round_robin_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/round_robin/creative_ad_round_robin_unittest.cc
@@ -74,52 +74,9 @@ TEST_F(BraveAdsCreativeAdRoundRobinTest,
   // Act
   creative_ad_round_robin_.Filter(creative_ads);
 
-  // Assert: `creative_ad_2` was last served so it is excluded from the next
-  // rotation to avoid an immediate repeat.
-  EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad_1));
-}
-
-TEST_F(BraveAdsCreativeAdRoundRobinTest,
-       LastServedAdShouldBeExcludedWhenAllAdsHaveBeenServed) {
-  // Arrange
-  const CreativeNewTabPageAdInfo creative_ad_1 =
-      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
-                                      /*use_random_uuids=*/true);
-  const CreativeNewTabPageAdInfo creative_ad_2 =
-      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
-                                      /*use_random_uuids=*/true);
-  const CreativeNewTabPageAdInfo creative_ad_3 =
-      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
-                                      /*use_random_uuids=*/true);
-  CreativeNewTabPageAdList creative_ads = {creative_ad_1, creative_ad_2,
-                                           creative_ad_3};
-
-  creative_ad_round_robin_.MarkAsServed(creative_ad_1);
-  creative_ad_round_robin_.MarkAsServed(creative_ad_2);
-  creative_ad_round_robin_.MarkAsServed(creative_ad_3);
-
-  // Act
-  creative_ad_round_robin_.Filter(creative_ads);
-
-  // Assert
+  // Assert: the rotation resets once every ad has been served, so both ads
+  // are immediately eligible again, including the one served last.
   EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad_1, creative_ad_2));
-}
-
-TEST_F(BraveAdsCreativeAdRoundRobinTest,
-       LastServedAdShouldBeEligibleWhenItIsTheOnlyAd) {
-  // Arrange
-  const CreativeNewTabPageAdInfo creative_ad =
-      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
-                                      /*use_random_uuids=*/true);
-  CreativeNewTabPageAdList creative_ads = {creative_ad};
-
-  creative_ad_round_robin_.MarkAsServed(creative_ad);
-
-  // Act
-  creative_ad_round_robin_.Filter(creative_ads);
-
-  // Assert
-  EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad));
 }
 
 TEST_F(BraveAdsCreativeAdRoundRobinTest,
@@ -139,32 +96,6 @@ TEST_F(BraveAdsCreativeAdRoundRobinTest,
 
   // Assert
   EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad));
-}
-
-TEST_F(BraveAdsCreativeAdRoundRobinTest,
-       AllAdsShouldBeEligibleAfterFilteringEmptyList) {
-  // Arrange
-  const CreativeNewTabPageAdInfo creative_ad_1 =
-      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
-                                      /*use_random_uuids=*/true);
-  const CreativeNewTabPageAdInfo creative_ad_2 =
-      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
-                                      /*use_random_uuids=*/true);
-
-  CreativeNewTabPageAdInfo stale_creative_ad;
-  stale_creative_ad.creative_instance_id = kStaleCreativeInstanceId;
-  creative_ad_round_robin_.MarkAsServed(stale_creative_ad);
-
-  CreativeNewTabPageAdList empty_ads;
-  creative_ad_round_robin_.Filter(empty_ads);
-
-  CreativeNewTabPageAdList creative_ads = {creative_ad_1, creative_ad_2};
-
-  // Act
-  creative_ad_round_robin_.Filter(creative_ads);
-
-  // Assert
-  EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad_1, creative_ad_2));
 }
 
 TEST_F(BraveAdsCreativeAdRoundRobinTest,
@@ -241,42 +172,16 @@ TEST_F(BraveAdsCreativeAdRoundRobinTest,
 }
 
 TEST_F(BraveAdsCreativeAdRoundRobinTest,
-       ShouldExcludeLastServedAdAfterBucketReset) {
-  // Arrange
-  CreativeNewTabPageAdInfo creative_ad_1 =
-      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
-                                      /*use_random_uuids=*/true);
-  creative_ad_1.priority = 1;
-  creative_ad_round_robin_.MarkAsServed(creative_ad_1);
-
-  CreativeNewTabPageAdInfo creative_ad_2 =
-      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
-                                      /*use_random_uuids=*/true);
-  creative_ad_2.priority = 1;
-  creative_ad_round_robin_.MarkAsServed(creative_ad_2);
-
-  CreativeNewTabPageAdList creative_ads = {creative_ad_1, creative_ad_2};
-
-  // Act
-  creative_ad_round_robin_.Filter(creative_ads);
-
-  // Assert
-  EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad_1));
-}
-
-TEST_F(BraveAdsCreativeAdRoundRobinTest,
        ShouldKeepUnservedAdEligibleWhenOtherAdHasBeenServed) {
   // Arrange
   CreativeNewTabPageAdInfo creative_ad_1 =
       test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
                                       /*use_random_uuids=*/true);
-  creative_ad_1.priority = 1;
   creative_ad_round_robin_.MarkAsServed(creative_ad_1);
 
   CreativeNewTabPageAdInfo creative_ad_2 =
       test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
                                       /*use_random_uuids=*/true);
-  creative_ad_2.priority = 1;
 
   CreativeNewTabPageAdList creative_ads = {creative_ad_1, creative_ad_2};
 
@@ -285,6 +190,30 @@ TEST_F(BraveAdsCreativeAdRoundRobinTest,
 
   // Assert
   EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad_2));
+}
+
+TEST_F(BraveAdsCreativeAdRoundRobinTest,
+       PriorityBucketsShouldRotateIndependently) {
+  // Arrange
+  CreativeNewTabPageAdInfo creative_ad_1 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_1.priority = 1;
+  creative_ad_round_robin_.MarkAsServed(creative_ad_1);
+
+  CreativeNewTabPageAdInfo creative_ad_2 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_2.priority = 2;
+
+  CreativeNewTabPageAdList other_priority_creative_ads = {creative_ad_2};
+
+  // Act: filtering a different priority bucket should be unaffected by
+  // `creative_ad_1`'s priority bucket having been fully rotated.
+  creative_ad_round_robin_.Filter(other_priority_creative_ads);
+
+  // Assert
+  EXPECT_THAT(other_priority_creative_ads, testing::ElementsAre(creative_ad_2));
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/serving/new_tab_page_ad_serving.cc
+++ b/components/brave_ads/core/internal/serving/new_tab_page_ad_serving.cc
@@ -153,6 +153,8 @@ void NewTabPageAdServing::GetEligibleAdsCallback(
               << creative_ad.creative_instance_id << " and a priority of "
               << creative_ad.priority);
 
+  creative_ad_round_robin_.MarkAsServed(creative_ad);
+
   ServeAd(BuildNewTabPageAd(creative_ad));
 }
 
@@ -161,8 +163,6 @@ void NewTabPageAdServing::ServeAd(const NewTabPageAdInfo& ad) {
     BLOG(0, "New tab page ad not served: Invalid ad");
     return FailedToServeAd();
   }
-
-  creative_ad_round_robin_.MarkAsServed(ad);
 
   eligible_ads_->SetLastServedAd(ad);
 

--- a/components/brave_ads/core/internal/serving/notification_ad_serving.cc
+++ b/components/brave_ads/core/internal/serving/notification_ad_serving.cc
@@ -181,6 +181,8 @@ void NotificationAdServing::GetEligibleAdsCallback(
               << creative_ad.creative_instance_id << " and a priority of "
               << creative_ad.priority);
 
+  creative_ad_round_robin_.MarkAsServed(creative_ad);
+
   ServeAd(BuildNotificationAd(creative_ad));
 }
 
@@ -225,8 +227,6 @@ void NotificationAdServing::ServeAd(const NotificationAdInfo& ad) {
     BLOG(0, "Notification ad not served: Invalid ad");
     return FailedToServeAd();
   }
-
-  creative_ad_round_robin_.MarkAsServed(ad);
 
   eligible_ads_->SetLastServedAd(ad);
 


### PR DESCRIPTION
Excluding the last-served creative after a rotation reset shortened the following round by one, causing that creative to be served less often over time. Round-robin state was also shared across priority buckets, letting a higher-priority bucket's rotation affect a lower priority bucket's eligibility. Key served state by priority bucket and drop the last-served exclusion.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/55422

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
