### PR TITLE
[VPN 2.0] Fix the agent IPC endpoint naming

### DIFF
--- a/components/brave_vpn/app/v2/agent/mac/launchd.plist
+++ b/components/brave_vpn/app/v2/agent/mac/launchd.plist
@@ -6,14 +6,6 @@
   <string>@VPN_AGENT_BUNDLE_ID@</string>
   <key>BundleProgram</key>
   <string>Contents/Frameworks/@FRAMEWORK_NAME@.framework/Helpers/@VPN_AGENT_NAME@.app/Contents/MacOS/@VPN_AGENT_NAME@</string>
-  <key>MachServices</key>
-  <dict>
-    <key>@VPN_AGENT_BUNDLE_ID@</key>
-    <dict>
-      <key>HideUntilCheckIn</key>
-      <true/>
-    </dict>
-  </dict>
   <key>RunAtLoad</key>
   <false/>
   <key>KeepAlive</key>

--- a/components/brave_vpn/common/v2/BUILD.gn
+++ b/components/brave_vpn/common/v2/BUILD.gn
@@ -11,17 +11,20 @@ assert(enable_brave_vpn_v2)
 
 buildflag_header("branding_buildflags") {
   header = "branding_buildflags.h"
+  flags = [ "VPN_AGENT_IPC_NAME=\"$vpn_agent_ipc_name\"" ]
   if (is_mac) {
-    flags = [ "VPN_AGENT_APP_NAME=\"$vpn_agent_product_full_name.app\"" ]
+    flags += [ "VPN_AGENT_APP_NAME=\"$vpn_agent_product_full_name.app\"" ]
   } else if (is_win) {
-    flags = [ "VPN_AGENT_EXE_NAME=\"$vpn_agent_executable_name.exe\"" ]
+    flags += [ "VPN_AGENT_EXE_NAME=\"$vpn_agent_executable_name.exe\"" ]
   } else {
-    flags = [ "VPN_AGENT_EXE_NAME=\"$vpn_agent_executable_name\"" ]
+    flags += [ "VPN_AGENT_EXE_NAME=\"$vpn_agent_executable_name\"" ]
   }
 }
 
 source_set("common") {
   sources = []
+
+  deps = []
 
   public_deps = []
 
@@ -30,6 +33,8 @@ source_set("common") {
       "agent_utils.cc",
       "agent_utils.h",
     ]
+
+    deps += [ ":branding_buildflags" ]
 
     public_deps += [
       "//base",

--- a/components/brave_vpn/common/v2/agent_utils.cc
+++ b/components/brave_vpn/common/v2/agent_utils.cc
@@ -5,40 +5,45 @@
 
 #include "brave/components/brave_vpn/common/v2/agent_utils.h"
 
+#include <string>
+#include <string_view>
+
 #include "base/check.h"
 #include "base/environment.h"
 #include "base/files/file_path.h"
 #include "base/logging.h"
-#include "base/path_service.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
+#include "brave/components/brave_vpn/common/v2/branding_buildflags.h"
 #include "build/build_config.h"
 
 #if BUILDFLAG(IS_WIN)
 #include <windows.h>
+#elif BUILDFLAG(IS_MAC)
+#include <servers/bootstrap.h>
 #endif
 
 namespace brave_vpn::v2 {
 namespace {
-constexpr char kAgentServerName[] = "brave_vpn_agent";
+constexpr char kAgentServerName[] = BUILDFLAG(VPN_AGENT_IPC_NAME);
 
-#if BUILDFLAG(IS_POSIX)
-// Returns the directory holding the agent's socket. This is where the
-// per-session scoping comes from on POSIX: both candidate directories are
-// already private to one login session, mode 0700, so the socket's own name can
-// be a constant.
-base::FilePath GetSocketDirectory() {
 #if BUILDFLAG(IS_MAC)
-  // The per-user confined NSTemporaryDirectory(), distinct for every user and
-  // unreadable by others, which is what "per session" means in practice on
-  // macOS, where concurrent GUI logins are per-user.
-  return base::PathService::CheckedGet(base::DIR_TEMP);
-#elif BUILDFLAG(IS_LINUX)
-  // /run/user/<uid>: mode 0700, created by pam_systemd at login and removed at
-  // last logout. Reading XDG_RUNTIME_DIR specifically: systemd exports
-  // XDG_RUNTIME_DIR to both session scopes and to `user@<uid>.service` units,
-  // so a systemd user unit and the browser agree on it.
+// Mojo only DCHECKs this, so a release build would silently register a
+// truncated or rejected name.
+static_assert(std::string_view(kAgentServerName).size() <
+                  static_cast<size_t>(BOOTSTRAP_MAX_NAME_LEN),
+              "Agent bootstrap name exceeds BOOTSTRAP_MAX_NAME_LEN");
+#endif  // BUILDFLAG(IS_MAC)
+
+#if BUILDFLAG(IS_LINUX)
+// Returns the directory holding the agent's socket. This is where the
+// per-session scoping comes from: a candidate directory is already private to
+// one login session, mode 0700, so the socket's own name can be a constant.
+// Reading XDG_RUNTIME_DIR specifically: systemd exports it to both session
+// scopes and to `user@<uid>.service` units, so a systemd user unit and the
+// browser agree on it.
+base::FilePath GetSocketDirectory() {
   auto env = base::Environment::Create();
   std::string runtime_dir =
       env->GetVar("XDG_RUNTIME_DIR").value_or(std::string());
@@ -48,11 +53,8 @@ base::FilePath GetSocketDirectory() {
     return base::FilePath();
   }
   return base::FilePath(runtime_dir);
-#else
-#error unsupported platform
-#endif
 }
-#endif  // BUILDFLAG(IS_POSIX)
+#endif  // BUILDFLAG(IS_LINUX)
 
 }  // namespace
 
@@ -65,22 +67,28 @@ std::optional<mojo::NamedPlatformChannel::ServerName> GetAgentServerName() {
   CHECK(::ProcessIdToSessionId(::GetCurrentProcessId(), &session_id));
   return base::ASCIIToWide(
       base::StrCat({kAgentServerName, ".", base::NumberToString(session_id)}));
-#else
+#elif BUILDFLAG(IS_MAC)
+  // Deliberately not scoped by a directory: the bootstrap namespace is already
+  // per-user and per-session, so a path prefix would add no benefit.
+  return std::string(kAgentServerName);
+#elif BUILDFLAG(IS_LINUX)
   return GetAgentServerNameForDirectory(GetSocketDirectory());
-#endif  // BUILDFLAG(IS_WIN)
+#else
+#error unsupported platform
+#endif
 }
 
-#if BUILDFLAG(IS_POSIX)
+#if BUILDFLAG(IS_LINUX)
 
 std::optional<mojo::NamedPlatformChannel::ServerName>
 GetAgentServerNameForDirectory(const base::FilePath& socket_dir) {
-  if (socket_dir.empty()) {
+  // Mojo uses the ServerName verbatim as the sockaddr_un path, so it must be
+  // absolute. A bare name would bind() into whatever the process's current
+  // working directory happens to be.
+  if (socket_dir.empty() || !socket_dir.IsAbsolute()) {
     return std::nullopt;
   }
 
-  // On POSIX mojo::NamedPlatformChannel uses the ServerName verbatim as the
-  // sockaddr_un path, so it must be absolute. A bare name would bind() into
-  // whatever the process's current working directory happens to be.
   const base::FilePath path = socket_dir.Append(kAgentServerName);
 
   // Deliberately no truncation or fallback: an over-long path makes bind() and
@@ -93,6 +101,6 @@ GetAgentServerNameForDirectory(const base::FilePath& socket_dir) {
   return path.value();
 }
 
-#endif  // BUILDFLAG(IS_POSIX)
+#endif  // BUILDFLAG(IS_LINUX)
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/common/v2/agent_utils.h
+++ b/components/brave_vpn/common/v2/agent_utils.h
@@ -20,24 +20,30 @@ namespace brave_vpn::v2 {
 // current OS session. The browser and the agent call this independently and
 // must arrive at the same value.
 //
-// The result is a socket path on POSIX and a bare pipe leaf name on Windows.
+// The form differs per platform, because mojo's NamedPlatformChannel is a
+// different OS primitive on each:
+// - Linux: an absolute Unix domain socket path.
+// - macOS: a flat Mach bootstrap name.
+// - Windows: a bare pipe leaf name.
+//
 // The name is not a secret and is discoverable by other local processes;
 // authentication of peers is expected.
 std::optional<mojo::NamedPlatformChannel::ServerName> GetAgentServerName();
 
-#if BUILDFLAG(IS_POSIX)
+#if BUILDFLAG(IS_LINUX)
 
-// Longest socket path mojo::NamedPlatformChannel can bind. |sun_path| is 104
-// bytes on macOS and 108 on Linux. The same code has to be correct on both, so
-// the shorter limit applies.
-inline constexpr size_t kMaxAgentSocketPathLength = 103;
+// Longest socket path mojo::NamedPlatformChannel can bind. |sun_path| is 108
+// bytes on Linux (including a terminator), and Linux is the only platform
+// reaching the socket code.
+inline constexpr size_t kMaxAgentSocketPathLength = 107;
 
 // Builds the server name for a socket living in |socket_dir|, or nullopt if the
-// directory is empty or the resulting path would exceed the sockaddr_un limit.
+// directory is empty or the resulting path is relative, or it would exceed the
+// sockaddr_un limit.
 std::optional<mojo::NamedPlatformChannel::ServerName>
 GetAgentServerNameForDirectory(const base::FilePath& socket_dir);
 
-#endif  // BUILDFLAG(IS_POSIX)
+#endif  // BUILDFLAG(IS_LINUX)
 
 }  // namespace brave_vpn::v2
 

--- a/components/brave_vpn/common/v2/agent_utils_unittest.cc
+++ b/components/brave_vpn/common/v2/agent_utils_unittest.cc
@@ -16,10 +16,15 @@
 #include "mojo/public/cpp/platform/named_platform_channel.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
+#if BUILDFLAG(IS_MAC)
+#include <servers/bootstrap.h>
+#endif
+
 namespace brave_vpn::v2 {
 namespace {
-#if BUILDFLAG(IS_POSIX)
-constexpr char kSocketRuntimeDir[] = "/run/user/1000";
+#if BUILDFLAG(IS_LINUX)
+constexpr char kSocketAbsoluteRuntimeDir[] = "/run/user/1000";
+constexpr char kSocketRelativeRuntimeDir[] = "run/user/1000";
 #endif
 }  // namespace
 
@@ -30,8 +35,8 @@ TEST(BraveVpnAgentUtils, ServerNameIsStableWithinProcess) {
   // Test bots frequently have no XDG_RUNTIME_DIR, which would leave both calls
   // below as nullopt and pass without a name ever being built. Safe to override
   // here because these tests start no threads.
-  base::ScopedEnvironmentVariableOverride runtime_dir("XDG_RUNTIME_DIR",
-                                                      kSocketRuntimeDir);
+  base::ScopedEnvironmentVariableOverride runtime_dir(
+      "XDG_RUNTIME_DIR", kSocketAbsoluteRuntimeDir);
 #endif  // BUILDFLAG(IS_LINUX)
 
   const std::optional<mojo::NamedPlatformChannel::ServerName> first =
@@ -52,18 +57,20 @@ TEST(BraveVpnAgentUtils, NoRuntimeDirectoryYieldsNoServerName) {
   EXPECT_FALSE(GetAgentServerName().has_value());
 }
 
-#endif  // BUILDFLAG(IS_LINUX)
-
-#if BUILDFLAG(IS_POSIX)
-
 // An unusable socket directory has to fail rather than fall back to a
 // relative path, which would bind into the working directory.
 TEST(BraveVpnAgentUtils, NoSocketDirectoryYieldsNoServerName) {
   EXPECT_FALSE(GetAgentServerNameForDirectory(base::FilePath()).has_value());
 }
 
+TEST(BraveVpnAgentUtils, RelativeSocketDirectoryYieldsNoServerName) {
+  EXPECT_FALSE(
+      GetAgentServerNameForDirectory(base::FilePath(kSocketRelativeRuntimeDir))
+          .has_value());
+}
+
 TEST(BraveVpnAgentUtils, ServerNameIsAnAbsolutePathInsideTheDirectory) {
-  const base::FilePath dir(kSocketRuntimeDir);
+  const base::FilePath dir(kSocketAbsoluteRuntimeDir);
 
   const std::optional<mojo::NamedPlatformChannel::ServerName> name =
       GetAgentServerNameForDirectory(dir);
@@ -79,7 +86,7 @@ TEST(BraveVpnAgentUtils, ServerNameIsAnAbsolutePathInsideTheDirectory) {
 // agent could disagree about which socket to use.
 TEST(BraveVpnAgentUtils, LeafNameDoesNotDependOnTheDirectory) {
   const std::optional<mojo::NamedPlatformChannel::ServerName> first =
-      GetAgentServerNameForDirectory(base::FilePath(kSocketRuntimeDir));
+      GetAgentServerNameForDirectory(base::FilePath(kSocketAbsoluteRuntimeDir));
   const std::optional<mojo::NamedPlatformChannel::ServerName> second =
       GetAgentServerNameForDirectory(base::FilePath("/tmp"));
 
@@ -115,15 +122,34 @@ TEST(BraveVpnAgentUtils, SocketPathLengthLimitIsEnforcedExactly) {
   EXPECT_FALSE(rejected.has_value());
 }
 
-#else  // BUILDFLAG(IS_POSIX)
+#elif BUILDFLAG(IS_MAC)
 
-TEST(BraveVpnAgentUtils, ServerNameIsAvailableOnNonPosix) {
+// Mojo hands the name to bootstrap APIs verbatim, so it has to be a flat name.
+// A path prefix would still "work" while wasting the length budget and coupling
+// the name to the environment.
+TEST(BraveVpnAgentUtils, ServerNameIsFlatBootstrapName) {
   const std::optional<mojo::NamedPlatformChannel::ServerName> name =
       GetAgentServerName();
   ASSERT_TRUE(name.has_value());
+
   EXPECT_FALSE(name->empty());
+  EXPECT_EQ(std::string::npos, name->find('/'));
+  EXPECT_LT(name->size(), static_cast<size_t>(BOOTSTRAP_MAX_NAME_LEN));
 }
 
-#endif  // BUILDFLAG(IS_POSIX)
+#elif BUILDFLAG(IS_WIN)
+
+// Mojo decorates this into "\\.\pipe\mojo.<name>", so the leaf must not carry
+// separators of its own.
+TEST(BraveVpnAgentUtils, ServerNameIsBarePipeLeaf) {
+  const std::optional<mojo::NamedPlatformChannel::ServerName> name =
+      GetAgentServerName();
+  ASSERT_TRUE(name.has_value());
+
+  EXPECT_FALSE(name->empty());
+  EXPECT_EQ(std::wstring::npos, name->find(L'\\'));
+}
+
+#endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_WIN)
 
 }  // namespace brave_vpn::v2

--- a/components/brave_vpn/common/v2/branding.gni
+++ b/components/brave_vpn/common/v2/branding.gni
@@ -6,6 +6,8 @@
 import("//build/util/branding.gni")
 
 vpn_agent_executable_name = "brave_vpn_agent_app"
+vpn_agent_ipc_name =
+    string_replace(chrome_product_full_name, " ", ".") + ".vpn.agent"
 
 if (is_mac) {
   vpn_agent_product_full_name = "$chrome_product_full_name VPN Agent"


### PR DESCRIPTION
The name was a fixed string, so every channel on a machine computed the same one and whichever agent registered first won. It now comes from `branding.gni` and varies per channel.

On macOS the name is a Mach bootstrap name, not a socket path, so it no longer carries a temp directory prefix; the socket helpers are Linux-only.

Also drops `MachServices` from the LaunchAgent plist: reserving the name for the job conflicts with the agent being startable by the browser or the user.

Resolves https://github.com/brave/brave-browser/issues/58882

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
