### PR TITLE
[iOS] Replace deprecated trait collection observation

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/Cells/FavoritesCollectionViewCell.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/Cells/FavoritesCollectionViewCell.swift
@@ -40,12 +40,6 @@ class FavoritesCollectionViewCell: UICollectionViewCell, CollectionViewReusable 
     backgroundColor = .clear
   }
 
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-
-    setTheme()
-  }
-
   override init(frame: CGRect) {
     super.init(frame: frame)
 
@@ -55,6 +49,13 @@ class FavoritesCollectionViewCell: UICollectionViewCell, CollectionViewReusable 
     doLayout()
 
     addInteraction(UIPointerInteraction(delegate: self))
+
+    registerForTraitChanges([
+      UITraitUserInterfaceStyle.self,
+      UITraitPreferredContentSizeCategory.self,
+    ]) { (self: Self, _) in
+      self.setTheme()
+    }
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/Cells/FavoritesRecentSearchCell.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/Cells/FavoritesRecentSearchCell.swift
@@ -58,15 +58,14 @@ class FavoritesRecentSearchCell: UICollectionViewCell, CollectionViewReusable {
     }
 
     openButton.addTarget(self, action: #selector(onOpenButtonPressed(_:)), for: .touchUpInside)
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.setTheme()
+    }
   }
 
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    setTheme()
   }
 
   private func setTheme() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/SupplementaryViews/FavoritesHeaderView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/SupplementaryViews/FavoritesHeaderView.swift
@@ -25,16 +25,15 @@ class FavoritesHeaderView: UICollectionReusableView {
     label.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.setTheme()
+    }
   }
 
   @available(*, unavailable)
   required init(coder: NSCoder) {
     fatalError()
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    setTheme()
   }
 
   private func setTheme() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/SupplementaryViews/FavoritesRecentSearchFooterView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/SupplementaryViews/FavoritesRecentSearchFooterView.swift
@@ -26,16 +26,15 @@ class FavoritesRecentSearchFooterView: UICollectionReusableView {
       $0.top.leading.trailing.equalToSuperview()
       $0.bottom.equalToSuperview().inset(24)
     }
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.setTheme()
+    }
   }
 
   @available(*, unavailable)
   required init(coder: NSCoder) {
     fatalError()
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    setTheme()
   }
 
   private func setTheme() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/SupplementaryViews/FavoritesRecentSearchHeaderView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/Views/SupplementaryViews/FavoritesRecentSearchHeaderView.swift
@@ -23,6 +23,10 @@ class FavoritesRecentSearchHeaderView: UICollectionReusableView {
 
     setTheme()
     doLayout()
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.setTheme()
+    }
   }
 
   @available(*, unavailable)
@@ -74,12 +78,6 @@ class FavoritesRecentSearchHeaderView: UICollectionReusableView {
       $0.setContentCompressionResistancePriority(.required, for: .horizontal)
       $0.contentHorizontalAlignment = .trailing
     }
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-
-    setTheme()
   }
 
   func setButtonVisibility(showClearButtonVisible: Bool) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NewTabPage/NewTabPageViewController.swift
@@ -398,6 +398,13 @@ class NewTabPageViewController: UIViewController {
         }
       }
     }
