### PR TITLE
Clear ads data when sponsored ads are disabled

### DIFF
--- a/browser/brave_ads/BUILD.gn
+++ b/browser/brave_ads/BUILD.gn
@@ -156,8 +156,6 @@ source_set("browser_tests") {
 
   sources = [
     "ads_service_delegate_browsertest.cc",
-    "ads_service_waiter.cc",
-    "ads_service_waiter.h",
     "analytics/p3a/brave_stats_helper_browsertest.cc",
     "application_state/notification_helper/notification_helper_impl_mock.cc",
     "application_state/notification_helper/notification_helper_impl_mock.h",
@@ -166,6 +164,7 @@ source_set("browser_tests") {
   deps = [
     ":brave_ads",
     ":impl",
+    "//brave/components/brave_ads/core/browser/service:test_support",
     "//chrome/browser",
     "//chrome/browser/lifetime",
     "//chrome/test:test_support",

--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -153,6 +153,7 @@ source_set("unit_tests") {
     "//brave/components/brave_ads/browser",
     "//brave/components/brave_ads/browser/application_state:test_support",
     "//brave/components/brave_ads/core",
+    "//brave/components/brave_ads/core/browser/service:test_support",
     "//brave/components/brave_ads/core/public:headers",
     "//brave/components/brave_component_updater/browser",
     "//brave/components/brave_policy:policy_initialization_waiter",

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -782,6 +782,17 @@ void AdsServiceImpl::InitializeSponsoredAdsPrefChangeRegistrar() {
 }
 
 void AdsServiceImpl::OnAdsPrefChanged(const std::string& path) {
+  if (path == prefs::kSponsoredEnabled && !IsSponsoredAdsEnabled()) {
+    // Clear ads data now that sponsored ads are disabled. Posted because
+    // `ClearData` can synchronously reach `ClearAdsPrefs`, which mutates
+    // `pref_change_registrar_` and must not do so re-entrantly from within
+    // this pref's own change notification.
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE, base::BindOnce(&AdsServiceImpl::ClearData,
+                                  weak_ptr_factory_.GetWeakPtr(),
+                                  /*intentional*/ base::DoNothing()));
+  }
+
   if (!CanStartBatAdsService()) {
     // The pref change made the service ineligible to run, so tear it down and
     // release resource components that are no longer needed.

--- a/components/brave_ads/browser/ads_service_impl_unittest.cc
+++ b/components/brave_ads/browser/ads_service_impl_unittest.cc
@@ -25,6 +25,7 @@
 #include "brave/components/brave_ads/browser/test/fake_shutdown_monitor.h"
 #include "brave/components/brave_ads/browser/test/fake_virtual_pref_provider_delegate.h"
 #include "brave/components/brave_ads/browser/test/mock_resource_component.h"
+#include "brave/components/brave_ads/core/browser/service/test/ads_service_waiter.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_names.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_registry.h"
 #include "brave/components/brave_policy/policy_initialization_waiter.h"
@@ -258,6 +259,52 @@ TEST_F(BraveAdsAdsServiceImplTest, ServiceStopsWhenSponsoredAdsAreDisabled) {
 }
 
 TEST_F(BraveAdsAdsServiceImplTest,
+       ClearsAdsDataWhenSponsoredAdsBecomeDisabled) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
+  Startup();
+  // A proxy for the `brave.brave_ads.*` prefs cleared alongside it.
+  prefs_.SetString(prefs::kDiagnosticId, "foo");
+  test::AdsServiceWaiter waiter(*ads_service_);
+
+  // Act
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
+  waiter.WaitForOnDidClearAdsServiceData();
+
+  // Assert
+  EXPECT_FALSE(prefs_.HasPrefPath(prefs::kDiagnosticId));
+  EXPECT_FALSE(prefs_.GetBoolean(prefs::kSponsoredEnabled));
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       DoesNotClearAdsDataWhenUnrelatedPrefChanges) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
+  Startup();
+  prefs_.SetString(prefs::kDiagnosticId, "foo");
+
+  // Act
+  prefs_.SetBoolean(prefs::kNotificationsEnabled, true);
+
+  // Assert
+  EXPECT_EQ("foo", prefs_.GetString(prefs::kDiagnosticId));
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       DoesNotClearAdsDataWhenSponsoredAdsAreEnabled) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
+  Startup();
+  prefs_.SetString(prefs::kDiagnosticId, "foo");
+
+  // Act
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
+
+  // Assert
+  EXPECT_EQ("foo", prefs_.GetString(prefs::kDiagnosticId));
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
        ServiceStartsAgainAfterSponsoredAdsAreDisabledThenReenabled) {
   // Arrange
   prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
@@ -272,6 +319,20 @@ TEST_F(BraveAdsAdsServiceImplTest,
 
   // Assert
   EXPECT_EQ(2U, bat_ads_service_factory_->launch_count());
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       DoesNotCrashWhenServiceShutsDownBeforePendingClearDataTaskRuns) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
+  Startup();
+
+  // Act
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
+  Shutdown();
+
+  // Assert
+  EXPECT_FALSE(prefs_.GetBoolean(prefs::kSponsoredEnabled));
 }
 
 TEST_F(BraveAdsAdsServiceImplTest,
@@ -364,6 +425,26 @@ TEST_F(
   // Assert
   EXPECT_EQ(1U, bat_ads_service_factory_->launch_count());
   EXPECT_EQ(0U, bat_ads_service_factory_->shutdown_count());
+}
+
+TEST_F(BraveAdsAdsServiceImplTest,
+       ClearsAdsDataWhenSponsoredAdsBecomeDisabledWhileServiceKeepsRunning) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
+  prefs_.SetBoolean(brave_rewards::prefs::kEnabled, true);
+  Startup();
+  ASSERT_EQ(1U, bat_ads_service_factory_->launch_count());
+  // A proxy for the `brave.brave_ads.*` prefs cleared alongside it.
+  prefs_.SetString(prefs::kDiagnosticId, "foo");
+  test::AdsServiceWaiter waiter(*ads_service_);
+
+  // Act
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
+  waiter.WaitForOnDidClearAdsServiceData();
+
+  // Assert
+  EXPECT_FALSE(prefs_.HasPrefPath(prefs::kDiagnosticId));
+  EXPECT_FALSE(prefs_.GetBoolean(prefs::kSponsoredEnabled));
 }
 #endif  // BUILDFLAG(ENABLE_BRAVE_REWARDS)
 

--- a/components/brave_ads/core/browser/service/BUILD.gn
+++ b/components/brave_ads/core/browser/service/BUILD.gn
@@ -37,5 +37,7 @@ source_set("test_support") {
   sources = [
     "test/ads_service_mock.cc",
     "test/ads_service_mock.h",
+    "test/ads_service_waiter.cc",
+    "test/ads_service_waiter.h",
   ]
 }

--- a/components/brave_ads/core/browser/service/test/ads_service_waiter.cc
+++ b/components/brave_ads/core/browser/service/test/ads_service_waiter.cc
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "brave/browser/brave_ads/ads_service_waiter.h"
+#include "brave/components/brave_ads/core/browser/service/test/ads_service_waiter.h"
 
 #include "brave/components/brave_ads/core/browser/service/ads_service.h"
 

--- a/components/brave_ads/core/browser/service/test/ads_service_waiter.h
+++ b/components/brave_ads/core/browser/service/test/ads_service_waiter.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_BROWSER_BRAVE_ADS_ADS_SERVICE_WAITER_H_
-#define BRAVE_BROWSER_BRAVE_ADS_ADS_SERVICE_WAITER_H_
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_BROWSER_SERVICE_TEST_ADS_SERVICE_WAITER_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_CORE_BROWSER_SERVICE_TEST_ADS_SERVICE_WAITER_H_
 
 #include "base/memory/raw_ref.h"
 #include "base/run_loop.h"
@@ -62,4 +62,4 @@ class AdsServiceWaiter final : public AdsServiceObserver {
 
 }  // namespace brave_ads
 
-#endif  // BRAVE_BROWSER_BRAVE_ADS_ADS_SERVICE_WAITER_H_
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_CORE_BROWSER_SERVICE_TEST_ADS_SERVICE_WAITER_H_

--- a/ios/browser/brave_ads/BUILD.gn
+++ b/ios/browser/brave_ads/BUILD.gn
@@ -55,7 +55,10 @@ optimize_ts("ads_media_reporting_js") {
 source_set("unit_tests") {
   testonly = true
 
-  sources = [ "ads_tab_helper_unittest.mm" ]
+  sources = [
+    "ads_service_impl_ios_unittest.mm",
+    "ads_tab_helper_unittest.mm",
+  ]
 
   deps = [
     ":brave_ads",
@@ -63,6 +66,7 @@ source_set("unit_tests") {
     "//brave/components/brave_ads/core/browser/service:test_support",
     "//brave/components/brave_ads/core/public:headers",
     "//brave/components/brave_rewards/core",
+    "//components/prefs:test_support",
     "//ios/chrome/browser/shared/model/profile/test",
     "//ios/chrome/test:test_support",
     "//ios/web/public/test",

--- a/ios/browser/brave_ads/ads_service_impl_ios.h
+++ b/ios/browser/brave_ads/ads_service_impl_ios.h
@@ -20,6 +20,7 @@
 #include "brave/components/brave_ads/core/public/ads_callback.h"
 #include "brave/components/brave_ads/core/public/ads_client/ads_client_notifier.h"
 #include "brave/components/brave_ads/core/public/common/functional/once_closure_task_queue.h"
+#include "components/prefs/pref_change_registrar.h"
 
 class PrefService;
 
@@ -165,7 +166,11 @@ class AdsServiceImplIOS : public AdsService {
   void ClearAdsPrefs();
   void ClearAdsDataCallback(ResultCallback callback);
 
+  void OnSponsoredAdsPrefChanged();
+
   const raw_ref<PrefService> prefs_;
+
+  PrefChangeRegistrar pref_change_registrar_;
 
   const scoped_refptr<base::SequencedTaskRunner> file_task_runner_;
 

--- a/ios/browser/brave_ads/ads_service_impl_ios.mm
+++ b/ios/browser/brave_ads/ads_service_impl_ios.mm
@@ -50,7 +50,13 @@ AdsServiceImplIOS::AdsServiceImplIOS(PrefService& prefs)
       file_task_runner_(base::ThreadPool::CreateSequencedTaskRunner(
           {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
            base::TaskShutdownBehavior::BLOCK_SHUTDOWN})),
-      ads_client_notifier_(std::make_unique<AdsClientNotifier>()) {}
+      ads_client_notifier_(std::make_unique<AdsClientNotifier>()) {
+  pref_change_registrar_.Init(&*prefs_);
+  pref_change_registrar_.Add(
+      prefs::kSponsoredEnabled,
+      base::BindRepeating(&AdsServiceImplIOS::OnSponsoredAdsPrefChanged,
+                          weak_ptr_factory_.GetWeakPtr()));
+}
 
 AdsServiceImplIOS::~AdsServiceImplIOS() = default;
 
@@ -519,7 +525,29 @@ void AdsServiceImplIOS::ClearAdsPrefs() {
 
 void AdsServiceImplIOS::ClearAdsDataCallback(ResultCallback callback) {
   NotifyDidClearAdsServiceData();
+
+  if (!ads_client_) {
+    // Never initialized, so there is nothing to restart, e.g. sponsored ads
+    // were disabled before the ads service was ever initialized.
+    return std::move(callback).Run(/*success=*/true);
+  }
+
   InitializeAds(std::move(callback));
+}
+
+void AdsServiceImplIOS::OnSponsoredAdsPrefChanged() {
+  if (prefs_->GetBoolean(prefs::kSponsoredEnabled)) {
+    return;
+  }
+
+  // Clear ads data now that sponsored ads are disabled. Posted because
+  // `ClearData` can synchronously reach `ClearAdsPrefs`, which mutates
+  // `pref_change_registrar_` and must not do so re-entrantly from within this
+  // pref's own change notification.
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE, base::BindOnce(&AdsServiceImplIOS::ClearData,
+                                weak_ptr_factory_.GetWeakPtr(),
+                                /*intentional*/ base::DoNothing()));
 }
 
 }  // namespace brave_ads

--- a/ios/browser/brave_ads/ads_service_impl_ios_unittest.mm
+++ b/ios/browser/brave_ads/ads_service_impl_ios_unittest.mm
@@ -1,0 +1,71 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/brave_ads/ads_service_impl_ios.h"
+
+#include "base/test/task_environment.h"
+#include "brave/components/brave_ads/core/browser/service/test/ads_service_waiter.h"
+#include "brave/components/brave_ads/core/public/prefs/pref_names.h"
+#include "brave/components/brave_ads/core/public/prefs/pref_registry.h"
+#include "components/prefs/testing_pref_service.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "testing/platform_test.h"
+
+namespace brave_ads {
+
+class AdsServiceImplIOSTest : public PlatformTest {
+ public:
+  AdsServiceImplIOSTest() {
+    RegisterProfilePrefs(prefs_.registry());
+    ads_service_ = std::make_unique<AdsServiceImplIOS>(prefs_);
+  }
+
+ protected:
+  base::test::TaskEnvironment task_environment_;
+  TestingPrefServiceSimple prefs_;
+  std::unique_ptr<AdsServiceImplIOS> ads_service_;
+};
+
+TEST_F(AdsServiceImplIOSTest, ClearsAdsDataWhenSponsoredAdsBecomeDisabled) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
+  // A proxy for the `brave.brave_ads.*` prefs cleared alongside it.
+  prefs_.SetString(prefs::kDiagnosticId, "foo");
+  test::AdsServiceWaiter waiter(*ads_service_);
+
+  // Act
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
+  waiter.WaitForOnDidClearAdsServiceData();
+
+  // Assert
+  EXPECT_FALSE(prefs_.HasPrefPath(prefs::kDiagnosticId));
+  EXPECT_FALSE(prefs_.GetBoolean(prefs::kSponsoredEnabled));
+}
+
+TEST_F(AdsServiceImplIOSTest, DoesNotClearAdsDataWhenUnrelatedPrefChanges) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
+  prefs_.SetString(prefs::kDiagnosticId, "foo");
+
+  // Act
+  prefs_.SetBoolean(prefs::kNotificationsEnabled, true);
+
+  // Assert
+  EXPECT_EQ("foo", prefs_.GetString(prefs::kDiagnosticId));
+}
+
+TEST_F(AdsServiceImplIOSTest, DoesNotClearAdsDataWhenSponsoredAdsAreEnabled) {
+  // Arrange
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, false);
+  prefs_.SetString(prefs::kDiagnosticId, "foo");
+
+  // Act
+  prefs_.SetBoolean(prefs::kSponsoredEnabled, true);
+
+  // Assert
+  EXPECT_EQ("foo", prefs_.GetString(prefs::kDiagnosticId));
+}
+
+}  // namespace brave_ads


### PR DESCRIPTION
Toggling off Enable Sponsored Ads left prior ads data in place. Clear it via the existing ClearData flow when the pref changes, deferred to a posted task to avoid re-entrantly mutating the pref change registrar from within its own notification.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58697

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
