### PR TITLE
[Android] Workaround YouTube fullscreen settings icon bug

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -497,6 +497,16 @@ const char* const kBraveSyncImplLink[1] = {"https://github.com/brave/go-sync"};
       FEATURE_VALUE_TYPE(                                                      \
           preferences::features::kBraveBackgroundVideoPlayback),               \
   })
+#define BRAVE_YOUTUBE_FULLSCREEN_SETTINGS_WORKAROUND_ANDROID                 \
+  EXPAND_FEATURE_ENTRIES({                                                   \
+      "brave-youtube-fullscreen-settings-workaround",                        \
+      "Fix YouTube settings taps in fullscreen playback",                    \
+      "Work around a bug on m.youtube.com where taps of the video's gear "   \
+      "icon no-ops.",                                                        \
+      kOsAndroid,                                                            \
+      FEATURE_VALUE_TYPE(                                                    \
+          preferences::features::kBraveYoutubeFullscreenSettingsWorkaround), \
+  })
 #define BRAVE_SAFE_BROWSING_ANDROID                                           \
   EXPAND_FEATURE_ENTRIES({                                                    \
       "brave-safe-browsing",                                                  \
@@ -534,6 +544,7 @@ const char* const kBraveSyncImplLink[1] = {"https://github.com/brave/go-sync"};
   })
 #else
 #define BRAVE_BACKGROUND_VIDEO_PLAYBACK_ANDROID
+#define BRAVE_YOUTUBE_FULLSCREEN_SETTINGS_WORKAROUND_ANDROID
 #define BRAVE_SAFE_BROWSING_ANDROID
 #define BRAVE_ADAPTIVE_BUTTON_IN_TOOLBAR_ANDROID
 #define BRAVE_CUSTOM_SEARCH_ENGINES
@@ -1620,6 +1631,7 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
   CONTAINERS_FEATURE_ENTRIES                                                   \
   TRAFFIC_CONTROL_FEATURE_ENTRIES                                              \
   BRAVE_BACKGROUND_VIDEO_PLAYBACK_ANDROID                                      \
+  BRAVE_YOUTUBE_FULLSCREEN_SETTINGS_WORKAROUND_ANDROID                         \
   BRAVE_SAFE_BROWSING_ANDROID                                                  \
   BRAVE_ADAPTIVE_BUTTON_IN_TOOLBAR_ANDROID                                     \
   BRAVE_ANDROID_TAB_GROUPS_SETTINGS                                            \

--- a/browser/android/youtube_script_injector/features.cc
+++ b/browser/android/youtube_script_injector/features.cc
@@ -17,5 +17,8 @@ BASE_FEATURE(kBraveBackgroundVideoPlayback,
 BASE_FEATURE(kBravePictureInPictureForYouTubeVideos,
              base::FEATURE_ENABLED_BY_DEFAULT);
 
+BASE_FEATURE(kBraveYoutubeFullscreenSettingsWorkaround,
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
 }  // namespace features
 }  // namespace preferences

--- a/browser/android/youtube_script_injector/features.h
+++ b/browser/android/youtube_script_injector/features.h
@@ -13,6 +13,7 @@ namespace features {
 
 BASE_DECLARE_FEATURE(kBraveBackgroundVideoPlayback);
 BASE_DECLARE_FEATURE(kBravePictureInPictureForYouTubeVideos);
+BASE_DECLARE_FEATURE(kBraveYoutubeFullscreenSettingsWorkaround);
 
 }  // namespace features
 }  // namespace preferences

--- a/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
+++ b/browser/android/youtube_script_injector/youtube_script_injector_tab_helper.cc
@@ -94,6 +94,38 @@ constexpr char16_t kYoutubePictureInPictureSupport[] =
 }());
 )";
 
+// m.youtube.com has a bug whereby taps of the video's gear icon no-ops.
+// Work around this by forcibly exiting fullscreen, then replay the player
+// settings icon tap through YouTube's handler. See
+// https://github.com/brave/brave-browser/issues/57763.
+constexpr char16_t kYoutubeFullscreenSettingsWorkaround[] =
+    uR"(
+(function() {
+  let pending = false;
+  document.addEventListener('click', async (event) => {
+    const playerSettingsIcon = event.target instanceof Element
+        ? event.target.closest('button.player-settings-icon') : null;
+    if (!playerSettingsIcon || !document.fullscreenElement) {
+      return;
+    }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    if (pending) {
+      return;
+    }
+    pending = true;
+    try {
+      await document.exitFullscreen();
+      document.querySelector('button.player-settings-icon')?.click();
+    } catch (error) {
+      // The document may have become inactive during the fullscreen exit.
+    } finally {
+      pending = false;
+    }
+  }, true);
+}());
+)";
+
 // Drives the YouTube player into fullscreen so the caller can follow up with
 // Picture in Picture. On a cold load the player and its controls hydrate
 // asynchronously, so the fullscreen button may be absent at injection time: the
@@ -382,6 +414,12 @@ void YouTubeScriptInjectorTabHelper::PrimaryMainDocumentElementAvailable() {
       IsAndroidPictureInPictureSupported()) {
     contents->GetPrimaryMainFrame()->ExecuteJavaScript(
         kYoutubePictureInPictureSupport, base::NullCallback());
+  }
+  if (IsYouTubeDomain(/*mobileOnly=*/true) &&
+      base::FeatureList::IsEnabled(
+          preferences::features::kBraveYoutubeFullscreenSettingsWorkaround)) {
+    contents->GetPrimaryMainFrame()->ExecuteJavaScript(
+        kYoutubeFullscreenSettingsWorkaround, base::NullCallback());
   }
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/57449.
- Resolves https://github.com/brave/brave-browser/issues/57763.

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->

### Overview

[m.youtube.com](https://m.youtube.com) has had a bug (since at least [July 23](https://community.brave.app/t/settings-button-doesnt-work-on-youtube-in-fullscreen-landscape/655958/2)) whereby tapping the gear/settings icon during a full screen video playback no-ops. 

From [this issue comment](https://github.com/brave/brave-browser/issues/57763#issuecomment-5613683437):
> I checked Chrome v146 & 154, Brave Nightly 1.97.2, Vivaldi and Firefox. All are not working.

So the issue is Android wide, and Google are seemingly in no hurry to fix it. 

This PR adds a workaround by inserting JS to intercept taps of the settings icon, then exits full screen and re-triggers the intended click. 

The workaround is wrapped around a new Android-specific `brave-youtube-fullscreen-settings-workaround` flag, so this can be disabled via Griffin if/when m.youtube.com is fixed. I will make a `brave-variations` ticket for this assuming this PR lands.

### Testing

This code only applies on `m.youtube.com`. 

I tested these variations, and none exhibited the issue:
* `youtube.com` with `"Desktop site"` enabled
* `music.youtube.com` playing a music video
* `gaming.youtube.com` now redirects to https://www.youtube.com/gaming so was N/A.

### Changes

**Add `brave-youtube-fullscreen-settings-workaround` flag**
- disabled by default

**Add override to fix full screen YT setting button**
If `kBraveYoutubeFullscreenSettingsWorkaround` is enabled, inject JS on `m.youtube.com` that intercepts `button.player-settings-icon` clicks while in native fullscreen, then:
- exits full screen
- re-triggers the `player-settings-icon` click


### Demos



https://github.com/user-attachments/assets/c30b1368-9378-4b9e-b77f-5cb79f4a9333

(note: this is the sound of me grumbling at the ["black bars" bug](https://github.com/brave/brave-browser/issues/56763) occurring during the landscape playback in this clip - I have assigned that bug to me).