+
+    registerForTraitChanges([UITraitVerticalSizeClass.self]) { (self: Self, _) in
+      self.calculateBackgroundCenterPoints()
+    }
+    registerForTraitChanges([UITraitHorizontalSizeClass.self]) { (self: Self, _) in
+      self.collectionView.reloadData()
+    }
   }
 
   override func viewWillAppear(_ animated: Bool) {
@@ -471,20 +478,6 @@ class NewTabPageViewController: UIViewController {
     backgroundView.imageView.image = parent == nil ? nil : background.backgroundImage
 
     lastViewedSponsoredBackgroundId = nil
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    if previousTraitCollection?.verticalSizeClass
-      != traitCollection.verticalSizeClass
-    {
-      calculateBackgroundCenterPoints()
-    }
-
-    if previousTraitCollection?.horizontalSizeClass
-      != traitCollection.horizontalSizeClass
-    {
-      collectionView.reloadData()
-    }
   }
 
   // MARK: - Background

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchURLBarInputView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchURLBarInputView.swift
@@ -193,17 +193,21 @@ class SearchURLBarInputView: UIView {
 
     updateColors()
     updateLocationBarRightView(showToolbarActions: true)
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      let clampedTraitCollection = self.traitCollection.clampingSizeCategory(
+        maximum: .accessibilityLarge
+      )
+      self.textField.font = .preferredFont(
+        forTextStyle: .body,
+        compatibleWith: clampedTraitCollection
+      )
+    }
   }
 
   @available(*, unavailable)
   required init(coder: NSCoder) {
     fatalError()
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    let clampedTraitCollection = traitCollection.clampingSizeCategory(maximum: .accessibilityLarge)
-    textField.font = .preferredFont(forTextStyle: .body, compatibleWith: clampedTraitCollection)
   }
 
   private func makePlaceholder(colors: some BrowserColors) -> NSAttributedString {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/Cells/SearchActionsCell.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/Cells/SearchActionsCell.swift
@@ -45,6 +45,10 @@ class SearchActionsCell: UICollectionViewCell, CollectionViewReusable {
 
     setTheme()
     doLayout()
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.setTheme()
+    }
   }
 
   @available(*, unavailable)
@@ -55,12 +59,6 @@ class SearchActionsCell: UICollectionViewCell, CollectionViewReusable {
   override func prepareForReuse() {
     super.prepareForReuse()
     backgroundColor = .clear
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-
-    setTheme()
   }
 
   private func doLayout() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/Cells/SearchFindInPageCell.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/Cells/SearchFindInPageCell.swift
@@ -64,15 +64,14 @@ class SearchFindInPageCell: UICollectionViewCell, CollectionViewReusable {
     searchImageView.snp.makeConstraints {
       $0.size.equalTo(20)
     }
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.setTheme()
+    }
   }
 
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    setTheme()
   }
 
   private func setTheme() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/Cells/SearchOnYourDeviceCell.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/Cells/SearchOnYourDeviceCell.swift
@@ -140,15 +140,14 @@ class SearchOnYourDeviceCell: UICollectionViewCell, CollectionViewReusable {
     badgeImageView.snp.makeConstraints {
       $0.size.equalTo(20.0)
     }
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.setTheme()
+    }
   }
 
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    setTheme()
   }
 
   private func setTheme() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/Cells/SearchSuggestionCell.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/Cells/SearchSuggestionCell.swift
@@ -52,11 +52,6 @@ class SearchSuggestionCell: UICollectionViewCell, CollectionViewReusable {
     }
   }
 
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    setTheme()
-  }
-
   override init(frame: CGRect) {
     super.init(frame: frame)
 
@@ -83,6 +78,10 @@ class SearchSuggestionCell: UICollectionViewCell, CollectionViewReusable {
     }
 
     openButton.addTarget(self, action: #selector(onOpenButtonPressed), for: .touchUpInside)
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.setTheme()
+    }
   }
 
   required init?(coder: NSCoder) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/SupplementaryViews/SearchSectionHeaderView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/Views/SupplementaryViews/SearchSectionHeaderView.swift
@@ -25,16 +25,15 @@ class SearchSectionHeaderView: UICollectionReusableView, CollectionViewReusable 
     label.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.setTheme()
+    }
   }
 
   @available(*, unavailable)
   required init(coder: NSCoder) {
     fatalError()
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    setTheme()
   }
 
   private func setTheme() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/SendTab/SendTabProcessController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/SendTab/SendTabProcessController.swift
@@ -91,12 +91,10 @@ class SendTabProcessController: SendTabTransitioningController {
     updateFont()
 
     changeProcessStatus()
-  }
 
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-
-    updateFont()
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.updateFont()
+    }
   }
 
   private func updateLayoutConstraints() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/SendTab/SendTabToSelfController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/SendTab/SendTabToSelfController.swift
