### PR TITLE
Restart GPU process when compositor presents stall

### DIFF
--- a/browser/BUILD.gn
+++ b/browser/BUILD.gn
@@ -121,6 +121,15 @@ source_set("unit_tests") {
   sources = []
   deps = []
 
+  if (!is_android) {
+    sources += [ "gpu/gpu_present_stall_detector_unittest.cc" ]
+    deps += [
+      "//base",
+      "//brave/browser",
+      "//testing/gtest",
+    ]
+  }
+
   if (is_win) {
     sources += [ "default_protocol_handler_utils_win_unittest.cc" ]
 

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -630,6 +630,21 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
           FEATURE_VALUE_TYPE(brave::kUpgradeWhenIdle),                         \
       }))
 
+#if !BUILDFLAG(IS_ANDROID)
+#define BRAVE_RESTART_GPU_ON_PRESENT_STALL_FEATURE_ENTRY                       \
+  EXPAND_FEATURE_ENTRIES({                                                     \
+      "brave-restart-gpu-on-present-stall",                                    \
+      "Restart GPU process on compositor present stall",                       \
+      "Restart the GPU process if a visible window keeps submitting frames "   \
+      "that never present. Recovers macOS UI freezes where the GPU process "   \
+      "is stuck in WindowServer/CATransaction and closing tabs does nothing.", \
+      kOsWin | kOsMac | kOsLinux,                                              \
+      FEATURE_VALUE_TYPE(features::kBraveRestartGpuOnPresentStall),            \
+  })
+#else
+#define BRAVE_RESTART_GPU_ON_PRESENT_STALL_FEATURE_ENTRY
+#endif
+
 #if defined(TOOLKIT_VIEWS)
 #define BRAVE_DARKER_THEME_FEATURE_ENTRIES                           \
   EXPAND_FEATURE_ENTRIES({                                           \
@@ -1619,6 +1634,7 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
   BRAVE_OMNIBOX_FEATURES                                                       \
   BRAVE_MIDDLE_CLICK_AUTOSCROLL_FEATURE_ENTRY                                  \
   BRAVE_UPGRADE_WHEN_IDLE_FEATURE_ENTRY                                        \
+  BRAVE_RESTART_GPU_ON_PRESENT_STALL_FEATURE_ENTRY                             \
   BRAVE_EXTENSIONS_MANIFEST_V2                                                 \
   BRAVE_EXTENSION_AUTO_UPDATE_FEATURE_ENTRY                                    \
   BRAVE_EXTENSION_MALWARE_BLOCKLIST_FEATURE_ENTRY                              \

--- a/browser/brave_browser_features.cc
+++ b/browser/brave_browser_features.cc
@@ -46,6 +46,21 @@ BASE_FEATURE(kBraveOverrideDownloadDangerLevel,
 BASE_FEATURE(kBraveDayZeroExperiment,
              base::FEATURE_DISABLED_BY_DEFAULT);
 
+#if !BUILDFLAG(IS_ANDROID)
+// Restart the GPU process when a visible compositor keeps committing frames
+// that never present. On macOS this recovers UI freezes caused by a GPU
+// process stuck in CATransaction/WindowServer, which the GPU watchdog does
+// not kill and which tab closes cannot recover.
+BASE_FEATURE(kBraveRestartGpuOnPresentStall,
+             "BraveRestartGpuOnPresentStall",
+#if BUILDFLAG(IS_MAC)
+             base::FEATURE_ENABLED_BY_DEFAULT
+#else
+             base::FEATURE_DISABLED_BY_DEFAULT
+#endif
+);
+#endif  // !BUILDFLAG(IS_ANDROID)
+
 #if BUILDFLAG(BRAVE_V8_ENABLE_DRUMBRAKE)
 // Run WebAssembly code in the DrumBrake interpreter instead of the optimizing
 // compiler. Automatically enabled when V8 is in jitless mode.
@@ -83,6 +98,24 @@ const base::FeatureParam<std::string> kBraveDayZeroExperimentVariant{
     &kBraveDayZeroExperiment,
     /*name=*/"variant",
     /*default_value=*/""};
+
+#if !BUILDFLAG(IS_ANDROID)
+const base::FeatureParam<int> kBraveRestartGpuOnPresentStallTimeoutSeconds{
+    &kBraveRestartGpuOnPresentStall,
+    /*name=*/"stall_timeout_seconds",
+    /*default_value=*/15};
+
+const base::FeatureParam<int> kBraveRestartGpuOnPresentStallCooldownSeconds{
+    &kBraveRestartGpuOnPresentStall,
+    /*name=*/"cooldown_seconds",
+    /*default_value=*/60};
+
+const base::FeatureParam<int>
+    kBraveRestartGpuOnPresentStallCheckIntervalSeconds{
+        &kBraveRestartGpuOnPresentStall,
+        /*name=*/"check_interval_seconds",
+        /*default_value=*/2};
+#endif  // !BUILDFLAG(IS_ANDROID)
 
 #if BUILDFLAG(IS_ANDROID)
 // The variant of the fresh NTP experiment: B (the default) or A for the control

--- a/browser/brave_browser_features.h
+++ b/browser/brave_browser_features.h
@@ -11,6 +11,7 @@
 #include "base/feature_list.h"
 #include "base/metrics/field_trial_params.h"
 #include "brave/components/v8/buildflags/buildflags.h"
+#include "build/build_config.h"
 
 namespace features {
 
@@ -21,6 +22,15 @@ BASE_DECLARE_FEATURE(kBraveCopyCleanLinkFromJs);
 BASE_DECLARE_FEATURE(kBraveOverrideDownloadDangerLevel);
 BASE_DECLARE_FEATURE(kBraveRoundedCornersByDefault);
 BASE_DECLARE_FEATURE(kBraveDayZeroExperiment);
+#if !BUILDFLAG(IS_ANDROID)
+BASE_DECLARE_FEATURE(kBraveRestartGpuOnPresentStall);
+extern const base::FeatureParam<int>
+    kBraveRestartGpuOnPresentStallTimeoutSeconds;
+extern const base::FeatureParam<int>
+    kBraveRestartGpuOnPresentStallCooldownSeconds;
+extern const base::FeatureParam<int>
+    kBraveRestartGpuOnPresentStallCheckIntervalSeconds;
+#endif  // !BUILDFLAG(IS_ANDROID)
 #if BUILDFLAG(BRAVE_V8_ENABLE_DRUMBRAKE)
 BASE_DECLARE_FEATURE(kBraveWebAssemblyJitless);
 #endif  // BUILDFLAG(BRAVE_V8_ENABLE_DRUMBRAKE)

--- a/browser/brave_browser_main_extra_parts.cc
+++ b/browser/brave_browser_main_extra_parts.cc
@@ -16,6 +16,7 @@
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 
 #if !BUILDFLAG(IS_ANDROID)
+#include "brave/browser/gpu/gpu_present_stall_restarter.h"
 #include "brave/browser/importer/brave_importer_p3a.h"
 #include "brave/browser/p3a/p3a_core_metrics.h"
 #include "brave/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.h"
@@ -93,6 +94,7 @@ void BraveBrowserMainExtraParts::PreMainMessageLoopRun() {
   // The code below is not supported on android.
 #if !BUILDFLAG(IS_ANDROID)
   brave::BraveWindowTracker::CreateInstance(g_browser_process->local_state());
+  brave::GpuPresentStallRestarter::GetInstance()->Start();
 #endif  // !BUILDFLAG(IS_ANDROID)
   g_brave_browser_process->process_misc_metrics()->uptime_monitor()->Init();
 }
@@ -105,5 +107,6 @@ void BraveBrowserMainExtraParts::PostDestroyThreads() {
   if (brave::BraveWindowTracker::HasInstance()) {
     brave::BraveWindowTracker::ClearInstance();
   }
+  brave::GpuPresentStallRestarter::GetInstance()->Stop();
 #endif  // !BUILDFLAG(IS_ANDROID)
 }

--- a/browser/gpu/gpu_present_stall_detector.cc
+++ b/browser/gpu/gpu_present_stall_detector.cc
@@ -1,0 +1,29 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/gpu/gpu_present_stall_detector.h"
+
+namespace brave {
+
+bool ShouldRestartGpuProcessForPresentStall(const GpuPresentStallInput& input,
+                                            base::TimeDelta stall_timeout,
+                                            base::TimeDelta cooldown) {
+  if (!input.compositor_visible) {
+    return false;
+  }
+  if (input.unacked_since.is_null()) {
+    return false;
+  }
+  if (input.now - input.unacked_since < stall_timeout) {
+    return false;
+  }
+  if (!input.last_restart.is_null() &&
+      input.now - input.last_restart < cooldown) {
+    return false;
+  }
+  return true;
+}
+
+}  // namespace brave

--- a/browser/gpu/gpu_present_stall_detector.h
+++ b/browser/gpu/gpu_present_stall_detector.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_GPU_GPU_PRESENT_STALL_DETECTOR_H_
+#define BRAVE_BROWSER_GPU_GPU_PRESENT_STALL_DETECTOR_H_
+
+#include "base/time/time.h"
+
+namespace brave {
+
+// Inputs for deciding whether a compositor present stall should restart the
+// GPU process. `unacked_since` is the first commit that has not been followed
+// by a present; it is null when presents are keeping up.
+struct GpuPresentStallInput {
+  bool compositor_visible = false;
+  base::TimeTicks now;
+  base::TimeTicks unacked_since;
+  base::TimeTicks last_restart;
+};
+
+// Returns true when a visible compositor has been waiting for a present longer
+// than `stall_timeout`, and a GPU restart is not still in cooldown.
+bool ShouldRestartGpuProcessForPresentStall(const GpuPresentStallInput& input,
+                                            base::TimeDelta stall_timeout,
+                                            base::TimeDelta cooldown);
+
+}  // namespace brave
+
+#endif  // BRAVE_BROWSER_GPU_GPU_PRESENT_STALL_DETECTOR_H_

--- a/browser/gpu/gpu_present_stall_detector_unittest.cc
+++ b/browser/gpu/gpu_present_stall_detector_unittest.cc
@@ -1,0 +1,72 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/gpu/gpu_present_stall_detector.h"
+
+#include "base/time/time.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave {
+namespace {
+
+constexpr base::TimeDelta kStallTimeout = base::Seconds(15);
+constexpr base::TimeDelta kCooldown = base::Seconds(60);
+
+TEST(GpuPresentStallDetectorTest, NoRestartWhenPresentsKeepUp) {
+  const base::TimeTicks t0 = base::TimeTicks() + base::Seconds(100);
+  GpuPresentStallInput input;
+  input.compositor_visible = true;
+  input.now = t0;
+  EXPECT_FALSE(ShouldRestartGpuProcessForPresentStall(input, kStallTimeout,
+                                                      kCooldown));
+}
+
+TEST(GpuPresentStallDetectorTest, NoRestartBeforeTimeout) {
+  const base::TimeTicks t0 = base::TimeTicks() + base::Seconds(100);
+  GpuPresentStallInput input;
+  input.compositor_visible = true;
+  input.now = t0 + base::Seconds(14);
+  input.unacked_since = t0;
+  EXPECT_FALSE(ShouldRestartGpuProcessForPresentStall(input, kStallTimeout,
+                                                      kCooldown));
+}
+
+TEST(GpuPresentStallDetectorTest, RestartAfterPresentStall) {
+  const base::TimeTicks t0 = base::TimeTicks() + base::Seconds(100);
+  GpuPresentStallInput input;
+  input.compositor_visible = true;
+  input.now = t0 + base::Seconds(15);
+  input.unacked_since = t0;
+  EXPECT_TRUE(ShouldRestartGpuProcessForPresentStall(input, kStallTimeout,
+                                                     kCooldown));
+}
+
+TEST(GpuPresentStallDetectorTest, NoRestartWhenCompositorHidden) {
+  const base::TimeTicks t0 = base::TimeTicks() + base::Seconds(100);
+  GpuPresentStallInput input;
+  input.compositor_visible = false;
+  input.now = t0 + base::Seconds(30);
+  input.unacked_since = t0;
+  EXPECT_FALSE(ShouldRestartGpuProcessForPresentStall(input, kStallTimeout,
+                                                      kCooldown));
+}
+
+TEST(GpuPresentStallDetectorTest, CooldownPreventsImmediateRerestart) {
+  const base::TimeTicks t0 = base::TimeTicks() + base::Seconds(100);
+  GpuPresentStallInput input;
+  input.compositor_visible = true;
+  input.now = t0 + base::Seconds(20);
+  input.unacked_since = t0;
+  input.last_restart = t0 + base::Seconds(15);
+  EXPECT_FALSE(ShouldRestartGpuProcessForPresentStall(input, kStallTimeout,
+                                                      kCooldown));
+
+  input.now = input.last_restart + kCooldown;
+  EXPECT_TRUE(ShouldRestartGpuProcessForPresentStall(input, kStallTimeout,
+                                                     kCooldown));
+}
+
+}  // namespace
+}  // namespace brave

--- a/browser/gpu/gpu_present_stall_restarter.cc
+++ b/browser/gpu/gpu_present_stall_restarter.cc
@@ -1,0 +1,183 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/gpu/gpu_present_stall_restarter.h"
+
+#include "base/logging.h"
+#include "base/metrics/histogram_macros.h"
+#include "base/no_destructor.h"
+#include "brave/browser/brave_browser_features.h"
+#include "brave/browser/gpu/gpu_present_stall_detector.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_list.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "content/browser/gpu/gpu_process_host.h"
+#include "content/public/browser/browser_thread.h"
+#include "ui/compositor/compositor.h"
+#include "ui/views/widget/widget.h"
+
+namespace brave {
+namespace {
+
+base::TimeDelta StallTimeout() {
+  return base::Seconds(
+      features::kBraveRestartGpuOnPresentStallTimeoutSeconds.Get());
+}
+
+base::TimeDelta Cooldown() {
+  return base::Seconds(
+      features::kBraveRestartGpuOnPresentStallCooldownSeconds.Get());
+}
+
+base::TimeDelta CheckInterval() {
+  return base::Seconds(
+      features::kBraveRestartGpuOnPresentStallCheckIntervalSeconds.Get());
+}
+
+}  // namespace
+
+// static
+GpuPresentStallRestarter* GpuPresentStallRestarter::GetInstance() {
+  static base::NoDestructor<GpuPresentStallRestarter> instance;
+  return instance.get();
+}
+
+GpuPresentStallRestarter::GpuPresentStallRestarter() = default;
+
+GpuPresentStallRestarter::~GpuPresentStallRestarter() {
+  Stop();
+}
+
+void GpuPresentStallRestarter::Start() {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  if (started_ ||
+      !base::FeatureList::IsEnabled(features::kBraveRestartGpuOnPresentStall)) {
+    return;
+  }
+  started_ = true;
+  ObserveDesktopCompositors();
+  check_timer_.Start(FROM_HERE, CheckInterval(), this,
+                     &GpuPresentStallRestarter::CheckForStall);
+}
+
+void GpuPresentStallRestarter::Stop() {
+  check_timer_.Stop();
+  for (auto& [compositor, state] : compositor_state_) {
+    if (state.observing && compositor) {
+      compositor->RemoveObserver(this);
+    }
+  }
+  compositor_state_.clear();
+  started_ = false;
+}
+
+void GpuPresentStallRestarter::OnCompositingDidCommit(
+    ui::Compositor* compositor) {
+  auto& state = compositor_state_[compositor];
+  if (state.unacked_since.is_null()) {
+    state.unacked_since = base::TimeTicks::Now();
+  }
+}
+
+void GpuPresentStallRestarter::OnDidPresentCompositorFrame(
+    ui::Compositor* compositor,
+    uint32_t /*frame_token*/,
+    const gfx::PresentationFeedback& /*feedback*/) {
+  compositor_state_[compositor].unacked_since = base::TimeTicks();
+}
+
+void GpuPresentStallRestarter::OnCompositingShuttingDown(
+    ui::Compositor* compositor) {
+  StopObserving(compositor);
+}
+
+void GpuPresentStallRestarter::OnCompositorVisibilityChanged(
+    ui::Compositor* compositor,
+    bool visible) {
+  auto& state = compositor_state_[compositor];
+  state.visible = visible;
+  if (!visible) {
+    state.unacked_since = base::TimeTicks();
+  }
+}
+
+void GpuPresentStallRestarter::ObserveDesktopCompositors() {
+  for (Browser* browser : *BrowserList::GetInstance()) {
+    BrowserView* browser_view = BrowserView::GetBrowserViewForBrowser(browser);
+    if (!browser_view) {
+      continue;
+    }
+    views::Widget* widget = browser_view->GetWidget();
+    if (!widget) {
+      continue;
+    }
+    ui::Compositor* compositor = widget->GetCompositor();
+    if (!compositor) {
+      continue;
+    }
+    const bool visible = widget->IsVisible() && !widget->IsMinimized();
+    EnsureObserving(compositor, visible);
+  }
+}
+
+void GpuPresentStallRestarter::EnsureObserving(ui::Compositor* compositor,
+                                               bool visible) {
+  auto& state = compositor_state_[compositor];
+  state.visible = visible;
+  if (state.observing) {
+    return;
+  }
+  compositor->AddObserver(this);
+  state.observing = true;
+}
+
+void GpuPresentStallRestarter::StopObserving(ui::Compositor* compositor) {
+  auto it = compositor_state_.find(compositor);
+  if (it == compositor_state_.end()) {
+    return;
+  }
+  if (it->second.observing && compositor) {
+    compositor->RemoveObserver(this);
+  }
+  compositor_state_.erase(it);
+}
+
+void GpuPresentStallRestarter::CheckForStall() {
+  ObserveDesktopCompositors();
+
+  const base::TimeTicks now = base::TimeTicks::Now();
+  const base::TimeDelta stall_timeout = StallTimeout();
+  const base::TimeDelta cooldown = Cooldown();
+  for (const auto& [compositor, state] : compositor_state_) {
+    GpuPresentStallInput input;
+    input.compositor_visible = state.visible;
+    input.now = now;
+    input.unacked_since = state.unacked_since;
+    input.last_restart = last_restart_;
+    if (ShouldRestartGpuProcessForPresentStall(input, stall_timeout,
+                                               cooldown)) {
+      RestartGpuProcess();
+      return;
+    }
+  }
+}
+
+void GpuPresentStallRestarter::RestartGpuProcess() {
+  last_restart_ = base::TimeTicks::Now();
+  for (auto& [compositor, state] : compositor_state_) {
+    state.unacked_since = base::TimeTicks();
+  }
+
+  LOG(WARNING) << "Restarting GPU process after compositor present stall";
+  UMA_HISTOGRAM_BOOLEAN("Brave.GPU.PresentStallRestart", true);
+
+  auto* host = content::GpuProcessHost::Get(
+      content::GPU_PROCESS_KIND_SANDBOXED, /*force_create=*/false);
+  if (host) {
+    host->ForceShutdown();
+  }
+}
+
+}  // namespace brave

--- a/browser/gpu/gpu_present_stall_restarter.h
+++ b/browser/gpu/gpu_present_stall_restarter.h
@@ -1,0 +1,81 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_GPU_GPU_PRESENT_STALL_RESTARTER_H_
+#define BRAVE_BROWSER_GPU_GPU_PRESENT_STALL_RESTARTER_H_
+
+#include <cstdint>
+
+#include "base/containers/flat_map.h"
+#include "base/memory/raw_ptr.h"
+#include "base/no_destructor.h"
+#include "base/time/time.h"
+#include "base/timer/timer.h"
+#include "ui/compositor/compositor_observer.h"
+
+namespace ui {
+class Compositor;
+}
+
+namespace gfx {
+struct PresentationFeedback;
+}
+
+namespace brave {
+
+// Watches desktop UI compositors for "commit without present" stalls.
+//
+// Chromium's GPU watchdog only notices the GPU thread failing to process
+// command buffers. On macOS the hang is often the GPU process main thread
+// blocked in CATransaction/WindowServer, so the watchdog never fires and
+// closing tabs cannot recover the UI. Restarting the GPU process from the
+// browser process is the recovery Chromium already uses after a GPU crash.
+class GpuPresentStallRestarter : public ui::CompositorObserver {
+ public:
+  static GpuPresentStallRestarter* GetInstance();
+
+  GpuPresentStallRestarter(const GpuPresentStallRestarter&) = delete;
+  GpuPresentStallRestarter& operator=(const GpuPresentStallRestarter&) = delete;
+
+  void Start();
+  void Stop();
+
+  // ui::CompositorObserver:
+  void OnCompositingDidCommit(ui::Compositor* compositor) override;
+  void OnDidPresentCompositorFrame(
+      ui::Compositor* compositor,
+      uint32_t frame_token,
+      const gfx::PresentationFeedback& feedback) override;
+  void OnCompositingShuttingDown(ui::Compositor* compositor) override;
+  void OnCompositorVisibilityChanged(ui::Compositor* compositor,
+                                     bool visible) override;
+
+ private:
+  friend class base::NoDestructor<GpuPresentStallRestarter>;
+
+  struct CompositorState {
+    bool visible = false;
+    bool observing = false;
+    base::TimeTicks unacked_since;
+  };
+
+  GpuPresentStallRestarter();
+  ~GpuPresentStallRestarter() override;
+
+  void ObserveDesktopCompositors();
+  void EnsureObserving(ui::Compositor* compositor, bool visible);
+  void StopObserving(ui::Compositor* compositor);
+  void CheckForStall();
+  void RestartGpuProcess();
+
+  base::RepeatingTimer check_timer_;
+  base::flat_map<raw_ptr<ui::Compositor>, CompositorState> compositor_state_;
+  base::TimeTicks last_restart_;
+  bool started_ = false;
+};
+
+}  // namespace brave
+
+#endif  // BRAVE_BROWSER_GPU_GPU_PRESENT_STALL_RESTARTER_H_

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -428,6 +428,10 @@ if (!is_android) {
   # BraveHidDelegate inherits from ChromeHidDelegate, and referenced by
   # BraveContentBrowserClient, so we put into the same source_set.
   brave_chrome_browser_sources += [
+    "//brave/browser/gpu/gpu_present_stall_detector.cc",
+    "//brave/browser/gpu/gpu_present_stall_detector.h",
+    "//brave/browser/gpu/gpu_present_stall_restarter.cc",
+    "//brave/browser/gpu/gpu_present_stall_restarter.h",
     "//brave/browser/hid/brave_hid_delegate.cc",
     "//brave/browser/hid/brave_hid_delegate.h",
   ]


### PR DESCRIPTION
## Summary
- Fixes [brave/brave-browser#58866](https://github.com/brave/brave-browser/issues/58866): on macOS the UI can freeze and **never recover** until Brave is force-quit. Closing tabs / opening new tabs does nothing because the hang is in the shared GPU process (`CA::Transaction::commit` / WindowServer), not in a renderer.
- Chromium's GPU watchdog does not kill this hang: the GPU thread is still making progress, while the GPU *main* thread is blocked in Apple code. HangWatcher only `DumpWithoutCrashing`.
- This PR watches visible UI compositors for commit-without-present stalls and restarts the GPU process from the browser process (the same recovery Chromium already uses after a GPU crash). Enabled by default on macOS; available behind `brave://flags/#brave-restart-gpu-on-present-stall` on desktop.

## Test plan
- [ ] `brave_unit_tests --gtest_filter=GpuPresentStallDetectorTest.*`
- [ ] macOS: enable hardware acceleration, keep a long session with a GPU-heavy tab (e.g. YouTube) until the UI stops painting. Confirm Brave recovers within ~15s without a full restart (GPU process PID changes, windows start painting again).
- [ ] Confirm closing/opening tabs after a freeze is no longer a dead end.
- [ ] Confirm `brave://flags/#brave-restart-gpu-on-present-stall` Disabled prevents the GPU restart.
- [ ] Confirm a healthy idle window (no damage / no commits) does not restart the GPU process.


Made with [Cursor](https://cursor.com)