### PR TITLE
[ads] Hide "Enable Sponsored Ads" toggle when Rewards disabled by policy

### DIFF
--- a/browser/resources/settings/brave_data_collection_page/brave_data_collection_page.html
+++ b/browser/resources/settings/brave_data_collection_page/brave_data_collection_page.html
@@ -32,12 +32,14 @@
     </template>
   </settings-toggle-button>
 <if expr="enable_brave_ads">
-  <settings-toggle-button id="sponsoredAdsEnabled"
-      class="hr"
-      pref="{{prefs.brave.brave_ads.sponsored.enabled}}"
-      label="$i18n{sponsoredAdsEnabledTitle}"
-      sub-label="$i18n{sponsoredAdsEnabledDesc}">
-  </settings-toggle-button>
+  <template is="dom-if" if="[[showSponsoredAdsEnabledToggle_]]">
+    <settings-toggle-button id="sponsoredAdsEnabled"
+        class="hr"
+        pref="{{prefs.brave.brave_ads.sponsored.enabled}}"
+        label="$i18n{sponsoredAdsEnabledTitle}"
+        sub-label="$i18n{sponsoredAdsEnabledDesc}">
+    </settings-toggle-button>
+  </template>
 </if>
   <template is="dom-if" if="[[showSurveyPanelist_]]">
     <cr-link-row id="surveyPanelistLinkRow"

--- a/browser/resources/settings/brave_data_collection_page/brave_data_collection_page.ts
+++ b/browser/resources/settings/brave_data_collection_page/brave_data_collection_page.ts
@@ -72,6 +72,7 @@ extends SettingBraveDataCollectionPageElementBase
         },
       },
       showRestartForMetricsReporting_: Boolean,
+      showSponsoredAdsEnabledToggle_: Boolean,
       showSurveyPanelist_: Boolean,
       isStatsReportingEnabledManaged_: Boolean,
       isP3AEnabledManaged_: Boolean,
@@ -82,6 +83,7 @@ extends SettingBraveDataCollectionPageElementBase
   private declare statsUsagePingEnabledPref_: Object
   private declare metricsReportingPref_: chrome.settingsPrivate.PrefObject<boolean>
   private declare showRestartForMetricsReporting_: boolean
+  private declare showSponsoredAdsEnabledToggle_: boolean
   private declare showSurveyPanelist_: boolean
   private declare isStatsReportingEnabledManaged_: boolean
   private declare isP3AEnabledManaged_: boolean
@@ -117,6 +119,7 @@ extends SettingBraveDataCollectionPageElementBase
     this.browserProxy_.getStatsUsagePingEnabled().then(
       (enabled: boolean) => setStatsUsagePingEnabledPref(enabled, this.isStatsReportingEnabledManaged_))
 
+    this.showSponsoredAdsEnabledToggle_ = loadTimeData.getBoolean('isSponsoredAdsAllowed')
     this.showSurveyPanelist_ = loadTimeData.getBoolean('isSurveyPanelistAllowed')
   }
 

--- a/browser/ui/webui/brave_settings_ui.cc
+++ b/browser/ui/webui/brave_settings_ui.cc
@@ -275,10 +275,15 @@ void BraveSettingsUI::AddResources(content::WebUIDataSource* html_source,
 #endif
 
 #if BUILDFLAG(IS_BRAVE_ORIGIN_BRANDED)
-  // Survey Panelist is tied to Brave Rewards, which is compiled out of Brave
-  // Origin branded builds, so the setting is never available there.
+  // Sponsored Ads and Survey Panelist are tied to Brave Rewards, which is
+  // compiled out of Brave Origin branded builds, so neither setting is ever
+  // available there.
+  html_source->AddBoolean("isSponsoredAdsAllowed", false);
   html_source->AddBoolean("isSurveyPanelistAllowed", false);
 #else
+  html_source->AddBoolean("isSponsoredAdsAllowed",
+                          !profile->GetPrefs()->GetBoolean(
+                              brave_rewards::prefs::kDisabledByPolicy));
   html_source->AddBoolean("isSurveyPanelistAllowed",
                           base::FeatureList::IsEnabled(
                               ntp_background_images::features::


### PR DESCRIPTION
This change hides "Enable Sponsored Ads" toggle in settings for Brave Origin upgrade version.

"Enable Sponsored Ads" toggle was added in https://github.com/brave/brave-browser/issues/57204.

### Test plan

Make sure that "Enable Sponsored Ads" toggle on Desktop:
* is visible for the standard Brave install (no origin/no policies)
* is hidden for the Brave Origin build flag version
* is hidden for the Brave Origin upgrade version
* is hidden when Brave Rewards disabled by a policy

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/58916

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