@@ -62,12 +62,13 @@ class SendTabToSelfController: SendTabTransitioningController {
     contentView.addSubview(contentNavigationController.view)
 
     updateLayoutConstraints()
-  }
 
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-
-    updateLayoutConstraints()
+    registerForTraitChanges([
+      UITraitHorizontalSizeClass.self,
+      UITraitVerticalSizeClass.self,
+    ]) { (self: Self, _) in
+      self.updateLayoutConstraints()
+    }
   }
 
   private func updateLayoutConstraints() {
@@ -250,13 +251,11 @@ class SendTabToSelfContentHeaderFooterView: UITableViewHeaderFooterView, TableVi
 
     updateFont()
     updateLayoutConstraints()
-  }
 
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-
-    updateFont()
-    updateLayoutConstraints()
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.updateFont()
+      self.updateLayoutConstraints()
+    }
   }
 
   private func updateFont() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabBarCell.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabBarCell.swift
@@ -72,6 +72,10 @@ class TabBarCell: UICollectionViewCell {
     updateFont()
 
     isSelected = false
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.updateFont()
+    }
   }
 
   private var privateModeCancellable: AnyCancellable?
@@ -133,11 +137,6 @@ class TabBarCell: UICollectionViewCell {
     }
     updateFont()
     updateColors()
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    updateFont()
   }
 
   func resetConfiguration() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
@@ -127,6 +127,11 @@ class TabsBarViewController: UIViewController {
         self.updatePlusButtonMenu()
         self.updateColors()
       })
+
+    registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, _) in
+      // Updates overflow colors which use CGColor's
+      self.overflowIndicators()
+    }
   }
 
   override func viewDidAppear(_ animated: Bool) {
@@ -159,12 +164,6 @@ class TabsBarViewController: UIViewController {
 
   deinit {
     NotificationCenter.default.removeObserver(self)
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    // Updates overflow colors which use CGColor's
-    overflowIndicators()
   }
 
   override func viewWillTransition(

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/BottomToolbarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/BottomToolbarView.swift
@@ -77,6 +77,14 @@ class BottomToolbarView: UIView, ToolbarProtocol {
     )
 
     updateColors()
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.helper?.updateForTraitCollection(
+        self.traitCollection,
+        browserColors: self.privateBrowsingManager.browserColors,
+        isBottomToolbar: true
+      )
+    }
   }
 
   private var privateModeCancellable: AnyCancellable?
@@ -106,15 +114,6 @@ class BottomToolbarView: UIView, ToolbarProtocol {
       make.height.equalTo(UIConstants.toolbarHeight)
     }
     super.updateConstraints()
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    helper?.updateForTraitCollection(
-      traitCollection,
-      browserColors: privateBrowsingManager.browserColors,
-      isBottomToolbar: true
-    )
   }
 
   private func setupAccessibility() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/EmptyStateOverlayView.swift
@@ -80,18 +80,19 @@ class EmptyStateOverlayView: UIView {
     doLayout(details: overlayDetails)
 
     updateFont()
+
+    registerForTraitChanges([
+      UITraitVerticalSizeClass.self,
+      UITraitPreferredContentSizeCategory.self,
+    ]) { (self: Self, _) in
+      self.doLayout(details: self.overlayDetails)
+      self.updateFont()
+    }
   }
 
   @available(*, unavailable)
   required init(coder: NSCoder) {
     fatalError()
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-
-    doLayout(details: overlayDetails)
-    updateFont()
   }
 
   override func layoutSubviews() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
@@ -163,11 +163,10 @@ class CollapsedURLBarView: UIView {
     }
 
     updateForTraitCollectionAndBrowserColors()
-  }
 
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    updateForTraitCollectionAndBrowserColors()
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.updateForTraitCollectionAndBrowserColors()
+    }
   }
 
   private func updateForTraitCollectionAndBrowserColors() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/PlaylistURLBarButton.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/PlaylistURLBarButton.swift
