### PR TITLE
[ads] Add round-robin test coverage

### DIFF
--- a/components/brave_ads/core/internal/serving/eligible_ads/round_robin/creative_ad_round_robin_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/round_robin/creative_ad_round_robin_unittest.cc
@@ -193,6 +193,48 @@ TEST_F(BraveAdsCreativeAdRoundRobinTest,
 }
 
 TEST_F(BraveAdsCreativeAdRoundRobinTest,
+       AdShouldBeEligibleAgainWhenItIsTheOnlyAd) {
+  // Arrange
+  const CreativeNewTabPageAdInfo creative_ad =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  CreativeNewTabPageAdList creative_ads = {creative_ad};
+
+  creative_ad_round_robin_.MarkAsServed(creative_ad);
+
+  // Act
+  creative_ad_round_robin_.Filter(creative_ads);
+
+  // Assert
+  EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad));
+}
+
+TEST_F(BraveAdsCreativeAdRoundRobinTest,
+       FilteringEmptyAdsShouldNotAffectServedState) {
+  // Arrange
+  const CreativeNewTabPageAdInfo creative_ad_1 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_round_robin_.MarkAsServed(creative_ad_1);
+
+  const CreativeNewTabPageAdInfo creative_ad_2 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+
+  CreativeNewTabPageAdList empty_creative_ads;
+
+  // Act: filtering an empty list is a no-op and should not reset the
+  // priority bucket's served state.
+  creative_ad_round_robin_.Filter(empty_creative_ads);
+
+  CreativeNewTabPageAdList creative_ads = {creative_ad_1, creative_ad_2};
+  creative_ad_round_robin_.Filter(creative_ads);
+
+  // Assert
+  EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad_2));
+}
+
+TEST_F(BraveAdsCreativeAdRoundRobinTest,
        PriorityBucketsShouldRotateIndependently) {
   // Arrange
   CreativeNewTabPageAdInfo creative_ad_1 =
@@ -214,6 +256,72 @@ TEST_F(BraveAdsCreativeAdRoundRobinTest,
 
   // Assert
   EXPECT_THAT(other_priority_creative_ads, testing::ElementsAre(creative_ad_2));
+}
+
+TEST_F(BraveAdsCreativeAdRoundRobinTest, FilteringTwiceShouldBeIdempotent) {
+  // Arrange
+  const CreativeNewTabPageAdInfo creative_ad_1 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  const CreativeNewTabPageAdInfo creative_ad_2 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad_round_robin_.MarkAsServed(creative_ad_1);
+
+  CreativeNewTabPageAdList creative_ads = {creative_ad_1, creative_ad_2};
+
+  // Act
+  creative_ad_round_robin_.Filter(creative_ads);
+  creative_ad_round_robin_.Filter(creative_ads);
+
+  // Assert
+  EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad_2));
+}
+
+TEST_F(BraveAdsCreativeAdRoundRobinTest,
+       MarkAsServedShouldCreateNewPriorityBucketOnDemand) {
+  // Arrange
+  CreativeNewTabPageAdInfo creative_ad =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  creative_ad.priority = 3;
+
+  // Act
+  creative_ad_round_robin_.MarkAsServed(creative_ad);
+
+  CreativeNewTabPageAdList creative_ads = {creative_ad};
+  creative_ad_round_robin_.Filter(creative_ads);
+
+  // Assert: the bucket for priority 3 was created and reset because the only
+  // ad in it has now been served.
+  EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad));
+}
+
+TEST_F(BraveAdsCreativeAdRoundRobinTest,
+       BucketShouldResetOnEveryRotationNotJustTheFirst) {
+  // Arrange
+  const CreativeNewTabPageAdInfo creative_ad_1 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+  const CreativeNewTabPageAdInfo creative_ad_2 =
+      test::BuildCreativeNewTabPageAd(CreativeNewTabPageAdWallpaperType::kImage,
+                                      /*use_random_uuids=*/true);
+
+  // Act & Assert: first rotation.
+  creative_ad_round_robin_.MarkAsServed(creative_ad_1);
+  creative_ad_round_robin_.MarkAsServed(creative_ad_2);
+
+  CreativeNewTabPageAdList creative_ads = {creative_ad_1, creative_ad_2};
+  creative_ad_round_robin_.Filter(creative_ads);
+  EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad_1, creative_ad_2));
+
+  // Act & Assert: second rotation.
+  creative_ad_round_robin_.MarkAsServed(creative_ad_1);
+  creative_ad_round_robin_.MarkAsServed(creative_ad_2);
+
+  creative_ads = {creative_ad_1, creative_ad_2};
+  creative_ad_round_robin_.Filter(creative_ads);
+  EXPECT_THAT(creative_ads, testing::ElementsAre(creative_ad_1, creative_ad_2));
 }
 
 }  // namespace brave_ads


### PR DESCRIPTION
Cover an empty Filter() call not resetting a priority bucket's served state, a single-ad bucket becoming eligible again after a full rotation, repeated Filter() calls being idempotent, MarkAsServed() creating a new priority bucket on demand, and a bucket resetting on every rotation rather than only the first.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
