### PR TITLE
[feature] Adding `FEATURE_DISABLED_BY_OVERRIDE`

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -20,6 +20,7 @@ source_set("base_unittests") {
   sources = [
     "//base/tools_sanity_unittest.cc",
     "build_time_unittest.cc",
+    "feature_override_state_unittest.cc",
     "test/current_test_vendor_is_brave_unittest.cc",
     "test/launcher/teamcity_reporter_integration_unittest.cc",
     "test/launcher/teamcity_reporter_unittest.cc",

--- a/base/feature_override_state_unittest.cc
+++ b/base/feature_override_state_unittest.cc
@@ -1,0 +1,49 @@
+/* Copyright (c) 2026 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <optional>
+
+#include "base/feature.h"
+#include "base/feature_list.h"
+#include "base/test/scoped_feature_list.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace base {
+namespace {
+
+BASE_FEATURE(kDisabledByOverride, FEATURE_DISABLED_BY_OVERRIDE);
+BASE_FEATURE(kDisabledByDefault, FEATURE_DISABLED_BY_DEFAULT);
+BASE_FEATURE(kEnabledByDefault, FEATURE_ENABLED_BY_DEFAULT);
+
+static_assert(!IsCountrySpecificFeatureState(FEATURE_DISABLED_BY_OVERRIDE));
+
+}  // namespace
+
+TEST(FeatureOverrideStateTest, FeatureIsDisabled) {
+  EXPECT_FALSE(FeatureList::IsEnabled(kDisabledByOverride));
+}
+
+TEST(FeatureOverrideStateTest, StateIsReportedAsAnOverride) {
+  EXPECT_EQ(FeatureList::GetStateIfOverridden(kDisabledByOverride), false);
+}
+
+TEST(FeatureOverrideStateTest, DefaultStatesAreNotReportedAsOverrides) {
+  EXPECT_FALSE(FeatureList::IsEnabled(kDisabledByDefault));
+  EXPECT_EQ(FeatureList::GetStateIfOverridden(kDisabledByDefault),
+            std::nullopt);
+
+  EXPECT_TRUE(FeatureList::IsEnabled(kEnabledByDefault));
+  EXPECT_EQ(FeatureList::GetStateIfOverridden(kEnabledByDefault), std::nullopt);
+}
+
+TEST(FeatureOverrideStateTest, RealOverridesTakePrecedence) {
+  test::ScopedFeatureList feature_list;
+  feature_list.InitAndEnableFeature(kDisabledByOverride);
+
+  EXPECT_TRUE(FeatureList::IsEnabled(kDisabledByOverride));
+  EXPECT_EQ(FeatureList::GetStateIfOverridden(kDisabledByOverride), true);
+}
+
+}  // namespace base

--- a/patches/base-feature.h.patch
+++ b/patches/base-feature.h.patch
@@ -1,0 +1,19 @@
+diff --git a/base/feature.h b/base/feature.h
+index be01a04d8d7f8c0e673b03fdbc0996581974dd00..9049e067053a3405f6a6954b5fd910a5d1f989bd 100644
+--- a/base/feature.h
++++ b/base/feature.h
+@@ -182,12 +182,14 @@ enum FeatureState {
+   // disabled if Chrome does not have information about the current country.
+   // Use only together with `BASE_FEATURE_WITH_COUNTRY_RESTRICTIONS`.
+   FEATURE_ENABLED_FOR_COUNTRIES,
++  FEATURE_DISABLED_BY_OVERRIDE,
+ };
+ 
+ constexpr bool IsCountrySpecificFeatureState(FeatureState state) {
+   switch (state) {
+     case FEATURE_DISABLED_BY_DEFAULT:
+     case FEATURE_ENABLED_BY_DEFAULT:
++    case FEATURE_DISABLED_BY_OVERRIDE:
+       return false;
+     case FEATURE_DISABLED_FOR_COUNTRIES:
+     case FEATURE_ENABLED_FOR_COUNTRIES:

--- a/patches/base-feature_list.cc.patch
+++ b/patches/base-feature_list.cc.patch
@@ -1,0 +1,25 @@
+diff --git a/base/feature_list.cc b/base/feature_list.cc
+index e41b0ac1f7a98a74ab57525dca4a90c3ad135868..c1c62a370ba5e254a1f19ecfb291e7685df11045 100644
+--- a/base/feature_list.cc
++++ b/base/feature_list.cc
+@@ -1114,6 +1114,7 @@ bool FeatureList::IsFeatureEnabled(const Feature& feature) const {
+ 
+ std::optional<bool> FeatureList::IsFeatureEnabledIfOverridden(
+     const Feature& feature) const {
++  std::optional<bool> state = [&]() -> std::optional<bool> {
+   OverrideState overridden_state = GetOverrideState(feature);
+ 
+   // If marked as OVERRIDE_USE_DEFAULT, fall through to returning empty.
+@@ -1122,6 +1123,12 @@ std::optional<bool> FeatureList::IsFeatureEnabledIfOverridden(
+   }
+ 
+   return std::nullopt;
++  }();
++  if (!state.has_value() &&
++      feature.default_state == FEATURE_DISABLED_BY_OVERRIDE) {
++    return false;
++  }
++  return state;
+ }
+ 
+ FeatureList::OverrideState FeatureList::GetOverrideState(

--- a/rewrite/base/feature.h.yaml
+++ b/rewrite/base/feature.h.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |-
+      Add a feature state that is reported as an override.
+
+      `FEATURE_DISABLED_BY_OVERRIDE` is similar to `FEATURE_DISABLED_BY_DEFAULT`
+      with the added behaviour that  `FeatureList::GetStateIfOverridden()`
+      reports it as overridden.
+
+      This is useful as several parts of Chromium rely on `GetStateIfOverridden`
+      to determine if other features must also be disabled.
+    add_enum_entries:
+      enum_name: FeatureState
+      entries: FEATURE_DISABLED_BY_OVERRIDE
+
+  - description: |-
+      Keep the new state out of the country-specific ones.
+
+      This switch is the only one over `FeatureState` in the tree, so it is
+      also the only place the compiler asks about the new state.
+    regex:
+      re_pattern: '( +)(case FEATURE_ENABLED_BY_DEFAULT:)'
+      replace: |-
+        \1\2
+        \1case FEATURE_DISABLED_BY_OVERRIDE:

--- a/rewrite/base/feature_list.cc.yaml
+++ b/rewrite/base/feature_list.cc.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+substitutions:
+  - description: |-
+      Report a default state that was declared as an override.
+
+      A real override still wins: the upstream body resolves those, and only a
+      feature left at its default state comes back empty.
+
+      Nothing else needs to know about `FEATURE_DISABLED_BY_OVERRIDE`: every
+      other place that reads a default state asks whether it is
+      `FEATURE_ENABLED_BY_DEFAULT`, which already answers no.
+    after_function_impl:
+      function_name: FeatureList::IsFeatureEnabledIfOverridden
+      result_var: state
+      code: |-
+        if (!state.has_value() &&
+            feature.default_state == FEATURE_DISABLED_BY_OVERRIDE) {
+          return false;
+        }
+        return state;


### PR DESCRIPTION
This new feature value is being introduced to correct an issue we are
having since we migrated away from `OVERRIDE_FEATURE_DEFAULT_STATES` to
use plaster to amend the default values of flags, and that had the
unintended effect of making these features to start returning `nullptr`
with `FeatureList::GetStateIfOverridden`. This consequently means that
updates done to these features now do not push their values over into
the renderer side.

There are different ways that we could approach this, including by
having tests that check to make sure renderer/browser features match the
intent of the override, however this is not enough, as it would only
solve the renderer code's matching, but there are other particular
places in the codebase where `FeatureList::GetStateIfOverridden` is
checked for other types of mapping.

`OVERRIDE_FEATURE_DEFAULT_STATES` alone is being introduced for now,
with no `ENABLED` equivalent, as the disabled state in particular is the
one where the `GetStateIfOverridden` check is more relevant. The
renderer already enables a feature, once the default is enabled in the
browser side, while the other mappings are all for features we do not
enable ourselves.

This PR is the first step, and follow up work will be done to make
plaster use this value when force-enabling a feature.

Bug: https://github.com/brave/brave-browser/issues/58871