@@ -180,15 +180,14 @@ class PlaylistURLBarButton: UIButton {
     imageView?.adjustsImageSizeForAccessibilityContentSizeCategory = true
 
     updateForTraitCollection()
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.updateForTraitCollection()
+    }
   }
 
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    updateForTraitCollection()
   }
 
   private func updateForTraitCollection() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/ReaderModeButton.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/ReaderModeButton.swift
@@ -22,6 +22,10 @@ class ReaderModeButton: UIButton {
     adjustsImageWhenHighlighted = false
     setImage(UIImage(braveSystemNamed: "leo.product.speedreader"), for: .normal)
     updateIconSize()
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.updateIconSize()
+    }
   }
 
   @available(*, unavailable)
@@ -52,11 +56,6 @@ class ReaderModeButton: UIButton {
   }
 
   private var _readerModeState: ReaderModeState = .unavailable
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    updateIconSize()
-  }
 
   private func updateIconSize() {
     let sizeCategory = traitCollection.toolbarButtonContentSizeCategory

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -426,16 +426,18 @@ class TabLocationView: UIView {
 
     updateForTraitCollection()
     updateColors()
+
+    registerForTraitChanges([
+      UITraitPreferredContentSizeCategory.self,
+      UITraitUserInterfaceStyle.self,
+    ]) { (self: Self, _) in
+      self.updateForTraitCollection()
+      self.updateColors()
+    }
   }
 
   required init(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    updateForTraitCollection()
-    updateColors()
   }
 
   override var accessibilityElements: [Any]? {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -368,22 +368,21 @@ class TopToolbarView: UIView, ToolbarProtocol {
     self.displayTabTraySwipeGestureRecognizer = swipeGestureRecognizer
 
     updateColors()
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.helper?.updateForTraitCollection(
+        self.traitCollection,
+        browserColors: self.privateBrowsingManager.browserColors,
+        isBottomToolbar: false,
+        additionalButtons: [self.shortcutButton]
+      )
+      self.updateForTraitCollection()
+    }
   }
 
   @available(*, unavailable)
   required init(coder: NSCoder) {
     fatalError()
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    helper?.updateForTraitCollection(
-      traitCollection,
-      browserColors: privateBrowsingManager.browserColors,
-      isBottomToolbar: false,
-      additionalButtons: [shortcutButton]
-    )
-    updateForTraitCollection()
   }
 
   private func updateForTraitCollection() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TranslateURLBarButton.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TranslateURLBarButton.swift
@@ -28,6 +28,10 @@ class TranslateURLBarButton: UIButton {
     adjustsImageWhenHighlighted = false
     setImage(imageIcon, for: .normal)
     updateIconSize()
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.updateIconSize()
+    }
   }
 
   @available(*, unavailable)
@@ -60,11 +64,6 @@ class TranslateURLBarButton: UIButton {
 
   private func updateAppearance() {
     self.tintColor = (isHighlighted || isSelected) ? selectedTintColor : unselectedTintColor
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    updateIconSize()
   }
 
   private func updateIconSize() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/WalletURLBarButton.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/WalletURLBarButton.swift
@@ -38,6 +38,10 @@ class WalletURLBarButton: UIButton {
     imageEdgeInsets = .init(top: 3, left: 3, bottom: 3, right: 3)
 
     updateIconSize()
+
+    registerForTraitChanges([UITraitPreferredContentSizeCategory.self]) { (self: Self, _) in
+      self.updateIconSize()
+    }
   }
 
   override open var isHighlighted: Bool {
@@ -68,11 +72,6 @@ class WalletURLBarButton: UIButton {
         make.centerY.equalTo(imageView.snp.top).inset(badgeSize / 4)
       }
     }
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    updateIconSize()
   }
 
   private func updateIconSize() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Reader/ReaderModeStyleViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Reader/ReaderModeStyleViewController.swift
