### PR TITLE
[Android] Fix PiP playback pausing on screen lock

### DIFF
--- a/android/java/org/chromium/chrome/browser/fullscreen/BraveFullscreenHtmlApiHandlerBase.java
+++ b/android/java/org/chromium/chrome/browser/fullscreen/BraveFullscreenHtmlApiHandlerBase.java
@@ -8,6 +8,7 @@ package org.chromium.chrome.browser.fullscreen;
 import android.app.Activity;
 
 import org.chromium.chrome.browser.app.BraveActivity;
+import org.chromium.chrome.browser.media.BraveFullscreenVideoPictureInPictureController;
 import org.chromium.chrome.browser.tab.TabHidingType;
 
 /**
@@ -27,16 +28,15 @@ public abstract class BraveFullscreenHtmlApiHandlerBase {
      */
     protected boolean mTabHiddenByChangedTabs;
 
-    /**
-     * Invoked from upstream observer hooks (tab hidden, activity stopped) to decide whether the
-     * persistent fullscreen teardown should be skipped. When a Brave-managed YouTube
-     * Picture-in-Picture session is alive we want to keep both the browser and DOM fullscreen state
-     * intact across transient hides (screen-off, PiP window occlusion) so there is no visible
-     * flicker when the user returns. {@code activity} is the activity bound to the calling
-     * fullscreen handler so that multi-window setups only preserve state for the window that owns
-     * the PiP session.
-     */
+    /** Keeps fullscreen state when hiding or stopping the activity interrupts an active PiP. */
     public boolean shouldPreservePersistentFullscreenForPictureInPicture(Activity activity) {
+        // Screen lock must not turn a playing PiP into a fullscreen-exit pause.
+        if (activity.isInPictureInPictureMode()
+                && BraveFullscreenVideoPictureInPictureController
+                        .shouldPreservePlaybackOnScreenLock()) {
+            return true;
+        }
+
         return activity instanceof final BraveActivity braveActivity
                 && braveActivity.isYouTubePictureInPictureActive();
     }

--- a/android/java/org/chromium/chrome/browser/media/BraveFullscreenVideoPictureInPictureController.java
+++ b/android/java/org/chromium/chrome/browser/media/BraveFullscreenVideoPictureInPictureController.java
@@ -9,6 +9,7 @@ import android.app.Activity;
 import android.app.PictureInPictureParams;
 import android.graphics.Rect;
 
+import org.chromium.base.CommandLine;
 import org.chromium.base.Log;
 import org.chromium.build.annotations.Nullable;
 import org.chromium.chrome.browser.app.BraveActivity;
