### PR TITLE
[iptc] Add feature flag guard during file deletion

### DIFF
--- a/browser/file_select/BUILD.gn
+++ b/browser/file_select/BUILD.gn
@@ -63,6 +63,7 @@ source_set("unit_tests") {
     ":file_select",
     "//base",
     "//base/test:test_support",
+    "//brave/components/image_metadata_stripper/common",
     "//testing/gtest",
   ]
 }

--- a/browser/file_select/brave_file_select_image_metadata_stripper.cc
+++ b/browser/file_select/brave_file_select_image_metadata_stripper.cc
@@ -239,6 +239,12 @@ bool MaybeStripImageMetadataForUpload(
 
 void MaybeDeleteImageMetadataStripperTemporaryDir(
     std::vector<base::FilePath>& paths) {
+  // This only makes sense when the feature is enabled.
+  if (!base::FeatureList::IsEnabled(
+          image_metadata_stripper::features::kStripImageMetadataV1)) {
+    return;
+  }
+
   const auto temp_root_dir =
       std::ranges::find_if(paths, [](const base::FilePath& path) {
         return !path.empty() && !path.ReferencesParent() &&

--- a/browser/file_select/brave_file_select_image_metadata_stripper_unittest.cc
+++ b/browser/file_select/brave_file_select_image_metadata_stripper_unittest.cc
@@ -9,12 +9,19 @@
 
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/test/scoped_feature_list.h"
+#include "brave/components/image_metadata_stripper/common/features.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace brave {
 
 class BraveFileSelectImageMetadataStripperUnitTest : public testing::Test {
  protected:
+  BraveFileSelectImageMetadataStripperUnitTest() {
+    feature_list_.InitAndEnableFeature(
+        image_metadata_stripper::features::kStripImageMetadataV1);
+  }
+
   void TearDown() override {
     for (const auto& path : cleanup_) {
       base::DeletePathRecursively(path);
@@ -46,6 +53,7 @@ class BraveFileSelectImageMetadataStripperUnitTest : public testing::Test {
   }
 
   std::vector<base::FilePath> cleanup_;
+  base::test::ScopedFeatureList feature_list_;
 };
 
 TEST_F(BraveFileSelectImageMetadataStripperUnitTest,
@@ -59,6 +67,24 @@ TEST_F(BraveFileSelectImageMetadataStripperUnitTest,
 
   EXPECT_TRUE(paths.empty());
   EXPECT_FALSE(base::PathExists(temp_root_dir));
+}
+
+TEST_F(BraveFileSelectImageMetadataStripperUnitTest,
+       DoesNothingWhenFeatureIsDisabled) {
+  base::test::ScopedFeatureList disabled_feature_list;
+  disabled_feature_list.InitAndDisableFeature(
+      image_metadata_stripper::features::kStripImageMetadataV1);
+
+  const base::FilePath temp_root_dir = CreateTempRootDir();
+  ASSERT_TRUE(
+      base::WriteFile(temp_root_dir.AppendASCII("photo.jpg"), "stripped"));
+
+  std::vector<base::FilePath> paths = {temp_root_dir};
+  MaybeDeleteImageMetadataStripperTemporaryDir(paths);
+
+  ASSERT_EQ(1u, paths.size());
+  EXPECT_EQ(temp_root_dir, paths[0]);
+  EXPECT_TRUE(base::PathExists(temp_root_dir));
 }
 
 TEST_F(BraveFileSelectImageMetadataStripperUnitTest,


### PR DESCRIPTION
This change adds a feature flag guard on `kStripImageMetadataV1` when deleting temporary files. 

<!-- Add brave-browser issue below that this PR will resolve -->
Related https://github.com/brave/brave-browser/issues/58705

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
