### PR TITLE
Shortcut to switch a video to PiP mode

### DIFF
--- a/app/brave_command_ids.h
+++ b/app/brave_command_ids.h
@@ -171,6 +171,8 @@
 // acceleratable so users can assign it a custom keyboard shortcut.
 #define IDC_BLOCK_ELEMENTS 56470
 
+#define IDC_TOGGLE_PICTURE_IN_PICTURE 56471
+
 #define IDC_BRAVE_COMMANDS_LAST 57000
 
 #endif  // BRAVE_APP_BRAVE_COMMAND_IDS_H_

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -325,6 +325,7 @@ void BraveBrowserCommandController::InitBraveCommandState() {
   UpdateCommandEnabled(IDC_OPEN_GUEST_PROFILE, open_guest_profile_enabled);
   UpdateCommandEnabled(IDC_COPY_CLEAN_LINK, true);
   UpdateCommandEnabled(IDC_TOGGLE_TAB_MUTE, true);
+  UpdateCommandEnabled(IDC_TOGGLE_PICTURE_IN_PICTURE, true);
 
 #if BUILDFLAG(ENABLE_SPEEDREADER)
   if (base::FeatureList::IsEnabled(
@@ -723,6 +724,9 @@ bool BraveBrowserCommandController::ExecuteBraveCommandWithDisposition(
       break;
     case IDC_TOGGLE_TAB_MUTE:
       brave::ToggleActiveTabAudioMute(&*browser_);
+      break;
+    case IDC_TOGGLE_PICTURE_IN_PICTURE:
+      brave::TogglePictureInPicture(&*browser_);
       break;
     case IDC_TOGGLE_VERTICAL_TABS:
       brave::ToggleVerticalTabStrip(&*browser_);

--- a/browser/ui/brave_browser_command_controller_browsertest.cc
+++ b/browser/ui/brave_browser_command_controller_browsertest.cc
@@ -47,7 +47,9 @@
 #include "components/prefs/pref_service.h"
 #include "components/saved_tab_groups/public/tab_group_sync_service.h"
 #include "components/sync/base/command_line_switches.h"
+#include "content/public/browser/media_session.h"
 #include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
 #include "content/public/test/test_utils.h"
 #include "net/test/embedded_test_server/embedded_test_server.h"
 
@@ -226,6 +228,86 @@ class BraveBrowserCommandControllerTest : public InProcessBrowserTest {
   policy::MockConfigurationPolicyProvider provider_;
   base::test::ScopedFeatureList scoped_feature_list_;
 };
+
+#if !BUILDFLAG(IS_ANDROID)
+class BraveBrowserCommandControllerPictureInPictureTest
+    : public BraveBrowserCommandControllerTest {
+ public:
+  void SetUpOnMainThread() override {
+    BraveBrowserCommandControllerTest::SetUpOnMainThread();
+    embedded_test_server()->ServeFilesFromSourceDirectory("chrome/test/data");
+    ASSERT_TRUE(embedded_test_server()->Start());
+  }
+
+  void LoadPlayingVideo() {
+    ASSERT_TRUE(ui_test_utils::NavigateToURL(
+        browser(), embedded_test_server()->GetURL(
+                       "/media/picture-in-picture/window-size.html")));
+    EXPECT_EQ(true, content::EvalJs(
+                        contents(),
+                        R"((async () => {
+                          const video = document.querySelector('video');
+                          video.loop = true;
+                          video.addEventListener('enterpictureinpicture', () => {
+                            document.title = 'enterpictureinpicture';
+                          });
+                          video.addEventListener('leavepictureinpicture', () => {
+                            document.title = 'leavepictureinpicture';
+                          });
+                          await video.play();
+                          return true;
+                        })())"));
+    ASSERT_TRUE(base::test::RunUntil([&]() {
+      return content::MediaSession::Get(contents())->GetRoutedFrame() != nullptr;
+    }));
+  }
+
+  content::WebContents* contents() {
+    return browser()->tab_strip_model()->GetActiveWebContents();
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerPictureInPictureTest,
+                       TogglePictureInPicture) {
+  ASSERT_NO_FATAL_FAILURE(LoadPlayingVideo());
+
+  content::TitleWatcher enter_watcher(contents(), u"enterpictureinpicture");
+  ASSERT_TRUE(
+      chrome::ExecuteCommand(browser(), IDC_TOGGLE_PICTURE_IN_PICTURE));
+  EXPECT_EQ(u"enterpictureinpicture", enter_watcher.WaitAndGetTitle());
+  EXPECT_TRUE(contents()->HasPictureInPictureVideo());
+
+  content::TitleWatcher leave_watcher(contents(), u"leavepictureinpicture");
+  ASSERT_TRUE(
+      chrome::ExecuteCommand(browser(), IDC_TOGGLE_PICTURE_IN_PICTURE));
+  EXPECT_EQ(u"leavepictureinpicture", leave_watcher.WaitAndGetTitle());
+  EXPECT_FALSE(contents()->HasPictureInPictureVideo());
+  EXPECT_EQ(false, content::EvalJs(
+                       contents(), "document.querySelector('video').paused"));
+}
+
+IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerPictureInPictureTest,
+                       NoVideo) {
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), GURL("about:blank")));
+  ASSERT_TRUE(
+      chrome::ExecuteCommand(browser(), IDC_TOGGLE_PICTURE_IN_PICTURE));
+  EXPECT_FALSE(contents()->HasPictureInPictureVideo());
+  EXPECT_FALSE(contents()->HasPictureInPictureDocument());
+}
+
+IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerPictureInPictureTest,
+                       UnavailableVideo) {
+  ASSERT_NO_FATAL_FAILURE(LoadPlayingVideo());
+  ASSERT_TRUE(content::ExecJs(
+      contents(),
+      "document.querySelector('video').disablePictureInPicture = true"));
+  ASSERT_TRUE(
+      chrome::ExecuteCommand(browser(), IDC_TOGGLE_PICTURE_IN_PICTURE));
+  EXPECT_FALSE(contents()->HasPictureInPictureVideo());
+  EXPECT_FALSE(contents()->HasPictureInPictureDocument());
+}
+
+#endif  // !BUILDFLAG(IS_ANDROID)
 
 // Regular window
 IN_PROC_BROWSER_TEST_F(BraveBrowserCommandControllerTest,

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -80,6 +80,7 @@
 #include "components/tab_groups/tab_group_visual_data.h"
 #include "components/tabs/public/tab_group.h"
 #include "content/public/browser/browser_thread.h"
+#include "content/public/browser/media_session.h"
 #include "content/public/browser/page_navigator.h"
 #include "content/public/browser/web_contents.h"
 #include "ui/base/clipboard/clipboard_buffer.h"
@@ -458,6 +459,21 @@ void ToggleActiveTabAudioMute(Browser* browser) {
   bool mute_tab = !contents->IsAudioMuted();
   SetTabAudioMuted(contents, mute_tab, TabMutedReason::kAudioIndicator,
                    std::string());
+}
+
+void TogglePictureInPicture(Browser* browser) {
+  WebContents* contents = browser->tab_strip_model()->GetActiveWebContents();
+  if (!contents) {
+    return;
+  }
+
+  auto* media_session = content::MediaSession::Get(contents);
+  if (contents->HasPictureInPictureVideo()) {
+    media_session->ExitPictureInPicture();
+    return;
+  }
+
+  media_session->EnterPictureInPicture();
 }
 
 void ToggleSidebarPosition(Browser* browser) {

--- a/browser/ui/browser_commands.h
+++ b/browser/ui/browser_commands.h
@@ -79,6 +79,7 @@ void ToggleVerticalTabStripFloatingMode(Browser* browser);
 void ToggleVerticalTabStripExpanded(Browser* browser);
 
 void ToggleActiveTabAudioMute(Browser* browser);
+void TogglePictureInPicture(Browser* browser);
 void ToggleSidebarPosition(Browser* browser);
 void ToggleSidebar(Browser* browser);
 

--- a/browser/ui/commands/accelerator_service_unittest.cc
+++ b/browser/ui/commands/accelerator_service_unittest.cc
@@ -9,6 +9,7 @@
 
 #include "base/test/scoped_feature_list.h"
 #include "brave/app/brave_command_ids.h"
+#include "brave/browser/ui/commands/default_accelerators.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
 #include "brave/components/brave_news/common/buildflags/buildflags.h"
@@ -91,6 +92,43 @@ class AcceleratorServiceUnitTest : public testing::Test {
   TestingProfile profile_;
   base::test::ScopedFeatureList features_;
 };
+
+TEST_F(AcceleratorServiceUnitTest, PictureInPictureShortcutCanBeCustomized) {
+  const auto default_shortcut = FromCodesString("Alt+KeyP");
+  const auto custom_shortcut = FromCodesString("Control+Alt+KeyP");
+
+  {
+    AcceleratorService service(profile().GetPrefs(), GetDefaultAccelerators());
+    auto command = service.GetCommandForTesting(IDC_TOGGLE_PICTURE_IN_PICTURE);
+    ASSERT_EQ(1u, command->accelerators.size());
+    EXPECT_FALSE(command->accelerators[0]->unmodifiable);
+    EXPECT_THAT(service.GetAcceleratorsForCommand(IDC_TOGGLE_PICTURE_IN_PICTURE),
+                testing::ElementsAre(default_shortcut));
+
+    service.UnassignAcceleratorFromCommand(IDC_TOGGLE_PICTURE_IN_PICTURE,
+                                           "Alt+KeyP");
+    EXPECT_TRUE(service.GetAcceleratorsForCommand(IDC_TOGGLE_PICTURE_IN_PICTURE)
+                    .empty());
+    service.AssignAcceleratorToCommand(IDC_TOGGLE_PICTURE_IN_PICTURE,
+                                       "Control+Alt+KeyP");
+  }
+
+  {
+    AcceleratorService service(profile().GetPrefs(), GetDefaultAccelerators());
+    EXPECT_THAT(
+        service.GetAcceleratorsForCommand(IDC_TOGGLE_PICTURE_IN_PICTURE),
+        testing::ElementsAre(custom_shortcut));
+    service.UnassignAcceleratorFromCommand(IDC_TOGGLE_PICTURE_IN_PICTURE,
+                                           "Control+Alt+KeyP");
+  }
+
+  AcceleratorService service(profile().GetPrefs(), GetDefaultAccelerators());
+  EXPECT_TRUE(
+      service.GetAcceleratorsForCommand(IDC_TOGGLE_PICTURE_IN_PICTURE).empty());
+  service.ResetAcceleratorsForCommand(IDC_TOGGLE_PICTURE_IN_PICTURE);
+  EXPECT_THAT(service.GetAcceleratorsForCommand(IDC_TOGGLE_PICTURE_IN_PICTURE),
+              testing::ElementsAre(default_shortcut));
+}
 
 TEST_F(AcceleratorServiceUnitTest, CanOverrideExistingShortcut) {
   commands::AcceleratorService service(

--- a/chromium_src/chrome/browser/ui/accelerator_table.cc
+++ b/chromium_src/chrome/browser/ui/accelerator_table.cc
@@ -17,6 +17,8 @@ constexpr AcceleratorMapping kBraveAcceleratorMap[] = {
     {ui::VKEY_S, ui::EF_PLATFORM_ACCELERATOR | ui::EF_SHIFT_DOWN,
      IDC_SHARING_HUB_SCREENSHOT},
     {ui::VKEY_M, ui::EF_CONTROL_DOWN, IDC_TOGGLE_TAB_MUTE},
+    // Alt+P (Option+P on Mac)
+    {ui::VKEY_P, ui::EF_ALT_DOWN, IDC_TOGGLE_PICTURE_IN_PICTURE},
     // Ctrl+B(or Cmd+B)
     {ui::VKEY_B, ui::EF_PLATFORM_ACCELERATOR, IDC_TOGGLE_SIDEBAR},
     // Ctrl+Alt+T (Cmd+Alt+T on Mac)

--- a/components/resources/commands.grdp
+++ b/components/resources/commands.grdp
@@ -385,6 +385,9 @@
   <message name="IDS_IDC_TOGGLE_TAB_MUTE">
     Toggle tab mute
   </message>
+  <message name="IDS_IDC_TOGGLE_PICTURE_IN_PICTURE" desc="Label of the keyboard shortcut command that enters or exits picture-in-picture (PiP) for the active tab">
+    Toggle picture-in-picture (PiP)
+  </message>
   <message name="IDS_IDC_SIDEBAR_TOGGLE_POSITION">
     Toggle sidebar position
   </message>


### PR DESCRIPTION
- Resolves https://github.com/brave/brave-browser/issues/44255

## Summary

Adds a configurable keyboard shortcut for toggling Picture-in-Picture (PiP) mode for video in the active tab.

The implementation integrates with Brave's existing command and keyboard-shortcut infrastructure and uses Chromium's existing `MediaSession` Picture-in-Picture support.

### Behavior

- Adds a new `Toggle picture-in-picture (PiP)` command.
- Adds a default shortcut:
  - **Windows/Linux:** `Alt+P`
  - **macOS:** `Option+P`
- Exposes the command in `brave://settings/system/shortcuts`.
- The shortcut can be changed, removed, and reset using Brave's existing shortcut settings.
- Operates only on the active tab.
- If the active tab is already in video or document PiP, the shortcut exits PiP.
- If PiP is available for the active media session, the shortcut enters PiP.
- If the page does not have an eligible PiP media session, the command safely does nothing.
- Does not introduce site-specific behavior, JavaScript injection, or additional permissions.

## Implementation

The change:

- Adds `IDC_TOGGLE_PICTURE_IN_PICTURE` as a Brave command.
- Registers the command with `BraveBrowserCommandController`.
- Implements the toggle through Chromium's `content::MediaSession`.
- Adds the default `Alt+P` accelerator to Brave's accelerator table.
- Adds the command label to Brave's command resources so it is available in the shortcut settings UI.
- Uses the existing Brave accelerator service for customization and persistence.

## Tests

Automated coverage has been added for:

- Default `Alt+P` shortcut registration.
- Shortcut customization.
- Shortcut removal.
- Persistence of customized shortcuts.
- Resetting the shortcut to its default.
- Entering Picture-in-Picture from the active tab.
- Exiting Picture-in-Picture by invoking the command again.
- Safe behavior on a page without video.
- Safe behavior when Picture-in-Picture is unavailable.
- Ensuring PiP belonging to another tab is not closed by the active tab's command.

## Manual test plan

1. Open a page containing a playable video.
2. Start video playback.
3. Press `Alt+P` on Windows/Linux or `Option+P` on macOS.
4. Verify that the video enters Picture-in-Picture.
5. Press the shortcut again and verify that Picture-in-Picture closes.
6. Open `brave://settings/system/shortcuts`.
7. Search for `Picture-in-Picture` or `PiP`.
8. Verify that the command appears with the default shortcut.
9. Change the shortcut and verify the new shortcut works.
10. Remove the shortcut and verify it no longer triggers PiP.
11. Reset the command and verify the default shortcut is restored.
12. Verify that triggering the command on a page without an eligible video is a safe no-op.

## Platforms

- Windows
- Linux
- macOS