@@ -29,6 +30,9 @@ public class BraveFullscreenVideoPictureInPictureController {
      * attemptPictureInPicture, so we can notify it if entry fails.
      */
     @Nullable private BraveActivity mPendingBraveActivityForPiP;
+
+    // Records a screen-lock stop so onResume() can keep the PiP window open.
+    private boolean mStoppedForScreenLock;
 
     /**
      * Performs the YouTube PiP entry that upstream's attemptPictureInPicture delegates to once the
@@ -100,6 +104,30 @@ public class BraveFullscreenVideoPictureInPictureController {
             return null;
         }
         return braveActivity;
+    }
+
+    public static boolean shouldPreservePlaybackOnScreenLock() {
+        // Chromium 153 added media suspension when the PiP activity stops.
+        // Allow playback through screen lock when Background play is enabled.
+        return BraveYouTubePictureInPictureController.isScreenOffOrLocked()
+                && CommandLine.getInstance().hasSwitch("disable-background-media-suspend");
+    }
+
+    protected boolean maybeHandleStopForScreenLock(boolean shouldSuspendMediaOnStop) {
+        if (!shouldSuspendMediaOnStop) return false;
+
+        // Skip suspension on screen lock without clearing the upstream stop flag.
+        // Closing PiP after unlocking must still suspend playback.
+        mStoppedForScreenLock = shouldPreservePlaybackOnScreenLock();
+        return mStoppedForScreenLock;
+    }
+
+    protected boolean maybeHandleResumeAfterScreenLock(Activity activity) {
+        // Normal onResume() dismisses PiP and clears the upstream stop flag.
+        // Skip that cleanup when unlocking leaves the activity in PiP.
+        boolean wasStoppedForScreenLock = mStoppedForScreenLock;
+        mStoppedForScreenLock = false;
+        return wasStoppedForScreenLock && activity.isInPictureInPictureMode();
     }
 
     protected boolean maybeHandleDismissActivityForYouTubePictureInPicture(

--- a/patches/chrome-android-java-src-org-chromium-chrome-browser-media-FullscreenVideoPictureInPictureController.java.patch
+++ b/patches/chrome-android-java-src-org-chromium-chrome-browser-media-FullscreenVideoPictureInPictureController.java.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/android/java/src/org/chromium/chrome/browser/media/FullscreenVideoPictureInPictureController.java b/chrome/android/java/src/org/chromium/chrome/browser/media/FullscreenVideoPictureInPictureController.java
-index 7b6c5309d15c802a517306b74278e0e952bebeeb..692f9f53131d8a22d4a18df7880b9d9d2b5b5cb9 100644
+index 7b6c5309d15c802a517306b74278e0e952bebeeb..6aa43a48d7c7511a3128f0a49704082fae90024f 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/media/FullscreenVideoPictureInPictureController.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/media/FullscreenVideoPictureInPictureController.java
 @@ -281,6 +281,10 @@ public class FullscreenVideoPictureInPictureController {
@@ -13,7 +13,29 @@ index 7b6c5309d15c802a517306b74278e0e952bebeeb..692f9f53131d8a22d4a18df7880b9d9d
          try {
              if (!mActivity.enterPictureInPictureMode(builder.build())) return;
          } catch (IllegalStateException | IllegalArgumentException e) {
-@@ -616,6 +620,16 @@ public class FullscreenVideoPictureInPictureController {
+@@ -407,6 +411,10 @@ public class FullscreenVideoPictureInPictureController {
+     // Closing used to suspend media as a side-effect of hiding the page, but that no longer happens
+     // on large form factors (see IsBackgroundMediaSuspendEnabled), so suspend it here.
+     public void onStop() {
++        if (BraveFullscreenVideoPictureInPictureController.class.cast(this)
++                .maybeHandleStopForScreenLock(mShouldSuspendMediaOnStop)) {
++            return;
++        }
+         if (mShouldSuspendMediaOnStop) {
+             mShouldSuspendMediaOnStop = false;
+ 
+@@ -418,6 +426,10 @@ public class FullscreenVideoPictureInPictureController {
+     }
+ 
+     public void onResume() {
++        if (BraveFullscreenVideoPictureInPictureController.class.cast(this)
++                .maybeHandleResumeAfterScreenLock(mActivity)) {
++            return;
++        }
+         // Pip was restored rather than closed, so media should keep playing.
+         mShouldSuspendMediaOnStop = false;
+         // Unconditionally dismiss pip, because the activity has been resumed.  This can happen if
+@@ -616,6 +628,16 @@ public class FullscreenVideoPictureInPictureController {
       * This will also update our auto-PiP preference with the framework, if it's changed.
       */
      private void dismissActivityIfNeeded(Activity activity, @MetricsEndReason int reason) {

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/FullscreenHtmlApiHandlerBase.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/fullscreen/FullscreenHtmlApiHandlerBase.java.yaml
@@ -5,13 +5,10 @@
 
 substitutions:
   - description: |-
-      Skip the tab-hidden fullscreen teardown while YouTube PiP is active.
+      Preserve fullscreen when a tab hide interrupts video PiP.
 
-      Inserts an early return at the top of the TabObserver onHidden hook so the
-      persistent fullscreen state is preserved when a tab is hidden while a
-      Brave-managed YouTube Picture-in-Picture session is active.
-      maybeSkipExitFullscreenOnTabHidden also records whether the tab was hidden
-      by a tab switch before deciding whether to skip.
+      The Brave hook preserves active YouTube sessions and any locked PiP with
+      background playback enabled. It also records tab switches for cleanup.
     regex:
       re_pattern: '(public void onHidden\(.*\)\s+\{)'
       replace: |-
@@ -23,15 +20,11 @@ substitutions:
                                 }
 
   - description: |-
-      Preserve fullscreen across transient activity stops while YouTube PiP is active.
+      Preserve fullscreen when an activity stop interrupts video PiP.
 
-      Inserts an early return at the top of the ActivityState.STOPPED branch of
-      onActivityStateChange so the fullscreen teardown
-      (mFullscreenManagerDelegate.onExitFullscreen(null)) is skipped while a
-      Brave-managed YouTube Picture-in-Picture session is active. This keeps the
-      browser and DOM fullscreen state intact across transient activity stops
-      (e.g. screen-off or PiP window occlusion) so there is no flicker when the
-      user returns. The DESTROYED branch is intentionally left untouched.
+      Exiting fullscreen on screen lock also suspends media. The Brave hook
+      preserves active YouTube sessions and any locked PiP with background
+      playback enabled. Activity destruction still performs normal cleanup.
     regex:
       re_pattern:
         '(public void onActivityStateChange\(Activity activity, int

--- a/rewrite/chrome/android/java/src/org/chromium/chrome/browser/media/FullscreenVideoPictureInPictureController.java.yaml
+++ b/rewrite/chrome/android/java/src/org/chromium/chrome/browser/media/FullscreenVideoPictureInPictureController.java.yaml
@@ -5,6 +5,39 @@
 
 substitutions:
   - description: |-
+      Preserve background playback when screen lock stops the PiP activity.
+
+      Chromium 153 added media suspension in onStop, treating an activity stop
+      as a PiP close:
+      https://chromium.googlesource.com/chromium/src/+/11ba5e6a08d432b71f625f56410410e0b6a6465b
+
+      Screen lock also stops the activity. When background playback is enabled,
+      this hook prevents screen lock from suspending playback on any website.
+      It keeps the pending stop flag so closing PiP later still pauses playback.
+    regex:
+      re_pattern: '(public void onStop\(\) \{)'
+      replace: |-
+        \1
+                if (BraveFullscreenVideoPictureInPictureController.class.cast(this)
+                        .maybeHandleStopForScreenLock(mShouldSuspendMediaOnStop)) {
+                    return;
+                }
+
+  - description: |-
+      Keep active PiP when unlocking resumes the activity.
+
+      A resume after screen lock is not the user expanding PiP. Preserve the
+      window and pending close flag until a real close or normal resume.
+    regex:
+      re_pattern: '(public void onResume\(\) \{)'
+      replace: |-
+        \1
+                if (BraveFullscreenVideoPictureInPictureController.class.cast(this)
+                        .maybeHandleResumeAfterScreenLock(mActivity)) {
+                    return;
+                }
+
+  - description: |-
       Delegate YouTube PiP entry to Brave.
 
       Inserts a guarded early return just before the inline


### PR DESCRIPTION


<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58827.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->


## Overview

Chromium 153 added media suspension in `onStop()`, treating an activity stop as a PiP close: https://chromium.googlesource.com/chromium/src/+/11ba5e6a08d432b71f625f56410410e0b6a6465b

Screen lock also stops the activity. Changes to restore background PiP playback:
- skip media suspension on lock when background play is enabled
- preserve fullscreen during screen lock
- keep PiP open after unlocking

## Tests

Note: extensive unit tests have been implemented, but per @SergeyZhukovsky's request, this PR should be as small as possible so it can be more easily uplifted. As such these tests will be added as part of a [dedicated follow-up ticket](https://github.com/brave/brave-browser/issues/58854) that I will submit upon this PR being merged.

I manually tested this changes on the following media:

* https://www.youtube.com/watch?v=wuFfiTEr2yc
* https://player.vimeo.com/video/1084537
* [Brave Technologist episode 136 MP4](https://traffic.libsyn.com/force-cdn/highwinds/thebravemarketer/David_1.mp4)

Note: given the toolbar's PiP icon only displays for YouTube, testing the Vimeo and Brave Technologist videos required commencing playback, entering full screen, then swiping Home to engage PiP.

## Demos

Note: turn sound 🔈 on:

https://github.com/user-attachments/assets/0a4ba411-991e-42ff-9c3b-0c40967f23a3

