### PR TITLE
[plaster] Test blink runtime dependant features are disabled

### DIFF
--- a/app/BUILD.gn
+++ b/app/BUILD.gn
@@ -133,6 +133,7 @@ source_set("unit_tests") {
     "//base",
     "//base/test:test_support",
     "//brave/components/variations:buildflags",
+    "//brave/test:runtime_feature_test_support",
     "//chrome/browser",
     "//chrome/browser:browser_features",
     "//chrome/browser/devtools",

--- a/app/DEPS
+++ b/app/DEPS
@@ -80,6 +80,7 @@ specific_include_rules = {
   ],
   "feature_defaults_unittest\.cc": [
     "+android_webview/common/aw_features.h",
+    "+brave/test/base/runtime_feature_test_support.h",
     "+components/browser_actuator/internal/features.h",
     "+components/browser_actuator/public/features.h",
     "+components/enterprise/connectors/core/features.h",

--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -3,9 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <algorithm>
+#include <string_view>
+
 #include "base/debug/debugging_buildflags.h"
 #include "base/feature_list.h"
 #include "base/features.h"
+#include "base/memory/raw_ptr.h"
+#include "base/test/scoped_feature_list.h"
+#include "brave/test/base/runtime_feature_test_support.h"
 #include "chrome/browser/browser_features.h"
 #include "chrome/browser/devtools/features.h"
 #include "chrome/browser/history_embeddings/history_embeddings_utils.h"
@@ -108,6 +114,12 @@
 #endif
 
 TEST(FeatureDefaultsTest, DisabledFeatures) {
+  // Keep patched defaults as defaults: overriding these features would make
+  // Blink's base-feature sync disable them and conceal missing renderer
+  // disables.
+  base::test::ScopedFeatureList feature_list;
+  feature_list.InitWithEmptyFeatureAndFieldTrialLists();
+
   // Please, keep alphabetized
   const base::Feature* disabled_features[] = {
       &attribution_reporting::features::kConversionMeasurement,
@@ -304,9 +316,53 @@ TEST(FeatureDefaultsTest, DisabledFeatures) {
       &webapps::features::kWebAppsEnableMLModelForPromotion,
   };
 
-  for (const auto* feature : disabled_features) {
-    EXPECT_FALSE(base::FeatureList::IsEnabled(*feature)) << feature->name;
+  const auto runtime_features =
+      brave::GetRendererRuntimeFeatureStatesForTesting();
+  ASSERT_FALSE(runtime_features.empty());
+
+  // These associations are made in Content/Brave renderer code rather than
+  // JSON5, and the base and runtime feature names differ.
+  struct RuntimeFeatureAlias {
+    const raw_ptr<const base::Feature> base_feature;
+    std::string_view runtime_name;
+  };
+  const RuntimeFeatureAlias runtime_feature_aliases[] = {
+      {&attribution_reporting::features::kConversionMeasurement,
+       "AttributionReporting"},
+      {&features::kDigitalGoodsApi, "DigitalGoods"},
+      {&network::features::kBrowsingTopics, "TopicsAPI"},
+  };
+  for (const auto& alias : runtime_feature_aliases) {
+    ASSERT_TRUE(std::ranges::any_of(runtime_features,
+                                    [&](const auto& runtime) {
+                                      return runtime.name == alias.runtime_name;
+                                    }))
+        << "Unknown Blink runtime feature: " << alias.runtime_name;
   }
+
+  size_t checked_runtime_features = 0;
+  for (const auto* feature : disabled_features) {
+    const bool base_enabled = base::FeatureList::IsEnabled(*feature);
+    EXPECT_FALSE(base_enabled) << feature->name;
+
+    for (const auto& runtime : runtime_features) {
+      const bool is_alias = std::ranges::any_of(
+          runtime_feature_aliases, [&](const RuntimeFeatureAlias& alias) {
+            return alias.base_feature == feature &&
+                   alias.runtime_name == runtime.name;
+          });
+      if (runtime.name != feature->name &&
+          runtime.base_feature_name != feature->name && !is_alias) {
+        continue;
+      }
+      ++checked_runtime_features;
+      EXPECT_EQ(base_enabled, runtime.enabled)
+          << "Base feature: " << feature->name
+          << "; Blink runtime feature after renderer initialization: "
+          << runtime.name;
+    }
+  }
+  EXPECT_GT(checked_runtime_features, 0u);
 }
 
 TEST(FeatureDefaultsTest, EnabledFeatures) {

--- a/chromium_src/content/public/renderer/content_renderer_client.h
+++ b/chromium_src/content/public/renderer/content_renderer_client.h
@@ -1,0 +1,25 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CONTENT_PUBLIC_RENDERER_CONTENT_RENDERER_CLIENT_H_
+#define BRAVE_CHROMIUM_SRC_CONTENT_PUBLIC_RENDERER_CONTENT_RENDERER_CLIENT_H_
+
+#include <content/public/renderer/content_renderer_client.h>
+
+namespace base {
+class CommandLine;
+}
+
+namespace content {
+
+// Runs the feature initialization sequence used by RenderThreadImpl, without
+// starting a renderer process. Exported for tests in component builds.
+CONTENT_EXPORT void InitializeRuntimeFeaturesForTesting(
+    ContentRendererClient& renderer_client,
+    const base::CommandLine& command_line);
+
+}  // namespace content
+
+#endif  // BRAVE_CHROMIUM_SRC_CONTENT_PUBLIC_RENDERER_CONTENT_RENDERER_CLIENT_H_

--- a/chromium_src/content/renderer/render_thread_impl.cc
+++ b/chromium_src/content/renderer/render_thread_impl.cc
@@ -1,0 +1,18 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <content/renderer/render_thread_impl.cc>
+
+namespace content {
+
+void InitializeRuntimeFeaturesForTesting(
+    ContentRendererClient& renderer_client,
+    const base::CommandLine& command_line) {
+  // Keep the order used by RenderThreadImpl::InitializeWebKit().
+  renderer_client.SetRuntimeFeaturesDefaultsBeforeBlinkInitialization();
+  SetRuntimeFeaturesDefaultsAndUpdateFromArgs(command_line);
+}
+
+}  // namespace content

--- a/chromium_src/third_party/blink/renderer/platform/exported/web_runtime_features.cc
+++ b/chromium_src/third_party/blink/renderer/platform/exported/web_runtime_features.cc
@@ -1,0 +1,41 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <memory>
+#include <utility>
+
+#include "base/functional/bind.h"
+
+#include <third_party/blink/renderer/platform/exported/web_runtime_features.cc>
+
+namespace blink {
+
+base::OnceClosure
+WebRuntimeFeatures::BackupAndResetRuntimeFeaturesForTesting() {
+  auto backup = std::make_unique<RuntimeEnabledFeatures::Backup>();
+  const bool overlay_scrollbars =
+      ScrollbarThemeSettings::OverlayScrollbarsEnabled();
+  const bool fluent_scrollbars =
+      ScrollbarThemeSettings::FluentScrollbarsEnabled();
+  const bool desktop_android_scrollbars =
+      ScrollbarThemeSettings::DesktopAndroidScrollbarsEnabled();
+
+  ResetRuntimeFeaturesForTesting();
+
+  return base::BindOnce(
+      [](std::unique_ptr<RuntimeEnabledFeatures::Backup> backup,
+         bool overlay_scrollbars, bool fluent_scrollbars,
+         bool desktop_android_scrollbars) {
+        backup->Restore();
+        ScrollbarThemeSettings::SetOverlayScrollbarsEnabled(overlay_scrollbars);
+        ScrollbarThemeSettings::SetFluentScrollbarsEnabled(fluent_scrollbars);
+        ScrollbarThemeSettings::SetDesktopAndroidScrollbarsEnabled(
+            desktop_android_scrollbars);
+      },
+      std::move(backup), overlay_scrollbars, fluent_scrollbars,
+      desktop_android_scrollbars);
+}
+
+}  // namespace blink

--- a/patches/third_party-blink-public-platform-web_runtime_features.h.patch
+++ b/patches/third_party-blink-public-platform-web_runtime_features.h.patch
@@ -1,0 +1,21 @@
+diff --git a/third_party/blink/public/platform/web_runtime_features.h b/third_party/blink/public/platform/web_runtime_features.h
+index d7584122c0b89e646cec244febbaeb9df57877dc..e650f13f235ffe224663ad19613df666feaea6b9 100644
+--- a/third_party/blink/public/platform/web_runtime_features.h
++++ b/third_party/blink/public/platform/web_runtime_features.h
+@@ -33,6 +33,8 @@
+ 
+ #include <string_view>
+ 
++#include "base/functional/callback.h"
++
+ #include "third_party/blink/public/platform/web_common.h"
+ #include "third_party/blink/public/platform/web_runtime_features_base.h"
+ 
+@@ -71,6 +73,7 @@ class BLINK_PLATFORM_EXPORT WebRuntimeFeatures : public WebRuntimeFeaturesBase {
+   static void EnableLocalNetworkAccessWebRTC(bool);
+ 
+   WebRuntimeFeatures() = delete;
++  static base::OnceClosure BackupAndResetRuntimeFeaturesForTesting();
+ };
+ 
+ }  // namespace blink

--- a/patches/third_party-blink-renderer-build-scripts-templates-web_runtime_features_base.cc.tmpl.patch
+++ b/patches/third_party-blink-renderer-build-scripts-templates-web_runtime_features_base.cc.tmpl.patch
@@ -1,0 +1,28 @@
+diff --git a/third_party/blink/renderer/build/scripts/templates/web_runtime_features_base.cc.tmpl b/third_party/blink/renderer/build/scripts/templates/web_runtime_features_base.cc.tmpl
+index a22d2d660644c990f3f8ea7c1e7a3756732b1aa8..6fd874c8ba2bfb3c22e199c7f47161294d25d408 100644
+--- a/third_party/blink/renderer/build/scripts/templates/web_runtime_features_base.cc.tmpl
++++ b/third_party/blink/renderer/build/scripts/templates/web_runtime_features_base.cc.tmpl
+@@ -9,6 +9,23 @@
+ 
+ namespace blink {
+ 
++std::vector<WebRuntimeFeaturesBase::RuntimeFeatureStateForTesting>
++WebRuntimeFeaturesBase::GetRuntimeFeatureStatesForTesting() {
++  return {
++{% for feature in features %}
++    {"{{feature.name}}", "{{feature.base_feature}}",
++     RuntimeEnabledFeatures::{{feature.name}}Enabled(nullptr)},
++{% endfor %}
++  };
++}
++
++void WebRuntimeFeaturesBase::ResetRuntimeFeaturesForTesting() {
++{% for feature in features %}
++  RuntimeEnabledFeatures::Set{{feature.name}}Enabled(false);
++{% endfor %}
++  RuntimeEnabledFeatures::SetStableFeaturesEnabled(true);
++}
++
+ {% for feature in features %}
+ {% if feature.public %}
+ // static

--- a/patches/third_party-blink-renderer-build-scripts-templates-web_runtime_features_base.h.tmpl.patch
+++ b/patches/third_party-blink-renderer-build-scripts-templates-web_runtime_features_base.h.tmpl.patch
@@ -1,0 +1,31 @@
+diff --git a/third_party/blink/renderer/build/scripts/templates/web_runtime_features_base.h.tmpl b/third_party/blink/renderer/build/scripts/templates/web_runtime_features_base.h.tmpl
+index bdeb4e992059c55e2c92e68ac501a798a7fe5011..02399320cb8184e32a3eb525cab9592cc20ad160 100644
+--- a/third_party/blink/renderer/build/scripts/templates/web_runtime_features_base.h.tmpl
++++ b/third_party/blink/renderer/build/scripts/templates/web_runtime_features_base.h.tmpl
+@@ -6,6 +6,9 @@
+ #ifndef {{header_guard}}
+ #define {{header_guard}}
+ 
++#include <string_view>
++#include <vector>
++
+ #include "third_party/blink/public/platform/web_common.h"
+ 
+ namespace blink {
+@@ -23,6 +26,16 @@ class BLINK_PLATFORM_EXPORT WebRuntimeFeaturesBase {
+ {% endif %}
+ {% endfor %}
+ 
++  struct RuntimeFeatureStateForTesting {
++    std::string_view name;
++    std::string_view base_feature_name;
++    bool enabled;
++  };
++
++  static std::vector<RuntimeFeatureStateForTesting>
++  GetRuntimeFeatureStatesForTesting();
++  static void ResetRuntimeFeaturesForTesting();
++
+   WebRuntimeFeaturesBase() = delete;
+ };
+ 

--- a/rewrite/third_party/blink/public/platform/web_runtime_features.h.yaml
+++ b/rewrite/third_party/blink/public/platform/web_runtime_features.h.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+blank_macros_for_ast_parsing: true
+
+substitutions:
+  - description: 'Include the callback used to restore runtime feature state.'
+    regex:
+      pattern: '#include <string_view>'
+      replace: |-
+        #include <string_view>
+
+        #include "base/functional/callback.h"
+
+  - description: |-
+      Allow tests to isolate renderer feature initialization.
+
+      The returned closure restores the original runtime flags and scrollbar
+      settings after a test has exercised the production startup sequence.
+    add_to_public:
+      class_name: WebRuntimeFeatures
+      code: |-
+        static base::OnceClosure BackupAndResetRuntimeFeaturesForTesting();

--- a/rewrite/third_party/blink/renderer/build/scripts/templates/web_runtime_features_base.cc.tmpl.yaml
+++ b/rewrite/third_party/blink/renderer/build/scripts/templates/web_runtime_features_base.cc.tmpl.yaml
@@ -1,0 +1,32 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |-
+      Generate runtime feature readers and a fresh-start reset for tests.
+
+      Use the normal getters to account for dependencies, implications and
+      protected flags. A null context queries without an origin-trial token.
+    regex:
+      pattern: 'namespace blink {'
+      replace: |-
+        namespace blink {
+
+        std::vector<WebRuntimeFeaturesBase::RuntimeFeatureStateForTesting>
+        WebRuntimeFeaturesBase::GetRuntimeFeatureStatesForTesting() {
+          return {
+        {% for feature in features %}
+            {"{{feature.name}}", "{{feature.base_feature}}",
+             RuntimeEnabledFeatures::{{feature.name}}Enabled(nullptr)},
+        {% endfor %}
+          };
+        }
+
+        void WebRuntimeFeaturesBase::ResetRuntimeFeaturesForTesting() {
+        {% for feature in features %}
+          RuntimeEnabledFeatures::Set{{feature.name}}Enabled(false);
+        {% endfor %}
+          RuntimeEnabledFeatures::SetStableFeaturesEnabled(true);
+        }

--- a/rewrite/third_party/blink/renderer/build/scripts/templates/web_runtime_features_base.h.tmpl.yaml
+++ b/rewrite/third_party/blink/renderer/build/scripts/templates/web_runtime_features_base.h.tmpl.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: 'Include the types used by the runtime feature test catalogue.'
+    regex:
+      pattern: '#include "third_party/blink/public/platform/web_common.h"'
+      replace: |-
+        #include <string_view>
+        #include <vector>
+
+        #include "third_party/blink/public/platform/web_common.h"
+
+  - description: |-
+      Expose runtime feature associations and values to tests.
+
+      Include non-public features, so tests can find Blink counterparts for
+      base features without maintaining a second list of runtime flags.
+    regex:
+      re_pattern: '(^[ \t]*)WebRuntimeFeaturesBase\(\) = delete;'
+      re_flags: [MULTILINE]
+      replace: |-
+        \1struct RuntimeFeatureStateForTesting {
+        \1  std::string_view name;
+        \1  std::string_view base_feature_name;
+        \1  bool enabled;
+        \1};
+
+        \1static std::vector<RuntimeFeatureStateForTesting>
+        \1GetRuntimeFeatureStatesForTesting();
+        \1static void ResetRuntimeFeaturesForTesting();
+
+        \1WebRuntimeFeaturesBase() = delete;

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -105,6 +105,21 @@ static_library("brave_test_support_unit") {
   }
 }
 
+source_set("runtime_feature_test_support") {
+  testonly = true
+  sources = [
+    "base/runtime_feature_test_support.cc",
+    "base/runtime_feature_test_support.h",
+  ]
+  public_deps = [ "//third_party/blink/public:blink" ]
+  deps = [
+    "//base",
+    "//base/test:test_support",
+    "//brave/renderer",
+    "//content/public/renderer",
+  ]
+}
+
 test("brave_unit_tests") {
   testonly = true
 

--- a/test/DEPS
+++ b/test/DEPS
@@ -9,3 +9,11 @@ include_rules = [
   "+content/public/test",
   "+ui/compositor",
 ]
+
+specific_include_rules = {
+  "runtime_feature_test_support\\.(cc|h)": [
+    "+brave/renderer/brave_content_renderer_client.h",
+    "+content/public/renderer/content_renderer_client.h",
+    "+third_party/blink/public/platform/web_runtime_features.h",
+  ],
+}

--- a/test/base/runtime_feature_test_support.cc
+++ b/test/base/runtime_feature_test_support.cc
@@ -1,0 +1,32 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/test/base/runtime_feature_test_support.h"
+
+#include "base/command_line.h"
+#include "base/functional/callback_helpers.h"
+#include "base/test/scoped_command_line.h"
+#include "base/test/task_environment.h"
+#include "brave/renderer/brave_content_renderer_client.h"
+#include "content/public/renderer/content_renderer_client.h"
+
+namespace brave {
+
+std::vector<blink::WebRuntimeFeatures::RuntimeFeatureStateForTesting>
+GetRendererRuntimeFeatureStatesForTesting() {
+  base::test::ScopedCommandLine command_line;
+  *command_line.GetProcessCommandLine() =
+      base::CommandLine(base::CommandLine::NO_PROGRAM);
+  base::test::TaskEnvironment task_environment;
+  base::ScopedClosureRunner restore_runtime_features(
+      blink::WebRuntimeFeatures::BackupAndResetRuntimeFeaturesForTesting());
+
+  BraveContentRendererClient renderer_client;
+  content::InitializeRuntimeFeaturesForTesting(
+      renderer_client, *command_line.GetProcessCommandLine());
+  return blink::WebRuntimeFeatures::GetRuntimeFeatureStatesForTesting();
+}
+
+}  // namespace brave

--- a/test/base/runtime_feature_test_support.h
+++ b/test/base/runtime_feature_test_support.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_TEST_BASE_RUNTIME_FEATURE_TEST_SUPPORT_H_
+#define BRAVE_TEST_BASE_RUNTIME_FEATURE_TEST_SUPPORT_H_
+
+#include <vector>
+
+#include "third_party/blink/public/platform/web_runtime_features.h"
+
+namespace brave {
+
+// Snapshots Blink's feature values after Brave and Content initialize renderer
+// features, then restores the calling test's runtime state and command line.
+std::vector<blink::WebRuntimeFeatures::RuntimeFeatureStateForTesting>
+GetRendererRuntimeFeatureStatesForTesting();
+
+}  // namespace brave
+
+#endif  // BRAVE_TEST_BASE_RUNTIME_FEATURE_TEST_SUPPORT_H_


### PR DESCRIPTION
Certain browser `base::Feature` entries have a correponding blink
runtime feature that must also be disabled. This is exclusively relevant
for features that we disabled in upstream, as we want to make sure we
still have the guarantees provided as if they were returning
`FeatureList::GetStateIfOverridden`, causing the corresponding blink
feature to be disabled.

This change introduces extra steps in the existing test for disabled
features, that verifies if a given feature has a corresponding blink
runtime feature that should also be disabled.

Bug: https://github.com/brave/brave-browser/issues/58871
