### PR TITLE
[Wallet]: Reject fractional Zcash birthday blocks

### DIFF
--- a/components/brave_wallet_ui/components/desktop/popup-modals/shield_zcash_account/shield_zcash_account.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/shield_zcash_account/shield_zcash_account.tsx
@@ -37,8 +37,12 @@ import {
 } from './shield_zcash_account.style'
 import { Column, Text, Row } from '../../../shared/style'
 import { NumberInput } from '../../../shared/number_input/number_input'
-
-const MIN_ACCOUNT_BIRTHDAY_BLOCK = 1687104
+import {
+  getZCashBirthdayBlockError,
+  isAllowedZCashBirthdayBlockInput,
+  MIN_ACCOUNT_BIRTHDAY_BLOCK,
+  shouldBlockZCashBirthdayBlockKey,
+} from './zcash_birthday_block'
 
 interface Props {
   account: BraveWallet.AccountInfo
@@ -70,14 +74,11 @@ export const ShieldZCashAccountModal = (props: Props) => {
   const existingShieldBirthday = zcashAccountInfo?.accountShieldBirthday
   const accountBirthdayBlock =
     customBirthdayBlock !== '' ? Number(customBirthdayBlock) : 0
-  const birthdayBlockIsToLow =
-    customBirthdayBlock !== ''
-    && accountBirthdayBlock < MIN_ACCOUNT_BIRTHDAY_BLOCK
-  const birthdayBlockIsToHigh =
-    customBirthdayBlock !== ''
-    && chainTipStatus?.chainTip !== undefined
-    && accountBirthdayBlock > chainTipStatus.chainTip
-  const invalidBirthdayBlock = birthdayBlockIsToLow || birthdayBlockIsToHigh
+  const birthdayBlockError = getZCashBirthdayBlockError(
+    customBirthdayBlock,
+    chainTipStatus?.chainTip,
+  )
+  const invalidBirthdayBlock = birthdayBlockError !== undefined
   const isBusy = isShielding || isResettingBirthday
   const birthdayBlockIsDifferent =
     existingShieldBirthday
@@ -91,7 +92,7 @@ export const ShieldZCashAccountModal = (props: Props) => {
 
   // Methods
   const onShieldAccount = React.useCallback(async () => {
-    if (!account.accountId) {
+    if (!account.accountId || invalidBirthdayBlock) {
       return
     }
     setIsShielding(true)
@@ -101,10 +102,16 @@ export const ShieldZCashAccountModal = (props: Props) => {
     })
     setIsShielding(false)
     onClose()
-  }, [shieldAccount, account, onClose, accountBirthdayBlock])
+  }, [
+    shieldAccount,
+    account,
+    onClose,
+    accountBirthdayBlock,
+    invalidBirthdayBlock,
+  ])
 
   const onResetShieldAccountBirthday = React.useCallback(async () => {
-    if (!account.accountId || !existingShieldBirthday) {
+    if (!account.accountId || !existingShieldBirthday || invalidBirthdayBlock) {
       return
     }
     setIsResettingBirthday(true)
@@ -120,11 +127,31 @@ export const ShieldZCashAccountModal = (props: Props) => {
     accountBirthdayBlock,
     existingShieldBirthday,
     onClose,
+    invalidBirthdayBlock,
   ])
 
   const onToggleShowAdvanced = () => {
     setShowAdvanced((prev) => !prev)
   }
+
+  const onBirthdayBlockInput = React.useCallback((e: { value: string }) => {
+    if (isAllowedZCashBirthdayBlockInput(e.value)) {
+      setCustomBirthdayBlock(e.value)
+    }
+  }, [])
+
+  const onBirthdayBlockKeyDown = React.useCallback(
+    (e: { innerEvent: Event }) => {
+      const event = e.innerEvent as KeyboardEvent
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return
+      }
+      if (shouldBlockZCashBirthdayBlockKey(event.key, customBirthdayBlock)) {
+        event.preventDefault()
+      }
+    },
+    [customBirthdayBlock],
+  )
 
   return (
     <PopupModal
@@ -237,12 +264,16 @@ export const ShieldZCashAccountModal = (props: Props) => {
                 </Text>
                 <NumberInput
                   size='small'
+                  step={1}
+                  min={1}
                   value={customBirthdayBlock}
-                  onInput={(e) => setCustomBirthdayBlock(e.value)}
+                  onKeyDown={onBirthdayBlockKeyDown}
+                  onInput={onBirthdayBlockInput}
                   showErrors={invalidBirthdayBlock}
                 />
               </Row>
-              {invalidBirthdayBlock && (
+              {(birthdayBlockError === 'too-low'
+                || birthdayBlockError === 'too-high') && (
                 <Row
                   padding='0px 8px 12px 28px'
                   justifyContent='flex-end'
@@ -252,7 +283,7 @@ export const ShieldZCashAccountModal = (props: Props) => {
                     textSize='12px'
                     isBold={false}
                   >
-                    {birthdayBlockIsToLow
+                    {birthdayBlockError === 'too-low'
                       ? getLocale(
                           S.BRAVE_WALLET_ACCOUNT_BIRTHDAY_TOO_LOW,
                         ).replace('$1', MIN_ACCOUNT_BIRTHDAY_BLOCK.toString())

--- a/components/brave_wallet_ui/components/desktop/popup-modals/shield_zcash_account/zcash_birthday_block.test.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/shield_zcash_account/zcash_birthday_block.test.ts
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import {
+  getZCashBirthdayBlockError,
+  isAllowedZCashBirthdayBlockInput,
+  MIN_ACCOUNT_BIRTHDAY_BLOCK,
+  shouldBlockZCashBirthdayBlockKey,
+} from './zcash_birthday_block'
+
+const CHAIN_TIP = 7687104
+
+describe('isAllowedZCashBirthdayBlockInput', () => {
+  it('allows an empty value', () => {
+    expect(isAllowedZCashBirthdayBlockInput('')).toBe(true)
+  })
+
+  it('allows a whole number without a leading zero', () => {
+    expect(isAllowedZCashBirthdayBlockInput('1687104')).toBe(true)
+  })
+
+  it('rejects a decimal, sign, leading zero, or exponent', () => {
+    expect(isAllowedZCashBirthdayBlockInput('1687104.5')).toBe(false)
+    expect(isAllowedZCashBirthdayBlockInput('1687104.')).toBe(false)
+    expect(isAllowedZCashBirthdayBlockInput('-1687104')).toBe(false)
+    expect(isAllowedZCashBirthdayBlockInput('+1687104')).toBe(false)
+    expect(isAllowedZCashBirthdayBlockInput('01687104')).toBe(false)
+    expect(isAllowedZCashBirthdayBlockInput('0')).toBe(false)
+    expect(isAllowedZCashBirthdayBlockInput('1e6')).toBe(false)
+  })
+})
+
+describe('shouldBlockZCashBirthdayBlockKey', () => {
+  it('blocks decimal, sign, and exponent keys', () => {
+    expect(shouldBlockZCashBirthdayBlockKey('.', '1687104')).toBe(true)
+    expect(shouldBlockZCashBirthdayBlockKey(',', '1687104')).toBe(true)
+    expect(shouldBlockZCashBirthdayBlockKey('-', '')).toBe(true)
+    expect(shouldBlockZCashBirthdayBlockKey('+', '')).toBe(true)
+    expect(shouldBlockZCashBirthdayBlockKey('e', '1')).toBe(true)
+    expect(shouldBlockZCashBirthdayBlockKey('E', '1')).toBe(true)
+  })
+
+  it('blocks a leading zero', () => {
+    expect(shouldBlockZCashBirthdayBlockKey('0', '')).toBe(true)
+    expect(shouldBlockZCashBirthdayBlockKey('0', '1687104')).toBe(false)
+  })
+
+  it('allows digits and editing keys', () => {
+    expect(shouldBlockZCashBirthdayBlockKey('1', '')).toBe(false)
+    expect(shouldBlockZCashBirthdayBlockKey('Backspace', '1687104')).toBe(false)
+  })
+})
+
+describe('getZCashBirthdayBlockError', () => {
+  it('allows an empty birthday so the default chain tip can be used', () => {
+    expect(getZCashBirthdayBlockError('', CHAIN_TIP)).toBeUndefined()
+  })
+
+  it('allows a whole-number birthday in range', () => {
+    expect(
+      getZCashBirthdayBlockError(
+        MIN_ACCOUNT_BIRTHDAY_BLOCK.toString(),
+        CHAIN_TIP,
+      ),
+    ).toBeUndefined()
+  })
+
+  it('rejects a fractional birthday before range checks', () => {
+    expect(getZCashBirthdayBlockError('1687104.5', CHAIN_TIP)).toBe('not-whole')
+  })
+
+  it('rejects a birthday below the minimum', () => {
+    expect(
+      getZCashBirthdayBlockError(
+        (MIN_ACCOUNT_BIRTHDAY_BLOCK - 1).toString(),
+        CHAIN_TIP,
+      ),
+    ).toBe('too-low')
+  })
+
+  it('rejects a birthday above the chain tip', () => {
+    expect(
+      getZCashBirthdayBlockError((CHAIN_TIP + 1).toString(), CHAIN_TIP),
+    ).toBe('too-high')
+  })
+})

--- a/components/brave_wallet_ui/components/desktop/popup-modals/shield_zcash_account/zcash_birthday_block.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/shield_zcash_account/zcash_birthday_block.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+export const MIN_ACCOUNT_BIRTHDAY_BLOCK = 1687104
+
+const ALLOWED_BIRTHDAY_BLOCK_INPUT = /^(?:|[1-9]\d*)$/
+const BLOCKED_BIRTHDAY_BLOCK_KEYS = new Set(['.', ',', '-', '+', 'e', 'E'])
+
+export const isAllowedZCashBirthdayBlockInput = (value: string): boolean => {
+  return ALLOWED_BIRTHDAY_BLOCK_INPUT.test(value)
+}
+
+export const shouldBlockZCashBirthdayBlockKey = (
+  key: string,
+  currentValue: string,
+): boolean => {
+  if (BLOCKED_BIRTHDAY_BLOCK_KEYS.has(key)) {
+    return true
+  }
+  return key === '0' && currentValue === ''
+}
+
+export type ZCashBirthdayBlockError = 'not-whole' | 'too-low' | 'too-high'
+
+export const getZCashBirthdayBlockError = (
+  customBirthdayBlock: string,
+  chainTip?: number,
+): ZCashBirthdayBlockError | undefined => {
+  if (customBirthdayBlock === '') {
+    return undefined
+  }
+
+  const accountBirthdayBlock = Number(customBirthdayBlock)
+  if (!Number.isInteger(accountBirthdayBlock)) {
+    return 'not-whole'
+  }
+  if (accountBirthdayBlock < MIN_ACCOUNT_BIRTHDAY_BLOCK) {
+    return 'too-low'
+  }
+  if (chainTip !== undefined && accountBirthdayBlock > chainTip) {
+    return 'too-high'
+  }
+  return undefined
+}


### PR DESCRIPTION
## Description 

- Fixes fractional Zcash account birthday (e.g. `1687104.5`)
- Birthday blocks must be whole numbers in range. Typing `.`, `-`, `+`, `e`/`E`, or a leading `0` is ignored; values that aren't a whole number are not committed.
- Empty still means “use the default chain tip” when shielding a new account. Existing too-low / too-high errors are unchanged.

## Test plan
- [ ] Open **Shield account** → Advanced settings. Enter `1687104.5` (or try to type a `.`). Confirm the decimal is not accepted and Shield stays disabled if the field is invalid.
- [ ] Enter a valid whole number ≥ `1687104` and below the chain tip. Confirm Shield is enabled and succeeds.
- [ ] Enter a block below `1687104`. Confirm the too-low error and that Shield is disabled.
- [ ] Enter a block above the chain tip. Confirm the too-high error and that Shield is disabled.
- [ ] Leave the birthday field empty (new shield). Confirm Shield stays enabled (default chain tip).
- [ ] On an already shielded account, **Reset account birthday**: same validation; button stays disabled until the value is a different, valid whole number.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/58757>

<!-- CI-related labels that can be applied to this PR:
* CI/disable-pipeline-step-cache - do not cache build steps between runs for the same commit hash
* CI/enable-coverage - enable coverage reporting
* CI/enable-test-only-affected - only run tests affected by changes in the PR
* CI/run-audit-deps (1) - run audit_deps
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/run-network-audit (1) - run network-audit
* CI/run-perf-smoke-tests - run perf_tests
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-origin - do not run any builds for Brave Origin
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Make sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `pnpm run test brave_browser_tests`, `pnpm run test brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `pnpm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `pnpm run gn_check`
- Run `git rebase master` (if needed)
-->