@@ -188,12 +188,10 @@ class ReaderModeStyleViewController: UIViewController {
     updateFontSizeButtons()
     selectTheme(readerModeStyle.theme)
     slider.value = Float(UIScreen.main.brightness)
-  }
 
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-
-    view.backgroundColor = UX.fontTypeRowBackground
+    registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, _) in
+      self.view.backgroundColor = UX.fontTypeRowBackground
+    }
   }
 
   /// Setup constraints for a row of buttons. Left to right. They are all given the same width.

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/General/SearchEngines/CustomEngines/CustomEngineViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/General/SearchEngines/CustomEngines/CustomEngineViewController.swift
@@ -148,11 +148,10 @@ class CustomEngineViewController: UIViewController {
     doLayout()
 
     doneButtonStatus = customEngineActionType == .add ? .enabled : .disabled
-  }
 
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    setTheme()
+    registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, _) in
+      self.setTheme()
+    }
   }
 
   // MARK: Internal

--- a/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncPairWordsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncPairWordsViewController.swift
@@ -71,12 +71,6 @@ class SyncPairWordsViewController: SyncViewController {
     fatalError()
   }
 
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-
-    containerView.layer.shadowColor = UIColor(braveSystemName: .dividerStrong).cgColor
-  }
-
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -98,6 +92,10 @@ class SyncPairWordsViewController: SyncViewController {
     )
 
     edgesForExtendedLayout = UIRectEdge()
+
+    registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, _) in
+      self.containerView.layer.shadowColor = UIColor(braveSystemName: .dividerStrong).cgColor
+    }
   }
 
   override func viewWillAppear(_ animated: Bool) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Widgets/BottomSheetViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Widgets/BottomSheetViewController.swift
@@ -142,6 +142,13 @@ class BottomSheetViewController: UIViewController {
     contentView.isHidden = true
 
     makeConstraints()
+
+    registerForTraitChanges([
+      UITraitHorizontalSizeClass.self,
+      UITraitUserInterfaceIdiom.self,
+    ]) { (self: Self, _) in
+      self.view.setNeedsUpdateConstraints()
+    }
   }
 
   override func viewDidAppear(_ animated: Bool) {
@@ -151,11 +158,6 @@ class BottomSheetViewController: UIViewController {
 
   override func viewDidLayoutSubviews() {
     yPosition = contentView.isHidden ? view.frame.maxY : initialDrawerYPosition
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    view.setNeedsUpdateConstraints()
   }
 
   override func updateViewConstraints() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Widgets/SnackBar.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Widgets/SnackBar.swift
@@ -146,13 +146,11 @@ class SnackBar: UIView {
     layer.cornerRadius = 6
     layer.cornerCurve = .continuous
     clipsToBounds = true
-  }
 
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-
-    self.layer.borderColor =
-      UIColor(braveSystemName: .dividerStrong).resolvedColor(with: traitCollection).cgColor
+    registerForTraitChanges([UITraitUserInterfaceStyle.self]) { (self: Self, _) in
+      self.layer.borderColor =
+        UIColor(braveSystemName: .dividerStrong).resolvedColor(with: self.traitCollection).cgColor
+    }
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Widgets/TabsButton.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Widgets/TabsButton.swift
@@ -46,6 +46,13 @@ class TabsButton: UIButton {
       $0.edges.equalToSuperview()
     }
     updateForTraitCollectionAndBrowserColors()
+
+    registerForTraitChanges([
+      UITraitUserInterfaceStyle.self,
+      UITraitPreferredContentSizeCategory.self,
+    ]) { (self: Self, _) in
+      self.updateForTraitCollectionAndBrowserColors()
+    }
   }
 
   @available(*, unavailable)
@@ -59,11 +66,6 @@ class TabsButton: UIButton {
       countLabel.textColor = color
       borderView.layer.borderColor = color.resolvedColor(with: traitCollection).cgColor
     }
-  }
-
-  override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-    super.traitCollectionDidChange(previousTraitCollection)
-    updateForTraitCollectionAndBrowserColors()
   }
 
   private func updateForTraitCollectionAndBrowserColors() {


### PR DESCRIPTION
This replaces all of the `traitCollectionDidChange` method overrides which are deprecated with the new `registerForTraitChanges` API, passing in the necessary traits needed for the particular view
